### PR TITLE
update cephfs_data to cephfs-data

### DIFF
--- a/examples/cephfs/storageclass.yaml
+++ b/examples/cephfs/storageclass.yaml
@@ -20,7 +20,7 @@ parameters:
 
   # Ceph pool into which the volume shall be created
   # Required for provisionVolume: "true"
-  pool: cephfs_data
+  pool: cephfs-data
 
   # Root path of an existing CephFS volume
   # Required for provisionVolume: "false"


### PR DESCRIPTION
cannot create file system with name cephfs_data

```bash
cat cluster/examples/kubernetes/ceph/filesystem.yaml
apiVersion: ceph.rook.io/v1
kind: CephFilesystem
metadata:
  name: cephfs_data
  namespace: rook-ceph
spec:
  # The metadata pool spec
  metadataPool:
    replicated:
...
```

```
kube create -f cluster/examples/kubernetes/ceph/filesystem.yaml
The CephFilesystem "cephfs_data" is invalid: metadata.name: Invalid value: "cephfs_data": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

this PR updates the cepfs pool name
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>