### PR TITLE
Add nonempty option to ceph-fuse to support ReadWriteMany

### DIFF
--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -40,6 +40,7 @@ func mountFuse(mountPoint string, cr *credentials, volOptions *volumeOptions, vo
 		"-n", cephEntityClientPrefix + cr.id,
 		"--keyring", getCephKeyringPath(volUuid, cr.id),
 		"-r", volOptions.RootPath,
+		"-o", "nonempty",
 	}
 
 	out, err := execCommand("ceph-fuse", args[:]...)


### PR DESCRIPTION
fuse mount does not allow to mount directory if it contains some
files. Due to this, currently scaled pod with cephfs failed to mount
by ceph-fuse.

This patch adds nonempty option to ceph-fuse command to support
ReadWriteMany with ceph-fuse.

Fixes https://github.com/ceph/ceph-csi/issues/54