### PR TITLE
[WIP][DNM][RFC] Create a unified binary and container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ RBD_IMAGE_VERSION=$(if $(ENV_RBD_IMAGE_VERSION),$(ENV_RBD_IMAGE_VERSION),v1.0.0)
 CEPHFS_IMAGE_NAME=$(if $(ENV_CEPHFS_IMAGE_NAME),$(ENV_CEPHFS_IMAGE_NAME),quay.io/cephcsi/cephfsplugin)
 CEPHFS_IMAGE_VERSION=$(if $(ENV_CEPHFS_IMAGE_VERSION),$(ENV_CEPHFS_IMAGE_VERSION),v1.0.0)
 
+CSI_IMAGE_NAME?=quay.io/cephcsi/cephcsi
+CSI_IMAGE_VERSION?=v1.0.0
+
 $(info rbd    image settings: $(RBD_IMAGE_NAME) version $(RBD_IMAGE_VERSION))
 $(info cephfs image settings: $(CEPHFS_IMAGE_NAME) version $(CEPHFS_IMAGE_VERSION))
 
@@ -36,20 +39,21 @@ static-check:
 	./scripts/lint-go.sh
 	./scripts/lint-text.sh
 
-rbdplugin:
+.PHONY: cephcsi
+cephcsi:
 	if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o  _output/rbdplugin ./cmd/rbd
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o  _output/cephcsi ./cmd/
 
-image-rbdplugin: rbdplugin
-	cp _output/rbdplugin  deploy/rbd/docker
+image-cephcsi: cephcsi
+	cp deploy/cephcsi/image/Dockerfile _output
+	$(CONTAINER_CMD) build -t $(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION) _output
+
+image-rbdplugin: cephcsi
+	cp _output/cephcsi deploy/rbd/docker/rbdplugin
 	$(CONTAINER_CMD) build -t $(RBD_IMAGE_NAME):$(RBD_IMAGE_VERSION) deploy/rbd/docker
 
-cephfsplugin:
-	if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o  _output/cephfsplugin ./cmd/cephfs
-
-image-cephfsplugin: cephfsplugin
-	cp _output/cephfsplugin deploy/cephfs/docker
+image-cephfsplugin: cephcsi
+	cp _output/cephsci deploy/cephfs/docker/cephfsplugin
 	$(CONTAINER_CMD) build -t $(CEPHFS_IMAGE_NAME):$(CEPHFS_IMAGE_VERSION) deploy/cephfs/docker
 
 push-image-rbdplugin: image-rbdplugin

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/ceph/ceph-csi/pkg/cephfs"
+	"github.com/ceph/ceph-csi/pkg/rbd"
+	"github.com/ceph/ceph-csi/pkg/util"
+	"k8s.io/klog"
+)
+
+const (
+	rbdType    = "rbd"
+	cephfsType = "cephfs"
+
+	rbdDefaultName    = "rbd.csi.ceph.com"
+	cephfsDefaultName = "cephfs.csi.ceph.com"
+)
+
+var (
+	// common flags
+	vtype           = flag.String("type", "", "driver type [rbd|cephfs]")
+	endpoint        = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
+	driverName      = flag.String("drivername", "", "name of the driver")
+	nodeID          = flag.String("nodeid", "", "node id")
+	metadataStorage = flag.String("metadatastorage", "", "metadata persistence method [node|k8s_configmap]")
+
+	// rbd related flags
+	containerized = flag.Bool("containerized", true, "whether run as containerized")
+	configRoot    = flag.String("configroot", "/etc/csi-config", "directory in which CSI specific Ceph"+
+		" cluster configurations are present, OR the value \"k8s_objects\" if present as kubernetes secrets")
+
+	// cephfs related flags
+	volumeMounter = flag.String("volumemounter", "", "default volume mounter (possible options are 'kernel', 'fuse')")
+	mountCacheDir = flag.String("mountcachedir", "", "mount info cache save dir")
+)
+
+func init() {
+	klog.InitFlags(nil)
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		klog.Exitf("failed to set logtostderr flag: %v", err)
+	}
+	flag.Parse()
+}
+
+func getType() string {
+	if vtype == nil || len(*vtype) == 0 {
+		a0 := path.Base(os.Args[0])
+		if strings.Contains(a0, rbdType) {
+			return rbdType
+		}
+		if strings.Contains(a0, cephfsType) {
+			return cephfsType
+		}
+		return ""
+	}
+	return *vtype
+}
+
+func getDriverName() string {
+	// was explicitly passed a driver name
+	if driverName != nil && len(*driverName) != 0 {
+		return *driverName
+	}
+	// select driver name based on volume type
+	switch getType() {
+	case rbdType:
+		return rbdDefaultName
+	case cephfsType:
+		return cephfsDefaultName
+	default:
+		return ""
+	}
+}
+
+func main() {
+	driverType := getType()
+	if len(driverType) == 0 {
+		klog.Fatalln("driver type not specified")
+	}
+
+	dname := getDriverName()
+	err := util.ValidateDriverName(dname)
+	if err != nil {
+		klog.Fatalln(err) // calls exit
+	}
+
+	switch driverType {
+	case rbdType:
+		rbd.PluginFolder = rbd.PluginFolder + dname
+		cp, err := util.CreatePersistanceStorage(
+			rbd.PluginFolder, *metadataStorage, dname)
+		if err != nil {
+			os.Exit(1)
+		}
+		driver := rbd.NewDriver()
+		driver.Run(dname, *nodeID, *endpoint, *configRoot, *containerized, cp)
+
+	case cephfsType:
+		cephfs.PluginFolder = cephfs.PluginFolder + dname
+		cp, err := util.CreatePersistanceStorage(
+			cephfs.PluginFolder, *metadataStorage, dname)
+		if err != nil {
+			os.Exit(1)
+		}
+		driver := cephfs.NewDriver()
+		driver.Run(dname, *nodeID, *endpoint, *volumeMounter, *mountCacheDir, cp)
+
+	default:
+		klog.Fatalln("invalid volume type", vtype) // calls exit
+	}
+
+	os.Exit(0)
+}

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,0 +1,14 @@
+
+FROM ceph/ceph:v14.2
+LABEL maintainers="Ceph-CSI Authors"
+LABEL description="Ceph-CSI Plugin"
+
+ENV CSIBIN=/usr/local/bin/cephcsi
+
+COPY cephcsi $CSIBIN
+
+RUN chmod +x $CSIBIN && \
+    ln -sf $CSIBIN /usr/local/bin/cephcsi-rbd && \
+    ln -sf $CSIBIN /usr/local/bin/cephcsi-cephfs
+
+ENTRYPOINT ["/usr/local/bin/cephcsi"]


### PR DESCRIPTION
Creating a unified binary and container image has come up a few times in conversations I've been involved with (generally in-person). I confirmed this was still something on the table with @travisn but it might be nice if you could confirm @rootfs.

Regardless, the PR is the start of a single image and binary. Currently, this only adds the new unified version and leaves the current items as-is. This is mainly to start the discussion and the final version would remove them.

Some points I'd like to discuss:
* Currently a cli switch must be provided to select between rbd and cephfs. I was wondering it it would be nicer to select mode (also) by "argv 0" and have symlinks to the binary under the previous names such that the new binary can behave similarly to the old split binaries
* Since this is early its a good time to "bikeshed" any of the naming
* Does the "CEPH_VERSION" env var in the Dockerfile do anything? If not should it be removed?