### PR TITLE
Avoid keyring message while logging

### DIFF
--- a/pkg/util/cephconf.go
+++ b/pkg/util/cephconf.go
@@ -32,7 +32,10 @@ fuse_set_user_groups = false
 
 const (
 	cephConfigRoot = "/etc/ceph"
+	// CephConfigPath ceph configuration file
 	CephConfigPath = "/etc/ceph/ceph.conf"
+
+	keyRing = "/etc/ceph/keyring"
 )
 
 func createCephConfigRoot() error {
@@ -46,5 +49,23 @@ func WriteCephConfig() error {
 		return err
 	}
 
-	return ioutil.WriteFile(CephConfigPath, cephConfig, 0640)
+	err := ioutil.WriteFile(CephConfigPath, cephConfig, 0640)
+	if err != nil {
+		return err
+	}
+
+	return createKeyRingFile()
+}
+
+/*
+if any ceph commands fails it will log below error message
+
+7f39ff02a700 -1 auth: unable to find a keyring on
+/etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,
+/etc/ceph/keyring.bin,: (2) No such file or directory
+*/
+// createKeyRingFile creates the keyring files to fix above error message logging
+func createKeyRingFile() error {
+	_, err := os.Create(keyRing)
+	return err
 }


### PR DESCRIPTION
# Describe what this PR does #
Avoid keyring message while logging
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Fixes: #354 


logs:
before logs:
```
csi.volumes.default) in pool (rbd): (an error (exit status 1) occurred while running rados args: [-m 10.106.133.206:6789 --id admin --key=***stripped*** -c /etc/ceph/ceph.conf -p rbd getomapval csi.volumes.default csi.volume.pvc-9e43bcce-1de1-40a3-8f51-89abe87043c6 /tmp/omap-get-875833669])
E0723 04:34:10.735520       1 utils.go:109] GRPC error: rpc error: code = Internal desc = error (an error (exit status 1) occurred while running rados args: [-m 10.106.133.206:6789 --id admin --key=***stripped*** -c /etc/ceph/ceph.conf -p rbd getomapval csi.volumes.default csi.volume.pvc-9e43bcce-1de1-40a3-8f51-89abe87043c6 /tmp/omap-get-875833669]) occurred, command output streams is ( 2019-07-23 04:34:10.665 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.666 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.666 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.703 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.703 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.703 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.714 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.715 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2019-07-23 04:34:10.715 7ff04f6b0880 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
error opening pool rbd: (2) No such file or directory
```
### After this fix
```
E0723 04:35:29.967042       1 cephcmds.go:185] failed getting omap value for key (csi.volume.pvc-e61748de-ba71-492d-952b-b8437d58ecec) from omap (csi.volumes.default) in pool (rbd): (an error (exit status 1) occurred while running rados args: [-m 10.106.133.206:6789 --id admin --key=***stripped*** -c /etc/ceph/ceph.conf -p rbd getomapval csi.volumes.default csi.volume.pvc-e61748de-ba71-492d-952b-b8437d58ecec /tmp/omap-get-471389962])
E0723 04:35:29.967118       1 utils.go:109] GRPC error: rpc error: code = Internal desc = error (an error (exit status 1) occurred while running rados args: [-m 10.106.133.206:6789 --id admin --key=***stripped*** -c /etc/ceph/ceph.conf -p rbd getomapval csi.volumes.default csi.volume.pvc-e61748de-ba71-492d-952b-b8437d58ecec /tmp/omap-get-471389962]) occurred, command output streams is ( error opening pool rbd: (2) No such file or directory
)

```