### PR TITLE
Build versioned images in autobuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,11 @@ cephcsi:
 image-cephcsi: cephcsi
 	cp _output/cephcsi deploy/cephcsi/image/cephcsi
 	$(CONTAINER_CMD) build -t $(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION) deploy/cephcsi/image
+	if [ "canary" != "$(CSI_IMAGE_VERSION)" ]; then $(CONTAINER_CMD) tag $(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION) $(CSI_IMAGE_NAME):canary; fi
 
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) push $(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION)
+	if [ "canary" != "$(CSI_IMAGE_VERSION)" ]; then $(CONTAINER_CMD) push $(CSI_IMAGE_NAME):canary; fi
 
 
 clean:

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,7 +28,8 @@ if [ "${TRAVIS_BRANCH}" == 'csi-v0.3' ]; then
 	export ENV_RBD_IMAGE_VERSION='v0.3-canary'
 	export ENV_CEPHFS_IMAGE_VERSION='v0.3-canary'
 elif [ "${TRAVIS_BRANCH}" == 'master' ]; then
-	export ENV_CSI_IMAGE_VERSION='canary'
+	ENV_CSI_IMAGE_VERSION=$(git describe --tags --dirty)
+	export ENV_CSI_IMAGE_VERSION
 else
 	echo "!!! Branch ${TRAVIS_BRANCH} is not a deployable branch; exiting"
 	exit 0 # Exiting 0 so that this isn't marked as failing


### PR DESCRIPTION
# Describe what this PR does #

This make the image autobuilder, build images with unique tags and push them to the registry. The built images will also be tagged 'canary' to allow workflows using the 'canary' images to continue working.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.
