### PR TITLE
csi-rbdplugin: Install xfsprogs to support fsType: xfs

### DIFF
--- a/deploy/rbd/docker/Dockerfile
+++ b/deploy/rbd/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL description="RBD CSI Plugin"
 
 ENV CEPH_VERSION "mimic"
 RUN yum  install -y centos-release-ceph && \
-    yum install -y ceph-common e2fsprogs rbd-nbd && \ 
+    yum install -y ceph-common e2fsprogs xfsprogs rbd-nbd && \ 
     yum clean all
 
 COPY rbdplugin /rbdplugin


### PR DESCRIPTION
Proposed fix for https://github.com/ceph/ceph-csi/issues/87

I haven't tested this yet, but I'll see what I can do.