### PR TITLE
cephfs: forbid deletion of shares not provisioned by the driver

### DIFF
--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -121,7 +121,7 @@ func bindMount(from, to string, readOnly bool) error {
 }
 
 func bindVolume(volUuid, target string, readOnly bool) error {
-	volDataRoot := getVolumeDataPath_local(volUuid)
+	volDataRoot := getVolumeRootPath_local(volUuid)
 
 	if err := createMountPoint(volDataRoot); err != nil {
 		return err


### PR DESCRIPTION
This PR makes deleting a volume that has not been provisioned by the driver forbidden (determined by the StorageClass parameter `provisionVolume` [docs](https://github.com/ceph/ceph-csi#configuration-requirements-1)). This prevents accidental loss of data by just deleting a PVC with an existing CephFS share.

Rationale: the provisioning party should be the one who also deletes the volume. It's should not be the responsibility of the driver to delete a statically-provisioned volume.

In case of calling `DeleteVolume()` with volume parameter `provisionVolume=false`, it will log a warning message and exit with success. Otherwise (`provisionVolume=true`) it will proceed according to `retainPolicy`.

PS: There's also the `UNIMPLEMENTED` [error code](https://github.com/container-storage-interface/spec/blob/master/spec.md#deletevolume-errors) which would suit this exact scenario, but this will still leave behind the PersistentVolume that is retrying delete forever.