### PR TITLE
[Proposal] Maintain a stateless CSI implementation

### DIFF
--- a/docs/design/proposals/stateless-csi-plugin.md
+++ b/docs/design/proposals/stateless-csi-plugin.md
@@ -2,57 +2,119 @@
 
 ## Terminology
 
-- CO: Container orchestration system, communicates with CSI plugins using CSI RPCs
-- NS: Node Service; CSI plugin service per node in the CO, responsible for staging volumes for application pod consumption
-- CS: Controller Service; CSI plugin service responsible for creation, deletion, snapshots, and expanding volumes for use in the CO system
+- CO: Container orchestration system, communicates with CSI plugins using CSI
+  RPCs
+- NS: Node Service; CSI plugin service per node in the CO, responsible for
+  staging volumes for application pod consumption
+- CS: Controller Service; CSI plugin service responsible for creation,
+  deletion, snapshots, and expanding volumes for use in the CO system
 
 **NOTE:**
 
-- Discussion below may use k8s specific terminology, but should be extensible to similar constructs on other container orchestration(CO) systems
+- Discussion below may use k8s specific terminology, but should be extensible
+  to similar constructs on other container orchestration(CO) systems
 
 ## Proposal/problem summary
 
-This document details a proposed solution, among presented alternatives, to implement a stateless Ceph-CSI plugin. It also details a naming scheme for volumes provisioned against a Ceph cluster and the resultant *volume_id* for the same that is shared with the CO system, enabling state to be carried by the *volume_id* where required.
+This document details a proposed solution, among presented alternatives, to
+implement a stateless Ceph-CSI plugin. It also details a naming scheme for
+volumes provisioned against a Ceph cluster and the resultant *volume_id* for
+the same that is shared with the CO system, enabling state to be carried by the
+*volume_id* where required.
 
-As of this writing, the plugin uses a config map to store *volume_name* to *volume_id* mapping, and also stores related Ceph cluster configuration information (e.g MON list, pool information) within the same tuple, to be able to find and operate on the provisioned volume. The implementation also depends on secrets from the StorageClass to perform NS related operations.
+As of this writing, the plugin uses a config map to store *volume_name* to
+*volume_id* mapping, and also stores related Ceph cluster configuration
+information (e.g MON list, pool information) within the same tuple, to be able
+to find and operate on the provisioned volume. The implementation also depends
+on secrets from the StorageClass to perform NS related operations.
 
-The existing strategy enables a single CSI instance to operate across any Ceph cluster that is fully defined by the StorageClass, but brings in the burden of storing and managing provisioned volumes by the plugin.
+The existing strategy enables a single CSI instance to operate across any Ceph
+cluster that is fully defined by the StorageClass, but brings in the burden of
+storing and managing provisioned volumes by the plugin.
 
-The proposal laid out here is to try and retain the ability for a single CSI instance to operate across any Ceph cluster, but remove the storage and management of provisioned CSI volumes by the plugin, or in short make the Ceph-CSI plugin stateless. Further, if this is achieved, it is also possible to run multiple replicas of the CS instance, to aid with load balancing of requests, than the current one instance limitation due to the existing config map.
+The proposal laid out here is to try and retain the ability for a single CSI
+instance to operate across any Ceph cluster, but remove the storage and
+management of provisioned CSI volumes by the plugin, or in short make the
+Ceph-CSI plugin stateless. Further, if this is achieved, it is also possible to
+run multiple replicas of the CS instance, to aid with load balancing of
+requests, than the current one instance limitation due to the existing config
+map.
 
 ## Proposed solution details
 
 ### Summary
 
-- Create a config map per Ceph cluster called `ceph-cluster-<cluster-fsid>` and a pair of secrets to go along with the same cluster called `ceph-cluster-<cluster-fsid>-provisioner-secret` and `ceph-cluster-<cluster-fsid>-publish-secret`
-- Allow the CS and NS namespaces access to the above config maps and secrets, in addition to the namespace that is responsible for creating and maintaining it
-    - **Needs Investigation** Unsure if secrets and config maps can be shared (via RBAC?) across namespaces or service accounts. This maybe needed if we need operator managed Ceph instances to be able to pass cluster configuration information to the CSI instance, and are in different namespaces for e.g.
-- Details about the Ceph cluster are maintained in `ceph-cluster-<cluster-fsid>`. Details include cluster-id, MONs, pools, and other relevant data. Also, these and the corresponding secrets are updated when they change, to reflect current values
-- The CSI plugin pod adds these config maps and secrets as volumes to its pod specification, thus ensuring auto-refresh of content when these are updated by the CO environment
-- VolumeCreate requests come against a targeted Ceph cluster-id and pool, enabling the CSI plugin to locate the appropriate configuration information for the cluster and its secrets to act on the request
-    - **NOTE:** The cluster-id and pool information is specified in the StorageClass for example
-    - **NOTE:** In the **future**, if it is desired that the CSI plugin CS choose which cluster and pool a request should be served from, this information can be omitted from the StorageClass
-- The *volume_id* carries information regarding the *cluster_id* and pool, enabling *volume_id* based RPC requests to operate using the provided configuration information against the respective cluster
-- Usual CSI spec based maps such as, *volume_context* and *publish_context* continue to carry information regarding required aspects about the provisioned volume to dependent RPCs
-- The NS also has access to the config maps and secrets to satisfy required node level RPC requests
+- Create a config map per Ceph cluster called `ceph-cluster-<cluster-fsid>` and
+  a pair of secrets to go along with the same cluster called
+  `ceph-cluster-<cluster-fsid>-provisioner-secret` and
+  `ceph-cluster-<cluster-fsid>-publish-secret`
+- Allow the CS and NS namespaces access to the above config maps and secrets,
+  in addition to the namespace that is responsible for creating and
+  maintaining it
+  - **Needs Investigation** Unsure if secrets and config maps can be
+    shared (via RBAC?) across namespaces or service accounts. This maybe
+    needed if we need operator managed Ceph instances to be able to pass
+    cluster configuration information to the CSI instance, and are in
+    different namespaces for e.g.
+- Details about the Ceph cluster are maintained in
+  `ceph-cluster-<cluster-fsid>`. Details include cluster-id, MONs, pools, and
+  other relevant data. Also, these and the corresponding secrets are updated
+  when they change, to reflect current values
+- The CSI plugin pod adds these config maps and secrets as volumes to its pod
+  specification, thus ensuring auto-refresh of content when these are updated
+  by the CO environment
+- VolumeCreate requests come against a targeted Ceph cluster-id and pool,
+  enabling the CSI plugin to locate the appropriate configuration information
+  for the cluster and its secrets to act on the request
+  - **NOTE:** The cluster-id and pool information is specified in the
+    StorageClass for example
+  - **NOTE:** In the **future**, if it is desired that the CSI plugin CS
+    choose which cluster and pool a request should be served from, this
+    information can be omitted from the StorageClass
+- The *volume_id* carries information regarding the *cluster_id* and pool,
+  enabling *volume_id* based RPC requests to operate using the provided
+  configuration information against the respective cluster
+- Usual CSI spec based maps such as, *volume_context* and *publish_context*
+  continue to carry information regarding required aspects about the
+  provisioned volume to dependent RPCs
+- The NS also has access to the config maps and secrets to satisfy required node
+  level RPC requests
 
 ### Pros
 
-- Addresses removal of the current config map that maintains list of provisioned volumes
-- Provides the ability for the CSI plugin to support all RPCs, as required information is present with the plugin across all Ceph clusters
-- Safeguards secrets and cluster configuration information access to only required namespaces that need to manage and use it
-- Provides the ability to have a single Ceph-CSI plugin instance per CO instance, even when the CO instance needs volumes provisioned from multiple Ceph clusters
-- Also, does not take away the capability, where needed, to use multiple Ceph-CSI plugin instances (specialized using provisioner name) per CO instance
-- Leaves the flexibility for the StorageClass to still override secrets, if such requirements arise
-    - **NOTE:** The credentials stored for a cluster and passed to the CSI plugins CS and NS, should be able to list volumes/images created using other secrets (IOW, should act like a supervisor/root) to correctly support ListVolumes and ListSnapshots operations
-- Provides the ability to deal with multi-cluster deployments, and possible best-fit provisioning in the **future**
-    - Enables the ability for the CSI plugin to act on Topology based requests
-    - Simplifies StorageClass definitions, leaving the choice of the cluster/pool to the CSI plugin
+- Addresses removal of the current config map that maintains list of
+  provisioned volumes
+- Provides the ability for the CSI plugin to support all RPCs, as required
+  information is present with the plugin across all Ceph clusters
+- Safeguards secrets and cluster configuration information access to only
+  required namespaces that need to manage and use it
+- Provides the ability to have a single Ceph-CSI plugin instance per CO
+  instance, even when the CO instance needs volumes provisioned from multiple
+  Ceph clusters
+- Also, does not take away the capability, where needed, to use multiple
+  Ceph-CSI plugin instances (specialized using provisioner name) per CO
+  instance
+- Leaves the flexibility for the StorageClass to still override secrets, if such
+  requirements arise
+  - **NOTE:** The credentials stored for a cluster and passed to the CSI
+    plugins CS and NS, should be able to list volumes/images created using
+    other secrets (IOW, should act like a supervisor/root) to correctly
+    support ListVolumes and ListSnapshots operations
+- Provides the ability to deal with multi-cluster deployments, and possible
+  best-fit provisioning in the **future**
+  - Enables the ability for the CSI plugin to act on Topology based requests
+  - Simplifies StorageClass definitions, leaving the choice of the
+    cluster/pool to the CSI plugin
 
 ### Cons
 
-- Addition/Removal of Ceph cluster configuration, to the CSI plugin, requires that the pod specification be updated, and thus the CS and NS pods require to be restarted, in order to pick up the latest cluster details
-    - If done right, the NS restarts should not impact existing volumes that are staged on the node, and the CS should have multiple instances running thus enabling restarting instances one at a time without impacting the provisioning service
+- Addition/Removal of Ceph cluster configuration, to the CSI plugin, requires
+  that the pod specification be updated, and thus the CS and NS pods require
+  to be restarted, in order to pick up the latest cluster details
+  - If done right, the NS restarts should not impact existing volumes that
+    are staged on the node, and the CS should have multiple instances
+    running thus enabling restarting instances one at a time without
+    impacting the provisioning service
 
 ### Configuration specifics
 
@@ -132,7 +194,8 @@ metadata:
   name: fast
 provisioner: csi-rbd
 parameters:
-  # [Optional] defaults to "ext4" allowed values depend on filesystems supported
+  # [Optional] defaults to "ext4" allowed values depend on filesystems
+  # supported
   fsType: ext4
   # [Optional] defaults to "2"
   imageFormat: "2"
@@ -144,7 +207,7 @@ parameters:
   # [Mandatory] carries the pool name to use in the Ceph cluster defined
   #     by clusterID
   pool: <pool-name>
-  # [Optional] All of the following are optional, and have uses as described in,
+  # [Optional] All of the following are optional, and as described in,
   #     https://kubernetes-csi.github.io/docs/secrets-and-credentials.html
   csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
   csi.storage.k8s.io/provisioner-secret-namespace: default
@@ -154,11 +217,18 @@ parameters:
 
 ### VolumeID and Ceph image/sub-directory naming
 
-This section details how we will deal with image/FS names on Ceph cluster, when provisioning volumes based on *volume_name* passed in by the CO, in the CreateVolume request to the CS.
+This section details how we will deal with image/FS names on Ceph cluster, when
+provisioning volumes based on *volume_name* passed in by the CO, in the
+CreateVolume request to the CS.
 
-As per the CSI spec, creation requests come with a *volume_name* that is controlled by the CO and is unique across different volume requests, and the same for a given volume to maintain idempotent create requests.
+As per the CSI spec, creation requests come with a *volume_name* that is
+controlled by the CO and is unique across different volume requests, and the
+same for a given volume to maintain idempotent create requests.
 
-The CSI plugin returns a *volume_id* that is passed to other plugin RPCs to refer to the volume, and is generated by the plugin. Snippet from the spec about the *volume_id*,
+The CSI plugin returns a *volume_id* that is passed to other plugin RPCs to
+refer to the volume, and is generated by the plugin. Snippet from the spec
+about the *volume_id*,
+
 ```
   // This field MUST contain enough information to uniquely identify
   // this specific volume vs all other volumes supported by this plugin.
@@ -168,81 +238,154 @@ The CSI plugin returns a *volume_id* that is passed to other plugin RPCs to refe
 
 #### Name terminology
 
-- **ImageName**: Name of the image as created on Ceph (rbd image name, or CephFS sub-directory)
+- **ImageName**: Name of the image as created on Ceph (rbd image name, or
+  CephFS sub-directory)
 - **volume_id**: Identifier for the *ImageName* as shared with the CO system
-- **csi-id**: Immutable CSI instance ID, to distinguish between different CSI instances, within or across CO systems, that may use the same Ceph cluster
-- **volume_name**: Name of the volume as recognized by the CO system, passed in only during VolumeCreate operation
+- **csi-id**: Immutable CSI instance ID, to distinguish between different CSI
+  instances, within or across CO systems, that may use the same Ceph cluster
+- **volume_name**: Name of the volume as recognized by the CO system, passed in
+  only during VolumeCreate operation
 - **cluster-id**: Ceph cluster fsid
 - **pool-name**: Ceph pool on which image is created
 
 #### Name interpolation rules
 
 1. *ImageName* is known only to Ceph, *volume_id* is known only to the CO system
-2. We should be able to generate *ImageName* given a *volume_id*
-    - This is needed in most NS operations, that receive only the *volume_id* and conditionally the *volume_context* and *publish_context*
-        - *volume_context* and *publish_context* are only cached, and not essentially persisted, hence we cannot rely on payload from the same to complete the transformation
-    - This transformation is needed by the CS specifically for DeleteVolume, DeleteSnapshot and ControllerExpandVolume operations
-3. We should generate the same *ImageName*, when a Create request comes in with the same *volume_name*
-    - CreateVolume may retry with the same *volume_name* on timeouts of the request, and hence we need to generate the same *ImageName* for a given *volume_name*
-4. We should be able to distinguish *ImageName*s that come from an instance of the CSI plugin
-    - When dealing with a common Ceph cluster shared across CO systems, we need the *ImageName* to be distinguishable, to avoid collisions and also to be able support/aid operations like ListVolumes/Snapshots
-    - The same also applies when dealing with different CSI plugin instance in the same CO system, using the same Ceph cluster
+1. We should be able to generate *ImageName* given a *volume_id*
+  - This is needed in most NS operations, that receive only the *volume_id*
+    and conditionally the *volume_context* and *publish_context*
+  - *volume_context* and *publish_context* are only cached, and not
+    essentially persisted, hence we cannot rely on payload from the same
+    to complete the transformation
+  - This transformation is needed by the CS specifically for DeleteVolume,
+    DeleteSnapshot and ControllerExpandVolume operations
+1. We should generate the same *ImageName*, when a Create request comes in with
+  the same *volume_name*
+  - CreateVolume may retry with the same *volume_name* on timeouts of the
+    request, and hence we need to generate the same *ImageName* for a given
+    *volume_name*
+1. We should be able to distinguish *ImageName*s that come from an instance of
+  the CSI plugin
+  - When dealing with a common Ceph cluster shared across CO systems, we need
+    the *ImageName* to be distinguishable, to avoid collisions and also to
+    be able support/aid operations like ListVolumes/Snapshots
+  - The same also applies when dealing with different CSI plugin instance in
+    the same CO system, using the same Ceph cluster
 
 #### Naming scheme
 
-ImageName format: `<csi-id>-xxhash(<volume_name>)`
+ImageName format: `[csi-id]-xxhash([volume_name])`
 
-volume_id format: `<cluster-id>-<pool-name>-xxhash(<volume_name>)`
+volume_id format: `[cluster-id]-[pool-name]-xxhash([volume_name])`
 
-The spec states strings are a maximum of 128 bytes in length. Both *volume_name* and *volume_id* are strings, hence interpolating one into the other can break the size rules. To avoid overflowing the string, we use a hash (suggested xxhash) of the *volume_name* instead. This brings a potential collision problem when 2 *volume_name* hashes clash, to resolve the same the following scheme would be used in CreateVolume,
+The spec states strings are a maximum of 128 bytes in length. Both
+*volume_name* and *volume_id* are strings, hence interpolating one into the
+other can break the size rules. To avoid overflowing the string, we use a hash
+(suggested xxhash) of the *volume_name* instead. This brings a potential
+collision problem when 2 *volume_name* hashes clash, to resolve the same the
+following scheme would be used in CreateVolume,
+
 1. Generate *ImageName* based in passed in *volume_name*
-2. If creation of the image on the Ceph cluster succeeds, stash the *volume_name* as an attribute of the image or an attribute on the root of the FS sub-directory
-3. If creation of the image on the Ceph cluster fails as pre-existing,
-    - Check the *volume_name* attribute of the image to compare against the passed in *volume_name* by the CO
-    - If this matches, the request is a duplicate, and respond with required return codes
-    - If this fails to match,
-        - Generate *ImageName* with a trailing monotonically increasing number (called *instance-n*) and repeat from step 2
+1. If creation of the image on the Ceph cluster succeeds, stash the
+  *volume_name* as an attribute of the image or an attribute on the root of
+  the FS sub-directory
+1. If creation of the image on the Ceph cluster fails as pre-existing,
+  - Check the *volume_name* attribute of the image to compare against the
+    passed in *volume_name* by the CO
+  - If this matches, the request is a duplicate, and respond with required
+    return codes
+  - If this fails to match, generate *ImageName* with a trailing monotonically
+    increasing number (called *instance-n*) and repeat from step 2
 
-*volume_id* hence would be of the following format and size, `<volume_id_version=1:2byte><cluster-id:32bytes><pool-name:80bytes><xxhash(<volume_name>):8bytes><instance-n:6bytes>`
+*volume_id* hence would be of the following format and size,
+`[volume_id_version=1:2byte]
+[cluster-id:32bytes]
+[pool-name:80bytes]
+[xxhash(<volume_name>):8bytes]
+[instance-n:6bytes]`
 
-*ImageName* would be, `<csi-id>-xxhash(<volume_name>)-<instance-n>`
+*ImageName* would be, `[csi-id]-xxhash([volume_name])-[instance-n]`
 
-**Needs Investigation** Each field is padded to reserve/save space if possible, else scheme would shift to using a non-conflicting separator between the same (using up to 4 bytes) or serialized structure elements (as appropriate).
+**Needs Investigation** Each field is padded to reserve/save space if possible,
+else scheme would shift to using a non-conflicting separator between the same
+(using up to 4 bytes) or serialized structure elements (as appropriate).
 
-**Needs Investigation** Need to understand maximum Ceph pool names, and if 76-80 bytes are enough to represent the same.
+**Needs Investigation** Need to understand maximum Ceph pool names, and if
+76-80 bytes are enough to represent the same.
 
 ## Open questions/observations
-- Config maps and secrets are length limited in most CO environments and need careful consideration on amount of information put into each. This is of consequence in design alternatives 1 and 2 below, where a single config map intends to store multiple cluster information.
-- Need to determine and understand how to share config maps and secrets across namespaces in the CO environment
-- Ceph pool names seem arbitrarily long, need to investigate if pools also have an unique ID that can be leveraged
-- Topology constraints as supported by CSI spec, seem to indicate that the CSI plugin can support provisioning volumes for specific zones, which in turn means the ability to process a request from a zone and choose a cluster that fits the need best. This in turn means we may need to support multiple clusters per CSI instance and possibly auto choose one for the request, unless Ceph can support pools across different zones (conceptually), but belong to the same Ceph cluster?
+
+- Config maps and secrets are length limited in most CO environments and need
+  careful consideration on amount of information put into each. This is of
+  consequence in design alternatives 1 and 2 below, where a single config map
+  intends to store multiple cluster information.
+- Need to determine and understand how to share config maps and secrets across
+  namespaces in the CO environment
+- Ceph pool names seem arbitrarily long, need to investigate if pools also have
+  an unique ID that can be leveraged
+- Topology constraints as supported by CSI spec, seem to indicate that the CSI
+  plugin can support provisioning volumes for specific zones, which in turn
+  means the ability to process a request from a zone and choose a cluster that
+  fits the need best. This in turn means we may need to support multiple
+  clusters per CSI instance and possibly auto choose one for the request,
+  unless Ceph can support pools across different zones (conceptually), but
+  belong to the same Ceph cluster?
 
 ## Appendix
+
 ### Solution Alternative-1
 
-#### Summary
-- Create a config map (**ceph-clusters**) containing all Ceph clusters that the CSI plugin may need to provision storage from, and keep this updated with new and changing information as required (by a human or an automated operator).
-- Further, create a secret blob (**ceph-cluster-secrets**), containing secrets for each Ceph cluster in the above **ceph-clusters**. This is updated as the secrets change or new clusters are added.
-- *ceph-clusters* is used by the CS, and required information passed to the NS via *volume_context* and *publish_context* maps, from CreateVolume and ControllerPublishVolume responses respectively (as per the CSI spec)
-    - *publish_context* carries the latest MON information, as this is invoked each time the volume needs to be published
-    - *volume_context* can carry other required information (e.g: cluster ID, pool name), information that remains immutable for the lifetime of the provisioned volume
-- *ceph-clusters-secret* is used by the CS and the NS, when the required secrets are not present in the CSI secrets fields (e.g: when not specified in the StorageClass)
+#### Summary alternative-1
 
-#### Pros:
-- Addresses removal of the current config map that maintains list of provisioned volumes
-- Adding new Ceph cluster details to *ceph-clusters* does not need the CS or NS pods to be restarted, as the config map updates will eventually refresh within the container
+- Create a config map (**ceph-clusters**) containing all Ceph clusters that the
+  CSI plugin may need to provision storage from, and keep this updated with
+  new and changing information as required (by a human or an automated
+  operator).
+- Further, create a secret blob (**ceph-cluster-secrets**), containing secrets
+  for each Ceph cluster in the above **ceph-clusters**. This is updated as the
+  secrets change or new clusters are added.
+- *ceph-clusters* is used by the CS, and required information passed to the NS
+  via *volume_context* and *publish_context* maps, from CreateVolume and
+  ControllerPublishVolume responses respectively (as per the CSI spec)
+  - *publish_context* carries the latest MON information, as this is invoked
+    each time the volume needs to be published
+  - *volume_context* can carry other required information (e.g: cluster ID,
+    pool name), information that remains immutable for the lifetime of the
+    provisioned volume
+- *ceph-clusters-secret* is used by the CS and the NS, when the required secrets
+  are not present in the CSI secrets fields (e.g: when not specified in the
+  StorageClass)
+
+#### Pros alternative-1
+
+- Addresses removal of the current config map that maintains list of provisioned
+  volumes
+- Adding new Ceph cluster details to *ceph-clusters* does not need the CS or NS
+  pods to be restarted, as the config map updates will eventually refresh
+  within the container
 - StorageClass can still specify secrets in case it wants it to be specialized,
-    - Although, we will not get the secret information in the following operations, ListVolumes, ListSnapshots, and GetCapacity
-- CS and NS pods do not need a restart when clusters are added or removed from the global config map
+  - Although, we will not get the secret information in the following
+    operations, ListVolumes, ListSnapshots, and GetCapacity
+- CS and NS pods do not need a restart when clusters are added or removed from
+  the global config map
 
-#### Cons:
-- *ceph-clusters* config map either needs to be exposed to namespaces that need to manage their cluster information instance (say multiple Rook instances, if each is managing a Ceph cluster of its own)
-- *ceph-cluster-secrets* also, suffers the above constraint and can be a security concern as different namespace admins can read/write others secrets
+#### Cons alternative-1
 
-#### Other notes:
-- GetCapacity request does not have targeted cluster information, hence response would be across all clusters in *ceph-clusters* that satisfy the passed in Topology
-- ListVolumes and ListSnapshots operations, will return all Volumes across all clusters that are a part of *ceph-clusters*
-    - Assuming ListSnapshots comes with no *source_volume_id* or *snapshot_id* as these are optional fields
+- *ceph-clusters* config map either needs to be exposed to namespaces that need
+  to manage their cluster information instance (say multiple Rook instances,
+  if each is managing a Ceph cluster of its own)
+- *ceph-cluster-secrets* also, suffers the above constraint and can be a
+  security concern as different namespace admins can read/write others secrets
+
+#### Other notes alternative-1
+
+- GetCapacity request does not have targeted cluster information, hence
+  response would be across all clusters in *ceph-clusters* that satisfy the
+  passed in Topology
+- ListVolumes and ListSnapshots operations, will return all Volumes across all
+  clusters that are a part of *ceph-clusters*
+  - Assuming ListSnapshots comes with no *source_volume_id* or *snapshot_id*
+    as these are optional fields
 
 #### Alternative-1 configuration details
 
@@ -279,53 +422,79 @@ The spec states strings are a maximum of 128 bytes in length. Both *volume_name*
 
 ### Solution Alternative-2
 
-#### Summary
+#### Summary alternative-2
 
-- Primary aim of this alternative is to avoid sharing the *ceph-cluster-secrets* across namespaces as in Alternative-1
-- Hence, move *ceph-cluster-secrets* to being mandatory in the StorageClass, avoiding sharing cross-cluster secrets in a single secrets blob
+- Primary aim of this alternative is to avoid sharing the *ceph-cluster-secrets*
+  across namespaces as in Alternative-1
+- Hence, move *ceph-cluster-secrets* to being mandatory in the StorageClass,
+  avoiding sharing cross-cluster secrets in a single secrets blob
 
-#### Pros:
+#### Pros alternative-2
 
 - Retains all of the prior pros in Alternative-1
-- Does not leak secrets across separate Ceph clusters, possibly managed by different namespaces as there exists no *ceph-cluster-secrets*
+- Does not leak secrets across separate Ceph clusters, possibly managed by
+  different namespaces as there exists no *ceph-cluster-secrets*
 
-#### Cons:
+#### Cons alternative-2
 
-- *ceph-cluster-secrets* is absent and hence following operations **cannot** be supported
-    - ListVolumes, ListSnapshots, and GetCapacity
-    - **NOTE:** Unless listing rbd and CephFS volumes can be done without credentials
+- *ceph-cluster-secrets* is absent and hence following operations **cannot**
+  be supported
+  - ListVolumes, ListSnapshots, and GetCapacity
+  - **NOTE:** Unless listing rbd and CephFS volumes can be done without
+    credentials
 - Bloats every StorageClass making secrets mandatory
 - Retains other cons as in Alternative-1
 
 ### Solution Alternative-3
 
-#### Summary
+#### Summary alternative-3
 
-- Address *ceph-clusters* being accessible to all namespaces that need to manage it
-- Move the information in *ceph-clusters* to secrets in the StorageClass (as in monValueFromSecret configuration implementation in the code as of this writing)
+- Address *ceph-clusters* being accessible to all namespaces that need to
+  manage it
+- Move the information in *ceph-clusters* to secrets in the StorageClass (as in
+  monValueFromSecret configuration implementation in the code as of this
+  writing)
 
-#### Pros and Cons
+#### Pros and cons alternative-3
 
-- Cons remains the same, with further added complexity in the StorageClass and its secrets
-- Removes the con in Alternate-1 and 2 where the *ceph-clusters* information is accessible across namespaces
+- Cons remains the same, with further added complexity in the StorageClass and
+  its secrets
+- Removes the con in Alternate-1 and 2 where the *ceph-clusters* information is
+  accessible across namespaces
 
 ### Solution Alternative-4
 
-#### Summary
+#### Summary alternative-4
 
-- Create a CSI plugin instance per Ceph cluster, with its own unique provisioner name
-- Each CSI plugin instance can now have its own *ceph-cluster* and *ceph-secrets* config maps, where *ceph-cluster* contains information regarding exactly one cluster and similarly the *ceph-secret* for the same
-- StorageClass points to the provisioner name and does not need secrets, cluster-id and may optionally choose to contain pool-name (can be omitted, if we choose to to allocate from an available pool in the cluster rather than a specific pool, based on the CreateVolume request parameters and Topology)
+- Create a CSI plugin instance per Ceph cluster, with its own unique provisioner
+  name
+- Each CSI plugin instance can now have its own *ceph-cluster* and
+  *ceph-secrets* config maps, where *ceph-cluster* contains information
+  regarding exactly one cluster and similarly the *ceph-secret* for the same
+- StorageClass points to the provisioner name and does not need secrets,
+  cluster-id and may optionally choose to contain pool-name (can be omitted,
+  if we choose to to allocate from an available pool in the cluster rather
+  than a specific pool, based on the CreateVolume request parameters and
+  Topology)
 
-#### Pros
+#### Pros alternative-4
 
-- Can support all Operations, as cluster information and secrets are per instance
-- The secrets and cluster information need not be shared across multiple namespaces
-- StorageClass becomes leaner, but still needs at least as many StorageClasses as there are clusters backing the CO environment
-- Allows for future merging of the CSI instances, reverting to the StorageClass as in the proposed solution
+- Can support all Operations, as cluster information and secrets are per
+  instance
+- The secrets and cluster information need not be shared across multiple
+  namespaces
+- StorageClass becomes leaner, but still needs at least as many StorageClasses
+  as there are clusters backing the CO environment
+- Allows for future merging of the CSI instances, reverting to the StorageClass
+  as in the proposed solution
 
-#### Cons
+#### Cons alternative-4
 
-- We will have as many NodeService entities as there are clusters in each node of the CO environment. This may consume more resources
-- We cannot, deal with multiple Ceph clusters backed by a single CSI plugin instance, due to the strict 1:1 mapping between the same, and thus do any form of intelligent provisioning across Ceph clusters for a request
-- **Needs Investigation** Does this hinder Topology based volume provisioning? As each instance is stuck to single Ceph cluster, we cannot provision from different Topologies (each with their own Ceph clusters)
+- We will have as many NodeService entities as there are clusters in each node
+  of the CO environment. This may consume more resources
+- We cannot, deal with multiple Ceph clusters backed by a single CSI plugin
+  instance, due to the strict 1:1 mapping between the same, and thus do any
+  form of intelligent provisioning across Ceph clusters for a request
+- **Needs Investigation** Does this hinder Topology based volume provisioning?
+  As each instance is stuck to single Ceph cluster, we cannot provision from
+  different Topologies (each with their own Ceph clusters)

--- a/docs/design/proposals/stateless-csi-plugin.md
+++ b/docs/design/proposals/stateless-csi-plugin.md
@@ -1,0 +1,331 @@
+# Stateless Ceph-CSI plugin implementation
+
+## Terminology
+
+- CO: Container orchestration system, communicates with CSI plugins using CSI RPCs
+- NS: Node Service; CSI plugin service per node in the CO, responsible for staging volumes for application pod consumption
+- CS: Controller Service; CSI plugin service responsible for creation, deletion, snapshots, and expanding volumes for use in the CO system
+
+**NOTE:**
+
+- Discussion below may use k8s specific terminology, but should be extensible to similar constructs on other container orchestration(CO) systems
+
+## Proposal/problem summary
+
+This document details a proposed solution, among presented alternatives, to implement a stateless Ceph-CSI plugin. It also details a naming scheme for volumes provisioned against a Ceph cluster and the resultant *volume_id* for the same that is shared with the CO system, enabling state to be carried by the *volume_id* where required.
+
+As of this writing, the plugin uses a config map to store *volume_name* to *volume_id* mapping, and also stores related Ceph cluster configuration information (e.g MON list, pool information) within the same tuple, to be able to find and operate on the provisioned volume. The implementation also depends on secrets from the StorageClass to perform NS related operations.
+
+The existing strategy enables a single CSI instance to operate across any Ceph cluster that is fully defined by the StorageClass, but brings in the burden of storing and managing provisioned volumes by the plugin.
+
+The proposal laid out here is to try and retain the ability for a single CSI instance to operate across any Ceph cluster, but remove the storage and management of provisioned CSI volumes by the plugin, or in short make the Ceph-CSI plugin stateless. Further, if this is achieved, it is also possible to run multiple replicas of the CS instance, to aid with load balancing of requests, than the current one instance limitation due to the existing config map.
+
+## Proposed solution details
+
+### Summary
+
+- Create a config map per Ceph cluster called `ceph-cluster-<cluster-fsid>` and a pair of secrets to go along with the same cluster called `ceph-cluster-<cluster-fsid>-provisioner-secret` and `ceph-cluster-<cluster-fsid>-publish-secret`
+- Allow the CS and NS namespaces access to the above config maps and secrets, in addition to the namespace that is responsible for creating and maintaining it
+    - **Needs Investigation** Unsure if secrets and config maps can be shared (via RBAC?) across namespaces or service accounts. This maybe needed if we need operator managed Ceph instances to be able to pass cluster configuration information to the CSI instance, and are in different namespaces for e.g.
+- Details about the Ceph cluster are maintained in `ceph-cluster-<cluster-fsid>`. Details include cluster-id, MONs, pools, and other relevant data. Also, these and the corresponding secrets are updated when they change, to reflect current values
+- The CSI plugin pod adds these config maps and secrets as volumes to its pod specification, thus ensuring auto-refresh of content when these are updated by the CO environment
+- VolumeCreate requests come against a targeted Ceph cluster-id and pool, enabling the CSI plugin to locate the appropriate configuration information for the cluster and its secrets to act on the request
+    - **NOTE:** The cluster-id and pool information is specified in the StorageClass for example
+    - **NOTE:** In the **future**, if it is desired that the CSI plugin CS choose which cluster and pool a request should be served from, this information can be omitted from the StorageClass
+- The *volume_id* carries information regarding the *cluster_id* and pool, enabling *volume_id* based RPC requests to operate using the provided configuration information against the respective cluster
+- Usual CSI spec based maps such as, *volume_context* and *publish_context* continue to carry information regarding required aspects about the provisioned volume to dependent RPCs
+- The NS also has access to the config maps and secrets to satisfy required node level RPC requests
+
+### Pros
+
+- Addresses removal of the current config map that maintains list of provisioned volumes
+- Provides the ability for the CSI plugin to support all RPCs, as required information is present with the plugin across all Ceph clusters
+- Safeguards secrets and cluster configuration information access to only required namespaces that need to manage and use it
+- Provides the ability to have a single Ceph-CSI plugin instance per CO instance, even when the CO instance needs volumes provisioned from multiple Ceph clusters
+- Also, does not take away the capability, where needed, to use multiple Ceph-CSI plugin instances (specialized using provisioner name) per CO instance
+- Leaves the flexibility for the StorageClass to still override secrets, if such requirements arise
+    - **NOTE:** The credentials stored for a cluster and passed to the CSI plugins CS and NS, should be able to list volumes/images created using other secrets (IOW, should act like a supervisor/root) to correctly support ListVolumes and ListSnapshots operations
+- Provides the ability to deal with multi-cluster deployments, and possible best-fit provisioning in the **future**
+    - Enables the ability for the CSI plugin to act on Topology based requests
+    - Simplifies StorageClass definitions, leaving the choice of the cluster/pool to the CSI plugin
+
+### Cons
+
+- Addition/Removal of Ceph cluster configuration, to the CSI plugin, requires that the pod specification be updated, and thus the CS and NS pods require to be restarted, in order to pick up the latest cluster details
+    - If done right, the NS restarts should not impact existing volumes that are staged on the node, and the CS should have multiple instances running thus enabling restarting instances one at a time without impacting the provisioning service
+
+### Configuration specifics
+
+#### `ceph-cluster-<cluster-fsid>` config map contents JSON representation
+
+```
+{
+  "<clusterID>": {
+    "monitors": [
+      "IP/DNS:port",
+      ...
+    ],
+    "pools": [
+      <pool-name>,
+      ...
+    ]
+  }
+}
+```
+
+#### `ceph-cluster-<cluster-fsid>-[provisioner|publish]-secret` definition
+
+```
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ceph-cluster-<cluster-fsid>-*-secret
+  namespace: default
+data:
+  # ID of the admin/user
+  subjectid: BASE64-ENCODED-ID
+  # Credentials of the above admin/user
+  credentials: BASE64-ENCODED-PASSWORD
+```
+
+#### Ceph-CSI pod specification to pass secrets and cluster configuration
+
+```
+...
+    spec:
+      containers:
+      - name: csi-rbdplugin
+        ...
+        volumeMounts:
+        - name: ceph-secrets-<cluster-fsid>
+          mountPath: "/etc/ceph-secrets"
+          readOnly: true
+        volumeMounts:
+        - name: ceph-cluster-<cluster-fsid>-map
+          mountPath: "/etc/ceph-configuration/"
+          readOnly: true
+        ...
+      volumes:
+      ...
+      - name: ceph-secrets-<cluster-fsid>
+        secret:
+          secretName: ceph-<cluster-cluster-fsid>-*-secret
+          items:
+          - key: subjectid
+            path: ceph-cluster-<cluster-fsid>-*-secret/subjectid
+          - key: credentials
+            path: ceph-cluster-<cluster-fsid>-*-secret/credentials
+      - name: ceph-cluster-<cluster-fsid>-map
+        configMap:
+          name: ceph-cluster-<cluster-fsid>
+      ...
+...
+```
+
+#### Annotated YAML for StorageClass
+
+```
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: csi-rbd
+parameters:
+  # [Optional] defaults to "ext4" allowed values depend on filesystems supported
+  fsType: ext4
+  # [Optional] defaults to "2"
+  imageFormat: "2"
+  # [Optional], can be specified when imageFormat is used, defaults to "",
+  #     possible values "layering"
+  imageFeatures: "layering"
+  # [Mandatory] carries the fsid of the Ceph cluster
+  clusterID: <ID>
+  # [Mandatory] carries the pool name to use in the Ceph cluster defined
+  #     by clusterID
+  pool: <pool-name>
+  # [Optional] All of the following are optional, and have uses as described in,
+  #     https://kubernetes-csi.github.io/docs/secrets-and-credentials.html
+  csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: default
+```
+
+### VolumeID and Ceph image/sub-directory naming
+
+This section details how we will deal with image/FS names on Ceph cluster, when provisioning volumes based on *volume_name* passed in by the CO, in the CreateVolume request to the CS.
+
+As per the CSI spec, creation requests come with a *volume_name* that is controlled by the CO and is unique across different volume requests, and the same for a given volume to maintain idempotent create requests.
+
+The CSI plugin returns a *volume_id* that is passed to other plugin RPCs to refer to the volume, and is generated by the plugin. Snippet from the spec about the *volume_id*,
+```
+  // This field MUST contain enough information to uniquely identify
+  // this specific volume vs all other volumes supported by this plugin.
+  // This field SHALL be used by the CO in subsequent calls to refer to
+  // this volume.
+```
+
+#### Name terminology
+
+- **ImageName**: Name of the image as created on Ceph (rbd image name, or CephFS sub-directory)
+- **volume_id**: Identifier for the *ImageName* as shared with the CO system
+- **csi-id**: Immutable CSI instance ID, to distinguish between different CSI instances, within or across CO systems, that may use the same Ceph cluster
+- **volume_name**: Name of the volume as recognized by the CO system, passed in only during VolumeCreate operation
+- **cluster-id**: Ceph cluster fsid
+- **pool-name**: Ceph pool on which image is created
+
+#### Name interpolation rules
+
+1. *ImageName* is known only to Ceph, *volume_id* is known only to the CO system
+2. We should be able to generate *ImageName* given a *volume_id*
+    - This is needed in most NS operations, that receive only the *volume_id* and conditionally the *volume_context* and *publish_context*
+        - *volume_context* and *publish_context* are only cached, and not essentially persisted, hence we cannot rely on payload from the same to complete the transformation
+    - This transformation is needed by the CS specifically for DeleteVolume, DeleteSnapshot and ControllerExpandVolume operations
+3. We should generate the same *ImageName*, when a Create request comes in with the same *volume_name*
+    - CreateVolume may retry with the same *volume_name* on timeouts of the request, and hence we need to generate the same *ImageName* for a given *volume_name*
+4. We should be able to distinguish *ImageName*s that come from an instance of the CSI plugin
+    - When dealing with a common Ceph cluster shared across CO systems, we need the *ImageName* to be distinguishable, to avoid collisions and also to be able support/aid operations like ListVolumes/Snapshots
+    - The same also applies when dealing with different CSI plugin instance in the same CO system, using the same Ceph cluster
+
+#### Naming scheme
+
+ImageName format: `<csi-id>-xxhash(<volume_name>)`
+
+volume_id format: `<cluster-id>-<pool-name>-xxhash(<volume_name>)`
+
+The spec states strings are a maximum of 128 bytes in length. Both *volume_name* and *volume_id* are strings, hence interpolating one into the other can break the size rules. To avoid overflowing the string, we use a hash (suggested xxhash) of the *volume_name* instead. This brings a potential collision problem when 2 *volume_name* hashes clash, to resolve the same the following scheme would be used in CreateVolume,
+1. Generate *ImageName* based in passed in *volume_name*
+2. If creation of the image on the Ceph cluster succeeds, stash the *volume_name* as an attribute of the image or an attribute on the root of the FS sub-directory
+3. If creation of the image on the Ceph cluster fails as pre-existing,
+    - Check the *volume_name* attribute of the image to compare against the passed in *volume_name* by the CO
+    - If this matches, the request is a duplicate, and respond with required return codes
+    - If this fails to match,
+        - Generate *ImageName* with a trailing monotonically increasing number (called *instance-n*) and repeat from step 2
+
+*volume_id* hence would be of the following format and size, `<volume_id_version=1:2byte><cluster-id:32bytes><pool-name:80bytes><xxhash(<volume_name>):8bytes><instance-n:6bytes>`
+
+*ImageName* would be, `<csi-id>-xxhash(<volume_name>)-<instance-n>`
+
+**Needs Investigation** Each field is padded to reserve/save space if possible, else scheme would shift to using a non-conflicting separator between the same (using up to 4 bytes) or serialized structure elements (as appropriate).
+
+**Needs Investigation** Need to understand maximum Ceph pool names, and if 76-80 bytes are enough to represent the same.
+
+## Open questions/observations
+- Config maps and secrets are length limited in most CO environments and need careful consideration on amount of information put into each. This is of consequence in design alternatives 1 and 2 below, where a single config map intends to store multiple cluster information.
+- Need to determine and understand how to share config maps and secrets across namespaces in the CO environment
+- Ceph pool names seem arbitrarily long, need to investigate if pools also have an unique ID that can be leveraged
+- Topology constraints as supported by CSI spec, seem to indicate that the CSI plugin can support provisioning volumes for specific zones, which in turn means the ability to process a request from a zone and choose a cluster that fits the need best. This in turn means we may need to support multiple clusters per CSI instance and possibly auto choose one for the request, unless Ceph can support pools across different zones (conceptually), but belong to the same Ceph cluster?
+
+## Appendix
+### Solution Alternative-1
+
+#### Summary
+- Create a config map (**ceph-clusters**) containing all Ceph clusters that the CSI plugin may need to provision storage from, and keep this updated with new and changing information as required (by a human or an automated operator).
+- Further, create a secret blob (**ceph-cluster-secrets**), containing secrets for each Ceph cluster in the above **ceph-clusters**. This is updated as the secrets change or new clusters are added.
+- *ceph-clusters* is used by the CS, and required information passed to the NS via *volume_context* and *publish_context* maps, from CreateVolume and ControllerPublishVolume responses respectively (as per the CSI spec)
+    - *publish_context* carries the latest MON information, as this is invoked each time the volume needs to be published
+    - *volume_context* can carry other required information (e.g: cluster ID, pool name), information that remains immutable for the lifetime of the provisioned volume
+- *ceph-clusters-secret* is used by the CS and the NS, when the required secrets are not present in the CSI secrets fields (e.g: when not specified in the StorageClass)
+
+#### Pros:
+- Addresses removal of the current config map that maintains list of provisioned volumes
+- Adding new Ceph cluster details to *ceph-clusters* does not need the CS or NS pods to be restarted, as the config map updates will eventually refresh within the container
+- StorageClass can still specify secrets in case it wants it to be specialized,
+    - Although, we will not get the secret information in the following operations, ListVolumes, ListSnapshots, and GetCapacity
+- CS and NS pods do not need a restart when clusters are added or removed from the global config map
+
+#### Cons:
+- *ceph-clusters* config map either needs to be exposed to namespaces that need to manage their cluster information instance (say multiple Rook instances, if each is managing a Ceph cluster of its own)
+- *ceph-cluster-secrets* also, suffers the above constraint and can be a security concern as different namespace admins can read/write others secrets
+
+#### Other notes:
+- GetCapacity request does not have targeted cluster information, hence response would be across all clusters in *ceph-clusters* that satisfy the passed in Topology
+- ListVolumes and ListSnapshots operations, will return all Volumes across all clusters that are a part of *ceph-clusters*
+    - Assuming ListSnapshots comes with no *source_volume_id* or *snapshot_id* as these are optional fields
+
+#### Alternative-1 configuration details
+
+##### JSON representation of *ceph-clusters*
+
+```
+{
+  "<clusterID>": {
+    "monitors": [
+      "IP/DNS:port",
+      ...
+    ],
+  },
+  ...
+}
+```
+
+##### JSON representation of *ceph-cluster-secrets*
+
+```
+{
+  "<clusterID>": {
+    "adminId": "kube",
+    "adminSecretName": "ceph-secret",
+    "adminSecretNamespace": "kube-system",
+
+    "userId": "kube",
+    "userSecretName": "ceph-secret-user",
+    "userSecretNamespace": "default",
+  },
+  ...
+}
+```
+
+### Solution Alternative-2
+
+#### Summary
+
+- Primary aim of this alternative is to avoid sharing the *ceph-cluster-secrets* across namespaces as in Alternative-1
+- Hence, move *ceph-cluster-secrets* to being mandatory in the StorageClass, avoiding sharing cross-cluster secrets in a single secrets blob
+
+#### Pros:
+
+- Retains all of the prior pros in Alternative-1
+- Does not leak secrets across separate Ceph clusters, possibly managed by different namespaces as there exists no *ceph-cluster-secrets*
+
+#### Cons:
+
+- *ceph-cluster-secrets* is absent and hence following operations **cannot** be supported
+    - ListVolumes, ListSnapshots, and GetCapacity
+    - **NOTE:** Unless listing rbd and CephFS volumes can be done without credentials
+- Bloats every StorageClass making secrets mandatory
+- Retains other cons as in Alternative-1
+
+### Solution Alternative-3
+
+#### Summary
+
+- Address *ceph-clusters* being accessible to all namespaces that need to manage it
+- Move the information in *ceph-clusters* to secrets in the StorageClass (as in monValueFromSecret configuration implementation in the code as of this writing)
+
+#### Pros and Cons
+
+- Cons remains the same, with further added complexity in the StorageClass and its secrets
+- Removes the con in Alternate-1 and 2 where the *ceph-clusters* information is accessible across namespaces
+
+### Solution Alternative-4
+
+#### Summary
+
+- Create a CSI plugin instance per Ceph cluster, with its own unique provisioner name
+- Each CSI plugin instance can now have its own *ceph-cluster* and *ceph-secrets* config maps, where *ceph-cluster* contains information regarding exactly one cluster and similarly the *ceph-secret* for the same
+- StorageClass points to the provisioner name and does not need secrets, cluster-id and may optionally choose to contain pool-name (can be omitted, if we choose to to allocate from an available pool in the cluster rather than a specific pool, based on the CreateVolume request parameters and Topology)
+
+#### Pros
+
+- Can support all Operations, as cluster information and secrets are per instance
+- The secrets and cluster information need not be shared across multiple namespaces
+- StorageClass becomes leaner, but still needs at least as many StorageClasses as there are clusters backing the CO environment
+- Allows for future merging of the CSI instances, reverting to the StorageClass as in the proposed solution
+
+#### Cons
+
+- We will have as many NodeService entities as there are clusters in each node of the CO environment. This may consume more resources
+- We cannot, deal with multiple Ceph clusters backed by a single CSI plugin instance, due to the strict 1:1 mapping between the same, and thus do any form of intelligent provisioning across Ceph clusters for a request
+- **Needs Investigation** Does this hinder Topology based volume provisioning? As each instance is stuck to single Ceph cluster, we cannot provision from different Topologies (each with their own Ceph clusters)


### PR DESCRIPTION
Introduce CSI plugin configuration, per Ceph cluster that is
used for provisioning storage, in lieu of the existing config
map based volume store.

Signed-off-by: ShyamsundarR <srangana@redhat.com>