### PR TITLE
Logging command and options for debug friendly

### DIFF
--- a/pkg/cephfs/util.go
+++ b/pkg/cephfs/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -35,6 +36,7 @@ func execCommand(command string, args ...string) ([]byte, error) {
 }
 
 func execCommandAndValidate(program string, args ...string) error {
+	glog.V(4).Infof("cephfs: executing command: %s with args: %s", program, args)
 	out, err := execCommand(program, args...)
 	if err != nil {
 		return fmt.Errorf("cephfs: %s failed with following error: %s\ncephfs: %s output: %s", program, err, program, out)
@@ -121,6 +123,8 @@ func newMounter(volOptions *volumeOptions) volumeMounter {
 	if mounter == "" {
 		mounter = DefaultVolumeMounter
 	}
+
+	glog.V(4).Infof("cephfs: setting volume mounter to: %s", mounter)
 
 	switch mounter {
 	case volumeMounter_fuse:


### PR DESCRIPTION
Some commands were executed in ceph-csi, but users do not know what
commands with what options were executed. Hence, it is difficult to
debug once the command did not work fine.

This patch adds logging what commmand and options are executed.