### PR TITLE
Integrate static tools to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@
 # need for docker build
 sudo: true
 
+addons:
+  apt:
+    packages:
+      - realpath
+      - ruby
+
 language: go
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 # need for docker build
 sudo: true
 
@@ -12,25 +13,36 @@ go: 1.11.x
 env:
   global:
     - GO_METALINTER_VERSION="v3.0.0"
+    - TEST_COVERAGE=stdout
+    - GO_METALINTER_THREADS=1
+    - GO_COVER_DIR=_output
 
-install:
-  # install gometalinter
-  - curl -L
-    "https://raw.githubusercontent.com/alecthomas/gometalinter/"${GO_METALINTER_VERSION}"/scripts/install.sh"
-    | bash -s -- -b $GOPATH/bin "${GO_METALINTER_VERSION}"
+jobs:
+  include:
+    - name: Linter
+      install:
+        - gem install mdl
+        - pip install --user --upgrade pip
+        - pip install --user yamllint
+        # install gometalinter
+        - curl -L
+         "https://raw.githubusercontent.com/alecthomas/gometalinter/"${GO_METALINTER_VERSION}"/scripts/install.sh"
+         | bash -s -- -b $GOPATH/bin "${GO_METALINTER_VERSION}"
+      script:
+        - scripts/lint-text.sh --require-all
+        - scripts/lint-go.sh
+        - scripts/test-go.sh
 
-before_script:
-  - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
+    - name: rbdplugin
+      script:
+        - make rbdplugin
 
-script:
-  - gometalinter --deadline=10m -j 4 --enable=misspell --enable=staticcheck --vendor ./...
-  - test -z $(gofmt -s -l $GO_FILES)
-  - make rbdplugin
-  - make cephfsplugin
+    - name: cephfsplugin
+      script:
+        - make cephfsplugin
 
 deploy:
   - provider: script
-    script:
-      - ./deploy.sh
-    on:
+    on:  # yamllint disable-line rule:truthy
       all_branches: true
+    script: ./deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,14 @@ $(info cephfs image settings: $(CEPHFS_IMAGE_NAME) version $(CEPHFS_IMAGE_VERSIO
 
 all: rbdplugin cephfsplugin
 
-test:
-	go test github.com/ceph/ceph-csi/pkg/... -cover
-	go vet github.com/ceph/ceph-csi/pkg/...
+test: go-test static-check
+
+go-test:
+	./scripts/test-go.sh
+
+static-check:
+	./scripts/lint-go.sh  
+	./scripts/lint-text.sh
 
 rbdplugin:
 	if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Ceph CSI 1.0.0
 
-[Container Storage Interface (CSI)](https://github.com/container-storage-interface/) driver, provisioner, and attacher for Ceph RBD and CephFS.
+[Container Storage Interface
+(CSI)](https://github.com/container-storage-interface/) driver, provisioner,
+and attacher for Ceph RBD and CephFS.
 
 ## Overview
 
-Ceph CSI plugins implement an interface between CSI enabled Container Orchestrator (CO) and CEPH cluster. It allows dynamically provisioning CEPH volumes and attaching them to workloads. Current implementation of Ceph CSI plugins was tested in Kubernetes environment (requires Kubernetes 1.11+), but the code does not rely on any Kubernetes specific calls (WIP to make it k8s agnostic) and should be able to run with any CSI enabled CO.
+Ceph CSI plugins implement an interface between CSI enabled Container
+Orchestrator (CO) and CEPH cluster.
+It allows dynamically provisioning CEPH volumes and attaching them to
+workloads.
+Current implementation of Ceph CSI plugins was tested in Kubernetes
+environment (requires Kubernetes 1.13+), but the code does not rely on
+any Kubernetes specific calls (WIP to make it k8s agnostic) and
+should be able to run with any CSI enabled CO.
 
-For details about configuration and deployment of RBD and CephFS CSI plugins, see documentation in `docs/`.
+For details about configuration and deployment of RBD and
+CephFS CSI plugins, see documentation in `docs/`.
 
 For example usage of RBD and CephFS CSI plugins, see examples in `examples/`.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,54 +1,53 @@
 #!/bin/bash
 
 if [ "${TRAVIS_BRANCH}" == 'master' ]; then
-	export RBD_IMAGE_VERSION='v0.3.0';
-	export CEPHFS_IMAGE_VERSION='v0.3.0';
+	export RBD_IMAGE_VERSION='v0.3.0'
+	export CEPHFS_IMAGE_VERSION='v0.3.0'
 elif [ "${TRAVIS_BRANCH}" == 'csi-v1.0' ]; then
-	export RBD_IMAGE_VERSION='v1.0.0';
-	export CEPHFS_IMAGE_VERSION='v1.0.0';
+	export RBD_IMAGE_VERSION='v1.0.0'
+	export CEPHFS_IMAGE_VERSION='v1.0.0'
 else
-	echo "!!! Branch ${TRAVIS_BRANCH} is not a deployable branch; exiting";
-	exit 0; # Exiting 0 so that this isn't marked as failing
-fi;
+	echo "!!! Branch ${TRAVIS_BRANCH} is not a deployable branch; exiting"
+	exit 0 # Exiting 0 so that this isn't marked as failing
+fi
 
 if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
 	docker login -u "${QUAY_IO_USERNAME}" -p "${QUAY_IO_PASSWORD}" quay.io
 	make push-image-rbdplugin push-image-cephfsplugin
 
 	set -xe
-	
+
 	mkdir -p tmp
-	pushd tmp > /dev/null
-	
-	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh
+	pushd tmp >/dev/null
+
+	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get >get_helm.sh
 	chmod 700 get_helm.sh
 	./get_helm.sh
-	
+
 	git clone https://github.com/ceph/csi-charts
-	
+
 	mkdir -p csi-charts/docs
-        popd > /dev/null
+	popd >/dev/null
 
 	CHANGED=0
-	VERSION=$(cat deploy/rbd/helm/Chart.yaml | awk '{if(/^version:/){print $2}}')
-	
+	VERSION=$(grep 'version:' deploy/rbd/helm/Chart.yaml | awk '{print $2}')
+
 	if [ ! -f "tmp/csi-charts/docs/rbd/ceph-csi-rbd-$VERSION.tgz" ]; then
-	    CHANGED=1
-	    ln -s helm deploy/rbd/ceph-csi-rbd
-	    mkdir -p tmp/csi-charts/docs/rbd
-	    pushd tmp/csi-charts/docs/rbd > /dev/null
-	    helm init --client-only
-	    helm package ../../../../deploy/rbd/ceph-csi-rbd
-	    popd > /dev/null
+		CHANGED=1
+		ln -s helm deploy/rbd/ceph-csi-rbd
+		mkdir -p tmp/csi-charts/docs/rbd
+		pushd tmp/csi-charts/docs/rbd >/dev/null
+		helm init --client-only
+		helm package ../../../../deploy/rbd/ceph-csi-rbd
+		popd >/dev/null
 	fi
-	
+
 	if [ $CHANGED -eq 1 ]; then
-	    pushd tmp/csi-charts/docs > /dev/null
-	    helm repo index .
-	    git add --all :/ && git commit -m "Update repo"
-	    git push https://"$GITHUB_TOKEN"@github.com/ceph/csi-charts
-	    popd > /dev/null
+		pushd tmp/csi-charts/docs >/dev/null
+		helm repo index .
+		git add --all :/ && git commit -m "Update repo"
+		git push https://"$GITHUB_TOKEN"@github.com/ceph/csi-charts
+		popd >/dev/null
 	fi
 
-fi;
-
+fi

--- a/deploy/cephfs/kubernetes/csi-attacher-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-attacher-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-attacher.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-attacher.yaml
@@ -1,3 +1,4 @@
+---
 kind: Service
 apiVersion: v1
 metadata:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -1,3 +1,4 @@
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -44,7 +45,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           image: quay.io/cephcsi/cephfsplugin:v1.0.0
-          args :
+          args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
@@ -64,14 +65,14 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin            
+              mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
             - name: host-sys
               mountPath: /sys
             - name: lib-modules
               mountPath: /lib/modules
               readOnly: true
             - name: host-dev
-              mountPath: /dev              
+              mountPath: /dev
       volumes:
         - name: socket-dir
           hostPath:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -1,3 +1,4 @@
+---
 kind: DaemonSet
 apiVersion: apps/v1beta2
 metadata:
@@ -15,7 +16,7 @@ spec:
       hostNetwork: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
-      dnsPolicy: ClusterFirstWithHostNet      
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
@@ -26,7 +27,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                  command: ["/bin/sh", "-c", "rm -rf /registration/csi-cephfsplugin /registration/csi-cephfsplugin-reg.sock"]          
+                command: [
+                  "/bin/sh", "-c",
+                  "rm -rf /registration/csi-cephfsplugin \
+                  /registration/csi-cephfsplugin-reg.sock"
+                ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -44,7 +49,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: quay.io/cephcsi/cephfsplugin:v1.0.0
-          args :
+          args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -37,4 +38,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: cephfs-csi-nodeplugin
-  apiGroup: rbac.authorization.k8s.io          
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -27,7 +28,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create", "delete"]
-    
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbd/helm/Chart.yaml
+++ b/deploy/rbd/helm/Chart.yaml
@@ -1,12 +1,14 @@
+---
 apiVersion: v1
 appVersion: "1.0.0"
-description: Container Storage Interface (CSI) driver, provisioner, and attacher for Ceph RBD
+description: "Container Storage Interface (CSI) driver,
+provisioner, and attacher for Ceph RBD"
 name: ceph-csi-rbd
 version: 0.3.0
 keywords:
-- ceph
-- rbd
-- ceph-csi
+  - ceph
+  - rbd
+  - ceph-csi
 home: https://github.com/ceph/ceph-csi
 sources:
-- https://github.com/ceph/ceph-csi/tree/master/deploy/rbd/kubernetes
+  - https://github.com/ceph/ceph-csi/tree/master/deploy/rbd/kubernetes

--- a/deploy/rbd/helm/templates/provisioner-role.yaml
+++ b/deploy/rbd/helm/templates/provisioner-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create -}} 
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/rbd/helm/values.yaml
+++ b/deploy/rbd/helm/values.yaml
@@ -1,3 +1,4 @@
+---
 rbac:
   create: true
 
@@ -43,7 +44,7 @@ nodeplugin:
       repository: quay.io/k8scsi/csi-node-driver-registrar
       tag: v1.0.2
       pullPolicy: IfNotPresent
-    
+
     resources: {}
 
   plugin:
@@ -51,7 +52,7 @@ nodeplugin:
       repository: quay.io/cephcsi/rbdplugin
       tag: v1.0.0
       pullPolicy: IfNotPresent
-    
+
     resources: {}
 
   nodeSelector: {}

--- a/deploy/rbd/kubernetes/csi-attacher-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-attacher-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -37,4 +38,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: rbd-csi-nodeplugin
-  apiGroup: rbac.authorization.k8s.io          
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -42,7 +43,7 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create"]
-    
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml
@@ -1,3 +1,4 @@
+---
 kind: Service
 apiVersion: v1
 metadata:

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -1,3 +1,4 @@
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -59,7 +60,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           image: quay.io/cephcsi/rbdplugin:v1.0.0
-          args :
+          args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
@@ -68,7 +69,7 @@ spec:
             - "--metadatastorage=k8s_configmap"
           env:
             - name: HOST_ROOTFS
-              value: "/rootfs" 
+              value: "/rootfs"
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -86,7 +87,7 @@ spec:
             - mountPath: /dev
               name: host-dev
             - mountPath: /rootfs
-              name: host-rootfs            
+              name: host-rootfs
             - mountPath: /sys
               name: host-sys
             - mountPath: /lib/modules
@@ -98,13 +99,13 @@ spec:
             path: /dev
         - name: host-rootfs
           hostPath:
-            path: /            
+            path: /
         - name: host-sys
           hostPath:
             path: /sys
         - name: lib-modules
           hostPath:
-            path: /lib/modules              
+            path: /lib/modules
         - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi-rbdplugin

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -1,3 +1,4 @@
+---
 kind: DaemonSet
 apiVersion: apps/v1beta2
 metadata:
@@ -13,10 +14,10 @@ spec:
     spec:
       serviceAccount: rbd-csi-nodeplugin
       hostNetwork: true
-      hostPID: true      
+      hostPID: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
-      dnsPolicy: ClusterFirstWithHostNet      
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
@@ -27,7 +28,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                  command: ["/bin/sh", "-c", "rm -rf /registration/csi-rbdplugin /registration/csi-rbdplugin-reg.sock"]          
+                command: [
+                  "/bin/sh", "-c",
+                  "rm -rf /registration/csi-rbdplugin \
+                  /registration/csi-rbdplugin-reg.sock"
+                ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -45,7 +50,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: quay.io/cephcsi/rbdplugin:v1.0.0
-          args :
+          args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
@@ -54,7 +59,7 @@ spec:
             - "--metadatastorage=k8s_configmap"
           env:
             - name: HOST_ROOTFS
-              value: "/rootfs" 
+              value: "/rootfs"
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -78,7 +83,7 @@ spec:
             - mountPath: /dev
               name: host-dev
             - mountPath: /rootfs
-              name: host-rootfs            
+              name: host-rootfs
             - mountPath: /sys
               name: host-sys
             - mountPath: /lib/modules
@@ -90,7 +95,7 @@ spec:
             path: /var/lib/kubelet/plugins/csi-rbdplugin
             type: DirectoryOrCreate
         - name: plugin-mount-dir
-          hostPath: 
+          hostPath:
             path: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/
             type: DirectoryOrCreate
         - name: registration-dir
@@ -106,7 +111,7 @@ spec:
             path: /dev
         - name: host-rootfs
           hostPath:
-            path: /            
+            path: /
         - name: host-sys
           hostPath:
             path: /sys

--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -1,10 +1,15 @@
 # CSI CephFS plugin
 
-The CSI CephFS plugin is able to both provision new CephFS volumes and attach and mount existing ones to workloads.
+The CSI CephFS plugin is able to both provision new CephFS volumes
+and attach and mount existing ones to workloads.
 
 ## Building
 
-CSI CephFS plugin can be compiled in a form of a binary file or in a form of a Docker image. When compiled as a binary file, the result is stored in `_output/` directory with the name `cephfsplugin`. When compiled as an image, it's stored in the local Docker image store.
+CSI CephFS plugin can be compiled in a form of a binary file or in a form of a
+Docker image.
+When compiled as a binary file, the result is stored in `_output/`
+directory with the name `cephfsplugin`.
+When compiled as an image, it's stored in the local Docker image store.
 
 Building binary:
 
@@ -30,10 +35,13 @@ Option              | Default value         | Description
 `--volumemounter`   | _empty_               | default volume mounter. Available options are `kernel` and `fuse`. This is the mount method used if volume parameters don't specify otherwise. If left unspecified, the driver will first probe for `ceph-fuse` in system's path and will choose Ceph kernel client if probing failed.
 `--metadatastorage` | _empty_               | Whether should metadata be kept on node as file or in a k8s configmap (`node` or `k8s_configmap`)
 
-**Available environmental variables:**
-`KUBERNETES_CONFIG_PATH`: if you use `k8s_configmap` as metadata store, specify the path of your k8s config file (if not specified, the plugin will assume you're running it inside a k8s cluster and find the config itself).
+**Available environmental variables:** `KUBERNETES_CONFIG_PATH`: if you use
+`k8s_configmap` as metadata store, specify the path of your k8s config file (if
+not specified, the plugin will assume you're running it inside a k8s cluster and
+find the config itself).
 
-`POD_NAMESPACE`: if you use `k8s_configmap` as metadata store, `POD_NAMESPACE` is used to define in which namespace you want the configmaps to be stored
+`POD_NAMESPACE`: if you use `k8s_configmap` as metadata store, `POD_NAMESPACE`
+is used to define in which namespace you want the configmaps to be stored
 
 **Available volume parameters:**
 
@@ -48,25 +56,32 @@ Parameter                                                                       
 `csi.storage.k8s.io/provisioner-secret-name`, `csi.storage.k8s.io/node-stage-secret-name`           | for Kubernetes                                         | name of the Kubernetes Secret object containing Ceph client credentials. Both parameters should have the same value
 `csi.storage.k8s.io/provisioner-secret-namespace`, `csi.storage.k8s.io/node-stage-secret-namespace` | for Kubernetes                                         | namespaces of the above Secret objects
 
-**Required secrets for `provisionVolume=true`:**  
+**Required secrets for `provisionVolume=true`:**
 Admin credentials are required for provisioning new volumes
 
 * `adminID`: ID of an admin client
 * `adminKey`: key of the admin client
 
-**Required secrets for `provisionVolume=false`:**  
+**Required secrets for `provisionVolume=false`:**
 User credentials with access to an existing volume
 
 * `userID`: ID of a user client
 * `userKey`: key of a user client
 
-Notes on volume size: when provisioning a new volume, `max_bytes` quota attribute for this volume will be set to the requested volume size (see [Ceph quota documentation](http://docs.ceph.com/docs/mimic/cephfs/quota/)). A request for a zero-sized volume means no quota attribute will be set.
+Notes on volume size: when provisioning a new volume, `max_bytes` quota
+attribute for this volume will be set to the requested volume size (see [Ceph
+quota documentation](http://docs.ceph.com/docs/mimic/cephfs/quota/)). A request
+for a zero-sized volume means no quota attribute will be set.
 
 ## Deployment with Kubernetes
 
 Requires Kubernetes 1.13
 
-Your Kubernetes cluster must allow privileged pods (i.e. `--allow-privileged` flag must be set to true for both the API server and the kubelet). Moreover, as stated in the [mount propagation docs](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation), the Docker daemon of the cluster nodes must allow shared mounts.
+Your Kubernetes cluster must allow privileged pods (i.e. `--allow-privileged`
+flag must be set to true for both the API server and the kubelet). Moreover, as
+stated in the [mount propagation
+docs](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation),
+the Docker daemon of the cluster nodes must allow shared mounts.
 
 YAML manifests are located in `deploy/cephfs/kubernetes`.
 
@@ -78,7 +93,9 @@ kubectl create -f csi-provisioner-rbac.yaml
 kubectl create -f csi-nodeplugin-rbac.yaml
 ```
 
-Those manifests deploy service accounts, cluster roles and cluster role bindings. These are shared for both RBD and CephFS CSI plugins, as they require the same permissions.
+Those manifests deploy service accounts, cluster roles and cluster role
+bindings. These are shared for both RBD and CephFS CSI plugins, as they require
+the same permissions.
 
 **Deploy CSI sidecar containers:**
 
@@ -87,7 +104,8 @@ kubectl create -f csi-cephfsplugin-attacher.yaml
 kubectl create -f csi-cephfsplugin-provisioner.yaml
 ```
 
-Deploys stateful sets for external-attacher and external-provisioner sidecar containers for CSI CephFS.
+Deploys stateful sets for external-attacher and external-provisioner
+sidecar containers for CSI CephFS.
 
 **Deploy CSI CephFS driver:**
 
@@ -95,7 +113,8 @@ Deploys stateful sets for external-attacher and external-provisioner sidecar con
 kubectl create -f csi-cephfsplugin.yaml
 ```
 
-Deploys a daemon set with two containers: CSI driver-registrar and the CSI CephFS driver.
+Deploys a daemon set with two containers: CSI driver-registrar and
+the CSI CephFS driver.
 
 ## Verifying the deployment in Kubernetes
 
@@ -119,4 +138,7 @@ You can try deploying a demo pod from `examples/cephfs` to test the deployment f
 
 ### Notes on volume deletion
 
-Volumes that were provisioned dynamically (i.e. `provisionVolume=true`) are allowed to be deleted by the driver as well, if the user chooses to do so. Otherwise, the driver is forbidden to delete such volumes - attempting to delete them is a no-op.
+Volumes that were provisioned dynamically (i.e. `provisionVolume=true`) are
+allowed to be deleted by the driver as well, if the user chooses to do
+so.Otherwise, the driver is forbidden to delete such volumes - attempting to
+delete them is a no-op.

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -1,19 +1,25 @@
 # CSI RBD Plugin
 
-The RBD CSI plugin is able to provision new RBD images and attach and mount those to worlkoads.
+The RBD CSI plugin is able to provision new RBD images and
+attach and mount those to worlkoads.
 
 ## Building
 
-CSI RBD plugin can be compiled in a form of a binary file or in a form of a Docker image. When compiled as a binary file, the result is stored in `_output/` directory with the name `rbdplugin`. When compiled as an image, it's stored in the local Docker image store.
+CSI RBD plugin can be compiled in a form of a binary file or in a form of a
+Docker image. When compiled as a binary file, the result is stored in
+`_output/` directory with the name `rbdplugin`. When compiled as an image, it's
+stored in the local Docker image store.
 
 Building binary:
+
 ```bash
-$ make rbdplugin
+make rbdplugin
 ```
 
 Building Docker image:
+
 ```bash
-$ make image-rbdplugin
+make image-rbdplugin
 ```
 
 ## Configuration
@@ -31,9 +37,13 @@ Option | Default value | Description
 **Available environmental variables:**
 `HOST_ROOTFS`: rbdplugin searches `/proc` directory under the directory set by `HOST_ROOTFS`.
 
-`KUBERNETES_CONFIG_PATH`: if you use `k8s_configmap` as metadata store, specify the path of your k8s config file (if not specified, the plugin will assume you're running it inside a k8s cluster and find the config itself).
+`KUBERNETES_CONFIG_PATH`: if you use `k8s_configmap` as metadata store, specify
+the path of your k8s config file (if not specified, the plugin will assume
+you're running it inside a k8s cluster and find the config itself).
 
-`POD_NAMESPACE`: if you use `k8s_configmap` as metadata store, `POD_NAMESPACE` is used to define in which namespace you want the configmaps to be stored
+`POD_NAMESPACE`: if you use `k8s_configmap` as metadata store,
+`POD_NAMESPACE` is used to define in which namespace you want
+the configmaps to be stored
 
 **Available volume parameters:**
 
@@ -48,9 +58,11 @@ Parameter | Required | Description
 `csi.storage.k8s.io/provisioner-secret-namespace`, `csi.storage.k8s.io/node-publish-secret-namespace` | for Kubernetes | namespaces of the above Secret objects
 `mounter`| no | if set to `rbd-nbd`, use `rbd-nbd` on nodes that have `rbd-nbd` and `nbd` kernel modules to map rbd images
 
-**Required secrets:**  
-Admin credentials are required for provisioning new RBD images
-`ADMIN_NAME`: `ADMIN_PASSWORD` - note that the key of the key-value pair is the name of the client with admin privileges, and the value is its password
+**Required secrets:**
+
+Admin credentials are required for provisioning new RBD images `ADMIN_NAME`:
+`ADMIN_PASSWORD` - note that the key of the key-value pair is the name of the
+client with admin privileges, and the value is its password
 
 Also note that CSI RBD expects admin keyring and Ceph config file in `/etc/ceph`.
 
@@ -58,33 +70,40 @@ Also note that CSI RBD expects admin keyring and Ceph config file in `/etc/ceph`
 
 Requires Kubernetes 1.11
 
-Your Kubernetes cluster must allow privileged pods (i.e. `--allow-privileged` flag must be set to true for both the API server and the kubelet). Moreover, as stated in the [mount propagation docs](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation), the Docker daemon of the cluster nodes must allow shared mounts.
+Your Kubernetes cluster must allow privileged pods (i.e. `--allow-privileged`
+flag must be set to true for both the API server and the kubelet). Moreover, as
+stated in the [mount propagation
+docs](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation),
+the Docker daemon of the cluster nodes must allow shared mounts.
 
 YAML manifests are located in `deploy/rbd/kubernetes`.
 
 **Deploy RBACs for sidecar containers and node plugins:**
 
 ```bash
-$ kubectl create -f csi-attacher-rbac.yaml
-$ kubectl create -f csi-provisioner-rbac.yaml
-$ kubectl create -f csi-nodeplugin-rbac.yaml
+kubectl create -f csi-attacher-rbac.yaml
+kubectl create -f csi-provisioner-rbac.yaml
+kubectl create -f csi-nodeplugin-rbac.yaml
 ```
 
-Those manifests deploy service accounts, cluster roles and cluster role bindings. These are shared for both RBD and CephFS CSI plugins, as they require the same permissions.
+Those manifests deploy service accounts, cluster roles and cluster role
+bindings. These are shared for both RBD and CephFS CSI plugins, as they require
+the same permissions.
 
 **Deploy CSI sidecar containers:**
 
 ```bash
-$ kubectl create -f csi-rbdplugin-attacher.yaml
-$ kubectl create -f csi-rbdplugin-provisioner.yaml
+kubectl create -f csi-rbdplugin-attacher.yaml
+kubectl create -f csi-rbdplugin-provisioner.yaml
 ```
 
-Deploys stateful sets for external-attacher and external-provisioner sidecar containers for CSI RBD.
+Deploys stateful sets for external-attacher and external-provisioner
+sidecar containers for CSI RBD.
 
 **Deploy RBD CSI driver:**
 
 ```bash
-$ kubectl create -f csi-rbdplugin.yaml
+kubectl create -f csi-rbdplugin.yaml
 ```
 
 Deploys a daemon set with two containers: CSI driver-registrar and the CSI RBD driver.
@@ -119,7 +138,7 @@ The Helm chart is located in `deploy/rbd/helm`.
 **Deploy Helm Chart:**
 
 ```bash
-$ helm install ./deploy/rbd/helm
+helm install ./deploy/rbd/helm
 ```
 
 The Helm chart deploys all of the required resources to use the CSI RBD driver.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,20 @@
-## How to test RBD and CephFS plugins with Kubernetes 1.13
+# How to test RBD and CephFS plugins with Kubernetes 1.13
 
-Both `rbd` and `cephfs` directories contain `plugin-deploy.sh` and `plugin-teardown.sh` helper scripts. You can use those to help you deploy/tear down RBACs, sidecar containers and the plugin in one go. By default, they look for the YAML manifests in `../../deploy/{rbd,cephfs}/kubernetes`. You can override this path by running `$ ./plugin-deploy.sh /path/to/my/manifests`.
+Both `rbd` and `cephfs` directories contain `plugin-deploy.sh` and
+`plugin-teardown.sh` helper scripts.  You can use those to help you
+deploy/teardown RBACs, sidecar containers and the plugin in one go.
+By default, they look for the YAML manifests in
+`../../deploy/{rbd,cephfs}/kubernetes`.
+You can override this path by running `$ ./plugin-deploy.sh /path/to/my/manifests`.
 
-Once the plugin is successfuly deployed, you'll need to customize `storageclass.yaml` and `secret.yaml` manifests to reflect your Ceph cluster setup. Please consult the documentation for info about available parameters.
+Once the plugin is successfuly deployed, you'll need to customize
+`storageclass.yaml` and `secret.yaml` manifests to reflect your Ceph cluster
+setup.
+Please consult the documentation for info about available parameters.
 
-After configuring the secrets, monitors, etc. you can deploy a testing Pod mounting a RBD image / CephFS volume:
+After configuring the secrets, monitors, etc. you can deploy a
+testing Pod mounting a RBD image / CephFS volume:
+
 ```bash
 kubectl create -f secret.yaml
 kubectl create -f storageclass.yaml
@@ -13,16 +23,24 @@ kubectl create -f pod.yaml
 ```
 
 Other helper scripts:
+
 * `logs.sh` output of the plugin
 * `exec-bash.sh` logs into the plugin's container and runs bash
 
 ## How to test RBD Snapshot feature
 
-Before continuing, make sure you enabled the required feature gate `VolumeSnapshotDataSource=true` in your Kubernetes cluster.
+Before continuing, make sure you enabled the required
+feature gate `VolumeSnapshotDataSource=true` in your Kubernetes cluster.
 
-In the `examples/rbd` directory you will find two files related to snapshots: [snapshotclass.yaml](./rbd/snapshotclass.yaml) and [snapshot.yaml](./rbd/snapshot.yaml).
+In the `examples/rbd` directory you will find two files related to snapshots:
+[snapshotclass.yaml](./rbd/snapshotclass.yaml) and
+[snapshot.yaml](./rbd/snapshot.yaml).
 
-Once you created your RBD volume, you'll need to customize at least `snapshotclass.yaml` and make sure the `monitors` and `pool` parameters match your Ceph cluster setup. If you followed the documentation to create the rbdplugin, you shouldn't have to edit any other file.
+Once you created your RBD volume, you'll need to customize at least
+`snapshotclass.yaml` and make sure the `monitors` and `pool` parameters match
+your Ceph cluster setup.
+If you followed the documentation to create the rbdplugin, you shouldn't
+have to edit any other file.
 
 After configuring everything you needed, deploy the snapshot class:
 
@@ -43,7 +61,6 @@ Create a snapshot from the existing PVC:
 ```bash
 kubectl create -f snapshot.yaml
 ```
-
 
 To verify if your volume snapshot has successfully been created, run the following:
 
@@ -86,9 +103,12 @@ Status:
 Events:           <none>
 ```
 
-To be sure everything is OK you can run `rbd snap ls [your-pvc-name]` inside one of your Ceph pod.
+To be sure everything is OK you can run `rbd snap ls [your-pvc-name]` inside
+one of your Ceph pod.
 
-To restore the snapshot to a new PVC, deploy [pvc-restore.yaml](./rbd/pvc-restore.yaml) and a testing pod [pod-restore.yaml](./rbd/pvc-restore.yaml):
+To restore the snapshot to a new PVC, deploy
+[pvc-restore.yaml](./rbd/pvc-restore.yaml) and a testing pod
+[pod-restore.yaml](./rbd/pvc-restore.yaml):
 
 ```bash
 kubectl create -f pvc-restore.yaml

--- a/examples/cephfs/deployment.yaml
+++ b/examples/cephfs/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,13 +16,13 @@ spec:
         app: web-server
     spec:
       containers:
-       - name: web-server
-         image: nginx
-         volumeMounts:
-           - name: mypvc
-             mountPath: /var/lib/www/html
+        - name: web-server
+          image: nginx
+          volumeMounts:
+            - name: mypvc
+              mountPath: /var/lib/www/html
       volumes:
-       - name: mypvc
-         persistentVolumeClaim:
-           claimName: csi-cephfs-pvc
-           readOnly: false
+        - name: mypvc
+          persistentVolumeClaim:
+            claimName: csi-cephfs-pvc
+            readOnly: false

--- a/examples/cephfs/exec-bash.sh
+++ b/examples/cephfs/exec-bash.sh
@@ -4,7 +4,7 @@ CONTAINER_NAME=csi-cephfsplugin
 POD_NAME=$(kubectl get pods -l app=$CONTAINER_NAME -o=name | head -n 1)
 
 function get_pod_status() {
-	echo -n $(kubectl get $POD_NAME -o jsonpath="{.status.phase}")
+	echo -n "$(kubectl get "$POD_NAME" -o jsonpath="{.status.phase}")"
 }
 
 while [[ "$(get_pod_status)" != "Running" ]]; do
@@ -12,4 +12,4 @@ while [[ "$(get_pod_status)" != "Running" ]]; do
 	echo "Waiting for $POD_NAME (status $(get_pod_status))"
 done
 
-kubectl exec -it ${POD_NAME#*/} -c $CONTAINER_NAME bash
+kubectl exec -it "${POD_NAME#*/}" -c "$CONTAINER_NAME" bash

--- a/examples/cephfs/logs.sh
+++ b/examples/cephfs/logs.sh
@@ -4,7 +4,7 @@ CONTAINER_NAME=csi-cephfsplugin
 POD_NAME=$(kubectl get pods -l app=$CONTAINER_NAME -o=name | head -n 1)
 
 function get_pod_status() {
-	echo -n $(kubectl get $POD_NAME -o jsonpath="{.status.phase}")
+	echo -n "$(kubectl get "$POD_NAME" -o jsonpath="{.status.phase}")"
 }
 
 while [[ "$(get_pod_status)" != "Running" ]]; do
@@ -12,4 +12,4 @@ while [[ "$(get_pod_status)" != "Running" ]]; do
 	echo "Waiting for $POD_NAME (status $(get_pod_status))"
 done
 
-kubectl logs -f $POD_NAME -c $CONTAINER_NAME
+kubectl logs -f "$POD_NAME" -c "$CONTAINER_NAME"

--- a/examples/cephfs/plugin-deploy.sh
+++ b/examples/cephfs/plugin-deploy.sh
@@ -10,6 +10,6 @@ cd "$deployment_base" || exit 1
 
 objects=(csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac csi-cephfsplugin-attacher csi-cephfsplugin-provisioner csi-cephfsplugin)
 
-for obj in ${objects[@]}; do
+for obj in "${objects[@]}"; do
 	kubectl create -f "./$obj.yaml"
 done

--- a/examples/cephfs/plugin-teardown.sh
+++ b/examples/cephfs/plugin-teardown.sh
@@ -10,6 +10,6 @@ cd "$deployment_base" || exit 1
 
 objects=(csi-cephfsplugin-attacher csi-cephfsplugin-provisioner csi-cephfsplugin csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac)
 
-for obj in ${objects[@]}; do
+for obj in "${objects[@]}"; do
 	kubectl delete -f "./$obj.yaml"
 done

--- a/examples/cephfs/pod.yaml
+++ b/examples/cephfs/pod.yaml
@@ -1,17 +1,17 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: csicephfs-demo-pod
 spec:
   containers:
-   - name: web-server
-     image: nginx
-     volumeMounts:
-       - name: mypvc
-         mountPath: /var/lib/www
+    - name: web-server
+      image: nginx
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www
   volumes:
-   - name: mypvc
-     persistentVolumeClaim:
-       claimName: csi-cephfs-pvc
-       readOnly: false
-
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: csi-cephfs-pvc
+        readOnly: false

--- a/examples/cephfs/pvc.yaml
+++ b/examples/cephfs/pvc.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: csi-cephfs-pvc
 spec:
   accessModes:
-  - ReadWriteMany
+    - ReadWriteMany
   resources:
     requests:
       storage: 5Gi

--- a/examples/cephfs/secret.yaml
+++ b/examples/cephfs/secret.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/examples/cephfs/storageclass.yaml
+++ b/examples/cephfs/storageclass.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -5,7 +6,7 @@ metadata:
 provisioner: csi-cephfsplugin
 parameters:
   # Comma separated list of Ceph monitors
-  # if using FQDN, make sure csi plugin's dns policy is appropriate.  
+  # if using FQDN, make sure csi plugin's dns policy is appropriate.
   monitors: mon1:port,mon2:port,...
 
   # For provisionVolume: "true":
@@ -13,7 +14,8 @@ parameters:
   #   Requires admin credentials (adminID, adminKey).
   # For provisionVolume: "false":
   #   It is assumed the volume already exists and the user is expected
-  #   to provide path to that volume (rootPath) and user credentials (userID, userKey).
+  #   to provide path to that volume (rootPath) and user credentials
+  #   (userID, userKey).
   provisionVolume: "true"
 
   # Ceph pool into which the volume shall be created
@@ -30,8 +32,11 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret
   csi.storage.k8s.io/node-stage-secret-namespace: default
 
-  # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)
-  # If omitted, default volume mounter will be used - this is determined by probing for ceph-fuse
-  # or by setting the default mounter explicitly via --volumemounter command-line argument.
+  # (optional) The driver can use either ceph-fuse (fuse) or
+  # ceph kernelclient (kernel).
+  # If omitted, default volume mounter will be used - this is
+  # determined by probing for ceph-fuse
+  # or by setting the default mounter explicitly via
+  # --volumemounter command-line argument.
   # mounter: kernel
 reclaimPolicy: Delete

--- a/examples/rbd/exec-bash.sh
+++ b/examples/rbd/exec-bash.sh
@@ -4,7 +4,7 @@ CONTAINER_NAME=csi-rbdplugin
 POD_NAME=$(kubectl get pods -l app=$CONTAINER_NAME -o=name | head -n 1)
 
 function get_pod_status() {
-	echo -n $(kubectl get $POD_NAME -o jsonpath="{.status.phase}")
+	echo -n "$(kubectl get "$POD_NAME" -o jsonpath="{.status.phase}")"
 }
 
 while [[ "$(get_pod_status)" != "Running" ]]; do
@@ -12,4 +12,4 @@ while [[ "$(get_pod_status)" != "Running" ]]; do
 	echo "Waiting for $POD_NAME (status $(get_pod_status))"
 done
 
-kubectl exec -it ${POD_NAME#*/} -c $CONTAINER_NAME bash
+kubectl exec -it "${POD_NAME#*/}" -c "$CONTAINER_NAME" bash

--- a/examples/rbd/logs.sh
+++ b/examples/rbd/logs.sh
@@ -4,7 +4,7 @@ CONTAINER_NAME=csi-rbdplugin
 POD_NAME=$(kubectl get pods -l app=$CONTAINER_NAME -o=name | head -n 1)
 
 function get_pod_status() {
-	echo -n $(kubectl get $POD_NAME -o jsonpath="{.status.phase}")
+	echo -n "$(kubectl get "$POD_NAME" -o jsonpath="{.status.phase}")"
 }
 
 while [[ "$(get_pod_status)" != "Running" ]]; do
@@ -12,4 +12,4 @@ while [[ "$(get_pod_status)" != "Running" ]]; do
 	echo "Waiting for $POD_NAME (status $(get_pod_status))"
 done
 
-kubectl logs -f $POD_NAME -c $CONTAINER_NAME
+kubectl logs -f "$POD_NAME" -c "$CONTAINER_NAME"

--- a/examples/rbd/plugin-deploy.sh
+++ b/examples/rbd/plugin-deploy.sh
@@ -10,6 +10,6 @@ cd "$deployment_base" || exit 1
 
 objects=(csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac csi-rbdplugin-attacher csi-rbdplugin-provisioner csi-rbdplugin)
 
-for obj in ${objects[@]}; do
+for obj in "${objects[@]}"; do
 	kubectl create -f "./$obj.yaml"
 done

--- a/examples/rbd/plugin-teardown.sh
+++ b/examples/rbd/plugin-teardown.sh
@@ -10,6 +10,6 @@ cd "$deployment_base" || exit 1
 
 objects=(csi-rbdplugin-attacher csi-rbdplugin-provisioner csi-rbdplugin csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac)
 
-for obj in ${objects[@]}; do
+for obj in "${objects[@]}"; do
 	kubectl delete -f "./$obj.yaml"
 done

--- a/examples/rbd/pod-restore.yaml
+++ b/examples/rbd/pod-restore.yaml
@@ -1,17 +1,17 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: csirbd-restore-demo-pod
 spec:
   containers:
-   - name: web-server
-     image: nginx 
-     volumeMounts:
-       - name: mypvc
-         mountPath: /var/lib/www/html
+    - name: web-server
+      image: nginx
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www/html
   volumes:
-   - name: mypvc
-     persistentVolumeClaim:
-       claimName: rbd-pvc-restore
-       readOnly: false
-
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: rbd-pvc-restore
+        readOnly: false

--- a/examples/rbd/pod.yaml
+++ b/examples/rbd/pod.yaml
@@ -1,17 +1,17 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: csirbd-demo-pod
 spec:
   containers:
-   - name: web-server
-     image: nginx 
-     volumeMounts:
-       - name: mypvc
-         mountPath: /var/lib/www/html
+    - name: web-server
+      image: nginx
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www/html
   volumes:
-   - name: mypvc
-     persistentVolumeClaim:
-       claimName: rbd-pvc
-       readOnly: false
-
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: rbd-pvc
+        readOnly: false

--- a/examples/rbd/pvc.yaml
+++ b/examples/rbd/pvc.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: rbd-pvc
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi

--- a/examples/rbd/secret.yaml
+++ b/examples/rbd/secret.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: csi-rbd-secret
-  namespace: default 
+  namespace: default
 data:
   # Key value corresponds to a user name defined in ceph cluster
   admin: BASE64-ENCODED-PASSWORD
@@ -10,4 +11,4 @@ data:
   kubernetes: BASE64-ENCODED-PASSWORD
   # if monValueFromSecret is set to "monitors", uncomment the
   # following and set the mon there
-  #monitors: BASE64-ENCODED-Comma-Delimited-Mons
+  # monitors: BASE64-ENCODED-Comma-Delimited-Mons

--- a/examples/rbd/snapshot.yaml
+++ b/examples/rbd/snapshot.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: snapshot.storage.k8s.io/v1alpha1
 kind: VolumeSnapshot
 metadata:

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -1,37 +1,38 @@
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: csi-rbd
-provisioner: csi-rbdplugin 
+provisioner: csi-rbdplugin
 parameters:
-    # Comma separated list of Ceph monitors
-    # if using FQDN, make sure csi plugin's dns policy is appropriate.
-    monitors: mon1:port,mon2:port,...
+   # Comma separated list of Ceph monitors
+   # if using FQDN, make sure csi plugin's dns policy is appropriate.
+   monitors: mon1:port,mon2:port,...
 
-    # if "monitors" parameter is not set, driver to get monitors from same
-    # secret as admin/user credentials. "monValueFromSecret" provides the
-    # key in the secret whose value is the mons
-    #monValueFromSecret: "monitors"
+   # if "monitors" parameter is not set, driver to get monitors from same
+   # secret as admin/user credentials. "monValueFromSecret" provides the
+   # key in the secret whose value is the mons
+   # monValueFromSecret: "monitors"
 
-    
-    # Ceph pool into which the RBD image shall be created
-    pool: rbd
+   # Ceph pool into which the RBD image shall be created
+   pool: rbd
 
-    # RBD image format. Defaults to "2".
-    imageFormat: "2"
+   # RBD image format. Defaults to "2".
+   imageFormat: "2"
 
-    # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-    imageFeatures: layering
-    
-    # The secrets have to contain Ceph admin credentials.
-    csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
-    csi.storage.k8s.io/provisioner-secret-namespace: default
-    csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
-    csi.storage.k8s.io/node-publish-secret-namespace: default
+   # RBD image features. Available for imageFormat: "2"
+   # CSI RBD currently supports only `layering` feature.
+   imageFeatures: layering
 
-    # Ceph users for operating RBD
-    adminid: admin
-    userid: kubernetes
-    # uncomment the following to use rbd-nbd as mounter on supported nodes
-    #mounter: rbd-nbd
+   # The secrets have to contain Ceph admin credentials.
+   csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
+   csi.storage.k8s.io/provisioner-secret-namespace: default
+   csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
+   csi.storage.k8s.io/node-publish-secret-namespace: default
+
+   # Ceph users for operating RBD
+   adminid: admin
+   userid: kubernetes
+   # uncomment the following to use rbd-nbd as mounter on supported nodes
+   # mounter: rbd-nbd
 reclaimPolicy: Delete

--- a/scripts/lint-go.sh
+++ b/scripts/lint-go.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o pipefail
+
+if [[ -x "$(command -v gometalinter)" ]]; then
+  gometalinter -j "${GO_METALINTER_THREADS:-1}" \
+    --sort path --sort line --sort column --deadline=10m \
+    --enable=misspell --enable=staticcheck \
+    --vendor "${@-./...}"
+else
+  echo "WARNING: gometalinter not found, skipping lint tests" >&2
+fi

--- a/scripts/lint-text.sh
+++ b/scripts/lint-text.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+# vim: set ts=4 sw=4 et :
+
+# Usage: pre-commit.sh [--require-all]
+#   --require-all  Fail instead of warn if a checker is not found
+
+set -e
+
+# Run checks from root of the repo
+scriptdir="$(dirname "$(realpath "$0")")"
+cd "$scriptdir/.."
+
+# run_check <file_regex> <checker_exe> [optional args to checker...]
+function run_check() {
+    regex="$1"
+    shift
+    exe="$1"
+    shift
+
+    if [ -x "$(command -v "$exe")" ]; then
+        find . -path ./vendor -prune -o -regextype egrep -iregex "$regex" -print0 |
+            xargs -0rt -n1 "$exe" "$@"
+    elif [ "$all_required" -eq 0 ]; then
+        echo "Warning: $exe not found... skipping some tests."
+    else
+        echo "FAILED: All checks required, but $exe not found!"
+        exit 1
+    fi
+}
+
+all_required=0
+if [ "x$1" == "x--require-all" ]; then
+    all_required=1
+fi
+
+# markdownlint: https://github.com/markdownlint/markdownlint
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+# Install via: gem install mdl
+run_check '.*\.md' mdl --style scripts/mdl-style.rb
+
+# Install via: dnf install shellcheck
+run_check '.*\.(ba)?sh' shellcheck
+run_check '.*\.(ba)?sh' bash -n
+
+# Install via: pip install yamllint
+# disable yamlint chekck for helm chats
+run_check '.*\.ya?ml' yamllint -s -d "{extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml}"
+
+echo "ALL OK."

--- a/scripts/mdl-style.rb
+++ b/scripts/mdl-style.rb
@@ -1,0 +1,9 @@
+all
+
+#Refer below url for more information about the markdown rules.
+#https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+
+rule 'MD013', :code_blocks => false, :tables => false
+
+exclude_rule 'MD040' # Fenced code blocks should have a language specified
+exclude_rule 'MD041' # First line in file should be a top level header

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+GOPACKAGES="$(go list ./... | grep -v vendor | grep -v e2e)"
+COVERFILE="${GO_COVER_DIR}profile.cov"
+
+# no special options, exec to go test w/ all pkgs
+if [[ ${TEST_EXITFIRST} != "yes" && -z ${TEST_COVERAGE} ]]; then
+	# shellcheck disable=SC2086
+	exec go test ${GOPACKAGES}
+fi
+
+# our options are set so we need to handle each go package one
+# at at time
+if [[ ${TEST_COVERAGE} ]]; then
+	GOTESTOPTS="-covermode=count -coverprofile=cover.out"
+	echo "mode: count" > "${COVERFILE}"
+fi
+
+failed=0
+for gopackage in ${GOPACKAGES}; do
+	echo "--- testing: ${gopackage} ---"
+	# shellcheck disable=SC2086
+	go test ${GOTESTOPTS} "${gopackage}" || ((failed+=1))
+	if [[ -f cover.out ]]; then
+		# Append to coverfile
+		grep -v "^mode: count" cover.out >> "${COVERFILE}"
+	fi
+	if [[ ${TEST_COVERAGE} = "stdout" && -f cover.out ]]; then
+		go tool cover -func=cover.out
+	fi
+	if [[ ${TEST_COVERAGE} = "html" && -f cover.out ]]; then
+		mkdir -p coverage
+		fn="coverage/${gopackage////-}.html"
+		echo " * generating coverage html: ${fn}"
+		go tool cover -html=cover.out -o "${fn}"
+	fi
+	rm -f cover.out
+	if [[ ${failed} -ne 0 && ${TEST_EXITFIRST} = "yes" ]]; then
+		exit ${failed}
+	fi
+done
+exit ${failed}


### PR DESCRIPTION
Added below listed static tool check s in travis
* Yamllint
* Markdown lint
* Shell check
* updated to test running

# logs:
## yaml,markdown  lint and shell check
```
./scripts/lint-text.sh 
mdl --style scripts/mdl-style.rb ./docs/deploy-cephfs.md 
mdl --style scripts/mdl-style.rb ./docs/deploy-rbd.md 
mdl --style scripts/mdl-style.rb ./examples/README.md 
mdl --style scripts/mdl-style.rb ./README.md 
shellcheck ./examples/rbd/plugin-deploy.sh 
shellcheck ./examples/rbd/plugin-teardown.sh 
shellcheck ./examples/rbd/exec-bash.sh 
shellcheck ./examples/rbd/logs.sh 
shellcheck ./examples/cephfs/plugin-deploy.sh 
shellcheck ./examples/cephfs/plugin-teardown.sh 
shellcheck ./examples/cephfs/exec-bash.sh 
shellcheck ./examples/cephfs/logs.sh 
shellcheck ./deploy.sh 
shellcheck ./scripts/lint-text.sh 
shellcheck ./scripts/test-go.sh 
shellcheck ./scripts/lint-go.sh 
bash -n ./examples/rbd/plugin-deploy.sh 
bash -n ./examples/rbd/plugin-teardown.sh 
bash -n ./examples/rbd/exec-bash.sh 
bash -n ./examples/rbd/logs.sh 
bash -n ./examples/cephfs/plugin-deploy.sh 
bash -n ./examples/cephfs/plugin-teardown.sh 
bash -n ./examples/cephfs/exec-bash.sh 
bash -n ./examples/cephfs/logs.sh 
bash -n ./deploy.sh 
bash -n ./scripts/lint-text.sh 
bash -n ./scripts/test-go.sh 
bash -n ./scripts/lint-go.sh 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/pod-restore.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/pod.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/storageclass.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/pvc.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/secret.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/pvc-restore.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/snapshot.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/rbd/snapshotclass.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/cephfs/pod.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/cephfs/storageclass.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/cephfs/pvc.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/cephfs/deployment.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./examples/cephfs/secret.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./.travis.yml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/values.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/Chart.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/provisioner-role.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/attacher-clusterrolebinding.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/attacher-statefulset.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/nodeplugin-clusterrole.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/provisioner-statefulset.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/nodeplugin-serviceaccount.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/provisioner-clusterrolebinding.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/nodeplugin-daemonset.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/attacher-service.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/provisioner-serviceaccount.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/nodeplugin-clusterrolebinding.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/provisioner-service.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/provisioner-clusterrole.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/provisioner-rolebinding.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/attacher-clusterrole.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/helm/templates/attacher-serviceaccount.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/kubernetes/csi-attacher-rbac.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/kubernetes/csi-rbdplugin.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/rbd/kubernetes/csi-provisioner-rbac.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/cephfs/kubernetes/csi-attacher-rbac.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/cephfs/kubernetes/csi-cephfsplugin.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/cephfs/kubernetes/csi-cephfsplugin-attacher.yaml 
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: deploy/rbd/helm/templates/*.yaml} ./deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml 
ALL OK.

```

## go test
```
./scripts/test-go.sh 
?   	github.com/ceph/ceph-csi/cmd/cephfs	[no test files]
?   	github.com/ceph/ceph-csi/cmd/rbd	[no test files]
?   	github.com/ceph/ceph-csi/pkg/cephfs	[no test files]
?   	github.com/ceph/ceph-csi/pkg/rbd	[no test files]
?   	github.com/ceph/ceph-csi/pkg/util	[no test files]
```