### PR TITLE
rbd: protect against concurrent gRPC calls

### DIFF
--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -47,6 +47,9 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	s := strings.Split(strings.TrimSuffix(targetPath, "/mount"), "/")
 	volName := s[len(s)-1]
 
+	targetPathMutex.LockKey(targetPath)
+	defer targetPathMutex.UnlockKey(targetPath)
+
 	notMnt, err := ns.mounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -97,6 +100,8 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	targetPath := req.GetTargetPath()
+	targetPathMutex.LockKey(targetPath)
+	defer targetPathMutex.UnlockKey(targetPath)
 
 	notMnt, err := ns.mounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil {

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -75,7 +75,19 @@ type rbdSnapshot struct {
 }
 
 var (
+	// serializes operations based on "<rbd pool>/<rbd image>" as key
 	attachdetachMutex = keymutex.NewKeyMutex()
+	// serializes operations based on "volume name" as key
+	volumeNameMutex = keymutex.NewKeyMutex()
+	// serializes operations based on "volume id" as key
+	volumeIDMutex = keymutex.NewKeyMutex()
+	// serializes operations based on "snapshot name" as key
+	snapshotNameMutex = keymutex.NewKeyMutex()
+	// serializes operations based on "snapshot id" as key
+	snapshotIDMutex = keymutex.NewKeyMutex()
+	// serializes operations based on "mount target path" as key
+	targetPathMutex = keymutex.NewKeyMutex()
+
 	supportedFeatures = sets.NewString("layering")
 )
 


### PR DESCRIPTION
The timeout value in external-provisioner is fairly low. It's not
uncommon that it times out and retries before the rbdplugin is done
with CreateVolume. rbdplugin has to serialize calls and ensure that
they are idempotent to deal with this.

/cc @sbezverk

See also PR #29