### PR TITLE
add mergify as a merge engine

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+pull_request_rules:
+  - name: automatic merge
+    conditions:
+      - label!=DNM
+      - '#approved-reviews-by>=1'
+      - 'status-success=continuous-integration/travis-ci/pr'
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: merge
+        strict: smart
+      dismiss_reviews: {}
+      delete_head_branch: {}


### PR DESCRIPTION
From now on, each PR will be merged automatically if:

* there is no DNM label on the PR AND
* the PR has at least one approuval AND
* the travis CI successfully passed

Closes: https://github.com/ceph/ceph-csi/issues/154
Signed-off-by: Sébastien Han <seb@redhat.com>