### PR TITLE
Use a wrapper for formatAndMount with rbd specific actions.

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -65,7 +65,7 @@ var _ = Describe("RBD", func() {
 		createRBDPool()
 		createConfigMap(rbdDirPath, f.ClientSet, f)
 		deployRBDPlugin()
-		createRBDStorageClass(f.ClientSet, f)
+		createRBDStorageClass(f.ClientSet, f, make(map[string]string))
 		createRBDSecret(f.ClientSet, f)
 
 	})
@@ -115,6 +115,17 @@ var _ = Describe("RBD", func() {
 			By("create a PVC and Bind it to an app with normal user", func() {
 				validateNormalUserPVCAccess(pvcPath, f)
 			})
+			// Skipping ext4 FS testing
+			/*
+				By("create a PVC and Bind it to an app with ext4 as the FS ", func() {
+					deleteResource(rbdExamplePath + "storageclass.yaml")
+					createRBDStorageClass(f.ClientSet, f, map[string]string{"csi.storage.k8s.io/fstype": "ext4"})
+					validatePVCAndAppBinding(pvcPath, appPath, f)
+					deleteResource(rbdExamplePath + "storageclass.yaml")
+					createRBDStorageClass(f.ClientSet, f, make(map[string]string))
+				})
+			*/
+
 			// skipping snapshot testing
 
 			// By("create a PVC clone and Bind it to an app", func() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -213,7 +213,7 @@ func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, en
 	Expect(err).Should(BeNil())
 }
 
-func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework) {
+func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, parameters map[string]string) {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc := getStorageClass(scPath)
 	sc.Parameters["pool"] = "replicapool"
@@ -226,6 +226,9 @@ func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework) {
 	fsID = strings.Trim(fsID, "\n")
 
 	sc.Parameters["clusterID"] = fsID
+	for k, v := range parameters {
+		sc.Parameters[k] = v
+	}
 	_, err := c.StorageV1().StorageClasses().Create(&sc)
 	Expect(err).Should(BeNil())
 }

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -302,7 +302,7 @@ func getLegacyVolumeName(mountPath string) (string, error) {
 func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeStageVolumeRequest, stagingPath, devicePath string) error {
 	// Publish Path
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
-	diskMounter := &mount.SafeFormatAndMount{Interface: ns.mounter, Exec: mount.NewOsExec()}
+	diskMounter := &RFormatAndMount{mount.SafeFormatAndMount{Interface: ns.mounter, Exec: mount.NewOsExec()}}
 	opt := []string{}
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	var err error

--- a/pkg/rbd/rbd_mount.go
+++ b/pkg/rbd/rbd_mount.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/util/mount"
+	utilexec "k8s.io/utils/exec"
+)
+
+const (
+	// 'fsck' found errors and corrected them
+	fsckErrorsCorrected = 1
+	// 'fsck' found errors but exited without correcting them
+	fsckErrorsUncorrected = 4
+)
+
+// rFormatAndMount probes a device to see if it is formatted.
+// Namely it checks to see if a file system is present. If so it
+// mounts it otherwise the device is formatted first then mounted.
+type RFormatAndMount struct {
+	mount.SafeFormatAndMount
+}
+
+// formatAndMount uses unix utils to format and mount the given disk
+// nolint: gocyclo
+func (mounter *RFormatAndMount) FormatAndMount(source, target, fstype string, options []string) error {
+	readOnly := false
+	for _, option := range options {
+		if option == "ro" {
+			readOnly = true
+			break
+		}
+	}
+
+	options = append(options, "defaults")
+
+	if !readOnly {
+		// Run fsck on the disk to fix repairable issues, only do this for volumes requested as rw.
+		klog.V(4).Infof("Checking for issues with fsck on disk: %s", source)
+		args := []string{"-a", source}
+		out, err := mounter.Exec.Run("fsck", args...)
+		if err != nil {
+			ee, isExitError := err.(utilexec.ExitError)
+			switch {
+			case err == utilexec.ErrExecutableNotFound:
+				klog.Warningf("'fsck' not found on system; continuing mount without running 'fsck'")
+			case isExitError && ee.ExitStatus() == fsckErrorsCorrected:
+				klog.Infof("Device %s has errors which were corrected by fsck", source)
+			case isExitError && ee.ExitStatus() == fsckErrorsUncorrected:
+				return fmt.Errorf("'fsck' found errors on device %s but could not correct them: %s", source, string(out))
+			case isExitError && ee.ExitStatus() > fsckErrorsUncorrected:
+				klog.Infof("`fsck` error %s", string(out))
+			}
+		}
+	}
+
+	// Try to mount the disk
+	klog.V(4).Infof("Attempting to mount disk: %s %s %s", fstype, source, target)
+	mountErr := mounter.Interface.Mount(source, target, fstype, options)
+	if mountErr != nil {
+		// Mount failed. This indicates either that the disk is unformatted or
+		// it contains an unexpected filesystem.
+		existingFormat, err := mounter.GetDiskFormat(source)
+		if err != nil {
+			return err
+		}
+		if existingFormat == "" {
+			if readOnly {
+				// Don't attempt to format if mounting as readonly, return an error to reflect this.
+				return errors.New("failed to mount unformatted volume as read only")
+			}
+
+			// Disk is unformatted so format it.
+			args := []string{source}
+			// Use 'ext4' as the default
+			if fstype == "" {
+				fstype = "ext4"
+			}
+
+			if fstype == "ext4" || fstype == "ext3" {
+				args = []string{
+					"-F",           // Force flag
+					"-m0",          // Zero blocks reserved for super-user
+					"-E nodiscard", // Do not attempt to discard blocks at mkfs time - Mainly used for RBD performance.
+					source,
+				}
+
+			} else if fstype == "xfs" {
+				args = []string{
+					"-K", // Do not attempt to discard blocks at mkfs time - Mainly used for RBD performance.
+					source,
+				}
+			}
+			klog.Infof("Disk %q appears to be unformatted, attempting to format as type: %q with options: %v", source, fstype, args)
+			_, err := mounter.Exec.Run("mkfs."+fstype, args...)
+			if err == nil {
+				// the disk has been formatted successfully try to mount it again.
+				klog.Infof("Disk successfully formatted (mkfs): %s - %s %s", fstype, source, target)
+				return mounter.Interface.Mount(source, target, fstype, options)
+			}
+			klog.Errorf("format of disk %q failed: type:(%q) target:(%q) options:(%q)error:(%v)", source, fstype, target, options, err)
+			return err
+		}
+		// Disk is already formatted and failed to mount
+		if fstype == "" || fstype == existingFormat {
+			// This is mount error
+			return mountErr
+		}
+		// Block device is formatted with unexpected filesystem, let the user know
+		return fmt.Errorf("failed to mount the volume as %q, it already contains %s. Mount error: %v", fstype, existingFormat, mountErr)
+
+	}
+	return mountErr
+}


### PR DESCRIPTION
    Use a wrpper for formatAndMount with rbd specific actions.
    
    Currently rbd CSI plugin uses formatAndMount of
    mount.SafeFormatAndMount. This does not allow to pass or use
    specific formatting arguments with it. This patch introduce
    RBD specific formatting options with both `xfs` and `ext4`,
    for example: `-E no-discard` with ext4 and `-k` option with
    XFS to boost formatting performance of RBD device.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

Fixes: https://github.com/ceph/ceph-csi/issues/621

## Future concerns ##

Follow up PR required to take `fmtArgs` from SC.
