### PR TITLE
rename socket directory to a common name

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -34,11 +34,11 @@ spec:
             - "--v=5"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/cephfs.csi.ceph.com/csi-provisioner.sock
+              value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
+              mountPath: /csi
         - name: csi-cephfsplugin
           securityContext:
             privileged: true
@@ -61,11 +61,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CSI_ENDPOINT
-              value: unix://var/lib/kubelet/plugins/cephfs.csi.ceph.com/csi-provisioner.sock
+              value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
+              mountPath: /csi
             - name: host-sys
               mountPath: /sys
             - name: lib-modules

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -65,11 +65,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CSI_ENDPOINT
-              value: unix://var/lib/kubelet/plugins/cephfs.csi.ceph.com/csi.sock
+              value: unix:///csi/csi.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: plugin-dir
-              mountPath: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
+              mountPath: /csi
             - name: csi-plugins-dir
               mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
               mountPropagation: "Bidirectional"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-attacher.yaml
@@ -34,11 +34,11 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/rbd.csi.ceph.com/csi.sock
+              value: unix:///csi/csi-attacher.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/rbd.csi.ceph.com
+              mountPath: /csi
       volumes:
         - name: socket-dir
           hostPath:

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -34,11 +34,11 @@ spec:
             - "--v=5"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/rbd.csi.ceph.com/csi-provisioner.sock
+              value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/rbd.csi.ceph.com
+              mountPath: /csi
         - name: csi-snapshotter
           image: quay.io/k8scsi/csi-snapshotter:v1.0.1
           args:
@@ -47,13 +47,13 @@ spec:
             - "--v=5"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/rbd.csi.ceph.com/csi-provisioner.sock
+              value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/rbd.csi.ceph.com
+              mountPath: /csi
         - name: csi-rbdplugin
           securityContext:
             privileged: true
@@ -79,11 +79,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CSI_ENDPOINT
-              value: unix://var/lib/kubelet/plugins/rbd.csi.ceph.com/csi-provisioner.sock
+              value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/rbd.csi.ceph.com
+              mountPath: /csi
             - mountPath: /dev
               name: host-dev
             - mountPath: /rootfs

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -69,11 +69,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CSI_ENDPOINT
-              value: unix://var/lib/kubelet/plugins_registry/rbd.csi.ceph.com/csi.sock
+              value: unix:///csi/csi.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: plugin-dir
-              mountPath: /var/lib/kubelet/plugins_registry/rbd.csi.ceph.com
+              mountPath: /csi
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"


### PR DESCRIPTION
as the socket directory will be created inside the container no need to follow the plugin name in for the directory creation, this will also reduce the code changes if we want to change driver name.

Fixes: https://github.com/ceph/ceph-csi/pull/223#discussion_r263822438
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>