### PR TITLE
Add support for custom volume/snapshot name prefix

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -37,7 +37,7 @@ var _ = Describe("cephfs", func() {
 		createFileSystem(f.ClientSet)
 		createConfigMap(f.ClientSet, f)
 		deployCephfsPlugin()
-		createCephfsStorageClass(f.ClientSet, f)
+		createCephfsStorageClass(f.ClientSet, f, volNamePrefix)
 		createCephfsSecret(f.ClientSet, f)
 	})
 
@@ -82,6 +82,8 @@ var _ = Describe("cephfs", func() {
 				})
 
 				By("create/delete multiple PVCs and Apps", func() {
+					deleteResource(cephfsExamplePath + "storageclass.yaml")
+					createCephfsStorageClass(f.ClientSet, f, "")
 					totalCount := 2
 					pvc, err := loadPVC(pvcPath)
 					if err != nil {

--- a/examples/cephfs/storageclass.yaml
+++ b/examples/cephfs/storageclass.yaml
@@ -20,6 +20,10 @@ parameters:
   # Ceph pool into which the volume shall be created
   pool: cephfs_data
 
+  # With volumenameprefix option an admin can now prefix the desired volume
+  # name from storageclass.
+  # volumenameprefix: custom-vol-name
+
   # The secrets have to contain user and/or Ceph admin credentials.
   csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
   csi.storage.k8s.io/provisioner-secret-namespace: default

--- a/examples/rbd/snapshotclass.yaml
+++ b/examples/rbd/snapshotclass.yaml
@@ -13,6 +13,8 @@ parameters:
   # csi-config-map-sample.yaml, to accompany the string chosen to
   # represent the Ceph cluster in clusterID below
   clusterID: <cluster-id>
-
+  # With snapshotnameprefix option an admin can now prefix the desired snapshot
+  # name from storageclass.
+  # snapshotnameprefix: custom-snap-name
   csi.storage.k8s.io/snapshotter-secret-name: csi-rbd-secret
   csi.storage.k8s.io/snapshotter-secret-namespace: default

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -24,6 +24,10 @@ parameters:
    # CSI RBD currently supports only `layering` feature.
    imageFeatures: layering
 
+   # With volumenameprefix option an admin can now prefix the desired volume
+   # name from storageclass.
+   # volumenameprefix: custom-vol-name
+
    # The secrets have to contain Ceph credentials with required access
    # to the 'pool'.
    csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret

--- a/pkg/cephfs/driver.go
+++ b/pkg/cephfs/driver.go
@@ -27,9 +27,6 @@ import (
 
 const (
 
-	// volIDVersion is the version number of volume ID encoding scheme
-	volIDVersion uint16 = 1
-
 	// csiConfigFile is the location of the CSI config file
 	csiConfigFile = "/etc/ceph-csi-config/config.json"
 

--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -407,7 +407,10 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	}
 
 	// Create snap volume
-	rbdSnap := genSnapFromOptions(rbdVol, req.GetParameters())
+	rbdSnap, err := genSnapFromOptions(rbdVol, req.GetParameters())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
 	rbdSnap.RbdImageName = rbdVol.RbdImageName
 	rbdSnap.SizeBytes = rbdVol.VolSize
 	rbdSnap.SourceVolumeID = req.GetSourceVolumeId()

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -208,7 +208,7 @@ func getVolumeName(volID string) (string, error) {
 		return "", ErrInvalidVolID{err}
 	}
 
-	return volJournal.NamingPrefix() + vi.ObjectUUID, nil
+	return vi.VolNamePrefix + vi.ObjectUUID, nil
 }
 
 func getLegacyVolumeName(mountPath string) (string, error) {

--- a/pkg/rbd/rbd.go
+++ b/pkg/rbd/rbd.go
@@ -29,8 +29,6 @@ import (
 )
 
 const (
-	// volIDVersion is the version number of volume ID encoding scheme
-	volIDVersion uint16 = 1
 
 	// csiConfigFile is the location of the CSI config file
 	csiConfigFile = "/etc/ceph-csi-config/config.json"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -19,6 +19,7 @@ package util
 import (
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
+)
+
+var (
+	volumeNameRE = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 )
 
 // remove this once kubernetes v1.14.0 release is done
@@ -99,27 +104,6 @@ func ValidateDriverName(driverName string) error {
 	return err
 }
 
-// GenerateVolID generates a volume ID based on passed in parameters and version, to be returned
-// to the CO system
-func GenerateVolID(monitors string, cr *Credentials, pool, clusterID, objUUID string, volIDVersion uint16) (string, error) {
-	poolID, err := GetPoolID(monitors, cr, pool)
-	if err != nil {
-		return "", err
-	}
-
-	// generate the volume ID to return to the CO system
-	vi := CSIIdentifier{
-		LocationID:      poolID,
-		EncodingVersion: volIDVersion,
-		ClusterID:       clusterID,
-		ObjectUUID:      objUUID,
-	}
-
-	volID, err := vi.ComposeCSIID()
-
-	return volID, err
-}
-
 // CreateMountPoint creates the directory with given path
 func CreateMountPoint(mountPath string) error {
 	return os.MkdirAll(mountPath, 0750)
@@ -140,4 +124,9 @@ func IsMountPoint(p string) (bool, error) {
 func Mount(source, target, fstype string, options []string) error {
 	dummyMount := mount.New("")
 	return dummyMount.Mount(source, target, fstype, options)
+}
+
+// isValidName validates Volume name
+func isValidName(name string) bool {
+	return volumeNameRE.MatchString(name)
 }

--- a/pkg/util/volid.go
+++ b/pkg/util/volid.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -47,10 +48,20 @@ type CSIIdentifier struct {
 	EncodingVersion uint16
 	ClusterID       string
 	ObjectUUID      string
+	VolNamePrefix   string
 }
 
 // This maximum comes from the CSI spec on max bytes allowed in the various CSI ID fields
 const maxVolIDLen = 128
+
+// volIDVersion{V1,V2...} is the version number of volume ID encoding scheme
+const (
+	_ = iota
+	// EncodingV1 is to support decoding of the ID encoded using version v1
+	EncodingV1
+	// EncodingV2 supports volumenameprefix encoding
+	EncodingV2
+)
 
 /*
 ComposeCSIID composes a CSI ID from passed in parameters.
@@ -60,20 +71,39 @@ Version 1 of the encoding scheme is as follows,
 	[clusterID:36bytes (MAX)] + [-:1byte]
 	[poolID:16bytes] + [-:1byte]
 	[ObjectUUID:36bytes]
-
 	Total of constant field lengths, including '-' field separators would hence be,
 	4+1+4+1+1+16+1+36 = 64
 */
+
+/*
+ComposeCSIID composes a CSI ID from passed in parameters.
+Version 2 of the encoding scheme is as follows,
+	[csi_id_version=1:4byte] + [-:1byte]
+	[length of clusterID=1:4byte] + [-:1byte]
+	[clusterID:36bytes (MAX)] + [-:1byte]
+	[poolID:16bytes] + [-:1byte]
+	[length of volNamePrefix=1:4byte] + [-:1byte]
+	[volNamePrefix:36bytes (MAX)] + [-:1byte]
+	[ObjectUUID:36bytes]
+
+	Total of constant field lengths, including '-' field separators would hence be,
+	4+1+4+1+4+1+1+16+1+36 = 69
+*/
 const (
-	knownFieldSize = 64
-	uuidSize       = 36
+	knownV1FieldSize = 64
+	knownV2FieldSize = 69
+	uuidSize         = 36
+	volNamePrefix    = "volumenameprefix"
+	snapNamePrefix   = "snapshotnameprefix"
 )
 
+// ComposeCSIID composes a CSI ID from passed in parameters
 func (ci CSIIdentifier) ComposeCSIID() (string, error) {
 	buf16 := make([]byte, 2)
 	buf64 := make([]byte, 8)
 
-	if (knownFieldSize + len(ci.ClusterID)) > maxVolIDLen {
+	ci.EncodingVersion = EncodingV2
+	if (knownV2FieldSize+len(ci.ClusterID))+len(ci.VolNamePrefix) > maxVolIDLen {
 		return "", errors.New("CSI ID encoding length overflow")
 	}
 
@@ -90,18 +120,120 @@ func (ci CSIIdentifier) ComposeCSIID() (string, error) {
 	binary.BigEndian.PutUint64(buf64, uint64(ci.LocationID))
 	poolIDEncodedHex := hex.EncodeToString(buf64)
 
+	// remove '-' added for prefix and store
+	ci.VolNamePrefix = ci.VolNamePrefix[:len(ci.VolNamePrefix)-1]
+
+	binary.BigEndian.PutUint16(buf16, uint16(len(ci.VolNamePrefix)))
+	volNamePrefixLength := hex.EncodeToString(buf16)
+
 	return strings.Join([]string{versionEncodedHex, clusterIDLength, ci.ClusterID,
-		poolIDEncodedHex, ci.ObjectUUID}, "-"), nil
+		poolIDEncodedHex, volNamePrefixLength, ci.VolNamePrefix, ci.ObjectUUID}, "-"), nil
 }
 
 /*
-DecomposeCSIID composes a CSIIdentifier from passed in string
+DecomposeV2CSIID composes a CSIIdentifier from passed in string
 */
-func (ci *CSIIdentifier) DecomposeCSIID(composedCSIID string) (err error) {
+func (ci *CSIIdentifier) DecomposeV2CSIID(composedCSIID string) (err error) {
 	bytesToProcess := uint16(len(composedCSIID))
 
 	// if length is less that expected constant elements, then bail out!
-	if bytesToProcess < knownFieldSize {
+	if bytesToProcess < knownV2FieldSize {
+		return errors.New("failed to decode CSI identifier, string underflow")
+	}
+
+	buf16, err := hex.DecodeString(composedCSIID[0:4])
+	if err != nil {
+		return err
+	}
+	ci.EncodingVersion = binary.BigEndian.Uint16(buf16)
+
+	// 4 for version encoding and 1 for '-' separator
+	bytesToProcess -= 5
+
+	buf16, err = hex.DecodeString(composedCSIID[5:9])
+	if err != nil {
+		return err
+	}
+	clusterIDLength := binary.BigEndian.Uint16(buf16)
+	// 4 for length encoding and 1 for '-' separator
+	bytesToProcess -= 5
+
+	if bytesToProcess < (clusterIDLength + 1) {
+		return errors.New("failed to decode CSI identifier, string underflow")
+	}
+	ci.ClusterID = composedCSIID[10 : 10+clusterIDLength]
+	// additional 1 for '-' separator
+	bytesToProcess -= (clusterIDLength + 1)
+	nextFieldStartIdx := 10 + clusterIDLength + 1
+	if bytesToProcess < 17 {
+		return errors.New("failed to decode CSI identifier, string underflow")
+	}
+
+	buf64, err := hex.DecodeString(composedCSIID[nextFieldStartIdx : nextFieldStartIdx+16])
+	if err != nil {
+		return err
+	}
+	ci.LocationID = int64(binary.BigEndian.Uint64(buf64))
+	// 16 for poolID encoding and 1 for '-' separator
+	bytesToProcess -= 17
+	nextFieldStartIdx += 17
+	buf16, err = hex.DecodeString(composedCSIID[nextFieldStartIdx : nextFieldStartIdx+4])
+	if err != nil {
+		return err
+	}
+	volNamePrefixLength := binary.BigEndian.Uint16(buf16)
+	// 4 for length encoding and 1 for '-' separator
+	bytesToProcess -= 5
+	nextFieldStartIdx += 5
+	if bytesToProcess < (volNamePrefixLength + 1) {
+		return errors.New("failed to decode CSI identifier, string underflow")
+	}
+	ci.VolNamePrefix = composedCSIID[nextFieldStartIdx : nextFieldStartIdx+volNamePrefixLength]
+
+	// add - if to the prefix as we removed it while encoding it
+	ci.VolNamePrefix += "-"
+	// 16 for poolID encoding and 1 for '-' separator
+	// additional 1 for '-' separator
+	bytesToProcess -= (volNamePrefixLength + 1)
+	nextFieldStartIdx += volNamePrefixLength + 1
+	// has to be an exact match
+	if bytesToProcess != uuidSize {
+		return errors.New("failed to decode CSI identifier, string size mismatch")
+	}
+
+	ci.ObjectUUID = composedCSIID[nextFieldStartIdx : nextFieldStartIdx+uuidSize]
+
+	return err
+}
+
+/*
+DecomposeCSIID composes a CSIIdentifier from passed in string and also based
+on the Encoding version of the CSIID
+*/
+func (ci *CSIIdentifier) DecomposeCSIID(composedCSIID string) (err error) {
+
+	encodingVersion, err := ci.getVolEncodingVersion(composedCSIID)
+	if err != nil {
+		return err
+	}
+	if encodingVersion == EncodingV1 {
+		err := ci.DecomposeV1CSIID(composedCSIID)
+		if err == nil {
+			ci.VolNamePrefix = "csi-vol-"
+		}
+		return err
+	}
+	return ci.DecomposeV2CSIID(composedCSIID)
+}
+
+/*
+DecomposeV1CSIID composes a CSIIdentifier from passed in string
+*/
+func (ci *CSIIdentifier) DecomposeV1CSIID(composedCSIID string) (err error) {
+	bytesToProcess := uint16(len(composedCSIID))
+
+	// if length is less that expected constant elements, then bail out!
+	if bytesToProcess < knownV1FieldSize {
 		return errors.New("failed to decode CSI identifier, string underflow")
 	}
 
@@ -148,4 +280,74 @@ func (ci *CSIIdentifier) DecomposeCSIID(composedCSIID string) (err error) {
 	ci.ObjectUUID = composedCSIID[nextFieldStartIdx : nextFieldStartIdx+uuidSize]
 
 	return err
+}
+
+// GetVolNamePrefix checks volumenameprefix is present in storageclass
+// parameters and returns key is present in parameters and custom volume name
+// if present
+func GetVolNamePrefix(param map[string]string) (string, error) {
+	name, ok := param[volNamePrefix]
+	if ok {
+		ok = isValidName(name)
+		if !ok {
+			return "", fmt.Errorf("%s is not in valid format", name)
+		}
+		return name, nil
+	}
+	return "", nil
+}
+
+// GetSnapNamePrefix checks snapnameprefix is present in snapshotclass
+// parameters and returns the custom vol name
+func GetSnapNamePrefix(param map[string]string) (string, error) {
+	name, ok := param[snapNamePrefix]
+	if ok {
+		ok = isValidName(name)
+		if !ok {
+			return "", fmt.Errorf("%s is not in valid format", name)
+		}
+		return name, nil
+	}
+	return "", nil
+
+}
+
+// getVolEncodingVersion returns the encoding version, this will be helpful to
+// decode older volumes with version 1 and new volume with version 2 supports
+// volume encoding
+func (ci *CSIIdentifier) getVolEncodingVersion(composedCSIID string) (uint16, error) {
+	// if length is less that expected constant elements, then bail out!
+	bytesToProcess := uint16(len(composedCSIID))
+	if bytesToProcess < knownV1FieldSize {
+		return 0, errors.New("failed to decode CSI identifier, string underflow")
+
+	}
+	buf16, err := hex.DecodeString(composedCSIID[0:4])
+	if err != nil {
+		return 0, err
+	}
+	encodingVersion := binary.BigEndian.Uint16(buf16)
+	return encodingVersion, nil
+
+}
+
+// GenerateID generates a volume ID based on passed in parameters and version, to be returned
+// to the CO system
+func GenerateID(monitors string, cr *Credentials, pool, clusterID, objUUID, namePrefix string) (string, error) {
+	poolID, err := GetPoolID(monitors, cr, pool)
+	if err != nil {
+		return "", err
+	}
+
+	// generate the volume ID to return to the CO system
+	vi := CSIIdentifier{
+		LocationID:    poolID,
+		ClusterID:     clusterID,
+		VolNamePrefix: namePrefix,
+		ObjectUUID:    objUUID,
+	}
+
+	volID, err := vi.ComposeCSIID()
+
+	return volID, err
 }

--- a/pkg/util/volid_test.go
+++ b/pkg/util/volid_test.go
@@ -34,12 +34,55 @@ var testData = []testTuple{
 	{
 		vID: CSIIdentifier{
 			LocationID:      0xffff,
-			EncodingVersion: 0xffff,
+			EncodingVersion: EncodingV2,
 			ClusterID:       "01616094-9d93-4178-bf45-c7eac19e8b15",
+			VolNamePrefix:   "csi-vol-",
 			ObjectUUID:      "00000000-1111-2222-bbbb-cacacacacaca",
 		},
-		composedVolID: "ffff-0024-01616094-9d93-4178-bf45-c7eac19e8b15-000000000000ffff-00000000-1111-2222-bbbb-cacacacacaca",
+		composedVolID: "0002-0024-01616094-9d93-4178-bf45-c7eac19e8b15-000000000000ffff-0007-csi-vol-00000000-1111-2222-bbbb-cacacacacaca",
 		wantEnc:       true,
+		wantEncError:  false,
+		wantDec:       true,
+		wantDecError:  false,
+	},
+	{
+		vID: CSIIdentifier{
+			LocationID:      0xffff,
+			EncodingVersion: EncodingV2,
+			ClusterID:       "01616094-9d93-4178-bf45-c7eac19e8b15",
+			VolNamePrefix:   "testing-vol-name-",
+			ObjectUUID:      "00000000-1111-2222-bbbb-cacacacacaca",
+		},
+		composedVolID: "0002-0024-01616094-9d93-4178-bf45-c7eac19e8b15-000000000000ffff-0010-testing-vol-name-00000000-1111-2222-bbbb-cacacacacaca",
+		wantEnc:       true,
+		wantEncError:  false,
+		wantDec:       true,
+		wantDecError:  false,
+	},
+	{
+		vID: CSIIdentifier{
+			LocationID:      0xffff,
+			EncodingVersion: EncodingV2,
+			ClusterID:       "01616094-9d93-4178-bf45-c7eac19e8b15",
+			VolNamePrefix:   "testing-vol-name--",
+			ObjectUUID:      "00000000-1111-2222-bbbb-cacacacacaca",
+		},
+		composedVolID: "0002-0024-01616094-9d93-4178-bf45-c7eac19e8b15-000000000000ffff-0011-testing-vol-name--00000000-1111-2222-bbbb-cacacacacaca",
+		wantEnc:       true,
+		wantEncError:  false,
+		wantDec:       true,
+		wantDecError:  false,
+	},
+	{
+		vID: CSIIdentifier{
+			LocationID:      0xffff,
+			EncodingVersion: EncodingV1,
+			ClusterID:       "01616094-9d93-4178-bf45-c7eac19e8b15",
+			VolNamePrefix:   "csi-vol-",
+			ObjectUUID:      "00000000-3333-4444-bbbb-cacacacacaca",
+		},
+		composedVolID: "0001-0024-01616094-9d93-4178-bf45-c7eac19e8b15-000000000000ffff-00000000-3333-4444-bbbb-cacacacacaca",
+		wantEnc:       false,
 		wantEncError:  false,
 		wantDec:       true,
 		wantDecError:  false,
@@ -47,13 +90,12 @@ var testData = []testTuple{
 }
 
 func TestComposeDecomposeID(t *testing.T) {
-	var (
-		err           error
-		viDecompose   CSIIdentifier
-		composedVolID string
-	)
-
 	for _, test := range testData {
+		var (
+			err           error
+			viDecompose   CSIIdentifier
+			composedVolID string
+		)
 		if test.wantEnc {
 			composedVolID, err = test.vID.ComposeCSIID()
 
@@ -87,8 +129,7 @@ func TestComposeDecomposeID(t *testing.T) {
 			}
 
 			if !test.wantDecError && err == nil && viDecompose != test.vID {
-				t.Errorf("Decomposing failed: want (%#v), got (%#v %#v)",
-					test, viDecompose, err)
+				t.Errorf("Decomposing failed: want (%#v), got (%#v)", test.vID, viDecompose)
 			}
 		}
 	}


### PR DESCRIPTION
if the user provides a volume/snapshot name prefix via storage/snapshot class.we will be creating
the backend volume/snapshot with the prefix name, this will help admin to easily check which image
belongs to which storage class.

Fixes: #487 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

