### PR TITLE
Consider Kernel >=5.x as sufficient for using the Kernel mounter

### DIFF
--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -70,7 +70,7 @@ func loadAvailableMounters() error {
 		if err != nil {
 			return err
 		}
-		if (majorVers >= 4 && minorVers >= 17) || majorVers >= 5 {
+		if majorVers > 4 || (majorVers >= 4 && minorVers >= 17) {
 			klog.Infof("loaded mounter: %s", volumeMounterKernel)
 			availableMounters = append(availableMounters, volumeMounterKernel)
 		} else {

--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -70,7 +70,7 @@ func loadAvailableMounters() error {
 		if err != nil {
 			return err
 		}
-		if majorVers >= 4 && minorVers >= 17 {
+		if (majorVers >= 4 && minorVers >= 17) || majorVers >= 5 {
 			klog.Infof("loaded mounter: %s", volumeMounterKernel)
 			availableMounters = append(availableMounters, volumeMounterKernel)
 		} else {


### PR DESCRIPTION
# Describe what this PR does #

#571 allows the mounter to use the kernel Ceph FS client if the kernel is version 4.17 or higher. However, it requires the kernel's major version to be greater than or equal to 4 _and_ the minor version to be greater than or equal to 17. As a result, kernel version 5.x is considered invalid - at least until 5.17 is released!

This PR adds a logical OR to the version check so that if the major version is 5 or higher, it is considered safe to use the kernel mounter regardless of the minor version.

## Is there anything that requires special attention ##

As this is the first PR i've submitted to this project and I am still quite inexperienced with Go, a little extra scrutiny would be welcome even though the change is quite minor!

## Related issues ##

#571

## Future concerns ##

None