### PR TITLE
Format RBD volumes with `nodiscard` formatting options.

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -65,7 +65,7 @@ var _ = Describe("RBD", func() {
 		createRBDPool()
 		createConfigMap(rbdDirPath, f.ClientSet, f)
 		deployRBDPlugin()
-		createRBDStorageClass(f.ClientSet, f)
+		createRBDStorageClass(f.ClientSet, f, make(map[string]string))
 		createRBDSecret(f.ClientSet, f)
 
 	})
@@ -115,6 +115,16 @@ var _ = Describe("RBD", func() {
 			By("create a PVC and Bind it to an app with normal user", func() {
 				validateNormalUserPVCAccess(pvcPath, f)
 			})
+			// Skipping ext4 FS testing
+
+			By("create a PVC and Bind it to an app with ext4 as the FS ", func() {
+				deleteResource(rbdExamplePath + "storageclass.yaml")
+				createRBDStorageClass(f.ClientSet, f, map[string]string{"csi.storage.k8s.io/fstype": "ext4"})
+				validatePVCAndAppBinding(pvcPath, appPath, f)
+				deleteResource(rbdExamplePath + "storageclass.yaml")
+				createRBDStorageClass(f.ClientSet, f, make(map[string]string))
+			})
+
 			// skipping snapshot testing
 
 			// By("create a PVC clone and Bind it to an app", func() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -213,7 +213,7 @@ func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, en
 	Expect(err).Should(BeNil())
 }
 
-func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework) {
+func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, parameters map[string]string) {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc := getStorageClass(scPath)
 	sc.Parameters["pool"] = "replicapool"
@@ -226,6 +226,9 @@ func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework) {
 	fsID = strings.Trim(fsID, "\n")
 
 	sc.Parameters["clusterID"] = fsID
+	for k, v := range parameters {
+		sc.Parameters[k] = v
+	}
 	_, err := c.StorageV1().StorageClasses().Create(&sc)
 	Expect(err).Should(BeNil())
 }

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -313,9 +313,27 @@ func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeS
 	// Publish Path
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
 	diskMounter := &mount.SafeFormatAndMount{Interface: ns.mounter, Exec: mount.NewOsExec()}
+	existingFormat, err := diskMounter.GetDiskFormat(devicePath)
+	if err != nil {
+		klog.Errorf(util.Log(ctx, "failed to get disk format for path %s, error: %v"), devicePath, err)
+		return err
+	}
+	if existingFormat == "" && (fsType == "ext4" || fsType == "xfs") {
+		args := []string{}
+		if fsType == "ext4" {
+			args = []string{"-m0", "-Enodiscard", devicePath}
+		} else if fsType == "xfs" {
+			args = []string{"-K", devicePath}
+		}
+		_, err = diskMounter.Exec.Run("mkfs."+fsType, args...)
+		if err != nil {
+			klog.Errorf(util.Log(ctx, "failed to run mkfs, error: %v"), err)
+			return err
+		}
+	}
+
 	opt := []string{}
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
-	var err error
 
 	if isBlock {
 		opt = append(opt, "bind")


### PR DESCRIPTION
Currently rbd CSI plugin uses formatAndMount of
mount.SafeFormatAndMount. This does not allow to pass or use
specific formatting arguments with it. This patch introduce
RBD specific formatting options with both xfs and ext4,
for example: -E no-discard with ext4 and -k option with
XFS to boost formatting performance of RBD device.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
(cherry picked from commit 0e6617e1ffff4dc93e7606bfdf0dcaf60f3c327d)

