### PR TITLE
We were defaulting to ext4 at first and then moved toxfs.

### DIFF
--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -32,7 +32,7 @@ parameters:
    csi.storage.k8s.io/node-stage-secret-namespace: default
    # Specify the filesystem type of the volume. If not specified,
    # csi-provisioner will set default as `ext4`.
-   csi.storage.k8s.io/fstype: xfs
+   csi.storage.k8s.io/fstype: ext4
    # uncomment the following to use rbd-nbd as mounter on supported nodes
    # mounter: rbd-nbd
 reclaimPolicy: Delete


### PR DESCRIPTION

We were defaulting to ext4 at first and then moved to xfs.
However further testing shows that there are some issues with XFS locking while we use XFS on top of RBD device, while xfs issues are getting addressed, we are changing the default FS type to ext4.
This patch bring that change

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
(cherry picked from commit b44a81bdbc7abf4f4f565300cc82a1d4f36d7d00)

