### PR TITLE
cephfs: pass keys via args

### DIFF
--- a/pkg/cephfs/cephconf.go
+++ b/pkg/cephfs/cephconf.go
@@ -17,13 +17,8 @@ limitations under the License.
 package cephfs
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
-	"text/template"
-
-	"k8s.io/klog"
 )
 
 var cephConfig = []byte(`[global]
@@ -35,38 +30,10 @@ auth_client_required = cephx
 fuse_set_user_groups = false
 `)
 
-const cephKeyring = `[client.{{.UserID}}]
-key = {{.Key}}
-`
-
-const cephSecret = `{{.Key}}` // #nosec
-
 const (
-	cephConfigRoot         = "/etc/ceph"
-	cephConfigPath         = "/etc/ceph/ceph.conf"
-	cephKeyringFileNameFmt = "ceph.share.%s.client.%s.keyring"
-	cephSecretFileNameFmt  = "ceph.share.%s.client.%s.secret" // #nosec
+	cephConfigRoot = "/etc/ceph"
+	cephConfigPath = "/etc/ceph/ceph.conf"
 )
-
-var (
-	cephKeyringTempl *template.Template
-	cephSecretTempl  *template.Template
-)
-
-func init() {
-	fm := map[string]interface{}{
-		"perms": func(readOnly bool) string {
-			if readOnly {
-				return "r"
-			}
-
-			return "rw"
-		},
-	}
-
-	cephKeyringTempl = template.Must(template.New("keyring").Funcs(fm).Parse(cephKeyring))
-	cephSecretTempl = template.Must(template.New("secret").Parse(cephSecret))
-}
 
 func createCephConfigRoot() error {
 	return os.MkdirAll(cephConfigRoot, 0755) // #nosec
@@ -78,52 +45,4 @@ func writeCephConfig() error {
 	}
 
 	return ioutil.WriteFile(cephConfigPath, cephConfig, 0640)
-}
-
-func writeCephTemplate(fileName string, m os.FileMode, t *template.Template, data interface{}) error {
-	if err := createCephConfigRoot(); err != nil {
-		return err
-	}
-
-	f, err := os.OpenFile(path.Join(cephConfigRoot, fileName), os.O_CREATE|os.O_EXCL|os.O_WRONLY, m)
-	if err != nil {
-		if os.IsExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	defer func() {
-		if err := f.Close(); err != nil {
-			klog.Errorf("failed to close file %s with error %s", f.Name(), err)
-		}
-	}()
-
-	return t.Execute(f, data)
-}
-
-type cephKeyringData struct {
-	UserID, Key string
-	VolumeID    volumeID
-}
-
-func (d *cephKeyringData) writeToFile() error {
-	return writeCephTemplate(fmt.Sprintf(cephKeyringFileNameFmt, d.VolumeID, d.UserID), 0600, cephKeyringTempl, d)
-}
-
-type cephSecretData struct {
-	UserID, Key string
-	VolumeID    volumeID
-}
-
-func (d *cephSecretData) writeToFile() error {
-	return writeCephTemplate(fmt.Sprintf(cephSecretFileNameFmt, d.VolumeID, d.UserID), 0600, cephSecretTempl, d)
-}
-
-func getCephSecretPath(volID volumeID, userID string) string {
-	return path.Join(cephConfigRoot, fmt.Sprintf(cephSecretFileNameFmt, volID, userID))
-}
-
-func getCephKeyringPath(volID volumeID, userID string) string {
-	return path.Join(cephConfigRoot, fmt.Sprintf(cephKeyringFileNameFmt, volID, userID))
 }

--- a/pkg/cephfs/cephuser.go
+++ b/pkg/cephfs/cephuser.go
@@ -17,12 +17,7 @@ limitations under the License.
 package cephfs
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"os"
-
-	"k8s.io/klog"
 )
 
 const (
@@ -53,83 +48,47 @@ func getCephUserName(volID volumeID) string {
 	return cephUserPrefix + string(volID)
 }
 
-func getCephUser(volOptions *volumeOptions, adminCr *credentials, volID volumeID) (*cephEntity, error) {
-	entityName := cephEntityClientPrefix + getCephUserName(volID)
-
+func getSingleCephEntity(args ...string) (*cephEntity, error) {
 	var ents []cephEntity
-	args := [...]string{
-		"-m", volOptions.Monitors,
-		"auth", "-f", "json", "-c", cephConfigPath, "-n", cephEntityClientPrefix + adminCr.id, "--keyring", getCephKeyringPath(volID, adminCr.id),
-		"get", entityName,
-	}
-
-	out, err := execCommand("ceph", args[:]...)
-	if err != nil {
-		return nil, fmt.Errorf("cephfs: ceph failed with following error: %s\ncephfs: ceph output: %s", err, out)
-	}
-
-	// Workaround for output from `ceph auth get`
-	// Contains non-json data: "exported keyring for ENTITY\n\n"
-	offset := bytes.Index(out, []byte("[{"))
-
-	if err = json.NewDecoder(bytes.NewReader(out[offset:])).Decode(&ents); err != nil {
-		return nil, fmt.Errorf("failed to decode json: %v", err)
+	if err := execCommandJSON(&ents, "ceph", args...); err != nil {
+		return nil, err
 	}
 
 	if len(ents) != 1 {
-		return nil, fmt.Errorf("got unexpected number of entities for %s: expected 1, got %d", entityName, len(ents))
+		return nil, fmt.Errorf("got unexpected number of entities: expected 1, got %d", len(ents))
 	}
 
 	return &ents[0], nil
+}
+
+func getCephUser(volOptions *volumeOptions, adminCr *credentials, volID volumeID) (*cephEntity, error) {
+	return getSingleCephEntity(
+		"-m", volOptions.Monitors,
+		"-n", cephEntityClientPrefix+adminCr.id, "--key="+adminCr.key,
+		"-c", cephConfigPath,
+		"-f", "json",
+		"auth", "get", cephEntityClientPrefix+getCephUserName(volID),
+	)
 }
 
 func createCephUser(volOptions *volumeOptions, adminCr *credentials, volID volumeID) (*cephEntity, error) {
-	caps := cephEntityCaps{
-		Mds: fmt.Sprintf("allow rw path=%s", getVolumeRootPathCeph(volID)),
-		Mon: "allow r",
-		Osd: fmt.Sprintf("allow rw pool=%s namespace=%s", volOptions.Pool, getVolumeNamespace(volID)),
-	}
-
-	var ents []cephEntity
-	args := [...]string{
+	return getSingleCephEntity(
 		"-m", volOptions.Monitors,
-		"auth", "-f", "json", "-c", cephConfigPath, "-n", cephEntityClientPrefix + adminCr.id, "--keyring", getCephKeyringPath(volID, adminCr.id),
-		"get-or-create", cephEntityClientPrefix + getCephUserName(volID),
-		"mds", caps.Mds,
-		"mon", caps.Mon,
-		"osd", caps.Osd,
-	}
-
-	if err := execCommandJSON(&ents, args[:]...); err != nil {
-		return nil, fmt.Errorf("error creating ceph user: %v", err)
-	}
-
-	return &ents[0], nil
+		"-n", cephEntityClientPrefix+adminCr.id, "--key="+adminCr.key,
+		"-c", cephConfigPath,
+		"-f", "json",
+		"auth", "get-or-create", cephEntityClientPrefix+getCephUserName(volID),
+		"mds", fmt.Sprintf("allow rw path=%s", getVolumeRootPathCeph(volID)),
+		"mon", "allow r",
+		"osd", fmt.Sprintf("allow rw pool=%s namespace=%s", volOptions.Pool, getVolumeNamespace(volID)),
+	)
 }
 
 func deleteCephUser(volOptions *volumeOptions, adminCr *credentials, volID volumeID) error {
-	userID := getCephUserName(volID)
-
-	args := [...]string{
+	return execCommandErr("ceph",
 		"-m", volOptions.Monitors,
-		"-c", cephConfigPath, "-n", cephEntityClientPrefix + adminCr.id, "--keyring", getCephKeyringPath(volID, adminCr.id),
-		"auth", "rm", cephEntityClientPrefix + userID,
-	}
-
-	var err error
-	if err = execCommandAndValidate("ceph", args[:]...); err != nil {
-		return err
-	}
-
-	keyringPath := getCephKeyringPath(volID, adminCr.id)
-	if err = os.Remove(keyringPath); err != nil {
-		klog.Errorf("failed to remove keyring file %s with error %s", keyringPath, err)
-	}
-
-	secretPath := getCephSecretPath(volID, adminCr.id)
-	if err = os.Remove(secretPath); err != nil {
-		klog.Errorf("failed to remove secret file %s with error %s", secretPath, err)
-	}
-
-	return nil
+		"-n", cephEntityClientPrefix+adminCr.id, "--key="+adminCr.key,
+		"-c", cephConfigPath,
+		"auth", "rm", cephEntityClientPrefix+getCephUserName(volID),
+	)
 }

--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -67,11 +67,6 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 
-		if err = storeCephCredentials(volID, cr); err != nil {
-			klog.Errorf("failed to store admin credentials for '%s': %v", cr.id, err)
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-
 		if err = createVolume(volOptions, cr, volID, req.GetCapacityRange().GetRequiredBytes()); err != nil {
 			klog.Errorf("failed to create volume %s: %v", req.GetName(), err)
 			return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -51,10 +51,6 @@ func getCredentialsForVolume(volOptions *volumeOptions, volID volumeID, req *csi
 			return nil, fmt.Errorf("failed to get admin credentials from node stage secrets: %v", err)
 		}
 
-		if err = storeCephCredentials(volID, adminCr); err != nil {
-			return nil, fmt.Errorf("failed to store ceph admin credentials: %v", err)
-		}
-
 		// Then get the ceph user
 
 		entity, err := getCephUser(volOptions, adminCr, volID)
@@ -72,10 +68,6 @@ func getCredentialsForVolume(volOptions *volumeOptions, volID volumeID, req *csi
 		}
 
 		cr = userCr
-	}
-
-	if err := storeCephCredentials(volID, cr); err != nil {
-		return nil, fmt.Errorf("failed to store ceph user credentials: %v", err)
 	}
 
 	return cr, nil
@@ -241,7 +233,7 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	klog.Infof("cephfs: successfully umounted volume %s from %s", req.GetVolumeId(), stagingTargetPath)
+	klog.Infof("cephfs: successfully unmounted volume %s from %s", req.GetVolumeId(), stagingTargetPath)
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }

--- a/pkg/cephfs/volume.go
+++ b/pkg/cephfs/volume.go
@@ -48,7 +48,7 @@ func getVolumeNamespace(volID volumeID) string {
 }
 
 func setVolumeAttribute(root, attrName, attrValue string) error {
-	return execCommandAndValidate("setfattr", "-n", attrName, "-v", attrValue, root)
+	return execCommandErr("setfattr", "-n", attrName, "-v", attrValue, root)
 }
 
 func createVolume(volOptions *volumeOptions, adminCr *credentials, volID volumeID, bytesQuota int64) error {
@@ -124,7 +124,7 @@ func purgeVolume(volID volumeID, adminCr *credentials, volOptions *volumeOptions
 	defer unmountAndRemove(cephRoot)
 
 	if err := os.Rename(volRoot, volRootDeleting); err != nil {
-		return fmt.Errorf("coudln't mark volume %s for deletion: %v", volID, err)
+		return fmt.Errorf("couldn't mark volume %s for deletion: %v", volID, err)
 	}
 
 	if err := os.RemoveAll(volRootDeleting); err != nil {

--- a/pkg/util/stripsecrets.go
+++ b/pkg/util/stripsecrets.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/stripsecrets.go
+++ b/pkg/util/stripsecrets.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+)
+
+const (
+	keyArg              = "--key="
+	secretArg           = "secret="
+	optionsArgSeparator = ','
+	strippedKey         = "--key=***stripped***"
+	strippedSecret      = "secret=***stripped***"
+)
+
+// StripSecretInArgs strips values of either "--key" or "secret=".
+// `args` is left unchanged.
+// Expects only one occurrence of either "--key" or "secret=".
+func StripSecretInArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+
+	if !stripKey(out) {
+		stripSecret(out)
+	}
+
+	return out
+}
+
+func stripKey(out []string) bool {
+	for i := range out {
+		if strings.HasPrefix(out[i], keyArg) {
+			out[i] = strippedKey
+			return true
+		}
+	}
+
+	return false
+}
+
+func stripSecret(out []string) bool {
+	for i := range out {
+		arg := out[i]
+		begin := strings.Index(arg, secretArg)
+
+		if begin == -1 {
+			continue
+		}
+
+		end := strings.IndexByte(arg[begin+len(secretArg):], optionsArgSeparator)
+
+		out[i] = arg[:begin] + strippedSecret
+		if end != -1 {
+			out[i] += arg[end+len(secretArg):]
+		}
+
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
ceph-fuse mimic supports `--key` option, this PR makes use of it: all ceph calls are now appended with keys, keyrings are no longer stored on nodes (only as cmd args).