### PR TITLE
Fix snapshot time during snapshot create

### DIFF
--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
-	"time"
 
 	"github.com/ceph/ceph-csi/pkg/util"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/kubernetes-csi/drivers/pkg/csi-common"
 	"github.com/pborman/uuid"
@@ -325,7 +325,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		}
 	}
 
-	rbdSnap.CreatedAt = time.Now().UnixNano()
+	rbdSnap.CreatedAt = ptypes.TimestampNow().GetSeconds()
 
 	if err := cs.MetadataStore.Create(snapshotID, rbdSnap); err != nil {
 		glog.Warningf("rbd: failed to store snapInfo with error: %v", err)


### PR DESCRIPTION
Fixes: #146

logs:
```
Name:         rbd-pvc-snapshot4
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  snapshot.storage.k8s.io/v1alpha1
Kind:         VolumeSnapshot
Metadata:
  Creation Timestamp:  2019-01-25T13:32:03Z
  Finalizers:
    snapshot.storage.kubernetes.io/volumesnapshot-protection
  Generation:        5
  Resource Version:  37916
  Self Link:         /apis/snapshot.storage.k8s.io/v1alpha1/namespaces/default/volumesnapshots/rbd-pvc-snapshot4
  UID:               99df8983-20a5-11e9-a1e9-52540088830b
Spec:
  Snapshot Class Name:    csi-rbdplugin-snapclass
  Snapshot Content Name:  snapcontent-99df8983-20a5-11e9-a1e9-52540088830b
  Source:
    API Group:  <nil>
    Kind:       PersistentVolumeClaim
    Name:       rbd-pvc
Status:
  Creation Time:  2019-01-25T13:32:04Z
  Ready To Use:   true
  Restore Size:   1Gi
Events:           <none>

```
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>