### PR TITLE
Move locks to more granular locking than CPU count based

### DIFF
--- a/deploy/cephfs/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/cephfs/helm/templates/provisioner-statefulset.yaml
@@ -32,6 +32,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--timeout=60s"
+            - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS
               value: "{{ .Values.socketDir }}/{{ .Values.socketFile }}"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -35,6 +35,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--timeout=60s"
+            - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/rbd/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/rbd/helm/templates/provisioner-statefulset.yaml
@@ -32,6 +32,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--timeout=60s"
+            - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS
               value: "{{ .Values.socketDir }}/{{ .Values.socketFile }}"
@@ -46,8 +48,8 @@ spec:
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--v=5"
+            - "--timeout=60s"
           env:
             - name: ADDRESS
               value: "{{ .Values.socketDir }}/{{ .Values.socketFile }}"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -35,6 +35,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--timeout=60s"
+            - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock
@@ -46,8 +48,8 @@ spec:
           image: quay.io/k8scsi/csi-snapshotter:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--v=5"
+            - "--timeout=60s"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/pkg/cephfs/util.go
+++ b/pkg/cephfs/util.go
@@ -31,16 +31,9 @@ import (
 	"github.com/ceph/ceph-csi/pkg/util"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/utils/keymutex"
 )
 
 type volumeID string
-
-func mustUnlock(m keymutex.KeyMutex, key string) {
-	if err := m.UnlockKey(key); err != nil {
-		klog.Fatalf("failed to unlock mutex for %s: %v", key, err)
-	}
-}
 
 func execCommand(program string, args ...string) (stdout, stderr []byte, err error) {
 	var (

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
-	"k8s.io/utils/keymutex"
 )
 
 const (
@@ -83,17 +82,13 @@ type rbdSnapshot struct {
 
 var (
 	// serializes operations based on "<rbd pool>/<rbd image>" as key
-	attachdetachMutex = keymutex.NewHashed(0)
+	attachdetachLocker = util.NewIDLocker()
 	// serializes operations based on "volume name" as key
-	volumeNameMutex = keymutex.NewHashed(0)
-	// serializes operations based on "volume id" as key
-	volumeIDMutex = keymutex.NewHashed(0)
+	volumeNameLocker = util.NewIDLocker()
 	// serializes operations based on "snapshot name" as key
-	snapshotNameMutex = keymutex.NewHashed(0)
-	// serializes operations based on "snapshot id" as key
-	snapshotIDMutex = keymutex.NewHashed(0)
+	snapshotNameLocker = util.NewIDLocker()
 	// serializes operations based on "mount target path" as key
-	targetPathMutex = keymutex.NewHashed(0)
+	targetPathLocker = util.NewIDLocker()
 
 	supportedFeatures = sets.NewString("layering")
 )

--- a/pkg/util/idlocker.go
+++ b/pkg/util/idlocker.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+)
+
+/*
+IDLock is a per identifier lock with a use counter that retains a number of users of the lock.
+IDLocker is a map of IDLocks holding the IDLocks based on a passed in identifier.
+Typical usage (post creating an IDLocker) is to Lock/Unlock based on identifiers as per the API.
+*/
+type (
+	IDLock struct {
+		mtx      sync.Mutex
+		useCount int
+	}
+
+	IDLocker struct {
+		lMutex sync.Mutex
+		lMap   map[string]*IDLock
+	}
+)
+
+func NewIDLocker() *IDLocker {
+	return &IDLocker{
+		lMap: make(map[string]*IDLock),
+	}
+}
+
+func (lkr *IDLocker) Lock(identifier string) *IDLock {
+	var (
+		lk *IDLock
+		ok bool
+	)
+
+	newlk := new(IDLock)
+
+	lkr.lMutex.Lock()
+
+	if lk, ok = lkr.lMap[identifier]; !ok {
+		lk = newlk
+		lkr.lMap[identifier] = lk
+	}
+	lk.useCount++
+	lkr.lMutex.Unlock()
+
+	lk.mtx.Lock()
+
+	return lk
+}
+
+func (lkr *IDLocker) Unlock(lk *IDLock, identifier string) {
+	lk.mtx.Unlock()
+
+	lkr.lMutex.Lock()
+	lk.useCount--
+	if lk.useCount == 0 {
+		delete(lkr.lMap, identifier)
+	}
+	lkr.lMutex.Unlock()
+}

--- a/pkg/util/idlocker_test.go
+++ b/pkg/util/idlocker_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+// very basic tests for the moment
+func TestIDLocker(t *testing.T) {
+	myIDLocker := NewIDLocker()
+
+	lk1 := myIDLocker.Lock("lk1")
+	lk2 := myIDLocker.Lock("lk2")
+	lk3 := myIDLocker.Lock("lk3")
+
+	if lk1 == lk2 || lk2 == lk3 || lk3 == lk1 {
+		t.Errorf("Failed: lock variables clash when they should not!")
+	}
+
+	myIDLocker.Unlock(lk1, "lk1")
+	myIDLocker.Unlock(lk2, "lk2")
+	myIDLocker.Unlock(lk3, "lk3")
+}


### PR DESCRIPTION
As detailed in issue #279, current lock scheme has hash
buckets that are count of CPUs. This causes a lot of contention
when parallel requests are made to the CSI plugin. To reduce
lock contention, this commit introduces granular locks per
identifier.

The commit also changes the timeout for gRPC requests to Create
and Delete volumes, as the current timeout is 10s (kubernetes
documentation says 15s but code defaults are 10s). A virtual
setup takes about 12-15s to complete a request at times, that leads
to unwanted retries of the same request, hence the increased
timeout to enable operation completion with minimal retries.

Tests to create PVCs before and after these changes look like so,

Before:
Default master code + sidecar provisioner --timeout option set
to 30 seconds

20 PVCs
Creation: 3 runs, 396/391/400 seconds
Deletion: 3 runs, 218/271/118 seconds
  - Once was stalled for more than 8 minutes and cancelled the run

After:
Current commit + sidecar provisioner --timeout option set to 30 sec
20 PVCs
Creation: 3 runs, 42/59/65 seconds
Deletion: 3 runs, 32/32/31 seconds

Fixes: #279
Signed-off-by: ShyamsundarR <srangana@redhat.com>