### PR TITLE
Mark master driver version to `canary` instead of release versions.

### DIFF
--- a/pkg/cephfs/driver.go
+++ b/pkg/cephfs/driver.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// version of ceph driver
-	version = "1.0.0"
+	version = "canary"
 
 	// volIDVersion is the version number of volume ID encoding scheme
 	volIDVersion uint16 = 1

--- a/pkg/rbd/rbd.go
+++ b/pkg/rbd/rbd.go
@@ -46,7 +46,7 @@ type Driver struct {
 }
 
 var (
-	version = "1.0.0"
+	version = "canary"
 
 	// PluginFolder defines the location of ceph plugin
 	PluginFolder = "/var/lib/kubelet/plugins/"


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
