### PR TITLE
Exit travis if script failed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   include:
-    - name: Linter
+    - name: static-check-make
       install:
         - gem install mdl
         - pip install --user --upgrade pip
@@ -42,7 +42,7 @@ jobs:
 
     - name: cephcsi
       script:
-        - make cephcsi
+        - make cephcsi ||  travis_terminate 1;
 
 deploy:
   - provider: script


### PR DESCRIPTION
The patch enable travis to terminate the continuation of the pipeline if the script exit with an error code.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>