### PR TITLE
cephfs config scheme

### DIFF
--- a/pkg/cephfs/cephconf.go
+++ b/pkg/cephfs/cephconf.go
@@ -51,7 +51,7 @@ const cephSecret = `{{.Key}}`
 
 const (
 	cephConfigRoot         = "/etc/ceph"
-	cephConfigFileName     = "ceph.conf"
+	cephConfigFileNameFmt  = "ceph.share.%s.conf"
 	cephKeyringFileNameFmt = "ceph.client.%s.keyring"
 	cephSecretFileNameFmt  = "ceph.client.%s.secret"
 )
@@ -85,7 +85,8 @@ type cephConfigWriter interface {
 }
 
 type cephConfigData struct {
-	Monitors string
+	Monitors   string
+	VolumeUuid string
 }
 
 func writeCephTemplate(fileName string, m os.FileMode, t *template.Template, data interface{}) error {
@@ -107,7 +108,7 @@ func writeCephTemplate(fileName string, m os.FileMode, t *template.Template, dat
 }
 
 func (d *cephConfigData) writeToFile() error {
-	return writeCephTemplate(cephConfigFileName, 0640, cephConfigTempl, d)
+	return writeCephTemplate(fmt.Sprintf(cephConfigFileNameFmt, d.VolumeUuid), 0640, cephConfigTempl, d)
 }
 
 type cephKeyringData struct {
@@ -144,6 +145,6 @@ func getCephKeyringPath(userId string) string {
 	return path.Join(cephConfigRoot, fmt.Sprintf(cephKeyringFileNameFmt, userId))
 }
 
-func getCephConfPath() string {
-	return path.Join(cephConfigRoot, cephConfigFileName)
+func getCephConfPath(volUuid string) string {
+	return path.Join(cephConfigRoot, fmt.Sprintf(cephConfigFileNameFmt, volUuid))
 }

--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -77,12 +77,6 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	volId := newVolumeIdentifier(volOptions, req)
 
-	conf := cephConfigData{Monitors: volOptions.Monitors}
-	if err = conf.writeToFile(); err != nil {
-		glog.Errorf("couldn't generate ceph.conf: %v", err)
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
 	// Create a volume in case the user didn't provide one
 
 	if volOptions.ProvisionVolume {

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -121,7 +121,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	conf := cephConfigData{Monitors: volOptions.Monitors, VolumeUuid: volUuid}
 	if err = conf.writeToFile(); err != nil {
-		glog.Errorf("couldn't generate ceph.conf: %v", err)
+		glog.Errorf("failed to write ceph config file to %s: %v", getCephConfPath(volUuid), err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -119,6 +119,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	conf := cephConfigData{Monitors: volOptions.Monitors, VolumeUuid: volUuid}
+	if err = conf.writeToFile(); err != nil {
+		glog.Errorf("couldn't generate ceph.conf: %v", err)
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	// Check if the volume is already mounted
 
 	isMnt, err := isMountPoint(targetPath)


### PR DESCRIPTION
This PR fixes two things:
- if the share is provisioned by some external provisioner (e.g. the upcoming Manila provisioner), only `NodePublishVolume` gets called. Since the ceph config file is generated in `CreateVolume`, the mount would fail. This is resolved by moving the config generation to `NodePublishVolume`
- only one ceph config for all shares: this causes a problem when different shares have different monitors etc.