### PR TITLE
Fix issue in mon accessing

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainers="Ceph-CSI Authors"
 LABEL description="Ceph-CSI Plugin"
 
 # Removing ceph-iscsi repo to workaround the repo issue while upgrading
-RUN rm -f /etc/yum.repos.d/ceph-iscsi.repo && yum -y update && yum clean all
+#RUN rm -f /etc/yum.repos.d/ceph-iscsi.repo && yum -y update && yum clean all
 ENV CSIBIN=/usr/local/bin/cephcsi
 
 COPY cephcsi $CSIBIN

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -61,7 +61,6 @@ var _ = Describe("cephfs", func() {
 	BeforeEach(func() {
 		updateCephfsDirPath(f.ClientSet)
 		createFileSystem(f.ClientSet)
-		waitTillMonsAreUp(f)
 		createConfigMap(cephfsDirPath, f.ClientSet, f)
 		deployCephfsPlugin()
 		createCephfsSecret(f.ClientSet, f)

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -63,7 +63,6 @@ var _ = Describe("RBD", func() {
 	BeforeEach(func() {
 		updaterbdDirPath(f.ClientSet)
 		createRBDPool()
-		waitTillMonsAreUp(f)
 		createConfigMap(rbdDirPath, f.ClientSet, f)
 		deployRBDPlugin()
 		createRBDStorageClass(f.ClientSet, f)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -193,21 +193,6 @@ func getStorageClass(path string) scv1.StorageClass {
 // 	return sc
 // }
 
-// this is a  workaround, as we are hitting "unable to get monitor info from DNS SRV with service name: ceph-mon"
-func waitTillMonsAreUp(f *framework.Framework) {
-	opt := metav1.ListOptions{
-		LabelSelector: "app=rook-ceph-tools",
-	}
-	for i := 0; i < 10; i++ {
-		_, err := execCommandInPod(f, "ceph fsid", rookNS, &opt)
-		if err != "" {
-			time.Sleep(10 * time.Second)
-			continue
-		}
-		break
-	}
-}
-
 func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, enablePool bool) {
 	scPath := fmt.Sprintf("%s/%s", cephfsExamplePath, "storageclass.yaml")
 	sc := getStorageClass(scPath)


### PR DESCRIPTION
Fix mon endpoint issue in E2E

 In toolbox mon endpoints are not updated properly, this is causing an issue in E2E. This PR is a workaround to fix this issue.
    
logs from toolbox pod
```
Sep  4 09:01:34.815: INFO: stdout: "Wed Sep  4 09:00:10 UTC 2019 writing mon endpoints to /etc/ceph/ceph.conf: \nWed Sep  4 09:01:30 UTC 2019 writing mon endpoints to /etc/ceph/ceph.conf: a=10.96.112.168:6789\n"
```
This PR will check the mon configuration  in toolbox pod logs

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
