### PR TITLE
trim linebreaks, when concat mount options with id,key

### DIFF
--- a/pkg/cephfs/credentials.go
+++ b/pkg/cephfs/credentials.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package cephfs
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	credUserID   = "userID"
@@ -41,9 +44,13 @@ func getCredentials(idField, keyField string, secrets map[string]string) (*crede
 		return nil, fmt.Errorf("missing ID field '%s' in secrets", idField)
 	}
 
+	c.id = strings.TrimSuffix(c.id, "\n")
+
 	if c.key, ok = secrets[keyField]; !ok {
 		return nil, fmt.Errorf("missing key field '%s' in secrets", keyField)
 	}
+
+	c.key = strings.TrimSuffix(c.key, "\n")
 
 	return c, nil
 }


### PR DESCRIPTION
we have problems with mounting cephfs with mountoptions id,secret that the drive retrieve from k8ssecret. This secrets have linebreaks and this result in invalid mountoptions.

```
cephfs: EXEC mount [-t ceph 10.123.253.198:6790,10.123.253.199:6790,10.123.253.200:6790:/ /var/lib/kubelet/plugins/cephfs.csi.ceph.com/controller/volumes/root-
csi-cephfs-pvc-3bc3c19d-67e6-11e9-93ba-525400da0775 -o name=admin
,secret=***stripped***]
```

This PR removes linebreaks.
