### PR TITLE
backport use rook v1.1.0 in E2E testing

### DIFF
--- a/scripts/travis-functest.sh
+++ b/scripts/travis-functest.sh
@@ -11,6 +11,6 @@ sudo scripts/minikube.sh k8s-sidecar
 sudo chown -R travis: "$HOME"/.minikube /usr/local/bin/kubectl
 # functional tests
 
-go test github.com/ceph/ceph-csi/e2e --rook-version=master --deploy-rook=true --deploy-timeout=10 -timeout=30m -v
+go test github.com/ceph/ceph-csi/e2e --rook-version=v1.1.0 --deploy-rook=true --deploy-timeout=10 -timeout=30m -v
 
 sudo scripts/minikube.sh clean


### PR DESCRIPTION
rook master is not good enough to depend on for E2E testing, switching to v1.1.0 for E2E

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 18151e9ca8d288fcf80c5ee91a22b683c5178c41)

