### PR TITLE
csi-provisioner rbac add resources `nodes` get, list, watch

### DIFF
--- a/deploy/cephfs/helm/Chart.yaml
+++ b/deploy/cephfs/helm/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "1.0.0"
 description: "Container Storage Interface (CSI) driver,
 provisioner, and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
-version: 0.5.0
+version: 0.5.1
 keywords:
   - ceph
   - cephfs

--- a/deploy/cephfs/helm/templates/provisioner-clusterrole.yaml
+++ b/deploy/cephfs/helm/templates/provisioner-clusterrole.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]

--- a/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
@@ -11,6 +11,9 @@ metadata:
   name: cephfs-external-provisioner-runner
 rules:
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]

--- a/deploy/rbd/helm/Chart.yaml
+++ b/deploy/rbd/helm/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "1.0.0"
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter, and attacher for Ceph RBD"
 name: ceph-csi-rbd
-version: 0.5.0
+version: 0.5.1
 keywords:
   - ceph
   - rbd

--- a/deploy/rbd/helm/templates/provisioner-clusterrole.yaml
+++ b/deploy/rbd/helm/templates/provisioner-clusterrole.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -11,6 +11,9 @@ metadata:
   name: rbd-external-provisioner-runner
 rules:
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]


### PR DESCRIPTION
csi-provisioner 1.0 implement support VolumeNodeAffinity, it need  resources `nodes` get, list, watch 


Fixes #293 