### PR TITLE
rbd: don't delete volume/snapshot if metadata creation fails

### DIFF
--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -305,6 +305,7 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 
 // CreateSnapshot creates the snapshot in backend and stores metadata
 // in store
+// nolint: gocyclo
 func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 
 	if err := cs.validateSnapshotReq(req); err != nil {


### PR DESCRIPTION
When `MetadataStore.Create()` failed in either `CreateVolume` or `CreateSnapshot`, the rbd volume/snapshot would get deleted and the whole creation process would start over (volume created successfully -> failed to store metadata for volume -> delete volume -> create volume again -> try to store metadata again -> ...). This is quite expensive error handling.

This PR relies on idempotency of both creation of rbd volumes/snapshots and metadata. If the volume/snapshot was created successfully but metadata storage failed, reuse the volume/snapshot and in next attempt only try to store metadata:

`CreateVolume` first attempt:
1. create volume
2. volume created successfully
3. store volume metadata
4. failed to store metadata, exit with error

`CreateVolume` second attempt:
1. create volume
2. volume already exists
3. store volume metadata
4. let's say we're now successful :)

The same goes for snapshots.