### PR TITLE
WIP and PoC Use UserCredentials map for user and key

### DIFF
--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -49,11 +49,11 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, err
 	}
 
-	volOptions, err := getRBDVolumeOptions(req.Parameters, cs.clientSet)
+	volOptions, err := getRBDVolumeOptionsV2(req.Parameters, req.UserCredentials)
 	if err != nil {
 		return nil, err
 	}
-
+        fmt.Printf("><SB> volOptions %+v\n",volOptions)
 	// Generating Volume Name and Volume ID, as accoeding to CSI spec they MUST be different
 	volName := req.GetName()
 	uniqueID := uuid.NewUUID().String()


### PR DESCRIPTION
This PR uses the changes in k8s API (adding UserID to PV and PVC Spec and new StorageClass attribute) and instead of directly extracting key from the secret, it uses user id and key, passed from CSI in UserCredentials map.