### PR TITLE
backport: Consider Kernel >=5.x as sufficient for using the Kernel mounter

### DIFF
--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -70,7 +70,7 @@ func loadAvailableMounters() error {
 		if err != nil {
 			return err
 		}
-		if majorVers >= 4 && minorVers >= 17 {
+		if majorVers > 4 || (majorVers >= 4 && minorVers >= 17) {
 			klog.Infof("loaded mounter: %s", volumeMounterKernel)
 			availableMounters = append(availableMounters, volumeMounterKernel)
 		} else {


### PR DESCRIPTION
backport https://github.com/ceph/ceph-csi/pull/598