### PR TITLE
Start publishing v0.3-canary images

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 if [ "${TRAVIS_BRANCH}" == "csi-v0.3" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+    export ENV_RBD_IMAGE_VERSION='v0.3-canary'
+    export ENV_CEPHFS_IMAGE_VERSION='v0.3-canary'
+
     docker login -u "${QUAY_IO_USERNAME}" -p "${QUAY_IO_PASSWORD}" quay.io
     make push-image-rbdplugin push-image-cephfsplugin
 fi


### PR DESCRIPTION
and as a result stop updating the 0.3.0 image version with
every PR content.

In the near future we would need to decide when to cut a
0.3.1 release or if ever to do so based on fixes to this
branch.

Signed-off-by: ShyamsundarR <srangana@redhat.com>