### PR TITLE
Change e2e rook-ceph default version to 'v1.1.2' not 'master'

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -70,7 +70,7 @@ are available while running tests:
 
 | flag           | description                                                                   |
 | -------------- | ----------------------------------------------------------------------------- |
-| rook-version   | Rook version to pull yaml files to deploy rook operator (default: master)     |
+| rook-version   | Rook version to pull yaml files to deploy rook operator (default: v1.1.2)     |
 | deploy-rook    | Deploy rook operator to create  ceph cluster (default: true)                  |
 | deploy-timeout | Timeout to wait for created kubernetes resources (default: 10)                |
 | kubeconfig     | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config) |

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -20,7 +20,7 @@ var (
 
 func init() {
 	log.SetOutput(GinkgoWriter)
-	flag.StringVar(&RookVersion, "rook-version", "master", "rook version to pull yaml files")
+	flag.StringVar(&RookVersion, "rook-version", "v1.1.2", "rook version to pull yaml files")
 
 	flag.BoolVar(&rookRequired, "deploy-rook", true, "deploy rook on kubernetes")
 	flag.IntVar(&deployTimeout, "deploy-timeout", 10, "timeout to wait for created kubernetes resources")


### PR DESCRIPTION
## Describe what this PR does ##
When rook-ceph is upgraded and changed some feature, e2e can be
failed. Change rook-ceph default verion to 'v1.1.2' explicitly
which is working fine in current code.

## Is there anything that requires special attention ##
NOTHING

## Related issues ##
Fixes: #688 

## Future concerns ##
NOTHING