### PR TITLE
Fixed DeleteVolume/snapshot metadata idempotency

### DIFF
--- a/pkg/util/cachepersister.go
+++ b/pkg/util/cachepersister.go
@@ -23,12 +23,18 @@ import (
 )
 
 const (
-	//PluginFolder defines location of plugins
+	// PluginFolder defines location of plugins
 	PluginFolder = "/var/lib/kubelet/plugins"
 )
 
-// ForAllFunc stores metadata with identifier
+// ForAllFunc is a unary predicate for visiting all cache entries
+// matching the `pattern' in CachePersister's ForAll function.
 type ForAllFunc func(identifier string) error
+
+// CacheEntryNotFound is an error type for "Not Found" cache errors
+type CacheEntryNotFound struct {
+	error
+}
 
 // CachePersister interface implemented for store
 type CachePersister interface {

--- a/pkg/util/k8scmcache.go
+++ b/pkg/util/k8scmcache.go
@@ -159,6 +159,10 @@ func (k8scm *K8sCMCache) Create(identifier string, data interface{}) error {
 func (k8scm *K8sCMCache) Get(identifier string, data interface{}) error {
 	cm, err := k8scm.getMetadataCM(identifier)
 	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return &CacheEntryNotFound{err}
+		}
+
 		return err
 	}
 	err = json.Unmarshal([]byte(cm.Data[cmDataKey]), data)

--- a/pkg/util/nodecache.go
+++ b/pkg/util/nodecache.go
@@ -130,6 +130,10 @@ func (nc *NodeCache) Get(identifier string, data interface{}) error {
 	// #nosec
 	fp, err := os.Open(file)
 	if err != nil {
+		if os.IsNotExist(errors.Cause(err)) {
+			return &CacheEntryNotFound{err}
+		}
+
 		return errors.Wrapf(err, "node-cache: open error for %s", file)
 	}
 


### PR DESCRIPTION
In `DeleteVolume`/`DeleteSnapshot` RPCs, we perform the deletion of metadata as the final step, meaning all the steps before had to be successful. This PR makes those RPCs assume that if the metadata is missing, the volume/snapshot has been already deleted and will return with success - of course that doesn't protect us against accidental CM deletions causing volume/snapshot leaks, unfortunately.

* `Get()`-ing a non-existent cache entry will now result in a `CacheEntryNotFound` error. This is used to distinguish between "not found" errors and everything else when querying for entries
* if the error is "not found" in Delete operations, we return with success