### PR TITLE
skip functional tests for doc change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
 
     - name: cephcsi
       script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
         - make cephcsi ||  travis_terminate 1;
         - sudo scripts/minikube.sh up || travis_terminate 1;
         # pull docker images to speed up e2e

--- a/scripts/skip-doc-change.sh
+++ b/scripts/skip-doc-change.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+CHANGED_FILES=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
+
+[[ -z $CHANGED_FILES ]] && exit 1
+
+skip=0
+#files to be skipped
+declare -a FILES=(^docs/ .md$ ^scripts/ LICENSE .travis.yml .mergify.yml .github .gitignore)
+
+function check_file_present() {
+    local file=$1
+    for FILE in "${FILES[@]}"; do
+        if [[ $file =~ $FILE ]]; then
+            if [[ $file =~ minikube.sh ]]; then
+                continue
+            fi
+            return 0
+        fi
+    done
+    return 1
+}
+
+for CHANGED_FILE in $CHANGED_FILES; do
+    if ! check_file_present "$CHANGED_FILE"; then
+        skip=1
+    fi
+done
+if [ $skip -eq 0 ]; then
+    echo "Skipping functional tests"
+    exit 1
+fi


### PR DESCRIPTION
# Describe what this PR does #

in some cases, we don't need to do functional testing, like doc change or the yml files related to Travis
or mergify. This PR adds ability to skip functional testing for this kind of changes.
