### PR TITLE
docs: Clarify that Nautilus means >=14.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ NOTE:
 |        | Provision volume from another volume                      | -              | -                  | -                | -                    | -                  |
 |        | Resize volume                                             | -              | -                  | -                | -                    | -                  |
 |        | Metrics Support                                           | -              | -                  | -                | -                    | -                  |
-| CephFS | Dynamically provision, de-provision File mode RWO volume  | Alpha          | >=v1.1.0           | >=v1.0.0         | Nautilus             | >=v1.13.0          |
-|        | Dynamically provision, de-provision File mode RWX volume  | Alpha          | >=v1.1.0           | >=v1.0.0         | Nautilus             | >=v1.13.0          |
+| CephFS | Dynamically provision, de-provision File mode RWO volume  | Alpha          | >=v1.1.0           | >=v1.0.0         | Nautilus (>=14.2.2)             | >=v1.13.0          |
+|        | Dynamically provision, de-provision File mode RWX volume  | Alpha          | >=v1.1.0           | >=v1.0.0         | Nautilus (>=v14.2.2)             | >=v1.13.0          |
 |        | Creating and deleting snapshot                            | -              | -                  | -                | -                    | -                  |
 |        | Provision volume from snapshot                            | -              | -                  | -                | -                    | -                  |
 |        | Provision volume from another volume                      | -              | -                  | -                | -                    | -                  |


### PR DESCRIPTION
Clarifies the Nautilus requirements in the README, everything below 14.2.2 has no `ceph fs subvolumegroup` command and the provisioner fails.
See #513 for some context :)

