### PR TITLE
cephfs: Choose kernel mounter when mounter specified is kernel

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -99,12 +99,12 @@ var _ = Describe("cephfs", func() {
 			}
 
 			By("create a storage class with pool and a PVC then Bind it to an app", func() {
-				createCephfsStorageClass(f.ClientSet, f, true)
+				createCephfsStorageClass(f.ClientSet, f, true, make(map[string]string))
 				validatePVCAndAppBinding(pvcPath, appPath, f)
 				deleteResource(cephfsExamplePath + "storageclass.yaml")
 			})
 
-			createCephfsStorageClass(f.ClientSet, f, false)
+			createCephfsStorageClass(f.ClientSet, f, false, make(map[string]string))
 
 			By("create and delete a PVC", func() {
 				By("create a PVC and Bind it to an app", func() {
@@ -114,6 +114,14 @@ var _ = Describe("cephfs", func() {
 
 				By("create a PVC and Bind it to an app with normal user", func() {
 					validateNormalUserPVCAccess(pvcPath, f)
+				})
+
+				By("create a PVC and Bind it to an app with kernel mounter", func() {
+					deleteResource(cephfsExamplePath + "storageclass.yaml")
+					createCephfsStorageClass(f.ClientSet, f, false, map[string]string{"mounter": "kernel"})
+					validatePVCAndAppBindingKernelMounter(pvcPath, appPath, f)
+					deleteResource(cephfsExamplePath + "storageclass.yaml")
+					createCephfsStorageClass(f.ClientSet, f, false, make(map[string]string))
 				})
 
 				By("create/delete multiple PVCs and Apps", func() {

--- a/examples/cephfs/storageclass.yaml
+++ b/examples/cephfs/storageclass.yaml
@@ -35,7 +35,9 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-namespace: default
 
   # (optional) The driver can use either ceph-fuse (fuse) or
-  # ceph kernelclient (kernel).
+  # ceph kernelclient (kernel). Choose kernel only when the
+  # kernel version is >= 4.17, otherwise the size limit on the
+  # PV will be ineffective.
   # If omitted, default volume mounter will be used - this is
   # determined by probing for ceph-fuse and mount.ceph
   # mounter: kernel


### PR DESCRIPTION
Currently, the kernel mounter is chosen only when the kernel version is >= 4.17,
as the quota feature required for PV creation, is not available in older kernels.
With this patch we are changing the behaviour to choose kernel mounter if the
mounter specified in SC is kernel, irrespective of the kernel version.

Fixes #617

Signed-off-by: Poornima G <pgurusid@redhat.com>