### PR TITLE
e2e: correct log format in execCommandInPod()

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -150,7 +150,7 @@ func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOpti
 	}
 	stdOut, stdErr, err := f.ExecWithOptions(podPot)
 	if stdErr != "" {
-		e2elog.Logf("stdErr occurred ", stdErr)
+		e2elog.Logf("stdErr occurred: %v", stdErr)
 	}
 	Expect(err).Should(BeNil())
 	return stdOut, stdErr


### PR DESCRIPTION
# Describe what this PR does #

`execCommandInPod()` does not use a correct formatting of the log message. This might get logged with the warning `%!(EXTRA string=`:
```
Aug 30 09:25:35.633: INFO: stdErr occurred 
%!(EXTRA string=unable to get monitor info from DNS SRV with service name: ceph-mon
[errno 2] error connecting to the cluster
```
