### PR TITLE
Set default FS to "ext4" on RBD device

### DIFF
--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -33,7 +33,7 @@ parameters:
    csi.storage.k8s.io/node-stage-secret-namespace: default
    # Specify the filesystem type of the volume. If not specified,
    # csi-provisioner will set default as `ext4`.
-   csi.storage.k8s.io/fstype: xfs
+   csi.storage.k8s.io/fstype: ext4
    # uncomment the following to use rbd-nbd as mounter on supported nodes
    # mounter: rbd-nbd
 reclaimPolicy: Delete


### PR DESCRIPTION
We were defaulting to ext4 at first and then moved to xfs.
However further testing shows that, ext4 should be
the default or preferred fs for RBD devices.

This patch bring that change

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

