### PR TITLE
Fixes broken migration to klog

### DIFF
--- a/cmd/cephfs/main.go
+++ b/cmd/cephfs/main.go
@@ -35,26 +35,7 @@ var (
 )
 
 func main() {
-	if err := flag.Set("logtostderr", "true"); err != nil {
-		klog.Errorf("failed to set logtostderr flag: %v", err)
-		os.Exit(1)
-	}
-
-	flag.Parse()
-
-	// TODO: remove this once github.com/kubernetes-csi/drivers/pkg/csi-common pkg moves to klog
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-
-	// Sync klog flags with glog
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		if f2 := klogFlags.Lookup(f1.Name); f2 != nil {
-			if err := f2.Value.Set(f1.Value.String()); err != nil {
-				klog.Errorf("failed to set %s flag: %v", f1.Name, err)
-				os.Exit(1)
-			}
-		}
-	})
+	util.InitLogging()
 
 	if err := createPersistentStorage(path.Join(cephfs.PluginFolder, "controller")); err != nil {
 		klog.Errorf("failed to create persistent storage for controller: %v", err)

--- a/cmd/cephfs/main.go
+++ b/cmd/cephfs/main.go
@@ -26,13 +26,6 @@ import (
 	"k8s.io/klog"
 )
 
-func init() {
-	if err := flag.Set("logtostderr", "true"); err != nil {
-		klog.Errorf("failed to set logtostderr flag: %v", err)
-		os.Exit(1)
-	}
-}
-
 var (
 	endpoint        = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	driverName      = flag.String("drivername", "csi-cephfsplugin", "name of the driver")
@@ -42,7 +35,26 @@ var (
 )
 
 func main() {
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		klog.Errorf("failed to set logtostderr flag: %v", err)
+		os.Exit(1)
+	}
+
 	flag.Parse()
+
+	// TODO: remove this once github.com/kubernetes-csi/drivers/pkg/csi-common pkg moves to klog
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+
+	// Sync klog flags with glog
+	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
+		if f2 := klogFlags.Lookup(f1.Name); f2 != nil {
+			if err := f2.Value.Set(f1.Value.String()); err != nil {
+				klog.Errorf("failed to set %s flag: %v", f1.Name, err)
+				os.Exit(1)
+			}
+		}
+	})
 
 	if err := createPersistentStorage(path.Join(cephfs.PluginFolder, "controller")); err != nil {
 		klog.Errorf("failed to create persistent storage for controller: %v", err)

--- a/cmd/rbd/main.go
+++ b/cmd/rbd/main.go
@@ -26,13 +26,6 @@ import (
 	"k8s.io/klog"
 )
 
-func init() {
-	if err := flag.Set("logtostderr", "true"); err != nil {
-		klog.Errorf("failed to set logtostderr flag: %v", err)
-		os.Exit(1)
-	}
-}
-
 var (
 	endpoint        = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	driverName      = flag.String("drivername", "csi-rbdplugin", "name of the driver")
@@ -42,7 +35,26 @@ var (
 )
 
 func main() {
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		klog.Errorf("failed to set logtostderr flag: %v", err)
+		os.Exit(1)
+	}
+
 	flag.Parse()
+
+	// TODO: remove this once github.com/kubernetes-csi/drivers/pkg/csi-common pkg moves to klog
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+
+	// Sync klog flags with glog
+	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
+		if f2 := klogFlags.Lookup(f1.Name); f2 != nil {
+			if err := f2.Value.Set(f1.Value.String()); err != nil {
+				klog.Errorf("failed to set %s flag: %v", f1.Name, err)
+				os.Exit(1)
+			}
+		}
+	})
 
 	if err := createPersistentStorage(path.Join(rbd.PluginFolder, "controller")); err != nil {
 		klog.Errorf("failed to create persistent storage for controller %v", err)

--- a/cmd/rbd/main.go
+++ b/cmd/rbd/main.go
@@ -35,26 +35,7 @@ var (
 )
 
 func main() {
-	if err := flag.Set("logtostderr", "true"); err != nil {
-		klog.Errorf("failed to set logtostderr flag: %v", err)
-		os.Exit(1)
-	}
-
-	flag.Parse()
-
-	// TODO: remove this once github.com/kubernetes-csi/drivers/pkg/csi-common pkg moves to klog
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-
-	// Sync klog flags with glog
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		if f2 := klogFlags.Lookup(f1.Name); f2 != nil {
-			if err := f2.Value.Set(f1.Value.String()); err != nil {
-				klog.Errorf("failed to set %s flag: %v", f1.Name, err)
-				os.Exit(1)
-			}
-		}
-	})
+	util.InitLogging()
 
 	if err := createPersistentStorage(path.Join(rbd.PluginFolder, "controller")); err != nil {
 		klog.Errorf("failed to create persistent storage for controller %v", err)

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"flag"
+	"os"
+
+	"k8s.io/klog"
+)
+
+// InitLogging initializes klog alongside glog
+// XXX: This is just a temporary solution till all deps move to klog
+func InitLogging() {
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		klog.Errorf("failed to set logtostderr flag: %v", err)
+		os.Exit(1)
+	}
+
+	flag.Parse()
+
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+
+	// Sync klog flags with glog
+	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
+		if f2 := klogFlags.Lookup(f1.Name); f2 != nil {
+			f2.Value.Set(f1.Value.String()) // nolint: errcheck, gosec
+		}
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/ceph/ceph-csi/issues/187

Bug introduced in https://github.com/ceph/ceph-csi/pull/150 (quite insufficient testing - plugins would panic immediately, https://github.com/ceph/ceph-csi/issues/168) by not playing nicely with vendor'd packages that still use glog ([github.com/kubernetes-csi/drivers/pkg/csi-common](https://github.com/ceph/ceph-csi/tree/csi-v1.0/vendor/github.com/kubernetes-csi/drivers/pkg/csi-common)).

This then continued on in https://github.com/ceph/ceph-csi/pull/169 which fixed the panic, but skipping `klog.InitFlags()` means `logtostderr` cmd flag doesn't get propagated to klog.

This PR reintroduces `klog.InitFlags()` in a hopefully less conflicting manner with glog.