### PR TITLE
cephfs: specify monitors explicitly

### DIFF
--- a/pkg/cephfs/driver.go
+++ b/pkg/cephfs/driver.go
@@ -99,11 +99,15 @@ func (fs *Driver) Run(driverName, nodeID, endpoint, volumeMounter string, cacheP
 
 	klog.Infof("cephfs: setting default volume mounter to %s", DefaultVolumeMounter)
 
+	if err := writeCephConfig(); err != nil {
+		klog.Fatalf("failed to write ceph configuration file: %v", err)
+	}
+
 	// Initialize default library driver
 
 	fs.cd = csicommon.NewCSIDriver(driverName, version, nodeID)
 	if fs.cd == nil {
-		klog.Fatalln("Failed to initialize CSI driver")
+		klog.Fatalln("failed to initialize CSI driver")
 	}
 
 	fs.cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -104,7 +104,8 @@ type fuseMounter struct{}
 func mountFuse(mountPoint string, cr *credentials, volOptions *volumeOptions, volID volumeID) error {
 	args := [...]string{
 		mountPoint,
-		"-c", getCephConfPath(volID),
+		"-m", volOptions.Monitors,
+		"-c", cephConfigPath,
 		"-n", cephEntityClientPrefix + cr.id,
 		"--keyring", getCephKeyringPath(volID, cr.id),
 		"-r", volOptions.RootPath,


### PR DESCRIPTION
Being able to override monitors via secrets makes it not the best idea to store them in the ceph config file - things can get out of sync.

This PR makes it so that the monitor list is always passed explicitly to all ceph/mount calls instead of storing it in the `ceph.conf`. As a bonus, `ceph.conf` is now generated and stored only once.

+ a few minor fixes where wrong ceph user IDs were passed, which led to errors when cleaning unused keyrings ("file not found")