### PR TITLE
Fix the ceph csi `rbdplugin` container build issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ rbdplugin:
 
 rbdplugin-container: rbdplugin 
 	cp _output/rbdplugin  deploy/rbd/docker
-	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) deploy/rbd/docker
+	docker build -t $(RBD_IMAGE_NAME):$(RBD_IMAGE_VERSION) deploy/rbd/docker
 
 cephfsplugin:
 	if [ ! -d ./vendor ]; then dep ensure; fi


### PR DESCRIPTION
This PR is trying to fix the issue #34. We use 'RBD_IMAGE_NAME' and
'RBD_IMAGE_VERSION' instead of the obsolete 'IMAGE_NAME' and 'IMAGE_VERSION'
to address this issue.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>