### PR TITLE
Fix Cephfs plugin to return false to ValidateVolumeCapabilities if Block volume is specified

### DIFF
--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -185,5 +185,11 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 func (cs *controllerServer) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	// Cephfs doesn't support Block volume
+	for _, cap := range req.VolumeCapabilities {
+		if cap.GetBlock() != nil {
+			return &csi.ValidateVolumeCapabilitiesResponse{Supported: false, Message: ""}, nil
+		}
+	}
 	return &csi.ValidateVolumeCapabilitiesResponse{Supported: true}, nil
 }


### PR DESCRIPTION
Cephfs doesn't have a feature to provide Block Volume, therefore it should return ```false``` to ```ValidateVolumeCapabilities``` if Block Volume is specified.

Fixes #44