### PR TITLE
Implement NodeStage and NodeUnstage for rbd

### DIFF
--- a/deploy/cephfs/helm/templates/nodeplugin-daemonset.yaml
+++ b/deploy/cephfs/helm/templates/nodeplugin-daemonset.yaml
@@ -87,13 +87,13 @@ spec:
           volumeMounts:
             - name: mount-cache-dir
               mountPath: /mount-cache-dir
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: {{ .Values.socketDir }}
-            - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+            - name: plugin-dir
+              mountPath: {{ .Values.pluginDir }}
               mountPropagation: "Bidirectional"
-            - name: plugin-mount-dir
-              mountPath: {{ .Values.volumeDevicesDir }}
+            - name: mointpoint-dir
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
             - mountPath: /dev
               name: host-dev
@@ -111,22 +111,22 @@ spec:
       volumes:
         - name: mount-cache-dir
           emptyDir: {}
-        - name: plugin-dir
+        - name: socket-dir
           hostPath:
             path: {{ .Values.socketDir }}
-            type: DirectoryOrCreate
-        - name: plugin-mount-dir
-          hostPath:
-            path: {{ .Values.volumeDevicesDir }}
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: {{ .Values.registrationDir }}
             type: Directory
-        - name: pods-mount-dir
+        - name: plugin-dir
+          hostPath:
+            path: {{ .Values.pluginDir }}
+            type: Directory
+        - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods
-            type: Directory
+            type: DirectoryOrCreate
         - name: host-dev
           hostPath:
             path: /dev

--- a/deploy/cephfs/helm/values.yaml
+++ b/deploy/cephfs/helm/values.yaml
@@ -16,7 +16,7 @@ serviceAccounts:
 socketDir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
 socketFile: csi.sock
 registrationDir: /var/lib/kubelet/plugins_registry
-volumeDevicesDir: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices
+pluginDir: /var/lib/kubelet/plugins
 driverName: cephfs.csi.ceph.com
 configMapName: ceph-csi-config
 attacher:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -38,7 +38,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
@@ -73,13 +73,13 @@ spec:
           volumeMounts:
             - name: mount-cache-dir
               mountPath: /mount-cache-dir
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
-            - name: csi-plugins-dir
-              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-              mountPropagation: "Bidirectional"
-            - name: pods-mount-dir
+            - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins
               mountPropagation: "Bidirectional"
             - name: host-sys
               mountPath: /sys
@@ -93,21 +93,21 @@ spec:
       volumes:
         - name: mount-cache-dir
           emptyDir: {}
-        - name: plugin-dir
+        - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/cephfs.csi.ceph.com/
-            type: DirectoryOrCreate
-        - name: csi-plugins-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/kubernetes.io/csi
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
             type: Directory
-        - name: pods-mount-dir
+        - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
             type: Directory
         - name: host-sys
           hostPath:

--- a/deploy/rbd/helm/templates/nodeplugin-daemonset.yaml
+++ b/deploy/rbd/helm/templates/nodeplugin-daemonset.yaml
@@ -14,6 +14,8 @@ spec:
       app: {{ include "ceph-csi-rbd.name" . }}
       component: {{ .Values.nodeplugin.name }}
       release: {{ .Release.Name }}
+  updateStrategy:
+    type: OnDelete
   template:
     metadata:
       labels:
@@ -51,7 +53,7 @@ spec:
                   fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.nodeplugin.registrar.image.pullPolicy }}
           volumeMounts:
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
@@ -84,13 +86,13 @@ spec:
               value: "unix:/{{ .Values.socketDir }}/{{ .Values.socketFile }}"
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           volumeMounts:
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: {{ .Values.socketDir }}
-            - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+            - name: plugin-dir
+              mountPath: {{ .Values.pluginDir }}
               mountPropagation: "Bidirectional"
-            - name: plugin-mount-dir
-              mountPath: {{ .Values.volumeDevicesDir }}
+            - name: mointpoint-dir
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
             - mountPath: /dev
               name: host-dev
@@ -106,22 +108,22 @@ spec:
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
       volumes:
-        - name: plugin-dir
+        - name: socket-dir
           hostPath:
             path: {{ .Values.socketDir }}
-            type: DirectoryOrCreate
-        - name: plugin-mount-dir
-          hostPath:
-            path: {{ .Values.volumeDevicesDir }}
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: {{ .Values.registrationDir }}
             type: Directory
-        - name: pods-mount-dir
+        - name: plugin-dir
+          hostPath:
+            path: {{ .Values.pluginDir }}
+            type: Directory
+        - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods
-            type: Directory
+            type: DirectoryOrCreate
         - name: host-dev
           hostPath:
             path: /dev

--- a/deploy/rbd/helm/values.yaml
+++ b/deploy/rbd/helm/values.yaml
@@ -16,7 +16,7 @@ serviceAccounts:
 socketDir: /var/lib/kubelet/plugins/rbd.csi.ceph.com
 socketFile: csi.sock
 registrationDir: /var/lib/kubelet/plugins_registry
-volumeDevicesDir: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices
+pluginDir: /var/lib/kubelet/plugins
 driverName: rbd.csi.ceph.com
 configMapName: ceph-csi-config
 

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       app: csi-rbdplugin
+  updateStrategy:
+    type: OnDelete
   template:
     metadata:
       labels:
@@ -39,7 +41,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
@@ -69,14 +71,8 @@ spec:
               value: unix:///csi/csi.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
-            - name: plugin-dir
+            - name: socket-dir
               mountPath: /csi
-            - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: "Bidirectional"
-            - name: plugin-mount-dir
-              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/
-              mountPropagation: "Bidirectional"
             - mountPath: /dev
               name: host-dev
             - mountPath: /rootfs
@@ -88,22 +84,28 @@ spec:
               readOnly: true
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins
+              mountPropagation: "Bidirectional"
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
       volumes:
-        - name: plugin-dir
+        - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/rbd.csi.ceph.com
             type: DirectoryOrCreate
-        - name: plugin-mount-dir
+        - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/
+            path: /var/lib/kubelet/plugins
+            type: Directory
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
-            type: Directory
-        - name: pods-mount-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
             type: Directory
         - name: host-dev
           hostPath:

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -117,6 +117,13 @@ var _ = Describe("cephfs", func() {
 					}
 				})
 
+				By("check data persist after recreating pod with same pvc", func() {
+					err := checkDataPersist(pvcPath, appPath, f)
+					if err != nil {
+						Fail(err.Error())
+					}
+				})
+
 			})
 
 		})

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -189,6 +189,13 @@ var _ = Describe("RBD", func() {
 					Fail("validate multiple pvc failed")
 				}
 			})
+
+			By("check data persist after recreating pod with same pvc", func() {
+				err := checkDataPersist(pvcPath, appPath, f)
+				if err != nil {
+					Fail(err.Error())
+				}
+			})
 		})
 	})
 

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -759,3 +759,52 @@ func GivePermToCephfsRoot(f *framework.Framework) {
 	out = execCommandInPod(f, "chmod 777 /mnt/cephfs/", rookNS, &opt)
 	e2elog.Logf("Setting chmod 777 on the cepfs root %s", out)
 }
+
+func checkDataPersist(pvcPath, appPath string, f *framework.Framework) error {
+	data := "checking data persist"
+	pvc, err := loadPVC(pvcPath)
+	if pvc == nil {
+		return err
+	}
+	pvc.Namespace = f.UniqueName
+	e2elog.Logf("The PVC  template %+v", pvc)
+
+	app, err := loadApp(appPath)
+	if err != nil {
+		return err
+	}
+	app.Labels = map[string]string{"app": "validate-data"}
+	app.Namespace = f.UniqueName
+
+	err = createPVCAndApp("", f, pvc, app)
+	if err != nil {
+		return err
+	}
+
+	opt := metav1.ListOptions{
+		LabelSelector: "app=validate-data",
+	}
+	// write data to PVC
+	filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
+
+	execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, filePath), app.Namespace, &opt)
+
+	// delete app
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return err
+	}
+	// recreate app and check data persist
+	err = createApp(f.ClientSet, app, deployTimeout)
+	if err != nil {
+		return err
+	}
+	persistData := execCommandInPod(f, fmt.Sprintf("cat %s", filePath), app.Namespace, &opt)
+
+	if !strings.Contains(persistData, data) {
+		return fmt.Errorf("data not persistent expected data %s received data %s  ", data, persistData)
+	}
+
+	err = deletePVCAndApp("", f, pvc, app)
+	return err
+}

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -28,8 +28,8 @@ parameters:
    # to the 'pool'.
    csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
    csi.storage.k8s.io/provisioner-secret-namespace: default
-   csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
-   csi.storage.k8s.io/node-publish-secret-namespace: default
+   csi.storage.k8s.io/node-stage-secret-name: csi-rbd-secret
+   csi.storage.k8s.io/node-stage-secret-namespace: default
 
    # uncomment the following to use rbd-nbd as mounter on supported nodes
    # mounter: rbd-nbd

--- a/pkg/cephfs/mountcache.go
+++ b/pkg/cephfs/mountcache.go
@@ -43,7 +43,7 @@ func initVolumeMountCache(driverName, mountCacheDir string) {
 }
 
 func remountCachedVolumes() error {
-	if err := os.MkdirAll(volumeMountCache.nodeCacheStore.BasePath, 0755); err != nil {
+	if err := util.CreateMountPoint(volumeMountCache.nodeCacheStore.BasePath); err != nil {
 		klog.Errorf("mount-cache: failed to create %s: %v", volumeMountCache.nodeCacheStore.BasePath, err)
 		return err
 	}
@@ -124,7 +124,7 @@ func mountOneCacheEntry(volOptions *volumeOptions, vid *volumeIdentifier, me *vo
 		return err
 	}
 
-	isMnt, err := isMountPoint(me.StagingPath)
+	isMnt, err := util.IsMountPoint(me.StagingPath)
 	if err != nil {
 		isMnt = false
 		klog.Infof("mount-cache: failed to check volume mounted %s: %s %v", volID, me.StagingPath, err)

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -84,8 +84,8 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		volOptions *volumeOptions
 		vid        *volumeIdentifier
 	)
-	if err := validateNodeStageVolumeRequest(req); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if err := util.ValidateNodeStageVolumeRequest(req); err != nil {
+		return nil, err
 	}
 
 	// Configuration
@@ -115,7 +115,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	if err = createMountPoint(stagingTargetPath); err != nil {
+	if err = util.CreateMountPoint(stagingTargetPath); err != nil {
 		klog.Errorf("failed to create staging mount point at %s for volume %s: %v", stagingTargetPath, volID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -125,7 +125,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	// Check if the volume is already mounted
 
-	isMnt, err := isMountPoint(stagingTargetPath)
+	isMnt, err := util.IsMountPoint(stagingTargetPath)
 
 	if err != nil {
 		klog.Errorf("stat failed: %v", err)
@@ -180,8 +180,8 @@ func (*NodeServer) mount(volOptions *volumeOptions, req *csi.NodeStageVolumeRequ
 func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 
 	mountOptions := []string{"bind"}
-	if err := validateNodePublishVolumeRequest(req); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if err := util.ValidateNodePublishVolumeRequest(req); err != nil {
+		return nil, err
 	}
 
 	// Configuration
@@ -189,7 +189,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	targetPath := req.GetTargetPath()
 	volID := req.GetVolumeId()
 
-	if err := createMountPoint(targetPath); err != nil {
+	if err := util.CreateMountPoint(targetPath); err != nil {
 		klog.Errorf("failed to create mount point at %s: %v", targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -218,7 +218,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// Check if the volume is already mounted
 
-	isMnt, err := isMountPoint(targetPath)
+	isMnt, err := util.IsMountPoint(targetPath)
 
 	if err != nil {
 		klog.Errorf("stat failed: %v", err)
@@ -255,8 +255,8 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 // NodeUnpublishVolume unmounts the volume from the target path
 func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	var err error
-	if err = validateNodeUnpublishVolumeRequest(req); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if err = util.ValidateNodeUnpublishVolumeRequest(req); err != nil {
+		return nil, err
 	}
 
 	targetPath := req.GetTargetPath()
@@ -283,8 +283,8 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 // NodeUnstageVolume unstages the volume from the staging path
 func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	var err error
-	if err = validateNodeUnstageVolumeRequest(req); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if err = util.ValidateNodeUnstageVolumeRequest(req); err != nil {
+		return nil, err
 	}
 
 	stagingTargetPath := req.GetStagingTargetPath()

--- a/pkg/cephfs/volume.go
+++ b/pkg/cephfs/volume.go
@@ -132,7 +132,7 @@ func mountCephRoot(volID volumeID, volOptions *volumeOptions, adminCr *util.Cred
 	// Access to cephfs's / is required
 	volOptions.RootPath = "/"
 
-	if err := createMountPoint(cephRoot); err != nil {
+	if err := util.CreateMountPoint(cephRoot); err != nil {
 		return err
 	}
 

--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -155,7 +155,7 @@ func mountFuse(mountPoint string, cr *util.Credentials, volOptions *volumeOption
 }
 
 func (m *fuseMounter) mount(mountPoint string, cr *util.Credentials, volOptions *volumeOptions) error {
-	if err := createMountPoint(mountPoint); err != nil {
+	if err := util.CreateMountPoint(mountPoint); err != nil {
 		return err
 	}
 
@@ -186,7 +186,7 @@ func mountKernel(mountPoint string, cr *util.Credentials, volOptions *volumeOpti
 }
 
 func (m *kernelMounter) mount(mountPoint string, cr *util.Credentials, volOptions *volumeOptions) error {
-	if err := createMountPoint(mountPoint); err != nil {
+	if err := util.CreateMountPoint(mountPoint); err != nil {
 		return err
 	}
 
@@ -235,8 +235,4 @@ func unmountVolume(mountPoint string) error {
 	}
 
 	return nil
-}
-
-func createMountPoint(root string) error {
-	return os.MkdirAll(root, 0750)
 }

--- a/pkg/rbd/rbd_attach.go
+++ b/pkg/rbd/rbd_attach.go
@@ -231,8 +231,6 @@ func attachRBDImage(volOptions *rbdVolume, cr *util.Credentials) (string, error)
 	var err error
 
 	image := volOptions.RbdImageName
-	imagePath := fmt.Sprintf("%s/%s", volOptions.Pool, image)
-
 	useNBD := false
 	moduleName := rbd
 	if volOptions.Mounter == rbdTonbd && hasNBD {
@@ -242,9 +240,6 @@ func attachRBDImage(volOptions *rbdVolume, cr *util.Credentials) (string, error)
 
 	devicePath, found := waitForPath(volOptions.Pool, image, 1, useNBD)
 	if !found {
-		idLk := attachdetachLocker.Lock(imagePath)
-		defer attachdetachLocker.Unlock(idLk, imagePath)
-
 		_, err = execCommand("modprobe", []string{moduleName})
 		if err != nil {
 			klog.Warningf("rbd: failed to load rbd kernel module:%v", err)

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -90,16 +90,16 @@ type rbdSnapshot struct {
 }
 
 var (
-	// serializes operations based on "<rbd pool>/<rbd image>" as key
-	attachdetachLocker = util.NewIDLocker()
 	// serializes operations based on "volume name" as key
 	volumeNameLocker = util.NewIDLocker()
 	// serializes operations based on "snapshot name" as key
 	snapshotNameLocker = util.NewIDLocker()
-	// serializes operations based on "mount target path" as key
-	targetPathLocker = util.NewIDLocker()
 	// serializes delete operations on legacy volumes
 	legacyVolumeIDLocker = util.NewIDLocker()
+	// serializes operations based on "mount staging path" as key
+	nodeVolumeIDLocker = util.NewIDLocker()
+	// serializes operations based on "mount target path" as key
+	targetPathLocker = util.NewIDLocker()
 
 	supportedFeatures = sets.NewString("layering")
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,8 +22,11 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/util/mount"
 )
 
 // remove this once kubernetes v1.14.0 release is done
@@ -58,12 +61,12 @@ func roundUpSize(volumeSizeBytes, allocationUnitBytes int64) int64 {
 // CreatePersistanceStorage creates storage path and initializes new cache
 func CreatePersistanceStorage(sPath, metaDataStore, driverName string) (CachePersister, error) {
 	var err error
-	if err = createPersistentStorage(path.Join(sPath, "controller")); err != nil {
+	if err = CreateMountPoint(path.Join(sPath, "controller")); err != nil {
 		klog.Errorf("failed to create persistent storage for controller: %v", err)
 		return nil, err
 	}
 
-	if err = createPersistentStorage(path.Join(sPath, "node")); err != nil {
+	if err = CreateMountPoint(path.Join(sPath, "node")); err != nil {
 		klog.Errorf("failed to create persistent storage for node: %v", err)
 		return nil, err
 	}
@@ -74,10 +77,6 @@ func CreatePersistanceStorage(sPath, metaDataStore, driverName string) (CachePer
 		return nil, err
 	}
 	return cp, err
-}
-
-func createPersistentStorage(persistentStoragePath string) error {
-	return os.MkdirAll(persistentStoragePath, os.FileMode(0755))
 }
 
 // ValidateDriverName validates the driver name
@@ -119,4 +118,26 @@ func GenerateVolID(monitors string, cr *Credentials, pool, clusterID, objUUID st
 	volID, err := vi.ComposeCSIID()
 
 	return volID, err
+}
+
+// CreateMountPoint creates the directory with given path
+func CreateMountPoint(mountPath string) error {
+	return os.MkdirAll(mountPath, 0750)
+}
+
+// IsMountPoint checks if the given path is mountpoint or not
+func IsMountPoint(p string) (bool, error) {
+	dummyMount := mount.New("")
+	notMnt, err := dummyMount.IsLikelyNotMountPoint(p)
+	if err != nil {
+		return false, status.Error(codes.Internal, err.Error())
+	}
+
+	return !notMnt, nil
+}
+
+// Mount mounts the source to target path
+func Mount(source, target, fstype string, options []string) error {
+	dummyMount := mount.New("")
+	return dummyMount.Mount(source, target, fstype, options)
 }

--- a/pkg/util/validate.go
+++ b/pkg/util/validate.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ValidateNodeStageVolumeRequest validates the node stage request
+func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
+	if req.GetVolumeCapability() == nil {
+		return status.Error(codes.InvalidArgument, "volume capability missing in request")
+	}
+
+	if req.GetVolumeId() == "" {
+		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	}
+
+	if req.GetStagingTargetPath() == "" {
+		return status.Error(codes.InvalidArgument, "staging target path missing in request")
+	}
+
+	if req.GetSecrets() == nil || len(req.GetSecrets()) == 0 {
+		return status.Error(codes.InvalidArgument, "stage secrets cannot be nil or empty")
+	}
+
+	return nil
+}
+
+// ValidateNodeUnstageVolumeRequest validates the node unstage request
+func ValidateNodeUnstageVolumeRequest(req *csi.NodeUnstageVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	}
+
+	if req.GetStagingTargetPath() == "" {
+		return status.Error(codes.InvalidArgument, "staging target path missing in request")
+	}
+
+	return nil
+}
+
+// ValidateNodePublishVolumeRequest validates the node publish request
+func ValidateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
+	if req.GetVolumeCapability() == nil {
+		return status.Error(codes.InvalidArgument, "volume capability missing in request")
+	}
+
+	if req.GetVolumeId() == "" {
+		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	}
+
+	if req.GetTargetPath() == "" {
+		return status.Error(codes.InvalidArgument, "target path missing in request")
+	}
+
+	if req.GetStagingTargetPath() == "" {
+		return status.Error(codes.InvalidArgument, "staging target path missing in request")
+	}
+
+	return nil
+}
+
+// ValidateNodeUnpublishVolumeRequest validates the node unpublish request
+func ValidateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	}
+
+	if req.GetTargetPath() == "" {
+		return status.Error(codes.InvalidArgument, "target path missing in request")
+	}
+
+	return nil
+}


### PR DESCRIPTION


# Describe what this PR does #

In NodeStage RPC call we have to map the device to the node plugin and make sure the device will be mounted to the global path.

in  nodeUnstage request unmount the device from the global path and unmap the device if the volume mode is block  we will be creating a file inside a stageTargetPath  and it will be
considered as the global path.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #153