### PR TITLE
allow csi-rbdplugin deploy to master

### DIFF
--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -18,6 +18,10 @@ spec:
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet
+      # if you want to allow run the plugin on the master node, uncomment the toleration part
+      # tolerations:
+      # - key: node-role.kubernetes.io/master
+      #   effect: NoSchedule
       containers:
         - name: driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2


### PR DESCRIPTION

# Describe what this PR does #
allow  csi-rbdplugin deploy to master
 
Provide some context for the reviewer
csi-rbdplugi not deploy on master of kubernetes
we should install ceph plugin on all node, like cni plugin does

## Is there anything that requires special attention ##
