### PR TITLE
rbd: refuse to create block volumes

### DIFF
--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -54,6 +54,11 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if req.VolumeCapabilities == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume Capabilities cannot be empty")
 	}
+	for _, cap := range req.VolumeCapabilities {
+		if cap.GetBlock() != nil {
+			return nil, status.Error(codes.Unimplemented, "Block Volume not supported")
+		}
+	}
 
 	volumeNameMutex.LockKey(req.GetName())
 	defer volumeNameMutex.UnlockKey(req.GetName())


### PR DESCRIPTION
Without this check, the driver fails one of the E2E storage tests in
Kubernetes 1.13: provisioning a block volume is expected to fail in
https://github.com/kubernetes/kubernetes/blob/e689d515f77cda51898045d626ec4070e3328194/test/e2e/storage/testsuites/volumemode.go#L329-L330