### PR TITLE
cephfs: volumemounter probe

### DIFF
--- a/pkg/cephfs/driver.go
+++ b/pkg/cephfs/driver.go
@@ -82,6 +82,10 @@ func (fs *cephfsDriver) Run(driverName, nodeId, endpoint, volumeMounter string) 
 		glog.Errorf("cephfs: failed to read volume cache: %v", err)
 	}
 
+	if err := loadAvailableMounters(); err != nil {
+		glog.Fatalf("cephfs: failed to load ceph mounters: %v", err)
+	}
+
 	if volumeMounter != "" {
 		if err := validateMounter(volumeMounter); err != nil {
 			glog.Fatalln(err)
@@ -89,11 +93,9 @@ func (fs *cephfsDriver) Run(driverName, nodeId, endpoint, volumeMounter string) 
 			DefaultVolumeMounter = volumeMounter
 		}
 	} else {
-		availableMounters := getAvailableMounters()
-		if len(availableMounters) == 0 {
-			glog.Fatal("no ceph mounters found on system")
-		}
-
+		// Pick the first available mounter as the default one.
+		// The choice is biased towards "fuse" in case both
+		// ceph fuse and kernel mounters are available.
 		DefaultVolumeMounter = availableMounters[0]
 	}
 

--- a/pkg/cephfs/driver.go
+++ b/pkg/cephfs/driver.go
@@ -46,14 +46,6 @@ var (
 	DefaultVolumeMounter string
 )
 
-func getVolumeMounterByProbing() string {
-	if execCommandAndValidate("ceph-fuse", "--version") == nil {
-		return volumeMounter_fuse
-	} else {
-		return volumeMounter_kernel
-	}
-}
-
 func NewCephFSDriver() *cephfsDriver {
 	return &cephfsDriver{}
 }
@@ -97,7 +89,12 @@ func (fs *cephfsDriver) Run(driverName, nodeId, endpoint, volumeMounter string) 
 			DefaultVolumeMounter = volumeMounter
 		}
 	} else {
-		DefaultVolumeMounter = getVolumeMounterByProbing()
+		availableMounters := getAvailableMounters()
+		if len(availableMounters) == 0 {
+			glog.Fatal("no ceph mounters found on system")
+		}
+
+		DefaultVolumeMounter = availableMounters[0]
 	}
 
 	glog.Infof("cephfs: setting default volume mounter to %s", DefaultVolumeMounter)

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -134,9 +134,12 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	m := newMounter(volOptions)
-	glog.V(4).Infof("cephfs: mounting volume %s with %s", volId, m.name())
+	m, err := newMounter(volOptions)
+	if err != nil {
+		glog.Errorf("failed to create mounter for volume %s: %v", volId, err)
+	}
 
+	glog.V(4).Infof("cephfs: mounting volume %s with %s", volId, m.name())
 	if err = m.mount(stagingTargetPath, cr, volOptions, volId); err != nil {
 		glog.Errorf("failed to mount volume %s: %v", volId, err)
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/cephfs/util.go
+++ b/pkg/cephfs/util.go
@@ -97,23 +97,6 @@ func storeCephCredentials(volId volumeID, cr *credentials) error {
 	return nil
 }
 
-func newMounter(volOptions *volumeOptions) volumeMounter {
-	mounter := volOptions.Mounter
-
-	if mounter == "" {
-		mounter = DefaultVolumeMounter
-	}
-
-	switch mounter {
-	case volumeMounter_fuse:
-		return &fuseMounter{}
-	case volumeMounter_kernel:
-		return &kernelMounter{}
-	}
-
-	return nil
-}
-
 //
 // Controller service request validation
 //


### PR DESCRIPTION
Fixes #60 

The driver will now probe for either ceph fuse/kernel every time it's about to mount a cephfs volume.

This also affects `CreateVolume` and `DeleteVolume` where the mounting was hard-coded to ceph kernel client till now - mounter configuration and probing are now honored.

Probing is done by running:
* `ceph-fuse --version` for Ceph FUSE driver
* `mount.ceph` for Ceph kernel client

Expecting both to exit with `0`.