### PR TITLE
k8s metadata cache: delete shouldn't fail on NotFound errors

### DIFF
--- a/pkg/util/k8scmcache.go
+++ b/pkg/util/k8scmcache.go
@@ -110,7 +110,7 @@ func (k8scm *K8sCMCache) ForAll(pattern string, destObj interface{}, f ForAllFun
 			continue
 		}
 		if err = json.Unmarshal([]byte(data), destObj); err != nil {
-			return errors.Wrap(err, "k8s-cm-cache: unmarshal error")
+			return errors.Wrapf(err, "k8s-cm-cache: JSON unmarshaling failed for configmap %s", cm.ObjectMeta.Name)
 		}
 		if err = f(cm.ObjectMeta.Name); err != nil {
 			return err
@@ -123,12 +123,12 @@ func (k8scm *K8sCMCache) ForAll(pattern string, destObj interface{}, f ForAllFun
 func (k8scm *K8sCMCache) Create(identifier string, data interface{}) error {
 	cm, err := k8scm.getMetadataCM(identifier)
 	if cm != nil && err == nil {
-		klog.V(4).Infof("k8s-cm-cache: configmap already exists, skipping configmap creation")
+		klog.V(4).Infof("k8s-cm-cache: configmap %s already exists, skipping configmap creation", identifier)
 		return nil
 	}
 	dataJSON, err := json.Marshal(data)
 	if err != nil {
-		return errors.Wrap(err, "k8s-cm-cache: marshal error")
+		return errors.Wrapf(err, "k8s-cm-cache: JSON marshaling failed for configmap %s", identifier)
 	}
 	cm = &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -145,13 +145,13 @@ func (k8scm *K8sCMCache) Create(identifier string, data interface{}) error {
 	_, err = k8scm.Client.CoreV1().ConfigMaps(k8scm.Namespace).Create(cm)
 	if err != nil {
 		if apierrs.IsAlreadyExists(err) {
-			klog.V(4).Infof("k8s-cm-cache: configmap already exists")
+			klog.V(4).Infof("k8s-cm-cache: configmap %s already exists", identifier)
 			return nil
 		}
 		return errors.Wrapf(err, "k8s-cm-cache: couldn't persist %s metadata as configmap", identifier)
 	}
 
-	klog.V(4).Infof("k8s-cm-cache: configmap %s successfully created\n", identifier)
+	klog.V(4).Infof("k8s-cm-cache: configmap %s successfully created", identifier)
 	return nil
 }
 
@@ -163,7 +163,7 @@ func (k8scm *K8sCMCache) Get(identifier string, data interface{}) error {
 	}
 	err = json.Unmarshal([]byte(cm.Data[cmDataKey]), data)
 	if err != nil {
-		return errors.Wrap(err, "k8s-cm-cache: unmarshal error")
+		return errors.Wrapf(err, "k8s-cm-cache: JSON unmarshaling failed for configmap %s", identifier)
 	}
 	return nil
 }
@@ -172,6 +172,11 @@ func (k8scm *K8sCMCache) Get(identifier string, data interface{}) error {
 func (k8scm *K8sCMCache) Delete(identifier string) error {
 	err := k8scm.Client.CoreV1().ConfigMaps(k8scm.Namespace).Delete(identifier, nil)
 	if err != nil {
+		if apierrs.IsNotFound(err) {
+			klog.V(4).Infof("k8s-cm-cache: cannot delete missing metadata configmap %s, assuming it's already deleted", identifier)
+			return nil
+		}
+
 		return errors.Wrapf(err, "k8s-cm-cache: couldn't delete metadata configmap %s", identifier)
 	}
 	klog.V(4).Infof("k8s-cm-cache: successfully deleted metadata configmap %s", identifier)

--- a/pkg/util/nodecache.go
+++ b/pkg/util/nodecache.go
@@ -44,7 +44,7 @@ func (nc *NodeCache) EnsureCacheDirectory(cacheDir string) error {
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
 		// #nosec
 		if err := os.Mkdir(fullPath, 0755); err != nil {
-			return errors.Wrapf(err, "node-cache: failed to create %s folder with error: %v", fullPath, err)
+			return errors.Wrapf(err, "node-cache: failed to create %s folder", fullPath)
 		}
 	}
 	return nil
@@ -152,9 +152,13 @@ func (nc *NodeCache) Delete(identifier string) error {
 	file := path.Join(nc.BasePath, cacheDir, identifier+".json")
 	err := os.Remove(file)
 	if err != nil {
-		if err != os.ErrNotExist {
-			return errors.Wrapf(err, "node-cache: error removing file %s", file)
+		if err == os.ErrNotExist {
+			klog.V(4).Infof("node-cache: cannot delete missing metadata storage file %s, assuming it's already deleted", file)
+			return nil
 		}
+
+		return errors.Wrapf(err, "node-cache: error removing file %s", file)
+
 	}
 	klog.V(4).Infof("node-cache: successfully deleted metadata storage file at: %+v\n", file)
 	return nil


### PR DESCRIPTION
In order to maintain idempotency when deleting k8s metadata entries, we may assume that non-existent entries are already deleted.