### PR TITLE
Update invite link to slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ Please use the following to reach members of the community:
 
 - Slack: Join our [slack channel](https://cephcsi.slack.com) to discuss
   about anything related to this project. You can join the slack by
-  this [invite link](https://bit.ly/32vcEfO )
+  this [invite link](https://bit.ly/2MeS4KY )
 - Forums: [ceph-csi](https://groups.google.com/forum/#!forum/ceph-csi)
 - Twitter: [@CephCsi](https://twitter.com/CephCsi)


### PR DESCRIPTION
The previous invite link got expired and this never expires!
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

