### PR TITLE
RBD: Remove dead code

### DIFF
--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -99,9 +99,6 @@ func parseVolCreateRequest(req *csi.CreateVolumeRequest) (*rbdVolume, error) {
 	// Generating Volume Name and Volume ID, as according to CSI spec they MUST be different
 	volName := req.GetName()
 	uniqueID := uuid.NewUUID().String()
-	if len(volName) == 0 {
-		volName = rbdVol.Pool + "-dynamic-pvc-" + uniqueID
-	}
 	rbdVol.VolName = volName
 	volumeID := "csi-rbd-vol-" + uniqueID
 	rbdVol.VolID = volumeID


### PR DESCRIPTION
during volume creation we are validating
that volume name cannot be empty,removing
this check as we are not going to hit
this case

Fixes: #204

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>