### PR TITLE
Add gosec to the static tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ go: 1.12.x
 env:
   global:
     - GOLANGCI_VERSION=v1.17.0
+    - GOSEC_VERSION=2.0.0
     - TEST_COVERAGE=stdout
     - GO_METALINTER_THREADS=1
     - GO_COVER_DIR=_output
@@ -46,6 +47,10 @@ jobs:
         - curl -sf
           "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh"
           | bash -s -- -b $GOPATH/bin "${GOLANGCI_VERSION}"
+        # install gosec
+        - curl -sfL
+          "https://raw.githubusercontent.com/securego/gosec/master/install.sh"
+          | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}"
         # install helm for helm lint
         - curl -L https://git.io/get_helm.sh | bash
       script:

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ dep-check:
 static-check:
 	./scripts/lint-go.sh
 	./scripts/lint-text.sh --require-all
+	./scripts/gosec.sh
 
 func-test:
 	go test github.com/ceph/ceph-csi/e2e $(TESTOPTIONS)

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -226,6 +226,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	klog.Infof(util.Log(ctx, "cephfs: successfully bind-mounted volume %s to %s"), volID, targetPath)
 
+	// #nosec - allow anyone to write inside the target path
 	err = os.Chmod(targetPath, 0777)
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed to change targetpath permission for volume %s: %v"), volID, err)

--- a/pkg/cephfs/util.go
+++ b/pkg/cephfs/util.go
@@ -36,7 +36,7 @@ type volumeID string
 
 func execCommand(ctx context.Context, program string, args ...string) (stdout, stderr []byte, err error) {
 	var (
-		cmd           = exec.Command(program, args...) // nolint: gosec
+		cmd           = exec.Command(program, args...) // nolint: gosec, #nosec
 		sanitizedArgs = util.StripSecretInArgs(args)
 		stdoutBuf     bytes.Buffer
 		stderrBuf     bytes.Buffer

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -153,6 +153,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	isMounted = true
 
+	// #nosec - allow anyone to write inside the target path
 	err = os.Chmod(stagingTargetPath, 0777)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -202,7 +203,7 @@ func (ns *NodeServer) undoStagingTransaction(ctx context.Context, stagingParentP
 
 func (ns *NodeServer) createStageMountPoint(ctx context.Context, mountPath string, isBlock bool) error {
 	if isBlock {
-		pathFile, err := os.OpenFile(mountPath, os.O_CREATE|os.O_RDWR, 0750)
+		pathFile, err := os.OpenFile(mountPath, os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
 			klog.Errorf(util.Log(ctx, "failed to create mountPath:%s with error: %v"), mountPath, err)
 			return status.Error(codes.Internal, err.Error())

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -794,7 +794,7 @@ func lookupRBDImageMetadataStash(path string) (rbdImageMetadataStash, error) {
 	var imgMeta rbdImageMetadataStash
 
 	fPath := filepath.Join(path, stashFileName)
-	encodedBytes, err := ioutil.ReadFile(fPath)
+	encodedBytes, err := ioutil.ReadFile(fPath) // #nosec - intended reading from fPath
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return imgMeta, fmt.Errorf("failed to read stashed JSON image metadata from path (%s): (%v)", fPath, err)

--- a/pkg/util/cephcmds.go
+++ b/pkg/util/cephcmds.go
@@ -32,7 +32,7 @@ import (
 // ExecCommand executes passed in program with args and returns separate stdout and stderr streams
 func ExecCommand(program string, args ...string) (stdout, stderr []byte, err error) {
 	var (
-		cmd           = exec.Command(program, args...) // nolint: gosec
+		cmd           = exec.Command(program, args...) // nolint: gosec, #nosec
 		sanitizedArgs = StripSecretInArgs(args)
 		stdoutBuf     bytes.Buffer
 		stderrBuf     bytes.Buffer

--- a/pkg/util/credentials.go
+++ b/pkg/util/credentials.go
@@ -44,7 +44,8 @@ func storeKey(key string) (string, error) {
 	}
 	defer func() {
 		if err != nil {
-			os.Remove(tmpfile.Name())
+			// don't complain about unhandled error
+			_ = os.Remove(tmpfile.Name())
 		}
 	}()
 
@@ -89,7 +90,8 @@ func newCredentialsFromSecret(idField, keyField string, secrets map[string]strin
 }
 
 func (cr *Credentials) DeleteCredentials() {
-	os.Remove(cr.KeyFile)
+	// don't complain about unhandled error
+	_ = os.Remove(cr.KeyFile)
 }
 
 func NewUserCredentials(secrets map[string]string) (*Credentials, error) {

--- a/pkg/util/pidlimit.go
+++ b/pkg/util/pidlimit.go
@@ -71,7 +71,7 @@ func GetPIDLimit() (int, error) {
 		return 0, err
 	}
 
-	f, err := os.Open(pidsMax)
+	f, err := os.Open(pidsMax) // #nosec - intended reading from /sys/...
 	if err != nil {
 		return 0, err
 	}

--- a/scripts/gosec.sh
+++ b/scripts/gosec.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o pipefail
+
+if [[ -x "$(command -v gosec)" ]]; then
+  find cmd pkg -type d -print0 | xargs --null gosec
+else
+  echo "WARNING: gosec not found, skipping security tests" >&2
+fi


### PR DESCRIPTION
# Describe what this PR does #

`gosec` is a security scanning tool that can be used similar to `go vet` for standard security concerns. This PR addresses the reported issues and adds `gosec` to the standard tests.