### PR TITLE
Support mounting and deleting version 1.0.0 RBD volumes

### DIFF
--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -26,14 +26,15 @@ make image-cephcsi
 
 **Available command line arguments:**
 
-| Option            | Default value         | Description                                                                                                                                             |
-| ----------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--endpoint`      | `unix://tmp/csi.sock` | CSI endpoint, must be a UNIX socket                                                                                                                     |
-| `--drivername`    | `rbd.csi.ceph.com`    | name of the driver (Kubernetes: `provisioner` field in StorageClass must correspond to this value)                                                      |
-| `--nodeid`        | _empty_               | This node's ID                                                                                                                                          |
-| `--type`          | _empty_               | driver type `[rbd | cephfs]` If the driver type is set to  `rbd` it will act as a `rbd plugin` or if it's set to `cephfs` will act as a `cephfs plugin` |
-| `--containerized` | true                  | Whether running in containerized mode                                                                                                                   |
-| `--instanceid`    | "default"             | Unique ID distinguishing this instance of Ceph CSI among other instances, when sharing Ceph clusters across CSI instances for provisioning              |
+| Option              | Default value         | Description                                                                                                                                             |
+| ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--endpoint`        | `unix://tmp/csi.sock` | CSI endpoint, must be a UNIX socket                                                                                                                     |
+| `--drivername`      | `rbd.csi.ceph.com`    | Name of the driver (Kubernetes: `provisioner` field in StorageClass must correspond to this value)                                                      |
+| `--nodeid`          | _empty_               | This node's ID                                                                                                                                          |
+| `--type`            | _empty_               | Driver type `[rbd | cephfs]` If the driver type is set to  `rbd` it will act as a `rbd plugin` or if it's set to `cephfs` will act as a `cephfs plugin` |
+| `--containerized`   | true                  | Whether running in containerized mode                                                                                                                   |
+| `--instanceid`      | "default"             | Unique ID distinguishing this instance of Ceph CSI among other instances, when sharing Ceph clusters across CSI instances for provisioning              |
+| `--metadatastorage` | _empty_               | Points to where legacy (1.0.0 or older plugin versions) metadata about provisioned volumes are kept, as file or in as k8s configmap (`node` or `k8s_configmap` respectively)              |
 
 **Available environmental variables:**
 

--- a/pkg/rbd/errors.go
+++ b/pkg/rbd/errors.go
@@ -47,3 +47,13 @@ type ErrVolNameConflict struct {
 func (e ErrVolNameConflict) Error() string {
 	return e.err.Error()
 }
+
+// ErrInvalidVolID is returned when a CSI passed VolumeID does not conform to any known volume ID
+// formats
+type ErrInvalidVolID struct {
+	err error
+}
+
+func (e ErrInvalidVolID) Error() string {
+	return e.err.Error()
+}


### PR DESCRIPTION
This commit adds support to mount and delete volumes provisioned by older
plugin versions (1.0.0) in order to support backward compatibility to 1.0.0
created volumes.

It adds back the ability to specify where older meta data was specified, using
the metadatastorage option to the plugin. Further, using the provided meta data
to mount and delete the older volumes.

It also supports a variety of ways in which monitor information may have been
specified (in the storage class, or in the secret), to keep the monitor
information current.

Testing done:
- Mount/Delete 1.0.0 plugin created volume with monitors in the StorageClass
- Mount/Delete 1.0.0 plugin created volume with monitors in the secret with
  a key "monitors"
- Mount/Delete 1.0.0 plugin created volume with monitors in the secret with
  a user specified key
- PVC creation and deletion with the current version (to ensure at the minimum
  no broken functionality)
- Tested some negative cases, where monitor information is missing in secrets
  or present with a different key name, to understand if failure scenarios work
  as expected

Updates #378

Follow-up work:
- Documentation on how to upgrade to 1.1 plugin and retain above functionality
  for older volumes

Signed-off-by: ShyamsundarR <srangana@redhat.com>