### PR TITLE
mergify: Remove approved review when a PR changes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,12 @@
 ---
 pull_request_rules:
+  - name: remove outdated approvals
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
   - name: automatic merge
     conditions:
       - label!=DNM


### PR DESCRIPTION
# Describe what this PR does #

When people have reviewed a PR, and the contributor updates it, the
reviews are staying valid. This is unfortunate as the PR might need new
corrections.

Ideally a positive review (Approved) needs to be given again. And there
needs to be a confirmation that a negative review (Changes requested)
has been addressed.

## Related issues ##

Closes: #505
