### PR TITLE
update minikube and run E2E in kubernetes 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - GO_METALINTER_THREADS=1
     - GO_COVER_DIR=_output
     - VM_DRIVER=none
-    - MINIKUBE_VERSION=v1.1.1
+    - MINIKUBE_VERSION=v1.2.0
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,12 @@ jobs:
         - make image-cephcsi || travis_terminate 1;
         - scripts/travis-functest.sh v1.14.3 || travis_terminate 1;
 
+    - name: cephcsi with kube 1.15.0
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-functest.sh v1.15.0 || travis_terminate 1;
+
 deploy:
   - provider: script
     on:  # yamllint disable-line rule:truthy

--- a/scripts/skip-doc-change.sh
+++ b/scripts/skip-doc-change.sh
@@ -5,7 +5,7 @@ CHANGED_FILES=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
 
 skip=0
 #files to be skipped
-declare -a FILES=(^docs/ .md$ ^scripts/ LICENSE .travis.yml .mergify.yml .github .gitignore)
+declare -a FILES=(^docs/ .md$ ^scripts/ LICENSE .mergify.yml .github .gitignore)
 
 function check_file_present() {
     local file=$1


### PR DESCRIPTION
* Update minikube version to v1.2.0
* Enable Travis to run E2E against Kube 1.15.0
* Remove Travis.yml from skip doc check  checking

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>