### PR TITLE
Update images with ceph container as the base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ cephcsi:
 	if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o  _output/cephcsi ./cmd/
 
+rbdplugin: cephcsi
+	cp _output/cephcsi _output/rbdplugin
+
+cephfsplugin: cephcsi
+	cp _output/cephcsi _output/cephfsplugin
+
 image-cephcsi: cephcsi
 	cp deploy/cephcsi/image/Dockerfile _output
 	$(CONTAINER_CMD) build -t $(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION) _output
@@ -53,7 +59,7 @@ image-rbdplugin: cephcsi
 	$(CONTAINER_CMD) build -t $(RBD_IMAGE_NAME):$(RBD_IMAGE_VERSION) deploy/rbd/docker
 
 image-cephfsplugin: cephcsi
-	cp _output/cephsci deploy/cephfs/docker/cephfsplugin
+	cp _output/cephcsi deploy/cephfs/docker/cephfsplugin
 	$(CONTAINER_CMD) build -t $(CEPHFS_IMAGE_NAME):$(CEPHFS_IMAGE_VERSION) deploy/cephfs/docker
 
 push-image-rbdplugin: image-rbdplugin

--- a/deploy/cephfs/docker/Dockerfile
+++ b/deploy/cephfs/docker/Dockerfile
@@ -1,15 +1,12 @@
-FROM centos:7
-LABEL maintainers="Kubernetes Authors"
-LABEL description="CephFS CSI Plugin"
+FROM ceph/ceph:v14.2
+LABEL maintainers="Ceph-CSI Authors"
+LABEL description="Ceph-CSI Plugin"
 
-ENV CEPH_VERSION "mimic"
-RUN yum  install -y centos-release-ceph && \
-    yum install -y kmod ceph-common ceph-fuse attr && \
-    yum clean all
+ENV CSIBIN=/usr/local/bin/cephcsi
 
-COPY cephfsplugin /cephfsplugin
+COPY cephfsplugin $CSIBIN
 
-RUN chmod +x /cephfsplugin && \
-    mkdir -p /var/log/ceph
+RUN chmod +x $CSIBIN && \
+    ln -sf $CSIBIN /usr/local/bin/cephcsi-cephfs
 
-ENTRYPOINT ["/cephfsplugin"]
+ENTRYPOINT ["/usr/local/bin/cephcsi-cephfs"]

--- a/deploy/rbd/docker/Dockerfile
+++ b/deploy/rbd/docker/Dockerfile
@@ -1,12 +1,12 @@
-FROM centos:7
-LABEL maintainers="Kubernetes Authors"
-LABEL description="RBD CSI Plugin"
+FROM ceph/ceph:v14.2
+LABEL maintainers="Ceph-CSI Authors"
+LABEL description="Ceph-CSI Plugin"
 
-ENV CEPH_VERSION "mimic"
-RUN yum  install -y centos-release-ceph && \
-    yum install -y ceph-common e2fsprogs xfsprogs rbd-nbd && \ 
-    yum clean all
+ENV CSIBIN=/usr/local/bin/cephcsi
 
-COPY rbdplugin /rbdplugin
-RUN chmod +x /rbdplugin
-ENTRYPOINT ["/rbdplugin"]
+COPY rbdplugin $CSIBIN
+
+RUN chmod +x $CSIBIN && \
+    ln -sf $CSIBIN /usr/local/bin/cephcsi-rbd
+
+ENTRYPOINT ["/usr/local/bin/cephcsi-rbd"]


### PR DESCRIPTION
plugin images were using centos 7 images as the base image. This
is now moved to the ceph container image that supports required
content since 14.2 version.

Fixes #344

Signed-off-by: ShyamsundarR <srangana@redhat.com>