### PR TITLE
fixed a race condition in NodePublishVolume/NodeUnpublishVolume

### DIFF
--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -70,7 +70,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	targetPath := req.GetTargetPath()
 	volumeID := req.GetVolumeId()
 
-	if isVolumePending(req) {
+	if isVolumePending(volumeID) {
 		return nil, fmt.Errorf("rbd: NodePublishVolume for %s is pending", volumeID)
 	}
 

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -71,7 +71,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	volumeID := req.GetVolumeId()
 
 	if isVolumePending(volumeID) {
-		return nil, fmt.Errorf("rbd: NodePublishVolume for %s is pending", volumeID)
+		return nil, status.Errorf(codes.Aborted, "rbd: NodePublishVolume for %s is pending", volumeID)
 	}
 
 	markPending(volumeID)
@@ -141,7 +141,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	volOptions := &rbdVolumeOptions{}
 
 	if isVolumePending(volumeID) {
-		return nil, fmt.Errorf("rbd: NodeUnpublishVolume for %s is pending", volumeID)
+		return nil, status.Errorf(codes.Aborted, "rbd: NodeUnpublishVolume for %s is pending", volumeID)
 	}
 
 	markPending(volumeID)


### PR DESCRIPTION
Adds a mutex and a map with VolumeId as a key. Permits NodePublishVolume
and NodeUnpublishVolume functions to continue only when the map doesn't
contain that VolumeId, otherwise returns an error.

Rationale:

NodePublishVolume's SafeFormatAndMount may take quite a long time. This would
in turn trigger CO's timeout which would re-run NodePublishVolume again.

On a Linux system, SafeFormatAndMount calls fsck, mkfs.ext4 and mount.
Running those commands repeatedly and simultaneously on the same volume
may well break it.

As a follow-up question, is rbdplugin even supposed to format and mount the volume? It's a block device after all.