### PR TITLE
Fix broken cephfs provisioner

### DIFF
--- a/deploy/cephfs/kubernetes/csi-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner.yaml
@@ -78,7 +78,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v0.2.0
+          image: quay.io/k8scsi/csi-provisioner:v0.2.1
           args:
             - "--provisioner=csi-cephfsplugin"
             - "--csi-address=$(ADDRESS)"

--- a/pkg/cephfs/cephconf.go
+++ b/pkg/cephfs/cephconf.go
@@ -52,8 +52,8 @@ const cephSecret = `{{.Key}}`
 const (
 	cephConfigRoot         = "/etc/ceph"
 	cephConfigFileNameFmt  = "ceph.share.%s.conf"
-	cephKeyringFileNameFmt = "ceph.client.%s.keyring"
-	cephSecretFileNameFmt  = "ceph.client.%s.secret"
+	cephKeyringFileNameFmt = "ceph.share.%s.client.%s.keyring"
+	cephSecretFileNameFmt  = "ceph.share.%s.client.%s.secret"
 )
 
 var (
@@ -115,34 +115,37 @@ type cephKeyringData struct {
 	UserId, Key     string
 	RootPath        string
 	Pool, Namespace string
+	VolumeUuid      string
 }
 
 func (d *cephKeyringData) writeToFile() error {
-	return writeCephTemplate(fmt.Sprintf(cephKeyringFileNameFmt, d.UserId), 0600, cephKeyringTempl, d)
+	return writeCephTemplate(fmt.Sprintf(cephKeyringFileNameFmt, d.VolumeUuid, d.UserId), 0600, cephKeyringTempl, d)
 }
 
 type cephFullCapsKeyringData struct {
 	UserId, Key string
+	VolumeUuid  string
 }
 
 func (d *cephFullCapsKeyringData) writeToFile() error {
-	return writeCephTemplate(fmt.Sprintf(cephKeyringFileNameFmt, d.UserId), 0600, cephFullCapsKeyringTempl, d)
+	return writeCephTemplate(fmt.Sprintf(cephKeyringFileNameFmt, d.VolumeUuid, d.UserId), 0600, cephFullCapsKeyringTempl, d)
 }
 
 type cephSecretData struct {
 	UserId, Key string
+	VolumeUuid  string
 }
 
 func (d *cephSecretData) writeToFile() error {
-	return writeCephTemplate(fmt.Sprintf(cephSecretFileNameFmt, d.UserId), 0600, cephSecretTempl, d)
+	return writeCephTemplate(fmt.Sprintf(cephSecretFileNameFmt, d.VolumeUuid, d.UserId), 0600, cephSecretTempl, d)
 }
 
-func getCephSecretPath(userId string) string {
-	return path.Join(cephConfigRoot, fmt.Sprintf(cephSecretFileNameFmt, userId))
+func getCephSecretPath(volUuid, userId string) string {
+	return path.Join(cephConfigRoot, fmt.Sprintf(cephSecretFileNameFmt, volUuid, userId))
 }
 
-func getCephKeyringPath(userId string) string {
-	return path.Join(cephConfigRoot, fmt.Sprintf(cephKeyringFileNameFmt, userId))
+func getCephKeyringPath(volUuid, userId string) string {
+	return path.Join(cephConfigRoot, fmt.Sprintf(cephKeyringFileNameFmt, volUuid, userId))
 }
 
 func getCephConfPath(volUuid string) string {

--- a/pkg/cephfs/identityserver.go
+++ b/pkg/cephfs/identityserver.go
@@ -17,9 +17,26 @@ limitations under the License.
 package cephfs
 
 import (
+	"context"
+
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"github.com/kubernetes-csi/drivers/pkg/csi-common"
 )
 
 type identityServer struct {
 	*csicommon.DefaultIdentityServer
+}
+
+func (is *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	return &csi.GetPluginCapabilitiesResponse{
+		Capabilities: []*csi.PluginCapability{
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
+					},
+				},
+			},
+		},
+	}, nil
 }

--- a/pkg/cephfs/util.go
+++ b/pkg/cephfs/util.go
@@ -79,9 +79,10 @@ func tryLock(id string, mtx keymutex.KeyMutex, name string) error {
 
 func storeCephUserCredentials(volUuid string, cr *credentials, volOptions *volumeOptions) error {
 	keyringData := cephKeyringData{
-		UserId:   cr.id,
-		Key:      cr.key,
-		RootPath: volOptions.RootPath,
+		UserId:     cr.id,
+		Key:        cr.key,
+		RootPath:   volOptions.RootPath,
+		VolumeUuid: volUuid,
 	}
 
 	if volOptions.ProvisionVolume {
@@ -89,21 +90,22 @@ func storeCephUserCredentials(volUuid string, cr *credentials, volOptions *volum
 		keyringData.Namespace = getVolumeNamespace(volUuid)
 	}
 
-	return storeCephCredentials(cr, &keyringData)
+	return storeCephCredentials(volUuid, cr, &keyringData)
 }
 
-func storeCephAdminCredentials(cr *credentials) error {
-	return storeCephCredentials(cr, &cephFullCapsKeyringData{UserId: cr.id, Key: cr.key})
+func storeCephAdminCredentials(volUuid string, cr *credentials) error {
+	return storeCephCredentials(volUuid, cr, &cephFullCapsKeyringData{UserId: cr.id, Key: cr.key, VolumeUuid: volUuid})
 }
 
-func storeCephCredentials(cr *credentials, keyringData cephConfigWriter) error {
+func storeCephCredentials(volUuid string, cr *credentials, keyringData cephConfigWriter) error {
 	if err := keyringData.writeToFile(); err != nil {
 		return err
 	}
 
 	secret := cephSecretData{
-		UserId: cr.id,
-		Key:    cr.key,
+		UserId:     cr.id,
+		Key:        cr.key,
+		VolumeUuid: volUuid,
 	}
 
 	if err := secret.writeToFile(); err != nil {

--- a/pkg/cephfs/volume.go
+++ b/pkg/cephfs/volume.go
@@ -88,7 +88,7 @@ func createVolume(volOptions *volumeOptions, adminCr *credentials, volUuid strin
 	// Access to cephfs's / is required
 	volOptions.RootPath = "/"
 
-	if err := mountKernel(cephRoot, adminCr, volOptions); err != nil {
+	if err := mountKernel(cephRoot, adminCr, volOptions, volUuid); err != nil {
 		return fmt.Errorf("error mounting ceph root: %v", err)
 	}
 
@@ -144,7 +144,7 @@ func purgeVolume(volId string, cr *credentials, volOptions *volumeOptions) error
 		return err
 	}
 
-	if err := mountKernel(volRoot, cr, volOptions); err != nil {
+	if err := mountKernel(volRoot, cr, volOptions, volUuid); err != nil {
 		return err
 	}
 

--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -38,7 +38,7 @@ func mountFuse(mountPoint string, cr *credentials, volOptions *volumeOptions, vo
 		mountPoint,
 		"-c", getCephConfPath(volUuid),
 		"-n", cephEntityClientPrefix + cr.id,
-		"--keyring", getCephKeyringPath(cr.id),
+		"--keyring", getCephKeyringPath(volUuid, cr.id),
 		"-r", volOptions.RootPath,
 	}
 
@@ -74,7 +74,7 @@ func (m *fuseMounter) mount(mountPoint string, cr *credentials, volOptions *volu
 
 type kernelMounter struct{}
 
-func mountKernel(mountPoint string, cr *credentials, volOptions *volumeOptions) error {
+func mountKernel(mountPoint string, cr *credentials, volOptions *volumeOptions, volUuid string) error {
 	if err := execCommandAndValidate("modprobe", "ceph"); err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func mountKernel(mountPoint string, cr *credentials, volOptions *volumeOptions) 
 		fmt.Sprintf("%s:%s", volOptions.Monitors, volOptions.RootPath),
 		mountPoint,
 		"-o",
-		fmt.Sprintf("name=%s,secretfile=%s", cr.id, getCephSecretPath(cr.id)),
+		fmt.Sprintf("name=%s,secretfile=%s", cr.id, getCephSecretPath(volUuid, cr.id)),
 	)
 }
 
@@ -99,7 +99,7 @@ func (m *kernelMounter) mount(mountPoint string, cr *credentials, volOptions *vo
 		return err
 	}
 
-	if err := mountKernel(localVolRoot, cr, volOptions); err != nil {
+	if err := mountKernel(localVolRoot, cr, volOptions, volUuid); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`CreateVolume()` was missing ceph config, `NodePublishVolume()` was missing ceph admin credentials when creating a new user and the recent change in ceph config naming scheme - all of those broke share provisioning. This PR makes it work again + bumps `csi-provisioner` to 0.2.1