### PR TITLE
adds flags to make csi deployment optional

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -40,6 +40,9 @@ var _ = Describe("cephfs", func() {
 	f := framework.NewDefaultFramework("cephfs")
 	// deploy cephfs CSI
 	BeforeEach(func() {
+		if !csiRequired && !cephFsRequired {
+			Skip("Skipping Test cephfs CSI")
+		}
 		updateCephfsDirPath(f.ClientSet)
 		createFileSystem(f.ClientSet)
 		createConfigMap(cephfsDirPath, f.ClientSet, f)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -12,9 +12,12 @@ import (
 )
 
 var (
-	RookVersion   string
-	rookRequired  bool
-	deployTimeout int
+	RookVersion    string
+	rookRequired   bool
+	cephFsRequired bool
+	rbdRequired    bool
+	csiRequired    bool
+	deployTimeout  int
 )
 
 func init() {
@@ -22,6 +25,9 @@ func init() {
 	flag.StringVar(&RookVersion, "rook-version", "master", "rook version to pull yaml files")
 
 	flag.BoolVar(&rookRequired, "deploy-rook", true, "deploy rook on kubernetes")
+	flag.BoolVar(&csiRequired, "ceph-csi", true, "deploy ceph-csi on rook")
+	flag.BoolVar(&cephFsRequired, "cephfs-csi", false, "deploy cephfs-csi on rook")
+	flag.BoolVar(&rbdRequired, "rbd-csi", false, "deploy rbd-csi rook")
 	flag.IntVar(&deployTimeout, "deploy-timeout", 10, "timeout to wait for created kubernetes resources")
 	// Register framework flags, then handle flags
 	framework.HandleFlags()

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -42,13 +42,15 @@ var _ = Describe("RBD", func() {
 	f := framework.NewDefaultFramework("rbd")
 	// deploy RBD CSI
 	BeforeEach(func() {
+		if !csiRequired && !rbdRequired {
+			Skip("Skipping Test RBD CSI")
+		}
 		updaterbdDirPath(f.ClientSet)
 		createRBDPool()
 		createConfigMap(rbdDirPath, f.ClientSet, f)
 		deployRBDPlugin()
 		createRBDStorageClass(f.ClientSet, f)
 		createRBDSecret(f.ClientSet, f)
-
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

# Describe what this PR does #

--ceph-csi flag to enable/disable ceph-csi (default: true)
--cephfs-csi flag to enable/disable cephfs-csi only (default: false)
--rbd-csi flag to enable/disable rbd-csi only (default: false)

any combination of flags can be used to skip respective tests

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Fixes: #528 

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.
