### PR TITLE
cephfs/main: updated import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ script:
   - test -z $(gofmt -s -l $GO_FILES)
   - go vet -v $(go list ./... | grep -v /vendor/)
   - make rbdplugin
+  - make cephfsplugin
 
 deploy:
   - provider: script
     script:
-      - ./deploy.sh
+      - ./deploy-rbd.sh
+      - ./deploy-cephfs.sh

--- a/cephfs/main.go
+++ b/cephfs/main.go
@@ -21,8 +21,7 @@ import (
 	"os"
 	"path"
 
-	// "github.com/ceph/ceph-csi/pkg/cephfs"
-	"github.com/gman0/ceph-csi/pkg/cephfs"
+	"github.com/ceph/ceph-csi/pkg/cephfs"
 	"github.com/golang/glog"
 )
 


### PR DESCRIPTION
cephfs/main.go contains wrong import path for `cephfs` package