### PR TITLE
fix pvc access in example

### DIFF
--- a/examples/rbd/pvc-restore.yaml
+++ b/examples/rbd/pvc-restore.yaml
@@ -10,7 +10,7 @@ spec:
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
update example rbd PVC from ReadWriteMany to ReadWriteOnce as rbd supports ReadWriteMany
only if PVC mode is `block`.

log
```
E0612 12:42:12.398627       1 utils.go:109] GRPC error: rpc error: code = InvalidArgument desc = multi node access modes are only supported on rbd `block` type volumes
```
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

