### PR TITLE
store volume size in bytes in configmap

### DIFF
--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -181,6 +181,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if err != nil {
 		return nil, err
 	}
+	// store volume size in  bytes (snapshot and check existing volume needs volume
+	// size in bytes)
+	rbdVol.VolSize = rbdVol.VolSize * util.MiB
 
 	rbdVolumes[rbdVol.VolID] = rbdVol
 
@@ -191,7 +194,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      rbdVol.VolID,
-			CapacityBytes: rbdVol.VolSize * util.MiB,
+			CapacityBytes: rbdVol.VolSize,
 			VolumeContext: req.GetParameters(),
 		},
 	}, nil


### PR DESCRIPTION
during volume creation we check volume size in
bytes, and even during listing of volumes and
snapshots we need to check size in bytes

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

logs
```
[🎩]mrajanna@localhost rbd $]kubectl get pvc
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
rbd-pvc   Bound    pvc-9fb7314d-44c6-11e9-a8b9-525400973e8d   1Gi        RWO            csi-rbd        8s
```
```
[🎩]mrajanna@localhost rbd $]kubectl describe cm
Name:         csi-rbd-vol-a30ee2b3-44c6-11e9-90b3-0242ac11000e
Namespace:    default
Labels:       com.ceph.ceph-csi/metadata=csi-metadata
Annotations:  <none>

Data
====
content:
----
{"volName":"pvc-9fb7314d-44c6-11e9-a8b9-525400973e8d","volID":"csi-rbd-vol-a30ee2b3-44c6-11e9-90b3-0242ac11000e","monitors":"rook-ceph-mon-b.rook-ceph.svc.cluster.local:6789","monValueFromSecret":"","pool":"rbd","imageFormat":"2","imageFeatures":"layering","volSize":1073741824,"adminId":"admin","userId":"admin","mounter":"rbd","multiNodeWritable":""}

```
```
[🎩]mrajanna@localhost rbd $]kubectl describe volumesnapshot
Name:         rbd-pvc-snapshot
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  snapshot.storage.k8s.io/v1alpha1
Kind:         VolumeSnapshot
Metadata:
  Creation Timestamp:  2019-03-12T12:59:47Z
  Finalizers:
    snapshot.storage.kubernetes.io/volumesnapshot-protection
  Generation:        5
  Resource Version:  7533
  Self Link:         /apis/snapshot.storage.k8s.io/v1alpha1/namespaces/default/volumesnapshots/rbd-pvc-snapshot
  UID:               b6d3dfc0-44c6-11e9-a8b9-525400973e8d
Spec:
  Snapshot Class Name:    csi-rbdplugin-snapclass
  Snapshot Content Name:  snapcontent-b6d3dfc0-44c6-11e9-a8b9-525400973e8d
  Source:
    API Group:  <nil>
    Kind:       PersistentVolumeClaim
    Name:       rbd-pvc
Status:
  Creation Time:  2019-03-12T12:59:47Z
  Ready To Use:   true
  Restore Size:   1Gi
Events:           <none>

```