### PR TITLE
provisioners: add reconfiguring of PID limit

### DIFF
--- a/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin-provisioner.yaml
@@ -70,6 +70,7 @@ spec:
             - "--v=5"
             - "--drivername=cephfs.csi.ceph.com"
             - "--metadatastorage=k8s_configmap"
+            - "--pidlimit=-1"
           env:
             - name: NODE_ID
               valueFrom:

--- a/deploy/cephfs/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
@@ -71,6 +71,7 @@ spec:
             - "--v=5"
             - "--drivername=$(DRIVER_NAME)"
             - "--metadatastorage=k8s_configmap"
+            - "--pidlimit=-1"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
@@ -59,6 +59,7 @@ spec:
             - "--v=5"
             - "--drivername=cephfs.csi.ceph.com"
             - "--metadatastorage=k8s_configmap"
+            - "--pidlimit=-1"
           env:
             - name: NODE_ID
               valueFrom:

--- a/deploy/cephfs/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
@@ -74,6 +74,7 @@ spec:
             - "--v=5"
             - "--drivername=$(DRIVER_NAME)"
             - "--metadatastorage=k8s_configmap"
+            - "--pidlimit=-1"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
@@ -85,6 +85,7 @@ spec:
             - "--v=5"
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
+            - "--pidlimit=-1"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/deploy/rbd/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
+++ b/deploy/rbd/kubernetes/v1.13/helm/templates/provisioner-statefulset.yaml
@@ -88,6 +88,7 @@ spec:
             - "--v=5"
             - "--drivername=$(DRIVER_NAME)"
             - "--containerized=true"
+            - "--pidlimit=-1"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
@@ -75,6 +75,7 @@ spec:
             - "--v=5"
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
+            - "--pidlimit=-1"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/deploy/rbd/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/helm/templates/provisioner-deployment.yaml
@@ -92,6 +92,7 @@ spec:
             - "--v=5"
             - "--drivername=$(DRIVER_NAME)"
             - "--containerized=true"
+            - "--pidlimit=-1"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"

--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -53,6 +53,7 @@ that should be resolved in v14.2.3.
 | `--instanceid`      | "default"                   | Unique ID distinguishing this instance of Ceph CSI among other instances, when sharing Ceph clusters across CSI instances for provisioning                                                                                                                                             |
 | `--pluginpath`      | "/var/lib/kubelet/plugins/" | The location of cephcsi plugin on host                                                                                                                                                                                                                                                 |
 | `--metadatastorage` | _empty_                     | Points to where older (1.0.0 or older plugin versions) metadata about provisioned volumes are kept, as file or in as k8s configmap (`node` or `k8s_configmap` respectively)                                                                                                            |
+| `--pidlimit`        | _0_                         | Configure the PID limit in cgroups. The container runtime can restrict the number of processes/tasks which can cause problems while provisioning (or deleting) a large number of volumes. A value of `-1` configures the limit to the maximum, `0` does not configure limits at all.   |
 
 **Available environmental variables:**
 

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -35,6 +35,7 @@ make image-cephcsi
 | `--containerized`   | true                  | Whether running in containerized mode                                                                                                                                        |
 | `--instanceid`      | "default"             | Unique ID distinguishing this instance of Ceph CSI among other instances, when sharing Ceph clusters across CSI instances for provisioning                                   |
 | `--metadatastorage` | _empty_               | Points to where legacy (1.0.0 or older plugin versions) metadata about provisioned volumes are kept, as file or in as k8s configmap (`node` or `k8s_configmap` respectively) |
+| `--pidlimit`        | _0_                   | Configure the PID limit in cgroups. The container runtime can restrict the number of processes/tasks which can cause problems while provisioning (or deleting) a large number of volumes. A value of `-1` configures the limit to the maximum, `0` does not configure limits at all.   |
 
 **Available environmental variables:**
 

--- a/pkg/util/pidlimit.go
+++ b/pkg/util/pidlimit.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	procCgroup    = "/proc/self/cgroup"
+	sysPidsMaxFmt = "/sys/fs/cgroup/pids%s/pids.max"
+)
+
+// return the cgouprs "pids.max" file of the current process
+//
+// find the line containing the pids group from the /proc/self/cgroup file
+// $ grep 'pids' /proc/self/cgroup
+// 7:pids:/kubepods.slice/kubepods-besteffort.slice/....scope
+// $ cat /sys/fs/cgroup/pids + *.scope + /pids.max
+func getCgroupPidsFile() (string, error) {
+	cgroup, err := os.Open(procCgroup)
+	if err != nil {
+		return "", err
+	}
+	defer cgroup.Close()
+
+	scanner := bufio.NewScanner(cgroup)
+	var slice string
+	for scanner.Scan() {
+		parts := strings.Split(scanner.Text(), ":")
+		if parts == nil || len(parts) < 3 {
+			continue
+		}
+		if parts[1] == "pids" {
+			slice = parts[2]
+			break
+		}
+	}
+	if slice == "" {
+		return "", fmt.Errorf("could not find a cgroup for 'pids'")
+	}
+
+	pidsMax := fmt.Sprintf(sysPidsMaxFmt, slice)
+	return pidsMax, nil
+}
+
+// GetPIDLimit returns the current PID limit, or an error. A value of -1
+// translates to "max".
+func GetPIDLimit() (int, error) {
+	pidsMax, err := getCgroupPidsFile()
+	if err != nil {
+		return 0, err
+	}
+
+	f, err := os.Open(pidsMax)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	maxPidsStr, err := bufio.NewReader(f).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return 0, err
+	}
+	maxPidsStr = strings.TrimRight(maxPidsStr, "\n")
+
+	maxPids := -1
+	if maxPidsStr != "max" {
+		maxPids, err = strconv.Atoi(maxPidsStr)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return maxPids, nil
+}
+
+// SetPIDLimit configures the given PID limit for the current process. A value
+// of -1 translates to "max".
+func SetPIDLimit(limit int) error {
+	limitStr := "max"
+	if limit != -1 {
+		limitStr = fmt.Sprintf("%d", limit)
+	}
+
+	pidsMax, err := getCgroupPidsFile()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(pidsMax)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(limitStr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/util/pidlimit_test.go
+++ b/pkg/util/pidlimit_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+// minimal test to check if GetPIDLimit() returns an int
+// changing the limit require root permissions, not tested
+func TestGetPIDLimix(t *testing.T) {
+	limit, err := GetPIDLimit()
+
+	if err != nil {
+		t.Errorf("no error should be returned, got: %v", err)
+	}
+	if limit == 0 {
+		t.Errorf("a PID limit of 0 is invalid")
+	}
+
+	// this is expected to fail when not run as root
+	err = SetPIDLimit(4096)
+	if err != nil {
+		t.Logf("failed to set PID limit, are you running as root?")
+	} else {
+		// in case it worked, reset to the previous value
+		err = SetPIDLimit(limit)
+		if err != nil {
+			t.Logf("failed to reset PID to original limit %d", limit)
+		}
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #

The container runtime CRI-O limits the number of PIDs to 1024 by
default. When many PVCs are requested at the same time, it is possible
for the provisioner to start too many threads (or go routines) and
executing 'rbd' commands can start to fail. In case a go routine can not
get started, the process panics.

The PID limit can be changed by passing an argument to kubelet, but this
will affect all pids running on a host. Changing the parameters to
kubelet is also not a very elegant solution.

Instead, the provisioner pod can change the configuration itself. The
pod is running in privileged mode and can write to /sys/fs/cgroup where
the limit is configured.

With this change, the limit is configured to 'max', just as if there is
no limit at all. The logs of the csi-rbdplugin in the provisioner pod
will reflect the change it makes when starting the service:

    $ oc -n rook-ceph logs -c csi-rbdplugin csi-rbdplugin-provisioner-0
    ..
    I0726 13:59:19.737678       1 cephcsi.go:127] Initial PID limit is set to 1024
    I0726 13:59:19.737746       1 cephcsi.go:136] Reconfigured PID limit to -1 (max)
    ..

It is possible to pass a different limit on the commandline of the
cephcsi executable. The following flag has been added:

    --pidlimit=<int>       the PID limit to configure through cgroups

This accepts special values -1 (max) and 0 (default, do not
reconfigure). Other integers will be the limit that gets configured in
cgroups.

Fixes: #516 