### PR TITLE
Correct cephfsplugin binary path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ push-cephfsplugin-container: cephfsplugin-container
 clean:
 	go clean -r -x
 	rm -f deploy/rbd/docker/rbdplugin
-	rm -f deploy/cephfs/docker/rbdplugin
+	rm -f deploy/cephfs/docker/cephfsplugin


### PR DESCRIPTION
Makefile has a wrong path to `deploy/cephfs/docker/rbdplugin`. This
patch changes to `deploy/cephfs/docker/cephfsplugin`.