### PR TITLE
increase sidecar timeout to 150s from 60s

### DIFF
--- a/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin-provisioner.yaml
@@ -41,7 +41,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--timeout=60s"
+            - "--timeout=150s"
             - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS

--- a/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--timeout=60s"
+            - "--timeout=150s"
             - "--enable-leader-election=true"
             - "--leader-election-type=leases"
             - "--retry-interval-start=500ms"

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
@@ -41,7 +41,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--timeout=60s"
+            - "--timeout=150s"
             - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS
@@ -55,7 +55,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--timeout=60s"
+            - "--timeout=150s"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--timeout=60s"
+            - "--timeout=150s"
             - "--retry-interval-start=500ms"
             - "--enable-leader-election=true"
             - "--leader-election-type=leases"
@@ -56,7 +56,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--timeout=60s"
+            - "--timeout=150s"
             - "leader-election=true"
           env:
             - name: ADDRESS


### PR DESCRIPTION
At present, the request timeout of sidecars are at the 60s and this is a request to increase

this time out value to 150s or higher. The higher timeout value can help to reduce the
load of our backend ceph cluster and also can avoid throttling issues at sidecars to an extent.

Fix #602

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


