### PR TITLE
Use correct file descriptor to parse errors

### DIFF
--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -620,7 +620,7 @@ func getImageInfo(monitors string, cr *util.Credentials, poolName, imageName str
 
 	var imgInfo imageInfo
 
-	stdout, _, err := util.ExecCommand(
+	stdout, stderr, err := util.ExecCommand(
 		"rbd",
 		"-m", monitors,
 		"--id", cr.ID,
@@ -630,7 +630,7 @@ func getImageInfo(monitors string, cr *util.Credentials, poolName, imageName str
 		"info", poolName+"/"+imageName)
 	if err != nil {
 		klog.Errorf("failed getting information for image (%s): (%s)", poolName+"/"+imageName, err)
-		if strings.Contains(string(stdout), "rbd: error opening image "+imageName+
+		if strings.Contains(string(stderr), "rbd: error opening image "+imageName+
 			": (2) No such file or directory") {
 			return imgInfo, ErrImageNotFound{imageName, err}
 		}
@@ -669,7 +669,7 @@ func getSnapInfo(monitors string, cr *util.Credentials, poolName, imageName, sna
 		snaps   []snapInfo
 	)
 
-	stdout, _, err := util.ExecCommand(
+	stdout, stderr, err := util.ExecCommand(
 		"rbd",
 		"-m", monitors,
 		"--id", cr.ID,
@@ -680,7 +680,7 @@ func getSnapInfo(monitors string, cr *util.Credentials, poolName, imageName, sna
 	if err != nil {
 		klog.Errorf("failed getting snap (%s) information from image (%s): (%s)",
 			snapName, poolName+"/"+imageName, err)
-		if strings.Contains(string(stdout), "rbd: error opening image "+imageName+
+		if strings.Contains(string(stderr), "rbd: error opening image "+imageName+
 			": (2) No such file or directory") {
 			return snpInfo, ErrImageNotFound{imageName, err}
 		}

--- a/pkg/util/cephcmds.go
+++ b/pkg/util/cephcmds.go
@@ -237,10 +237,10 @@ func CreateObject(monitors string, cr *Credentials, poolName, namespace, objectN
 		args = append(args, "--namespace="+namespace)
 	}
 
-	stdout, _, err := ExecCommand("rados", args[:]...)
+	_, stderr, err := ExecCommand("rados", args[:]...)
 	if err != nil {
 		klog.Errorf("failed creating omap (%s) in pool (%s): (%v)", objectName, poolName, err)
-		if strings.Contains(string(stdout), "error creating "+poolName+"/"+objectName+
+		if strings.Contains(string(stderr), "error creating "+poolName+"/"+objectName+
 			": (17) File exists") {
 			return ErrObjectExists{objectName, err}
 		}
@@ -267,10 +267,10 @@ func RemoveObject(monitors string, cr *Credentials, poolName, namespace, oMapNam
 		args = append(args, "--namespace="+namespace)
 	}
 
-	stdout, _, err := ExecCommand("rados", args[:]...)
+	_, stderr, err := ExecCommand("rados", args[:]...)
 	if err != nil {
 		klog.Errorf("failed removing omap (%s) in pool (%s): (%v)", oMapName, poolName, err)
-		if strings.Contains(string(stdout), "error removing "+poolName+">"+oMapName+
+		if strings.Contains(string(stderr), "error removing "+poolName+">"+oMapName+
 			": (2) No such file or directory") {
 			return ErrObjectNotFound{oMapName, err}
 		}


### PR DESCRIPTION
File descriptors in use to parse errors from a few command
invocations were incorrect. This led to inability to detect
certain errors cases and act accordingly.

One of the easiest noticeable issues was when an image is deleted
but its RADOS keys and maps are still intact. In such cases
the DeleteVolume call always errored out unable to find the
image rather than, proceed with cleaning up the RADOS objects
and returning a success.

The original method of using stdout was incorrect, as the command
was tested from within a shell script and the scripts STDIN/OUT/ERR
was redirected to understand behavior. This is now tested using just
the CLI in question, and also examining Ceph code, and further
testing a couple of edge conditions by deleting backing images
for PVs

Signed-off-by: ShyamsundarR <srangana@redhat.com>