### PR TITLE
Remove requirement for ceph config and keyring  files

### DIFF
--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -55,7 +55,6 @@ Parameter                                                        | Required     
 Admin credentials are required for provisioning new RBD images
 `ADMIN_NAME`: `ADMIN_PASSWORD` - note that the key of the key-value pair is the name of the client with admin privileges, and the value is its password
 
-Also note that CSI RBD expects admin keyring and Ceph config file in `/etc/ceph`.
 
 ## Deployment with Kubernetes
 


### PR DESCRIPTION
RBD does not need the ceph config and keyring files.
The plugin uses the configuration from the storage/snapshot class and from the secret.