### PR TITLE
Temperory workaround for the regression to pass

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -39,6 +39,7 @@ var _ = Describe("cephfs", func() {
 		deployCephfsPlugin()
 		createCephfsStorageClass(f.ClientSet, f)
 		createCephfsSecret(f.ClientSet, f)
+		GivePermToCephfsRoot(f)
 	})
 
 	AfterEach(func() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -745,3 +745,17 @@ func listSnapshots(f *framework.Framework, pool, imageName string) ([]snapInfo, 
 	err := json.Unmarshal([]byte(stdout), &snapInfos)
 	return snapInfos, err
 }
+
+func GivePermToCephfsRoot(f *framework.Framework) {
+	opt := metav1.ListOptions{
+		LabelSelector: "app=rook-ceph-tools",
+	}
+	out := execCommandInPod(f, "mkdir /mnt/cephfs", rookNS, &opt)
+	e2elog.Logf("Creating temperory mount point in tools pod %s", out)
+
+	out = execCommandInPod(f, "ceph-fuse /mnt/cephfs >/dev/null 2>&1", rookNS, &opt)
+	e2elog.Logf("Mounting ceph file system at /mnt/cephfs %s", out)
+
+	out = execCommandInPod(f, "chmod 777 /mnt/cephfs/", rookNS, &opt)
+	e2elog.Logf("Setting chmod 777 on the cepfs root %s", out)
+}


### PR DESCRIPTION
Currently the cephfs PVC create/delete and all other operations
related to cephfs are failing. One of the recent commits in rook
900abbc967e108ad622648b740a7c57f1268209f has modified ceph-mgr
to run as ceph user rather than root user. The ceph user currently
has no permission to write to the root of the cephfs filesystem.
The fix will be external to CSI itself, but until that lands, sending
a workaround patch so the CSI CI is unblocked.

In this patch, we are setting the permission 777 on root of the cephfs
filesystem. Thus ceph user will be able to modify the cephfs filesystem.

Signed-off-by: Poornima G <pgurusid@redhat.com>