### PR TITLE
Add xfs fstype as default type in storageclass

### DIFF
--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -30,7 +30,9 @@ parameters:
    csi.storage.k8s.io/provisioner-secret-namespace: default
    csi.storage.k8s.io/node-stage-secret-name: csi-rbd-secret
    csi.storage.k8s.io/node-stage-secret-namespace: default
-
+   # Specify the filesystem type of the volume. If not specified,
+   # csi-provisioner will set default as `ext4`.
+   csi.storage.k8s.io/fstype: xfs
    # uncomment the following to use rbd-nbd as mounter on supported nodes
    # mounter: rbd-nbd
 reclaimPolicy: Delete


### PR DESCRIPTION
we have seen better performance in device format and mounting by setting the fstype to xfs from default ext4.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Fixes: #507

Note: #537 will be used for testing CI