### PR TITLE
Modify CephFs provisioner to use the ceph mgr commands

### DIFF
--- a/e2e/deploy-rook.go
+++ b/e2e/deploy-rook.go
@@ -69,8 +69,6 @@ func deployOperator(c kubernetes.Interface) {
 
 	_, err := framework.RunKubectl("create", "-f", opPath)
 	Expect(err).Should(BeNil())
-	err = waitForDaemonSets("rook-ceph-agent", rookNS, c, deployTimeout)
-	Expect(err).Should(BeNil())
 	err = waitForDaemonSets("rook-discover", rookNS, c, deployTimeout)
 	Expect(err).Should(BeNil())
 	err = waitForDeploymentComplete("rook-ceph-operator", rookNS, c, deployTimeout)
@@ -80,10 +78,12 @@ func deployOperator(c kubernetes.Interface) {
 func deployCluster(c kubernetes.Interface) {
 	opPath := fmt.Sprintf("%s/%s", rookURL, "cluster-test.yaml")
 	framework.RunKubectlOrDie("create", "-f", opPath)
+	err := waitForDaemonSets("rook-ceph-agent", rookNS, c, deployTimeout)
+	Expect(err).Should(BeNil())
 	opt := &metav1.ListOptions{
 		LabelSelector: "app=rook-ceph-mon",
 	}
-	err := checkCephPods(rookNS, c, 1, deployTimeout, opt)
+	err = checkCephPods(rookNS, c, 1, deployTimeout, opt)
 	Expect(err).Should(BeNil())
 }
 

--- a/pkg/cephfs/cephuser.go
+++ b/pkg/cephfs/cephuser.go
@@ -82,6 +82,10 @@ func getCephUser(volOptions *volumeOptions, adminCr *util.Credentials, volID vol
 
 func createCephUser(volOptions *volumeOptions, adminCr *util.Credentials, volID volumeID) (*cephEntity, error) {
 	adminID, userID := genUserIDs(adminCr, volID)
+	volRootPath, err := getVolumeRootPathCeph(volOptions, adminCr, volID)
+	if err != nil {
+		return nil, err
+	}
 
 	return getSingleCephEntity(
 		"-m", volOptions.Monitors,
@@ -91,7 +95,7 @@ func createCephUser(volOptions *volumeOptions, adminCr *util.Credentials, volID 
 		"-f", "json",
 		"auth", "get-or-create", userID,
 		// User capabilities
-		"mds", fmt.Sprintf("allow rw path=%s", getVolumeRootPathCeph(volID)),
+		"mds", fmt.Sprintf("allow rw path=%s", volRootPath),
 		"mon", "allow r",
 		"osd", fmt.Sprintf("allow rw pool=%s namespace=%s", volOptions.Pool, getVolumeNamespace(volID)),
 	)

--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -183,7 +183,7 @@ func (cs *ControllerServer) deleteVolumeDeprecated(req *csi.DeleteVolumeRequest)
 	idLk := volumeIDLocker.Lock(string(volID))
 	defer volumeIDLocker.Unlock(idLk, string(volID))
 
-	if err = purgeVolume(volID, cr, &ce.VolOptions); err != nil {
+	if err = purgeVolumeDeprecated(volID, cr, &ce.VolOptions); err != nil {
 		klog.Errorf("failed to delete volume %s: %v", volID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/cephfs/mountcache.go
+++ b/pkg/cephfs/mountcache.go
@@ -95,11 +95,16 @@ func mountOneCacheEntry(volOptions *volumeOptions, vid *volumeIdentifier, me *vo
 	volID := vid.VolumeID
 
 	if volOptions.ProvisionVolume {
-		volOptions.RootPath = getVolumeRootPathCeph(volumeID(vid.FsSubvolName))
 		cr, err = util.GetAdminCredentials(decodeCredentials(me.Secrets))
 		if err != nil {
 			return err
 		}
+
+		volOptions.RootPath, err = getVolumeRootPathCeph(volOptions, cr, volumeID(vid.FsSubvolName))
+		if err != nil {
+			return err
+		}
+
 		var entity *cephEntity
 		entity, err = getCephUser(volOptions, cr, volumeID(vid.FsSubvolName))
 		if err != nil {

--- a/pkg/cephfs/util.go
+++ b/pkg/cephfs/util.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 
 	"google.golang.org/grpc/codes"
@@ -85,11 +84,6 @@ func isMountPoint(p string) (bool, error) {
 	}
 
 	return !notMnt, nil
-}
-
-func pathExists(p string) bool {
-	_, err := os.Stat(p)
-	return err == nil
 }
 
 // Controller service request validation

--- a/pkg/cephfs/util.go
+++ b/pkg/cephfs/util.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"google.golang.org/grpc/codes"
@@ -84,6 +85,11 @@ func isMountPoint(p string) (bool, error) {
 	}
 
 	return !notMnt, nil
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
 }
 
 // Controller service request validation

--- a/pkg/cephfs/volume.go
+++ b/pkg/cephfs/volume.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cephfs
 
 import (
+	"fmt"
+	"os"
+	"path"
 	"strconv"
 	"strings"
 
@@ -36,6 +39,18 @@ var (
 	// its unnecessary
 	cephfsInit = false
 )
+
+func getCephRootVolumePathLocalDeprecated(volID volumeID) string {
+	return path.Join(getCephRootPathLocalDeprecated(volID), "csi-volumes", string(volID))
+}
+
+func getVolumeRootPathCephDeprecated(volID volumeID) string {
+	return path.Join("/", "csi-volumes", string(volID))
+}
+
+func getCephRootPathLocalDeprecated(volID volumeID) string {
+	return fmt.Sprintf("%s/controller/volumes/root-%s", PluginFolder, string(volID))
+}
 
 func getVolumeRootPathCeph(volOptions *volumeOptions, cr *util.Credentials, volID volumeID) (string, error) {
 	stdout, _, err := util.ExecCommand(
@@ -105,6 +120,70 @@ func createVolume(volOptions *volumeOptions, cr *util.Credentials, volID volumeI
 	if err != nil {
 		klog.Errorf("failed to create subvolume %s(%s) in fs %s", string(volID), err, volOptions.FsName)
 		return err
+	}
+
+	return nil
+}
+
+func mountCephRoot(volID volumeID, volOptions *volumeOptions, adminCr *util.Credentials) error {
+	cephRoot := getCephRootPathLocalDeprecated(volID)
+
+	// Root path is not set for dynamically provisioned volumes
+	// Access to cephfs's / is required
+	volOptions.RootPath = "/"
+
+	if err := createMountPoint(cephRoot); err != nil {
+		return err
+	}
+
+	m, err := newMounter(volOptions)
+	if err != nil {
+		return fmt.Errorf("failed to create mounter: %v", err)
+	}
+
+	if err = m.mount(cephRoot, adminCr, volOptions); err != nil {
+		return fmt.Errorf("error mounting ceph root: %v", err)
+	}
+
+	return nil
+}
+
+func unmountCephRoot(volID volumeID) {
+	cephRoot := getCephRootPathLocalDeprecated(volID)
+
+	if err := unmountVolume(cephRoot); err != nil {
+		klog.Errorf("failed to unmount %s with error %s", cephRoot, err)
+	} else {
+		if err := os.Remove(cephRoot); err != nil {
+			klog.Errorf("failed to remove %s with error %s", cephRoot, err)
+		}
+	}
+}
+
+func purgeVolumeDeprecated(volID volumeID, adminCr *util.Credentials, volOptions *volumeOptions) error {
+	if err := mountCephRoot(volID, volOptions, adminCr); err != nil {
+		return err
+	}
+	defer unmountCephRoot(volID)
+
+	var (
+		volRoot         = getCephRootVolumePathLocalDeprecated(volID)
+		volRootDeleting = volRoot + "-deleting"
+	)
+
+	if pathExists(volRoot) {
+		if err := os.Rename(volRoot, volRootDeleting); err != nil {
+			return fmt.Errorf("couldn't mark volume %s for deletion: %v", volID, err)
+		}
+	} else {
+		if !pathExists(volRootDeleting) {
+			klog.V(4).Infof("cephfs: volume %s not found, assuming it to be already deleted", volID)
+			return nil
+		}
+	}
+
+	if err := os.RemoveAll(volRootDeleting); err != nil {
+		return fmt.Errorf("failed to delete volume %s: %v", volID, err)
 	}
 
 	return nil

--- a/pkg/cephfs/volumeoptions.go
+++ b/pkg/cephfs/volumeoptions.go
@@ -18,7 +18,6 @@ package cephfs
 
 import (
 	"fmt"
-	"path"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -272,7 +271,7 @@ func newVolumeOptionsFromVersion1Context(volID string, options, secrets map[stri
 			return nil, nil, err
 		}
 
-		opts.RootPath = path.Join("/csi-volumes", string(volumeID(volID)))
+		opts.RootPath = getVolumeRootPathCephDeprecated(volumeID(volID))
 	} else {
 		if err = extractOption(&opts.RootPath, "rootPath", options); err != nil {
 			return nil, nil, err

--- a/pkg/cephfs/volumeoptions.go
+++ b/pkg/cephfs/volumeoptions.go
@@ -18,6 +18,7 @@ package cephfs
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -225,7 +226,11 @@ func newVolumeOptionsFromVolID(volID string, volOpt, secrets map[string]string) 
 		}
 	}
 
-	volOptions.RootPath = getVolumeRootPathCeph(volumeID(vid.FsSubvolName))
+	volOptions.RootPath, err = getVolumeRootPathCeph(&volOptions, cr, volumeID(vid.FsSubvolName))
+	if err != nil {
+		return nil, nil, err
+	}
+
 	volOptions.ProvisionVolume = true
 
 	return &volOptions, &vid, nil
@@ -267,7 +272,7 @@ func newVolumeOptionsFromVersion1Context(volID string, options, secrets map[stri
 			return nil, nil, err
 		}
 
-		opts.RootPath = getVolumeRootPathCeph(volumeID(volID))
+		opts.RootPath = path.Join("/csi-volumes", string(volumeID(volID)))
 	} else {
 		if err = extractOption(&opts.RootPath, "rootPath", options); err != nil {
 			return nil, nil, err

--- a/pkg/util/cephcmds.go
+++ b/pkg/util/cephcmds.go
@@ -31,9 +31,10 @@ import (
 // ExecCommand executes passed in program with args and returns separate stdout and stderr streams
 func ExecCommand(program string, args ...string) (stdout, stderr []byte, err error) {
 	var (
-		cmd       = exec.Command(program, args...) // nolint: gosec
-		stdoutBuf bytes.Buffer
-		stderrBuf bytes.Buffer
+		cmd           = exec.Command(program, args...) // nolint: gosec
+		sanitizedArgs = StripSecretInArgs(args)
+		stdoutBuf     bytes.Buffer
+		stderrBuf     bytes.Buffer
 	)
 
 	cmd.Stdout = &stdoutBuf
@@ -41,7 +42,7 @@ func ExecCommand(program string, args ...string) (stdout, stderr []byte, err err
 
 	if err := cmd.Run(); err != nil {
 		return stdoutBuf.Bytes(), stderrBuf.Bytes(), fmt.Errorf("an error (%v)"+
-			" occurred while running %s", err, program)
+			" occurred while running %s args: %v", err, program, sanitizedArgs)
 	}
 
 	return stdoutBuf.Bytes(), nil, nil

--- a/scripts/travis-functest.sh
+++ b/scripts/travis-functest.sh
@@ -11,6 +11,6 @@ sudo scripts/minikube.sh k8s-sidecar
 sudo chown -R travis: "$HOME"/.minikube /usr/local/bin/kubectl
 # functional tests
 
-go test github.com/ceph/ceph-csi/e2e --rook-version=v1.0.1 --deploy-rook=true --deploy-timeout=10 -timeout=30m -v
+go test github.com/ceph/ceph-csi/e2e --rook-version=master --deploy-rook=true --deploy-timeout=10 -timeout=30m -v
 
 sudo scripts/minikube.sh clean


### PR DESCRIPTION
Currently CephFs provisioner mounts the ceph filesystem
and creates a subdirectory as a part of provisioning the
volume. Ceph now supports commands to provision fs subvolumes,
hance modify the provisioner to use ceph mgr commands to
(de)provision fs subvolumes.

Signed-off-by: Poornima G <pgurusid@redhat.com>