### PR TITLE
Proceed to unmap RBD device on failing to find staging mount point

### DIFF
--- a/deploy/cephfs/kubernetes/v1.13/helm/templates/nodeplugin-daemonset.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/helm/templates/nodeplugin-daemonset.yaml
@@ -73,8 +73,6 @@ spec:
             - "--metadatastorage=k8s_configmap"
             - "--mountcachedir=/mount-cache-dir"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/deploy/cephfs/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
@@ -72,8 +72,6 @@ spec:
             - "--drivername=$(DRIVER_NAME)"
             - "--metadatastorage=k8s_configmap"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/deploy/cephfs/kubernetes/v1.14+/helm/templates/nodeplugin-daemonset.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/helm/templates/nodeplugin-daemonset.yaml
@@ -73,8 +73,6 @@ spec:
             - "--metadatastorage=k8s_configmap"
             - "--mountcachedir=/mount-cache-dir"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/deploy/cephfs/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
@@ -75,8 +75,6 @@ spec:
             - "--drivername=$(DRIVER_NAME)"
             - "--metadatastorage=k8s_configmap"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
@@ -86,8 +86,6 @@ spec:
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: NODE_ID
               valueFrom:
                 fieldRef:

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin.yaml
@@ -61,8 +61,6 @@ spec:
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: NODE_ID
               valueFrom:
                 fieldRef:

--- a/deploy/rbd/kubernetes/v1.13/helm/templates/nodeplugin-daemonset.yaml
+++ b/deploy/rbd/kubernetes/v1.13/helm/templates/nodeplugin-daemonset.yaml
@@ -74,8 +74,6 @@ spec:
             - "--drivername=$(DRIVER_NAME)"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/deploy/rbd/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/rbd/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
@@ -89,8 +89,6 @@ spec:
             - "--drivername=$(DRIVER_NAME)"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
@@ -76,8 +76,6 @@ spec:
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: NODE_ID
               valueFrom:
                 fieldRef:

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
@@ -61,8 +61,6 @@ spec:
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: NODE_ID
               valueFrom:
                 fieldRef:

--- a/deploy/rbd/kubernetes/v1.14+/helm/templates/nodeplugin-daemonset.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/helm/templates/nodeplugin-daemonset.yaml
@@ -74,8 +74,6 @@ spec:
             - "--drivername=$(DRIVER_NAME)"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/deploy/rbd/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
@@ -93,8 +93,6 @@ spec:
             - "--drivername=$(DRIVER_NAME)"
             - "--containerized=true"
           env:
-            - name: HOST_ROOTFS
-              value: "/rootfs"
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -36,10 +36,6 @@ make image-cephcsi
 | `--instanceid`      | "default"             | Unique ID distinguishing this instance of Ceph CSI among other instances, when sharing Ceph clusters across CSI instances for provisioning                                   |
 | `--metadatastorage` | _empty_               | Points to where legacy (1.0.0 or older plugin versions) metadata about provisioned volumes are kept, as file or in as k8s configmap (`node` or `k8s_configmap` respectively) |
 
-**Available environmental variables:**
-
-`HOST_ROOTFS`: rbdplugin searches `/proc` directory under the directory set by `HOST_ROOTFS`.
-
 **Available volume parameters:**
 
 | Parameter                                                                                             | Required             | Description                                                                                                                                                                                                             |

--- a/pkg/rbd/errors.go
+++ b/pkg/rbd/errors.go
@@ -57,3 +57,12 @@ type ErrInvalidVolID struct {
 func (e ErrInvalidVolID) Error() string {
 	return e.err.Error()
 }
+
+// ErrMissingStash is returned when the image metadata stash file is not found
+type ErrMissingStash struct {
+	err error
+}
+
+func (e ErrMissingStash) Error() string {
+	return e.err.Error()
+}

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -19,8 +19,6 @@ package rbd
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"regexp"
 	"strings"
 
 	csicommon "github.com/ceph/ceph-csi/pkg/csi-common"
@@ -45,9 +43,15 @@ type NodeServer struct {
 // Implementation notes:
 // - stagingTargetPath is the directory passed in the request where the volume needs to be staged
 //   - We stage the volume into a directory, named after the VolumeID inside stagingTargetPath if
-// it is a file system
+//    it is a file system
 //   - We stage the volume into a file, named after the VolumeID inside stagingTargetPath if it is
-// a block volume
+//    a block volume
+// - Order of operation execution: (useful for defer stacking and when Unstaging to ensure steps
+//	are done in reverse, this is done in undoStagingTransaction)
+//   - Stash image metadata under staging path
+//   - Map the image (creates a device)
+//   - Create the staging file/directory under staging path
+//   - Stage the device (mount the device mapped for image)
 func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	if err := util.ValidateNodeStageVolumeRequest(req); err != nil {
 		return nil, err
@@ -89,8 +93,8 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		isLegacyVolume = true
 	}
 
-	stagingTargetPath := req.GetStagingTargetPath()
-	stagingTargetPath += "/" + volID
+	stagingParentPath := req.GetStagingTargetPath()
+	stagingTargetPath := stagingParentPath + "/" + req.GetVolumeId()
 
 	idLk := nodeVolumeIDLocker.Lock(volID)
 	defer nodeVolumeIDLocker.Unlock(idLk, volID)
@@ -113,22 +117,29 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	volOptions.RbdImageName = volName
 
+	isMounted := false
+	isStagePathCreated := false
+	devicePath := ""
+
+	// Stash image details prior to mapping the image (useful during Unstage as it has no
+	// voloptions passed to the RPC as per the CSI spec)
+	err = stashRBDImageMetadata(volOptions, stagingParentPath)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer func() {
+		if err != nil {
+			ns.undoStagingTransaction(stagingParentPath, devicePath, volID, isStagePathCreated, isMounted)
+		}
+	}()
+
 	// Mapping RBD image
-	devicePath, err := attachRBDImage(volOptions, cr)
+	devicePath, err = attachRBDImage(volOptions, cr)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	klog.V(4).Infof("rbd image: %s/%s was successfully mapped at %s\n", req.GetVolumeId(), volOptions.Pool, devicePath)
 
-	isMounted := false
-	isStagePathCreated := false
-	// if mounting to stagingpath fails unmap the rbd device. this wont leave any
-	// stale rbd device if unstage is not called
-	defer func() {
-		if err != nil {
-			ns.cleanupStagingPath(stagingTargetPath, devicePath, volID, isStagePathCreated, isMounted)
-		}
-	}()
 	err = ns.createStageMountPoint(stagingTargetPath, isBlock)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -152,24 +163,40 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (ns *NodeServer) cleanupStagingPath(stagingTargetPath, devicePath, volID string, isStagePathCreated, isMounted bool) {
+func (ns *NodeServer) undoStagingTransaction(stagingParentPath, devicePath, volID string, isStagePathCreated, isMounted bool) {
 	var err error
+
+	stagingTargetPath := stagingParentPath + "/" + volID
 	if isMounted {
 		err = ns.mounter.Unmount(stagingTargetPath)
 		if err != nil {
 			klog.Errorf("failed to unmount stagingtargetPath: %s with error: %v", stagingTargetPath, err)
+			return
 		}
 	}
-	// remove the block file created on staging path
+
+	// remove the file/directory created on staging path
 	if isStagePathCreated {
 		err = os.Remove(stagingTargetPath)
 		if err != nil {
 			klog.Errorf("failed to remove stagingtargetPath: %s with error: %v", stagingTargetPath, err)
+			// continue on failure to unmap the image, as leaving stale images causes more issues than a stale file/directory
 		}
 	}
+
 	// Unmapping rbd device
-	if err = detachRBDDevice(devicePath); err != nil {
-		klog.Errorf("failed to unmap rbd device: %s for volume %s with error: %v", devicePath, volID, err)
+	if devicePath != "" {
+		err = detachRBDDevice(devicePath)
+		if err != nil {
+			klog.Errorf("failed to unmap rbd device: %s for volume %s with error: %v", devicePath, volID, err)
+			// continue on failure to delete the stash file, as kubernetes will fail to delete the staging path otherwise
+		}
+	}
+
+	// Cleanup the stashed image metadata
+	if err = cleanupRBDImageMetadataStash(stagingParentPath); err != nil {
+		klog.Errorf("failed to cleanup image metadata stash (%v)", err)
+		return
 	}
 }
 
@@ -190,8 +217,10 @@ func (ns *NodeServer) createStageMountPoint(mountPath string, isBlock bool) erro
 
 	err := os.Mkdir(mountPath, 0750)
 	if err != nil {
-		klog.Errorf("failed to create mountPath:%s with error: %v", mountPath, err)
-		return status.Error(codes.Internal, err.Error())
+		if !os.IsExist(err) {
+			klog.Errorf("failed to create mountPath:%s with error: %v", mountPath, err)
+			return status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	return nil
@@ -372,7 +401,7 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	klog.Infof("rbd: successfully unbinded volume %s from %s", req.GetVolumeId(), targetPath)
+	klog.Infof("rbd: successfully unbound volume %s from %s", req.GetVolumeId(), targetPath)
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
@@ -384,111 +413,72 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		return nil, err
 	}
 
-	stagingTargetPath := req.GetStagingTargetPath()
-	stagingTargetPath += "/" + req.GetVolumeId()
+	stagingParentPath := req.GetStagingTargetPath()
+	stagingTargetPath := stagingParentPath + "/" + req.GetVolumeId()
 
 	notMnt, err := mount.IsNotMountPoint(ns.mounter, stagingTargetPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			// staging targetPath has already been deleted
-			klog.V(4).Infof("stagingTargetPath: %s has already been deleted", stagingTargetPath)
-			return &csi.NodeUnstageVolumeResponse{}, nil
+		if !os.IsNotExist(err) {
+			return nil, status.Error(codes.NotFound, err.Error())
 		}
-		return nil, status.Error(codes.NotFound, err.Error())
+		// Continue on ENOENT errors as we may still have the image mapped
+		notMnt = true
 	}
-	if notMnt {
-		// TODO: IsNotExist error should have been caught above
-		if err = os.Remove(stagingTargetPath); err != nil {
+	if !notMnt {
+		// Unmounting the image
+		err = ns.mounter.Unmount(stagingTargetPath)
+		if err != nil {
+			klog.V(3).Infof("failed to unmount targetPath: %s with error: %v", stagingTargetPath, err)
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		return &csi.NodeUnstageVolumeResponse{}, nil
-	}
-
-	// Unmount the volume
-	devicePath, cnt, err := mount.GetDeviceNameFromMount(ns.mounter, stagingTargetPath)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if err = ns.unmount(stagingTargetPath, devicePath, cnt); err != nil {
-		return nil, err
 	}
 
 	if err = os.Remove(stagingTargetPath); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	klog.Infof("rbd: successfully unmounted volume %s from %s", req.GetVolumeId(), stagingTargetPath)
-
-	return &csi.NodeUnstageVolumeResponse{}, nil
-}
-
-func (ns *NodeServer) unmount(targetPath, devicePath string, cnt int) error {
-	var err error
-	// Bind mounted device needs to be resolved by using resolveBindMountedBlockDevice
-	if devicePath == "devtmpfs" {
-		devicePath, err = resolveBindMountedBlockDevice(targetPath)
-		if err != nil {
-			return status.Error(codes.Internal, err.Error())
+		// Any error is critical as Staging path is expected to be empty by Kubernetes, it otherwise
+		// keeps invoking Unstage. Hence any errors removing files within this path is a critical
+		// error
+		if !os.IsNotExist(err) {
+			klog.Errorf("failed to remove staging target path (%s): (%v)", stagingTargetPath, err)
+			return nil, status.Error(codes.Internal, err.Error())
 		}
-		klog.V(4).Infof("NodeUnpublishVolume: devicePath: %s, (original)cnt: %d\n", devicePath, cnt)
-		// cnt for GetDeviceNameFromMount is broken for bind mouted device,
-		// it counts total number of mounted "devtmpfs", instead of counting this device.
-		// So, forcibly setting cnt to 1 here.
-		// TODO : fix this properly
-		cnt = 1
 	}
 
-	klog.V(4).Infof("NodeUnpublishVolume: targetPath: %s, devicePath: %s\n", targetPath, devicePath)
-
-	// Unmounting the image
-	err = ns.mounter.Unmount(targetPath)
+	imgInfo, err := lookupRBDImageMetadataStash(stagingParentPath)
 	if err != nil {
-		klog.V(3).Infof("failed to unmount targetPath: %s with error: %v", targetPath, err)
-		return status.Error(codes.Internal, err.Error())
-	}
+		klog.V(2).Infof("failed to find image metadata: %v", err)
+		// It is an error if it was mounted, as we should have found the image metadata file with
+		// no errors
+		if !notMnt {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 
-	cnt--
-	if cnt != 0 {
-		// TODO should this be fixed not to success, so that driver can retry unmounting?
-		return nil
+		// If not mounted, and error is anything other than metadata file missing, it is an error
+		if _, ok := err.(ErrMissingStash); !ok {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		// It was not mounted and image metadata is also missing, we are done as the last step in
+		// in the staging transaction is complete
+		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 
 	// Unmapping rbd device
-	if err = detachRBDDevice(devicePath); err != nil {
-		klog.V(3).Infof("failed to unmap rbd device: %s with error: %v", devicePath, err)
-		return status.Error(codes.Internal, err.Error())
+	imageSpec := imgInfo.Pool + "/" + imgInfo.ImageName
+	if err = detachRBDImageOrDeviceSpec(imageSpec, true, imgInfo.NbdAccess); err != nil {
+		klog.Errorf("error unmapping volume (%s) from staging path (%s): (%v)",
+			req.GetVolumeId(), stagingTargetPath, err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return nil
-}
-func resolveBindMountedBlockDevice(mountPath string) (string, error) {
-	// #nosec
-	cmd := exec.Command("findmnt", "-n", "-o", "SOURCE", "--first-only", "--target", mountPath)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		klog.V(2).Infof("Failed findmnt command for path %s: %s %v", mountPath, out, err)
-		return "", err
-	}
-	return parseFindMntResolveSource(string(out))
-}
+	klog.Infof("successfully unmounted volume (%s) from staging path (%s)",
+		req.GetVolumeId(), stagingTargetPath)
 
-// parse output of "findmnt -o SOURCE --first-only --target" and return just the SOURCE
-func parseFindMntResolveSource(out string) (string, error) {
-	// cut trailing newline
-	out = strings.TrimSuffix(out, "\n")
-	// Check if out is a mounted device
-	reMnt := regexp.MustCompile("^(/[^/]+(?:/[^/]*)*)$")
-	if match := reMnt.FindStringSubmatch(out); match != nil {
-		return match[1], nil
+	if err = cleanupRBDImageMetadataStash(stagingParentPath); err != nil {
+		klog.Errorf("failed to cleanup image metadata stash (%v)", err)
+		return nil, status.Error(codes.Internal, err.Error())
 	}
-	// Check if out is a block device
-	// nolint
-	reBlk := regexp.MustCompile("^devtmpfs\\[(/[^/]+(?:/[^/]*)*)\\]$")
-	if match := reBlk.FindStringSubmatch(out); match != nil {
-		return fmt.Sprintf("/dev%s", match[1]), nil
-	}
-	return "", fmt.Errorf("parseFindMntResolveSource: %s doesn't match to any expected findMnt output", out)
+
+	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
 // NodeGetCapabilities returns the supported capabilities of the node server

--- a/pkg/rbd/rbd_journal.go
+++ b/pkg/rbd/rbd_journal.go
@@ -200,7 +200,7 @@ func checkVolExists(rbdVol *rbdVolume, cr *util.Credentials) (bool, error) {
 		return false, err
 	}
 
-	klog.V(4).Infof("found existng volume (%s) with image name (%s) for request (%s)",
+	klog.V(4).Infof("found existing volume (%s) with image name (%s) for request (%s)",
 		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.RequestName)
 
 	return true, nil

--- a/pkg/util/validate.go
+++ b/pkg/util/validate.go
@@ -27,7 +27,7 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 	// validate stagingpath exists
 	ok := checkDirExists(req.GetStagingTargetPath())
 	if !ok {
-		return status.Error(codes.InvalidArgument, "staging path doesnot exists on node")
+		return status.Error(codes.InvalidArgument, "staging path does not exists on node")
 	}
 	return nil
 }


### PR DESCRIPTION
Currently, we return a success if we do not find a mount at the staging
mount point. This is incorrect, as there are cases when a prior attempt
at unstage, umounts the staging path, but errors out due to RBD image
being busy (which maybe transient). Thus, on retries instead of attempting
to unmap the RBD image, the image is left mapped on the node.

The fix provided here is to attempt to find the RBD device mapped and
unmap the same if found, even when the staging mount point/path is missing.

The fix has a few parts to it,
- Move away from using staging path as the mount, when mounting the image as a filesystem, such that the staging path directory can be used to stash other metadata about the image
- Update how nbd based mapping it done to use the rbd command instead
  - Like "rbd device map --device-type [krbd|nbd]"
- Fix implementation of waitForPath to use rbd CLI to detect device and image names
  - Like, "rbd device list --format json --device-type [krbd|nbd]"
- Fix the current problem of using `rbd device list` and stashed JSON image matadata in the absence of a mount point to detect if an rbd image is mapped on the node

Future, as we get the fix from rbd CLI to add fsid to its device list output
  - stash the image fsid into a JSON file on the staging path before mapping the image
  - during unmap, when mount point does not exist (or even otherwise) consult the fsid and compare it to detect and unmap the correct image in case of image UUID conflicts

Fixes: #466 
Signed-off-by: ShyamsundarR <srangana@redhat.com>