### PR TITLE
Fix issue in deploy.sh to push helm charts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ services:
 language: go
 branches:
   only:
-    - csi-v0.3
     - master
 
 go: 1.12.x

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,37 +2,35 @@
 
 push_helm_charts() {
 	PACKAGE=$1
-	CHANGED=0
-	VERSION=${ENV_CSI_IMAGE_VERSION//v}  # Set version (without v prefix)
+	VERSION=${ENV_CSI_IMAGE_VERSION//v/} # Set version (without v prefix)
 
-  # Always run when version is canary, when versioned only when the package doesn't exist yet
-	if [ ! -f "tmp/csi-charts/docs/$PACKAGE/ceph-csi-$PACKAGE-$VERSION.tgz" ] && [ -z "$VERSION" ]; then
-		CHANGED=1
+	# update information in Chart.yaml if the branch is not master
+	if [ "$TRAVIS_BRANCH" != "master" ]; then
+		# Replace appVersion: canary and version: *-canary with the actual version
+		sed -i "s/\(\s.*canary\)/ $VERSION/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
 
-    # When version defined it is a release, not a canary build
-    if [ -z "$VERSION" ]; then
-      # Replace appVersion: canary and version: *-canary with the actual version
-      sed -i "s/\(\s.*canary\)/$VERSION/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
+		if [[ "$VERSION" == *"canary"* ]]; then
+			# Replace master with the version branch
+			sed -i "s/master/$TRAVIS_BRANCH/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
+		else
+			# This is not a canary release, replace master with the tagged branch
+			sed -i "s/master/v$VERSION/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
 
-      # Replace master with the version branch
-      sed -i "s/tree\/master/tree\/release-v$VERSION/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
-    fi
-
-		ln -s helm charts/ceph-csi-"$PACKAGE"
-		mkdir -p tmp/csi-charts/docs/"$PACKAGE"
-		pushd tmp/csi-charts/docs/"$PACKAGE" >/dev/null
-		helm init --client-only
-		helm package ../../../../charts/ceph-csi-"$PACKAGE"
-		popd >/dev/null
+		fi
 	fi
 
-	if [ $CHANGED -eq 1 ]; then
-		pushd tmp/csi-charts/docs >/dev/null
-		helm repo index .
-		git add --all :/ && git commit -m "Update repo"
-		git push https://"$GITHUB_TOKEN"@github.com/ceph/csi-charts
-		popd >/dev/null
-	fi
+	mkdir -p tmp/csi-charts/docs/"$PACKAGE"
+	pushd tmp/csi-charts/docs/"$PACKAGE" >/dev/null
+	helm init --client-only
+	helm package ../../../../charts/ceph-csi-"$PACKAGE"
+	popd >/dev/null
+
+	pushd tmp/csi-charts/docs >/dev/null
+	helm repo index .
+	git add --all :/ && git commit -m "Update for helm charts $PACKAGE-$VERSION"
+	git push https://"$GITHUB_TOKEN"@github.com/ceph/csi-charts
+	popd >/dev/null
+
 }
 
 if [ "${TRAVIS_BRANCH}" == 'master' ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,10 +35,7 @@ push_helm_charts() {
 	fi
 }
 
-if [ "${TRAVIS_BRANCH}" == 'csi-v0.3' ]; then
-	export ENV_RBD_IMAGE_VERSION='v0.3-canary'
-	export ENV_CEPHFS_IMAGE_VERSION='v0.3-canary'
-elif [ "${TRAVIS_BRANCH}" == 'master' ]; then
+if [ "${TRAVIS_BRANCH}" == 'master' ]; then
 	export ENV_CSI_IMAGE_VERSION='canary'
 else
 	echo "!!! Branch ${TRAVIS_BRANCH} is not a deployable branch; exiting"


### PR DESCRIPTION
helm charts are not getting pushed when PR is merged,  This PR will update the code to push helm charts and also to remove the csi-v0.3 reference in deploy.sh and travis.yaml file

from master and release-v1.2.0 branch we will be pushing the canary charts. when we are doing the release i.e v1.2.2 from release-v1.2.0 branch we will replace all canary to released tag v1.2.2 and push helm charts for v.1.2.2 and will revert back the changes in release-v1.2.0 branch push canary tagged charts( this will be same logic as pushing the container image)

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>