### PR TITLE
Support snapshot in rbdplugin

### DIFF
--- a/examples/rbd/secret.yaml
+++ b/examples/rbd/secret.yaml
@@ -6,3 +6,5 @@ metadata:
 data:
   # Key value corresponds to a user name defined in ceph cluster
   admin: BASE64-ENCODED-PASSWORD
+  # Key value corresponds to a user name defined in ceph cluster
+  kubernetes: BASE64-ENCODED-PASSWORD

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -21,4 +21,8 @@ parameters:
     csiProvisionerSecretNamespace: default
     csiNodePublishSecretName: csi-rbd-secret
     csiNodePublishSecretNamespace: default
+
+    # Ceph users for operating RBD
+    adminid: admin
+    userid: kubernetes
 reclaimPolicy: Delete

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -212,3 +212,11 @@ func (ns *nodeServer) NodeUnstageVolume(
 	*csi.NodeUnstageVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
+
+func (ns *nodeServer) NodeGetInfo(
+	ctx context.Context,
+	req *csi.NodeGetInfoRequest) (
+	*csi.NodeGetInfoResponse, error) {
+
+	return nil, status.Error(codes.Unimplemented, "")
+}

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -212,11 +212,3 @@ func (ns *nodeServer) NodeUnstageVolume(
 	*csi.NodeUnstageVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
-
-func (ns *nodeServer) NodeGetInfo(
-	ctx context.Context,
-	req *csi.NodeGetInfoRequest) (
-	*csi.NodeGetInfoResponse, error) {
-
-	return nil, status.Error(codes.Unimplemented, "")
-}

--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -236,6 +236,10 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	if err != nil {
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Source Volume ID %s cannot found", req.GetSourceVolumeId()))
 	}
+	if !hasSnapshotFeature(rbdVolume.ImageFeatures) {
+		return nil, fmt.Errorf("Volume(%s) has not snapshot feature(layering)", req.GetSourceVolumeId())
+	}
+
 	rbdSnap.VolName = rbdVolume.VolName
 	rbdSnap.SnapName = snapName
 	snapshotID := "csi-rbd-" + rbdVolume.VolName + "-snap-" + uniqueID

--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -18,7 +18,10 @@ package rbd
 
 import (
 	"fmt"
+	"os/exec"
 	"path"
+	"syscall"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"github.com/golang/glog"
@@ -77,7 +80,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, err
 	}
 
-	// Generating Volume Name and Volume ID, as accoeding to CSI spec they MUST be different
+	// Generating Volume Name and Volume ID, as according to CSI spec they MUST be different
 	volName := req.GetName()
 	uniqueID := uuid.NewUUID().String()
 	if len(volName) == 0 {
@@ -97,14 +100,39 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// Check if there is already RBD image with requested name
 	found, _, _ := rbdStatus(rbdVol, req.GetControllerCreateSecrets())
 	if !found {
-		if err := createRBDImage(rbdVol, volSizeGB, req.GetControllerCreateSecrets()); err != nil {
-			if err != nil {
-				glog.Warningf("failed to create volume: %v", err)
+		// if VolumeContentSource is not nil, this request is for snapshot
+		if req.VolumeContentSource != nil {
+			snapshot := req.VolumeContentSource.GetSnapshot()
+			if snapshot == nil {
+				return nil, status.Error(codes.InvalidArgument, "Volume Snapshot cannot be empty")
+			}
+
+			snapshotID := snapshot.GetId()
+			if snapshotID == "" {
+				return nil, status.Error(codes.InvalidArgument, "Volume Snapshot ID cannot be empty")
+			}
+
+			rbdSnap := &rbdSnapshot{}
+			if err := loadSnapInfo(snapshotID, path.Join(PluginFolder, "controller-snap"), rbdSnap); err != nil {
 				return nil, err
 			}
+
+			err = restoreSnapshot(rbdVol, rbdSnap, req.GetControllerCreateSecrets())
+			if err != nil {
+				return nil, err
+			}
+			glog.V(4).Infof("create volume %s from snapshot %s", volName, rbdSnap.SnapName)
+		} else {
+			if err := createRBDImage(rbdVol, volSizeGB, req.GetControllerCreateSecrets()); err != nil {
+				if err != nil {
+					glog.Warningf("failed to create volume: %v", err)
+					return nil, err
+				}
+			}
+			glog.V(4).Infof("create volume %s", volName)
 		}
-		glog.V(4).Infof("create volume %s", volName)
 	}
+
 	// Storing volInfo into a persistent file.
 	if err := persistVolInfo(volumeID, path.Join(PluginFolder, "controller"), rbdVol); err != nil {
 		glog.Warningf("rbd: failed to store volInfo with error: %v", err)
@@ -161,4 +189,207 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 
 func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	return &csi.ControllerPublishVolumeResponse{}, nil
+}
+
+func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
+		glog.Warningf("invalid create snapshot req: %v", req)
+		return nil, err
+	}
+
+	// Check sanity of request Snapshot Name, Source Volume Id
+	if len(req.Name) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Snapshot Name cannot be empty")
+	}
+	if len(req.SourceVolumeId) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Source Volume ID cannot be empty")
+	}
+
+	// Need to check for already existing snapshot name, and if found
+	// check for the requested source volume id and already allocated source volume id
+	if exSnap, err := getRBDSnapshotByName(req.GetName()); err == nil {
+		if req.SourceVolumeId == exSnap.SourceVolumeID {
+			return &csi.CreateSnapshotResponse{
+				Snapshot: &csi.Snapshot{
+					SizeBytes:      exSnap.SizeBytes,
+					Id:             exSnap.SnapID,
+					SourceVolumeId: exSnap.SourceVolumeID,
+					CreatedAt:      exSnap.CreatedAt,
+					Status: &csi.SnapshotStatus{
+						Type: csi.SnapshotStatus_READY,
+					},
+				},
+			}, nil
+		}
+		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Snapshot with the same name: %s but with different source volume id already exist", req.GetName()))
+	}
+
+	rbdSnap, err := getRBDSnapshotOptions(req.GetParameters())
+	if err != nil {
+		return nil, err
+	}
+
+	// Generating Snapshot Name and Snapshot ID, as according to CSI spec they MUST be different
+	snapName := req.GetName()
+	uniqueID := uuid.NewUUID().String()
+	rbdVolume, err := getRBDVolumeByID(req.GetSourceVolumeId())
+	if err != nil {
+		return nil, status.Error(codes.NotFound, fmt.Sprintf("Source Volume ID %s cannot found", req.GetSourceVolumeId()))
+	}
+	rbdSnap.VolName = rbdVolume.VolName
+	rbdSnap.SnapName = snapName
+	snapshotID := "csi-rbd-snapshot-" + uniqueID
+	rbdSnap.SnapID = snapshotID
+	rbdSnap.SourceVolumeID = req.GetSourceVolumeId()
+	rbdSnap.SizeBytes = rbdVolume.VolSize
+
+	err = createSnapshot(rbdSnap, req.GetCreateSnapshotSecrets())
+	// if we already have the snapshot, return the snapshot
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				if status.ExitStatus() == int(syscall.EEXIST) {
+					glog.Warningf("Snapshot with the same name: %s, we return this.", req.GetName())
+				} else {
+					glog.Warningf("failed to create snapshot: %v", err)
+					return nil, err
+				}
+			} else {
+				glog.Warningf("failed to create snapshot: %v", err)
+				return nil, err
+			}
+		} else {
+			glog.Warningf("failed to create snapshot: %v", err)
+			return nil, err
+		}
+	} else {
+		glog.V(4).Infof("create snapshot %s", snapName)
+		err = protectSnapshot(rbdSnap, req.GetCreateSnapshotSecrets())
+
+		if err != nil {
+			err = deleteSnapshot(rbdSnap, req.GetCreateSnapshotSecrets())
+			if err != nil {
+				return nil, fmt.Errorf("snapshot is created but failed to protect and delete snapshot: %v", err)
+			}
+			return nil, fmt.Errorf("Snapshot is created but failed to protect snapshot")
+		}
+	}
+
+	rbdSnap.CreatedAt = time.Now().UnixNano()
+
+	// Storing snapInfo into a persistent file.
+	if err := persistSnapInfo(snapshotID, path.Join(PluginFolder, "controller-snap"), rbdSnap); err != nil {
+		glog.Warningf("rbd: failed to store sanpInfo with error: %v", err)
+		return nil, err
+	}
+	rbdSnapshots[snapshotID] = *rbdSnap
+	return &csi.CreateSnapshotResponse{
+		Snapshot: &csi.Snapshot{
+			SizeBytes:      rbdSnap.SizeBytes,
+			Id:             snapshotID,
+			SourceVolumeId: req.GetSourceVolumeId(),
+			CreatedAt:      rbdSnap.CreatedAt,
+			Status: &csi.SnapshotStatus{
+				Type: csi.SnapshotStatus_READY,
+			},
+		},
+	}, nil
+}
+
+func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
+		glog.Warningf("invalid delete snapshot req: %v", req)
+		return nil, err
+	}
+
+	snapshotID := req.GetSnapshotId()
+	if snapshotID == "" {
+		return nil, status.Error(codes.InvalidArgument, "Snapshot ID cannot be empty")
+	}
+	rbdSnap := &rbdSnapshot{}
+	if err := loadSnapInfo(snapshotID, path.Join(PluginFolder, "controller-snap"), rbdSnap); err != nil {
+		return nil, err
+	}
+
+	// Unprotect snapshot
+	err := unprotectSnapshot(rbdSnap, req.GetDeleteSnapshotSecrets())
+	if err != nil {
+		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("failed to unprotect snapshot: %s/%s with error: %v", rbdSnap.Pool, rbdSnap.SnapName, err))
+	}
+
+	// Deleting snapshot
+	glog.V(4).Infof("deleting Snaphot %s", rbdSnap.SnapName)
+	if err := deleteSnapshot(rbdSnap, req.GetDeleteSnapshotSecrets()); err != nil {
+		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("failed to delete snapshot: %s/%s with error: %v", rbdSnap.Pool, rbdSnap.SnapName, err))
+	}
+
+	// Removing persistent storage file for the unmapped snapshot
+	if err := deleteSnapInfo(snapshotID, path.Join(PluginFolder, "controller-snap")); err != nil {
+		return nil, err
+	}
+
+	delete(rbdSnapshots, snapshotID)
+
+	return &csi.DeleteSnapshotResponse{}, nil
+}
+
+func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS); err != nil {
+		glog.Warningf("invalid list snapshot req: %v", req)
+		return nil, err
+	}
+
+	sourceVolumeId := req.GetSourceVolumeId()
+
+	// TODO (sngchlko) list with token
+
+	// list only a specific snapshot which has snapshot ID
+	if snapshotID := req.GetSnapshotId(); snapshotID != "" {
+		if rbdSnap, ok := rbdSnapshots[snapshotID]; ok {
+			// if source volume ID also set, check source volume id on the cache.
+			if sourceVolumeId != "" && rbdSnap.SourceVolumeID != sourceVolumeId {
+				return nil, status.Error(codes.Unknown, fmt.Sprintf("Requested Source Volume ID %s is different from %s", sourceVolumeId, rbdSnap.SourceVolumeID))
+			}
+			return &csi.ListSnapshotsResponse{
+				Entries: []*csi.ListSnapshotsResponse_Entry{
+					{
+						Snapshot: &csi.Snapshot{
+							SizeBytes:      rbdSnap.SizeBytes,
+							Id:             rbdSnap.SnapID,
+							SourceVolumeId: rbdSnap.SourceVolumeID,
+							CreatedAt:      rbdSnap.CreatedAt,
+							Status: &csi.SnapshotStatus{
+								Type: csi.SnapshotStatus_READY,
+							},
+						},
+					},
+				},
+			}, nil
+		} else {
+			return nil, status.Error(codes.NotFound, fmt.Sprintf("Snapshot ID %s cannot found", snapshotID))
+		}
+	}
+
+	entries := []*csi.ListSnapshotsResponse_Entry{}
+	for _, rbdSnap := range rbdSnapshots {
+		// if source volume ID also set, check source volume id on the cache.
+		if sourceVolumeId != "" && rbdSnap.SourceVolumeID != sourceVolumeId {
+			continue
+		}
+		entries = append(entries, &csi.ListSnapshotsResponse_Entry{
+			Snapshot: &csi.Snapshot{
+				SizeBytes:      rbdSnap.SizeBytes,
+				Id:             rbdSnap.SnapID,
+				SourceVolumeId: rbdSnap.SourceVolumeID,
+				CreatedAt:      rbdSnap.CreatedAt,
+				Status: &csi.SnapshotStatus{
+					Type: csi.SnapshotStatus_READY,
+				},
+			},
+		})
+	}
+
+	return &csi.ListSnapshotsResponse{
+		Entries: entries,
+	}, nil
 }

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -146,3 +146,11 @@ func (ns *nodeServer) NodeUnstageVolume(
 
 	return nil, status.Error(codes.Unimplemented, "")
 }
+
+func (ns *nodeServer) NodeGetInfo(
+	ctx context.Context,
+	req *csi.NodeGetInfoRequest) (
+	*csi.NodeGetInfoResponse, error) {
+
+	return nil, status.Error(codes.Unimplemented, "")
+}

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -146,11 +146,3 @@ func (ns *nodeServer) NodeUnstageVolume(
 
 	return nil, status.Error(codes.Unimplemented, "")
 }
-
-func (ns *nodeServer) NodeGetInfo(
-	ctx context.Context,
-	req *csi.NodeGetInfoRequest) (
-	*csi.NodeGetInfoResponse, error) {
-
-	return nil, status.Error(codes.Unimplemented, "")
-}

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -67,7 +67,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 	volOptions.VolName = volName
 	// Mapping RBD image
-	devicePath, err := attachRBDImage(volOptions, req.GetNodePublishSecrets())
+	devicePath, err := attachRBDImage(volOptions, volOptions.UserId, req.GetNodePublishSecrets())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rbd/rbd.go
+++ b/pkg/rbd/rbd.go
@@ -31,11 +31,9 @@ import (
 
 // PluginFolder defines the location of rbdplugin
 const (
-	PluginFolder = "/var/lib/kubelet/plugins/csi-rbdplugin"
-	// RBDUserID used as a key in credentials map to extract the key which is
-	// passed be the provisioner, the value od RBDUserID must match to the key used
-	// in Secret object.
-	RBDUserID = "admin"
+	PluginFolder      = "/var/lib/kubelet/plugins/csi-rbdplugin"
+	rbdDefaultAdminId = "admin"
+	rbdDefaultUserId  = rbdDefaultAdminId
 )
 
 type rbd struct {

--- a/pkg/rbd/rbd.go
+++ b/pkg/rbd/rbd.go
@@ -54,14 +54,14 @@ var (
 	version   = "0.3.0"
 )
 
-var rbdVolumes map[string]rbdVolume
-var rbdSnapshots map[string]rbdSnapshot
+var rbdVolumes map[string]*rbdVolume
+var rbdSnapshots map[string]*rbdSnapshot
 
 // Init checks for the persistent volume file and loads all found volumes
 // into a memory structure
 func init() {
-	rbdVolumes = map[string]rbdVolume{}
-	rbdSnapshots = map[string]rbdSnapshot{}
+	rbdVolumes = map[string]*rbdVolume{}
+	rbdSnapshots = map[string]*rbdSnapshot{}
 	if _, err := os.Stat(path.Join(PluginFolder, "controller")); os.IsNotExist(err) {
 		glog.Infof("rbd: folder %s not found. Creating... \n", path.Join(PluginFolder, "controller"))
 		if err := os.Mkdir(path.Join(PluginFolder, "controller"), 0755); err != nil {
@@ -108,7 +108,7 @@ func loadExSnapshots() {
 			fp.Close()
 			continue
 		}
-		rbdSnapshots[rbdSnap.SnapID] = rbdSnap
+		rbdSnapshots[rbdSnap.SnapID] = &rbdSnap
 	}
 	glog.Infof("rbd: Loaded %d snapshots from %s", len(rbdSnapshots), path.Join(PluginFolder, "controller-snap"))
 }
@@ -137,7 +137,7 @@ func loadExVolumes() {
 			fp.Close()
 			continue
 		}
-		rbdVolumes[rbdVol.VolID] = rbdVol
+		rbdVolumes[rbdVol.VolID] = &rbdVol
 	}
 	glog.Infof("rbd: Loaded %d volumes from %s", len(rbdVolumes), path.Join(PluginFolder, "controller"))
 }

--- a/pkg/rbd/rbd.go
+++ b/pkg/rbd/rbd.go
@@ -51,25 +51,66 @@ type rbd struct {
 
 var (
 	rbdDriver *rbd
-	version   = "0.2.0"
+	version   = "0.3.0"
 )
 
 var rbdVolumes map[string]rbdVolume
+var rbdSnapshots map[string]rbdSnapshot
 
 // Init checks for the persistent volume file and loads all found volumes
 // into a memory structure
 func init() {
 	rbdVolumes = map[string]rbdVolume{}
+	rbdSnapshots = map[string]rbdSnapshot{}
 	if _, err := os.Stat(path.Join(PluginFolder, "controller")); os.IsNotExist(err) {
 		glog.Infof("rbd: folder %s not found. Creating... \n", path.Join(PluginFolder, "controller"))
 		if err := os.Mkdir(path.Join(PluginFolder, "controller"), 0755); err != nil {
 			glog.Fatalf("Failed to create a controller's volumes folder with error: %v\n", err)
 		}
+	} else {
+		// Since "controller" folder exists, it means the rbdplugin has already been running, it means
+		// there might be some volumes left, they must be re-inserted into rbdVolumes map
+		loadExVolumes()
+	}
+	if _, err := os.Stat(path.Join(PluginFolder, "controller-snap")); os.IsNotExist(err) {
+		glog.Infof("rbd: folder %s not found. Creating... \n", path.Join(PluginFolder, "controller-snap"))
+		if err := os.Mkdir(path.Join(PluginFolder, "controller-snap"), 0755); err != nil {
+			glog.Fatalf("Failed to create a controller's snapshots folder with error: %v\n", err)
+		}
+	} else {
+		// Since "controller-snap" folder exists, it means the rbdplugin has already been running, it means
+		// there might be some snapshots left, they must be re-inserted into rbdSnapshots map
+		loadExSnapshots()
+	}
+}
+
+// loadExSnapshots check for any *.json files in the  PluginFolder/controller-snap folder
+// and loads then into rbdSnapshots map
+func loadExSnapshots() {
+	rbdSnap := rbdSnapshot{}
+	files, err := ioutil.ReadDir(path.Join(PluginFolder, "controller-snap"))
+	if err != nil {
+		glog.Infof("rbd: failed to read controller's snapshots folder: %s error:%v", path.Join(PluginFolder, "controller-snap"), err)
 		return
 	}
-	// Since "controller" folder exists, it means the rbdplugin has already been running, it means
-	// there might be some volumes left, they must be re-inserted into rbdVolumes map
-	loadExVolumes()
+	for _, f := range files {
+		if !strings.HasSuffix(f.Name(), ".json") {
+			continue
+		}
+		fp, err := os.Open(path.Join(PluginFolder, "controller-snap", f.Name()))
+		if err != nil {
+			glog.Infof("rbd: open file: %s err %%v", f.Name(), err)
+			continue
+		}
+		decoder := json.NewDecoder(fp)
+		if err = decoder.Decode(&rbdSnap); err != nil {
+			glog.Infof("rbd: decode file: %s err: %v", f.Name(), err)
+			fp.Close()
+			continue
+		}
+		rbdSnapshots[rbdSnap.SnapID] = rbdSnap
+	}
+	glog.Infof("rbd: Loaded %d snapshots from %s", len(rbdSnapshots), path.Join(PluginFolder, "controller-snap"))
 }
 
 // loadExVolumes check for any *.json files in the  PluginFolder/controller folder
@@ -78,7 +119,7 @@ func loadExVolumes() {
 	rbdVol := rbdVolume{}
 	files, err := ioutil.ReadDir(path.Join(PluginFolder, "controller"))
 	if err != nil {
-		glog.Infof("rbd: failed to read  controller's volumes folder: %s error:%v", path.Join(PluginFolder, "controller"), err)
+		glog.Infof("rbd: failed to read controller's volumes folder: %s error:%v", path.Join(PluginFolder, "controller"), err)
 		return
 	}
 	for _, f := range files {
@@ -134,6 +175,8 @@ func (rbd *rbd) Run(driverName, nodeID, endpoint string) {
 	rbd.driver.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+		csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 	})
 	rbd.driver.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})
 

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -446,29 +446,29 @@ func deleteSnapInfo(snapshot string, persistentStoragePath string) error {
 	return nil
 }
 
-func getRBDVolumeByID(volumeID string) (rbdVolume, error) {
+func getRBDVolumeByID(volumeID string) (*rbdVolume, error) {
 	if rbdVol, ok := rbdVolumes[volumeID]; ok {
 		return rbdVol, nil
 	}
-	return rbdVolume{}, fmt.Errorf("volume id %s does not exit in the volumes list", volumeID)
+	return nil, fmt.Errorf("volume id %s does not exit in the volumes list", volumeID)
 }
 
-func getRBDVolumeByName(volName string) (rbdVolume, error) {
+func getRBDVolumeByName(volName string) (*rbdVolume, error) {
 	for _, rbdVol := range rbdVolumes {
 		if rbdVol.VolName == volName {
 			return rbdVol, nil
 		}
 	}
-	return rbdVolume{}, fmt.Errorf("volume name %s does not exit in the volumes list", volName)
+	return nil, fmt.Errorf("volume name %s does not exit in the volumes list", volName)
 }
 
-func getRBDSnapshotByName(snapName string) (rbdSnapshot, error) {
+func getRBDSnapshotByName(snapName string) (*rbdSnapshot, error) {
 	for _, rbdSnap := range rbdSnapshots {
 		if rbdSnap.SnapName == snapName {
 			return rbdSnap, nil
 		}
 	}
-	return rbdSnapshot{}, fmt.Errorf("snapshot name %s does not exit in the snapshots list", snapName)
+	return nil, fmt.Errorf("snapshot name %s does not exit in the snapshots list", snapName)
 }
 
 func protectSnapshot(pOpts *rbdSnapshot, credentials map[string]string) error {

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -254,6 +254,16 @@ func getRBDSnapshotOptions(snapOptions map[string]string) (*rbdSnapshot, error) 
 	return rbdSnap, nil
 }
 
+func hasSnapshotFeature(imageFeatures string) bool {
+	arr := strings.Split(imageFeatures, ",")
+	for _, f := range arr {
+		if f == "layering" {
+			return true
+		}
+	}
+	return false
+}
+
 func attachRBDImage(volOptions *rbdVolume, userId string, credentials map[string]string) (string, error) {
 	var err error
 	var output []byte


### PR DESCRIPTION
Snapshot is one of the added features in CSI 3.0 spec.
This PR implements functions about the snapshot feature in rbdplugin.

What has been added:
  - CreateSnapshot:
      - creates a snapshot with `rbd snap create`
      - the snapshot is protected with `rbd snap protect` for cloning
  - DeleteSnapshot:
      - the snapshot is unprotected with `rbd snap unprotect`
      - remove snapshot with `rbd snap rm`
  - ListSnapshots:
      - get all snapshots from the cache.
      - if requested source volume id exists, get all snapshots which have same source volume id
      - if requested snapshot id exists, get a specific snapshot
  - Store snapshot information into the persistent file
      - use the same method like storing volume information but store in the different directory

What has been changed:
  - CreateVolume:
    - if this request is for restoring snapshot called by snapshot controller, creates a volume from the snapshot with `rbd clone`