### PR TITLE
provisioning: avoid useless service definitions

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-attacher.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-attacher.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-cephfsplugin-attacher
-  labels:
-    app: csi-cephfsplugin-attacher
-spec:
-  selector:
-    app: csi-cephfsplugin-attacher
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-cephfsplugin-provisioner
-  labels:
-    app: csi-cephfsplugin-provisioner
-spec:
-  selector:
-    app: csi-cephfsplugin-provisioner
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:

--- a/deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-rbdplugin-attacher
-  labels:
-    app: csi-rbdplugin-attacher
-spec:
-  selector:
-    app: csi-rbdplugin-attacher
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-rbdplugin-provisioner
-  labels:
-    app: csi-rbdplugin-provisioner
-spec:
-  selector:
-    app: csi-rbdplugin-provisioner
-  ports:
-    - name: dummy
-      port: 12345
-
----
 kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:

--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -94,10 +94,6 @@ pod/csi-cephfsplugin-attacher-0      1/1       Running   0          26s
 pod/csi-cephfsplugin-provisioner-0   1/1       Running   0          25s
 pod/csi-cephfsplugin-rljcv           2/2       Running   0          24s
 
-NAME                                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
-service/csi-cephfsplugin-attacher      ClusterIP   10.104.116.218   <none>        12345/TCP   27s
-service/csi-cephfsplugin-provisioner   ClusterIP   10.101.78.75     <none>        12345/TCP   26s
-
 ...
 ```
 

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -94,10 +94,6 @@ pod/csi-rbdplugin-attacher-0      1/1       Running   0          23s
 pod/csi-rbdplugin-fptqr           2/2       Running   0          21s
 pod/csi-rbdplugin-provisioner-0   1/1       Running   0          22s
 
-NAME                                TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
-service/csi-rbdplugin-attacher      ClusterIP   10.109.15.54   <none>        12345/TCP   26s
-service/csi-rbdplugin-provisioner   ClusterIP   10.104.2.130   <none>        12345/TCP   23s
-
 ...
 ```
 


### PR DESCRIPTION
The provisioner and attacher do not provider a service that can be
reached from outside, therefore there is no need to set up a useless
and confusing `Service` for them.

The `StatefulSet` definition must have a service name (it doesn't pass
validation otherwise), but as demonstrated by other CSI drivers (for
example, https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/deploy/kubernetes/stable/controller.yaml)
and also validated for ceph-csi, creating the pods works fine without
a corresponding `Service`.

Fixes: #81