### PR TITLE
Fix volsize for cephfs and rbd

### DIFF
--- a/pkg/cephfs/volumeoptions.go
+++ b/pkg/cephfs/volumeoptions.go
@@ -126,7 +126,7 @@ func getMonsAndClusterID(options map[string]string) (string, string, error) {
 
 // newVolumeOptions generates a new instance of volumeOptions from the provided
 // CSI request parameters
-func newVolumeOptions(ctx context.Context, requestName string, size int64, volOptions, secret map[string]string) (*volumeOptions, error) {
+func newVolumeOptions(ctx context.Context, requestName string, volOptions, secret map[string]string) (*volumeOptions, error) {
 	var (
 		opts volumeOptions
 		err  error
@@ -158,7 +158,6 @@ func newVolumeOptions(ctx context.Context, requestName string, size int64, volOp
 	}
 
 	opts.RequestName = requestName
-	opts.Size = size
 
 	cr, err := util.NewAdminCredentials(secret)
 	if err != nil {

--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -108,8 +108,8 @@ func (cs *ControllerServer) parseVolCreateRequest(ctx context.Context, req *csi.
 		volSizeBytes = req.GetCapacityRange().GetRequiredBytes()
 	}
 
-	// always round up the request size in bytes to the nearest MiB
-	rbdVol.VolSize = util.MiB * util.RoundUpToMiB(volSizeBytes)
+	// always round up the request size in bytes to the nearest MiB/GiB
+	rbdVol.VolSize = util.RoundOffBytes(volSizeBytes)
 
 	// NOTE: rbdVol does not contain VolID and RbdImageName populated, everything
 	// else is populated post create request parsing
@@ -172,7 +172,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}()
 
-	err = cs.createBackingImage(ctx, rbdVol, req, util.RoundUpToMiB(rbdVol.VolSize))
+	err = cs.createBackingImage(ctx, rbdVol, req, util.RoundOffVolSize(rbdVol.VolSize))
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}, nil
 }
 
-func (cs *ControllerServer) createBackingImage(ctx context.Context, rbdVol *rbdVolume, req *csi.CreateVolumeRequest, volSizeMiB int64) error {
+func (cs *ControllerServer) createBackingImage(ctx context.Context, rbdVol *rbdVolume, req *csi.CreateVolumeRequest, volSize int64) error {
 	var err error
 
 	// if VolumeContentSource is not nil, this request is for snapshot
@@ -201,7 +201,7 @@ func (cs *ControllerServer) createBackingImage(ctx context.Context, rbdVol *rbdV
 		}
 		defer cr.DeleteCredentials()
 
-		err = createImage(ctx, rbdVol, volSizeMiB, cr)
+		err = createImage(ctx, rbdVol, volSize, cr)
 		if err != nil {
 			klog.Warningf(util.Log(ctx, "failed to create volume: %v"), err)
 			return status.Error(codes.Internal, err.Error())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"math"
 	"os"
 	"path"
 	"strings"
@@ -36,12 +37,31 @@ import (
 const (
 	// MiB - MebiByte size
 	MiB = 1024 * 1024
+	GiB = MiB * 1024
 )
 
-// RoundUpToMiB rounds up given quantity upto chunks of MiB
-func RoundUpToMiB(size int64) int64 {
-	requestBytes := size
-	return roundUpSize(requestBytes, MiB)
+// RoundOffVolSize rounds up given quantity upto chunks of MiB/GiB
+func RoundOffVolSize(size int64) int64 {
+	size = RoundOffBytes(size)
+	// convert size back to MiB for rbd CLI
+	return size / MiB
+}
+
+// RoundOffBytes converts roundoff the size
+// 1.1MiB will be round off to 2MiB same for GiB
+// size less than 1MiB will be round off to 1MiB
+func RoundOffBytes(bytes int64) int64 {
+	var num int64
+	floatBytes := float64(bytes)
+	// round off the value if its in decimal
+	if floatBytes < GiB {
+		num = int64(math.Ceil(floatBytes / MiB))
+		num *= MiB
+	} else {
+		num = int64(math.Ceil(floatBytes / GiB))
+		num *= GiB
+	}
+	return num
 }
 
 // variables which will be set during the build time
@@ -80,14 +100,6 @@ type Config struct {
 	// rbd related flag
 	Containerized bool // whether run as containerized
 
-}
-
-func roundUpSize(volumeSizeBytes, allocationUnitBytes int64) int64 {
-	roundedUp := volumeSizeBytes / allocationUnitBytes
-	if volumeSizeBytes%allocationUnitBytes > 0 {
-		roundedUp++
-	}
-	return roundedUp
 }
 
 // CreatePersistanceStorage creates storage path and initializes new cache

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2019 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"testing"
+)
+
+func TestRoundOffBytes(t *testing.T) {
+	type args struct {
+		bytes int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		{
+			"1MiB conversions",
+			args{
+				bytes: 1048576,
+			},
+			1048576,
+		},
+		{
+			"1000kiB conversion",
+			args{
+				bytes: 1000,
+			},
+			1048576, // equal to 1MiB
+		},
+		{
+			"1.5Mib conversion",
+			args{
+				bytes: 1572864,
+			},
+			2097152, // equal to 2MiB
+		},
+		{
+			"1.1MiB conversion",
+			args{
+				bytes: 1153434,
+			},
+			2097152, // equal to 2MiB
+		},
+		{
+			"1.5GiB conversion",
+			args{
+				bytes: 1610612736,
+			},
+			2147483648, // equal to 2GiB
+		},
+		{
+			"1.1GiB conversion",
+			args{
+				bytes: 1181116007,
+			},
+			2147483648, // equal to 2GiB
+		},
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.name, func(t *testing.T) {
+			if got := RoundOffBytes(ts.args.bytes); got != ts.want {
+				t.Errorf("RoundOffBytes() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}
+
+func TestRoundOffVolSize(t *testing.T) {
+	type args struct {
+		size int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		{
+			"1MiB conversions",
+			args{
+				size: 1048576,
+			},
+			1, // MiB
+		},
+		{
+			"1000kiB conversion",
+			args{
+				size: 1000,
+			},
+			1, // MiB
+		},
+		{
+			"1.5Mib conversion",
+			args{
+				size: 1572864,
+			},
+			2, // MiB
+		},
+		{
+			"1.1MiB conversion",
+			args{
+				size: 1153434,
+			},
+			2, // MiB
+		},
+		{
+			"1.5GiB conversion",
+			args{
+				size: 1610612736,
+			},
+			2048, // MiB
+		},
+		{
+			"1.1GiB conversion",
+			args{
+				size: 1181116007,
+			},
+			2048, // MiB
+		},
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.name, func(t *testing.T) {
+			if got := RoundOffVolSize(ts.args.size); got != ts.want {
+				t.Errorf("RoundOffVolSize() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
once the PVC is required and backend is created kubernetes sidecar will round off the values to a human-readable format, we have to create images with the same size to avoid volume size mismatch between PVC response and backend image size.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

