### PR TITLE
Revert "Use Deployment with leader election instead of StatefulSet"

### DIFF
--- a/deploy/cephfs/helm/templates/provisioner-role.yaml
+++ b/deploy/cephfs/helm/templates/provisioner-role.yaml
@@ -16,7 +16,4 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
 {{- end -}}

--- a/deploy/cephfs/helm/templates/provisioner-service.yaml
+++ b/deploy/cephfs/helm/templates/provisioner-service.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ include "ceph-csi-cephfs.provisioner.fullname" . }}
+  labels:
+    app: {{ include "ceph-csi-cephfs.name" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    component: {{ .Values.provisioner.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    app: {{ include "ceph-csi-cephfs.name" . }}
+    component: {{ .Values.provisioner.name }}
+    release: {{ .Release.Name }}
+  ports:
+    - name: dummy
+      port: 12345

--- a/deploy/cephfs/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/cephfs/helm/templates/provisioner-statefulset.yaml
@@ -1,37 +1,37 @@
-kind: Deployment
-apiVersion: apps/v1
+kind: StatefulSet
+apiVersion: apps/v1beta1
 metadata:
-  name: {{ include "ceph-csi-rbd.provisioner.fullname" . }}
+  name: {{ include "ceph-csi-cephfs.provisioner.fullname" . }}
   labels:
-    app: {{ include "ceph-csi-rbd.name" . }}
-    chart: {{ include "ceph-csi-rbd.chart" . }}
+    app: {{ include "ceph-csi-cephfs.name" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
     component: {{ .Values.provisioner.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  serviceName: {{ include "ceph-csi-cephfs.provisioner.fullname" . }}
   replicas: {{ .Values.provisioner.replicas }}
   selector:
     matchLabels:
-      app: {{ include "ceph-csi-rbd.name" . }}
+      app: {{ include "ceph-csi-cephfs.name" . }}
       component: {{ .Values.provisioner.name }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "ceph-csi-rbd.name" . }}
-        chart: {{ include "ceph-csi-rbd.chart" . }}
+        app: {{ include "ceph-csi-cephfs.name" . }}
+        chart: {{ include "ceph-csi-cephfs.chart" . }}
         component: {{ .Values.provisioner.name }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
-      serviceAccountName: {{ include "ceph-csi-rbd.serviceAccountName.provisioner" . }}
+      serviceAccountName: {{ include "ceph-csi-cephfs.serviceAccountName.provisioner" . }}
       containers:
         - name: csi-provisioner
           image: "{{ .Values.provisioner.image.repository }}:{{ .Values.provisioner.image.tag }}"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: "{{ .Values.socketDir }}/{{ .Values.socketFile }}"
@@ -41,23 +41,6 @@ spec:
               mountPath: {{ .Values.socketDir }}
           resources:
 {{ toYaml .Values.provisioner.resources | indent 12 }}
-        - name: csi-snapshotter
-          image: {{ .Values.snapshotter.image.repository }}:{{ .Values.snapshotter.image.tag }}
-          imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
-          args:
-            - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
-            - "--v=5"
-          env:
-            - name: ADDRESS
-              value: "{{ .Values.socketDir }}/{{ .Values.socketFile }}"
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: socket-dir
-              mountPath: {{ .Values.socketDir }}
-          resources:
-{{ toYaml .Values.snapshotter.resources | indent 12 }}
         {{ if .Values.attacher.enabled }}
         - name: csi-attacher
           image: "{{ .Values.attacher.image.repository }}:{{ .Values.attacher.image.tag }}"
@@ -72,7 +55,7 @@ spec:
             - name: socket-dir
               mountPath: {{ .Values.socketDir }}
         {{ end }}
-        - name: csi-rbdplugin
+        - name: csi-cephfsplugin
           securityContext:
             privileged: true
             capabilities:
@@ -81,11 +64,11 @@ spec:
           image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"
           args :
             - "--nodeid=$(NODE_ID)"
-            - "--type=rbd"
+            - "--type=cephfs"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
             - "--drivername=$(DRIVER_NAME)"
-            - "--containerized=true"
+            - "--metadatastorage=k8s_configmap"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/deploy/cephfs/helm/values.yaml
+++ b/deploy/cephfs/helm/values.yaml
@@ -66,7 +66,7 @@ nodeplugin:
 provisioner:
   name: provisioner
 
-  replicaCount: 3
+  replicaCount: 1
 
   image:
     repository: quay.io/k8scsi/csi-provisioner

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -1,13 +1,25 @@
 ---
-kind: Deployment
-apiVersion: apps/v1
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-cephfsplugin-provisioner
+  labels:
+    app: csi-cephfsplugin-provisioner
+spec:
+  selector:
+    app: csi-cephfsplugin-provisioner
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
 metadata:
   name: csi-cephfsplugin-provisioner
 spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: csi-cephfsplugin-provisioner
+  serviceName: "csi-cephfsplugin-provisioner"
+  replicas: 1
   template:
     metadata:
       labels:
@@ -20,7 +32,6 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
@@ -75,9 +75,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create", "delete"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: RoleBinding

--- a/deploy/rbd/helm/templates/provisioner-service.yaml
+++ b/deploy/rbd/helm/templates/provisioner-service.yaml
@@ -1,6 +1,5 @@
-{{- if .Values.rbac.create -}} 
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+kind: Service
+apiVersion: v1
 metadata:
   name: {{ include "ceph-csi-rbd.provisioner.fullname" . }}
   labels:
@@ -9,8 +8,11 @@ metadata:
     component: {{ .Values.provisioner.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch", "create", "delete"]
-{{- end -}}
+spec:
+  selector:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    component: {{ .Values.provisioner.name }}
+    release: {{ .Release.Name }}
+  ports:
+    - name: dummy
+      port: 12345

--- a/deploy/rbd/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/rbd/helm/templates/provisioner-statefulset.yaml
@@ -1,36 +1,36 @@
-kind: Deployment
-apiVersion: apps/v1
+kind: StatefulSet
+apiVersion: apps/v1beta1
 metadata:
-  name: {{ include "ceph-csi-cephfs.provisioner.fullname" . }}
+  name: {{ include "ceph-csi-rbd.provisioner.fullname" . }}
   labels:
-    app: {{ include "ceph-csi-cephfs.name" . }}
-    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
     component: {{ .Values.provisioner.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  serviceName: {{ include "ceph-csi-rbd.provisioner.fullname" . }}
   replicas: {{ .Values.provisioner.replicas }}
   selector:
     matchLabels:
-      app: {{ include "ceph-csi-cephfs.name" . }}
+      app: {{ include "ceph-csi-rbd.name" . }}
       component: {{ .Values.provisioner.name }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "ceph-csi-cephfs.name" . }}
-        chart: {{ include "ceph-csi-cephfs.chart" . }}
+        app: {{ include "ceph-csi-rbd.name" . }}
+        chart: {{ include "ceph-csi-rbd.chart" . }}
         component: {{ .Values.provisioner.name }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
-      serviceAccountName: {{ include "ceph-csi-cephfs.serviceAccountName.provisioner" . }}
+      serviceAccountName: {{ include "ceph-csi-rbd.serviceAccountName.provisioner" . }}
       containers:
         - name: csi-provisioner
           image: "{{ .Values.provisioner.image.repository }}:{{ .Values.provisioner.image.tag }}"
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--leader-election-type=leases"
             - "--v=5"
           env:
             - name: ADDRESS
@@ -41,6 +41,23 @@ spec:
               mountPath: {{ .Values.socketDir }}
           resources:
 {{ toYaml .Values.provisioner.resources | indent 12 }}
+        - name: csi-snapshotter
+          image: {{ .Values.snapshotter.image.repository }}:{{ .Values.snapshotter.image.tag }}
+          imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--connection-timeout=15s"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: "{{ .Values.socketDir }}/{{ .Values.socketFile }}"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: socket-dir
+              mountPath: {{ .Values.socketDir }}
+          resources:
+{{ toYaml .Values.snapshotter.resources | indent 12 }}
         {{ if .Values.attacher.enabled }}
         - name: csi-attacher
           image: "{{ .Values.attacher.image.repository }}:{{ .Values.attacher.image.tag }}"
@@ -55,7 +72,7 @@ spec:
             - name: socket-dir
               mountPath: {{ .Values.socketDir }}
         {{ end }}
-        - name: csi-cephfsplugin
+        - name: csi-rbdplugin
           securityContext:
             privileged: true
             capabilities:
@@ -64,11 +81,11 @@ spec:
           image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"
           args :
             - "--nodeid=$(NODE_ID)"
-            - "--type=cephfs"
+            - "--type=rbd"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
             - "--drivername=$(DRIVER_NAME)"
-            - "--metadatastorage=k8s_configmap"
+            - "--containerized=true"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/deploy/rbd/helm/values.yaml
+++ b/deploy/rbd/helm/values.yaml
@@ -67,7 +67,7 @@ nodeplugin:
 provisioner:
   name: provisioner
 
-  replicaCount: 3
+  replicaCount: 1
 
   image:
     repository: quay.io/k8scsi/csi-provisioner

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -87,9 +87,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: RoleBinding

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -1,13 +1,25 @@
 ---
-kind: Deployment
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-rbdplugin-provisioner
+  labels:
+    app: csi-rbdplugin-provisioner
+spec:
+  selector:
+    app: csi-rbdplugin-provisioner
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:
   name: csi-rbdplugin-provisioner
 spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: csi-rbdplugin-provisioner
+  serviceName: "csi-rbdplugin-provisioner"
+  replicas: 1
   template:
     metadata:
       labels:
@@ -20,7 +32,6 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - --leader-election-type=leases"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo" // nolint
 
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -50,8 +52,9 @@ var _ = Describe("cephfs", func() {
 
 	Context("Test cephfs CSI", func() {
 		It("Test cephfs CSI", func() {
-			By("checking provisioner deployment is completed")
-			err := waitForDeploymentComplete(cephfsDeploymentName, namespace, f.ClientSet, deployTimeout)
+			By("checking provisioner statefulset is running")
+			timeout := time.Duration(deployTimeout) * time.Minute
+			err := framework.WaitForStatefulSetReplicasReady(cephfsDeploymentName, namespace, f.ClientSet, 1*time.Second, timeout)
 			if err != nil {
 				Fail(err.Error())
 			}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo" // nolint
 
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -52,8 +54,9 @@ var _ = Describe("RBD", func() {
 
 	Context("Test RBD CSI", func() {
 		It("Test RBD CSI", func() {
-			By("checking provisioner deployment is completed")
-			err := waitForDeploymentComplete(rbdDeploymentName, namespace, f.ClientSet, deployTimeout)
+			By("checking provisioner statefulset is running")
+			timeout := time.Duration(deployTimeout) * time.Minute
+			err := framework.WaitForStatefulSetReplicasReady(rbdDeploymentName, namespace, f.ClientSet, 1*time.Second, timeout)
 			if err != nil {
 				Fail(err.Error())
 			}


### PR DESCRIPTION

# Describe what this PR does #

This reverts commit a151bec94b93f0f8ddbe50b572bcbe94e4c344ae.
we need to revert back to use statefulset as we will face issue in using deployment

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.
