### PR TITLE
allow monitors be embedded in credential secret

### DIFF
--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -33,7 +33,8 @@ Option | Default value | Description
 
 Parameter | Required | Description
 --------- | -------- | -----------
-`monitors` | yes | Comma separated list of Ceph monitors (e.g. `192.168.100.1:6789,192.168.100.2:6789,192.168.100.3:6789`)
+`monitors` | one of `monitors` and `monValueFromSecret` must be set | Comma separated list of Ceph monitors (e.g. `192.168.100.1:6789,192.168.100.2:6789,192.168.100.3:6789`)
+`monValueFromSecret` | one of `monitors` and `monValueFromSecret` must be set | a string pointing the key in the credential secret, whose value is the mon. This is used for the case when the monitors' IP or hostnames are changed, the secret can be updated to pick up the new monitors.
 `pool` | yes | Ceph pool into which the RBD image shall be created
 `imageFormat` | no | RBD image format. Defaults to `2`. See [man pages](http://docs.ceph.com/docs/mimic/man/8/rbd/#cmdoption-rbd-image-format)
 `imageFeatures` | no | RBD image features. Available for `imageFormat=2`. CSI RBD currently supports only `layering` feature. See [man pages](http://docs.ceph.com/docs/mimic/man/8/rbd/#cmdoption-rbd-image-feature)

--- a/examples/rbd/secret.yaml
+++ b/examples/rbd/secret.yaml
@@ -8,3 +8,6 @@ data:
   admin: BASE64-ENCODED-PASSWORD
   # Key value corresponds to a user name defined in ceph cluster
   kubernetes: BASE64-ENCODED-PASSWORD
+  # if monValueFromSecret is set to "monitors", uncomment the
+  # following and set the mon there
+  #monitors: BASE64-ENCODED-Comma-Delimited-Mons

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -8,6 +8,12 @@ parameters:
     # if using FQDN, make sure csi plugin's dns policy is appropriate.
     monitors: mon1:port,mon2:port,...
 
+    # if "monitors" parameter is not set, driver to get monitors from same
+    # secret as admin/user credentials. "monValueFromSecret" provides the
+    # key in the secret whose value is the mons
+    #monValueFromSecret: "monitors"
+
+    
     # Ceph pool into which the RBD image shall be created
     pool: rbd
 

--- a/pkg/rbd/rbd_attach.go
+++ b/pkg/rbd/rbd_attach.go
@@ -266,13 +266,18 @@ func attachRBDImage(volOptions *rbdVolume, userId string, credentials map[string
 			return "", err
 		}
 
-		glog.V(3).Infof("rbd: map mon %s", volOptions.Monitors)
+		mon, err := getMon(volOptions, credentials)
+		if err != nil {
+			return "", err
+		}
+
+		glog.V(5).Infof("rbd: map mon %s", mon)
 		key, err := getRBDKey(userId, credentials)
 		if err != nil {
 			return "", err
 		}
 		output, err = execCommand(cmdName, []string{
-			"map", imagePath, "--id", userId, "-m", volOptions.Monitors, "--key=" + key})
+			"map", imagePath, "--id", userId, "-m", mon, "--key=" + key})
 		if err != nil {
 			glog.Warningf("rbd: map error %v, rbd output: %s", err, string(output))
 			return "", fmt.Errorf("rbd: map failed %v, rbd output: %s", err, string(output))


### PR DESCRIPTION
this is to deal with the case where monitors are changed but PVs cannot be updated to pick up the new monitors. 

Embedding monitors in secret is temporary. If in the future CSI driver supports ConfigMap reference, the monitors will be set there.

@gman0 