### PR TITLE
Remove redundant 777 chmod during the mount of cephfs subvolume

### DIFF
--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -243,12 +243,6 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	klog.Infof("cephfs: successfully bind-mounted volume %s to %s", volID, targetPath)
 
-	err = os.Chmod(targetPath, 0777)
-	if err != nil {
-		klog.Errorf("failed to change targetpath permission for volume %s: %v", volID, err)
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 


### PR DESCRIPTION
Ceph mgr command that creates the cephfs subvolume also takes mode
as argument, hence we need not set the mode during mount again.

Signed-off-by: Poornima G <pgurusid@redhat.com>