### PR TITLE
Add configurations to handle kubelet-plugin-watcher to sample yaml files

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -19,8 +19,11 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           env:
             - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -29,6 +32,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
+            - name: registration-dir
+              mountPath: /registration
         - name: csi-cephfsplugin
           securityContext:
             privileged: true
@@ -67,6 +72,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-cephfsplugin
             type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet/pods

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -19,8 +19,11 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           env:
             - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -29,6 +32,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+            - name: registration-dir
+              mountPath: /registration
         - name: csi-rbdplugin 
           securityContext:
             privileged: true
@@ -67,6 +72,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-rbdplugin
             type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet/pods


### PR DESCRIPTION
As plugin watcher feature became beta, it is enabled in k8s by default. Therefore, both rbd and cephfs csi driver need to add [configurations](https://kubernetes-csi.github.io/docs/print.html#kubelet-plugin-watcher) to handle kubelet-plugin-watcher.

Fixes: #73 
