### PR TITLE
Changing tags from latest to v0.1.0 for branch v0.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@
 
 .PHONY: all rbdplugin
 
-IMAGE_NAME=csi_images/rbdplugin
-IMAGE_VERSION=latest
+IMAGE_NAME=quay.io/k8scsi/rbdplugin
+IMAGE_VERSION=v0.1.0
 
 all: rbdplugin
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ workloads.
 
 ### Feature Status
 
+### CSI Spec version
+v0.1.0 branch of ceph-csi repo correpsonds to version 0.1.0 of CSI spec, in order for a  plugin
+to operate sucessfully, other components: external-attacher, external-provisioner and driver-registrar must
+be built for the same CSI spec version.
+ 
 ### 1.9: Alpha
 
 **Important:** `CSIPersistentVolume` and `MountPropagation`
@@ -52,7 +57,7 @@ $ docker images | grep rbdplugin
 ```
 You should see the following line in the output:
 ```
-csi_images/rbdplugin   latest  248ddba297fa        30 seconds ago    431 MB
+csi_images/rbdplugin   v0.1.0  248ddba297fa        30 seconds ago    431 MB
 ```
 
 ### Testing

--- a/deploy/kubernetes/csi-attacher.yaml
+++ b/deploy/kubernetes/csi-attacher.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: docker.io/k8scsi/csi-attacher:latest
+          image: quay.io/k8scsi/csi-attacher:v0.1.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/csi-provisioner.yaml
+++ b/deploy/kubernetes/csi-provisioner.yaml
@@ -75,7 +75,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:latest
+          image: quay.io/k8scsi/csi-provisioner:v0.1.0
           args:
             - "--provisioner=rbdplugin"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/rbdplugin.yaml
+++ b/deploy/kubernetes/rbdplugin.yaml
@@ -61,7 +61,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: docker.io/k8scsi/driver-registrar:latest
+          image: quay.io/k8scsi/driver-registrar:v0.1.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -81,7 +81,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: csi_images/rbdplugin:latest
+          image: quay.io/k8scsi/rbdplugin:v0.1.0
           args :
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
Need to start using version tags per CSI spec release.  As version 0.1.0 images will not work with v0.2.0 images.