### PR TITLE
rbd volumes fail to delete with useless 'exit status 1' error message

### DIFF
--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -50,9 +50,10 @@ const (
 	// Output strings returned during invocation of "ceph rbd task add remove <imagespec>" when
 	// command is not supported by ceph manager. Used to check errors and recover when the command
 	// is unsupported.
-	rbdTaskRemoveCmdInvalidString1      = "no valid command found"
-	rbdTaskRemoveCmdInvalidString2      = "Error EINVAL: invalid command"
-	rbdTaskRemoveCmdAccessDeniedMessage = "Error EACCES:"
+	rbdTaskRemoveCmdInvalidString1          = "no valid command found"
+	rbdTaskRemoveCmdInvalidString2          = "Error EINVAL: invalid command"
+	rbdTaskRemoveCmdAccessDeniedMessage     = "Error EACCES:"
+	rbdTaskRemoveCmdPermissionDeniedMessage = "Error EPERM:"
 )
 
 // rbdVolume represents a CSI volume and its RBD image specifics
@@ -187,6 +188,9 @@ func rbdManagerTaskDeleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.C
 				" deletion (minimum ceph version required is v14.2.3)"), pOpts.ClusterID)
 		} else if strings.HasPrefix(string(output), rbdTaskRemoveCmdAccessDeniedMessage) {
 			klog.Infof(util.Log(ctx, "access denied to Ceph MGR-based RBD image deletion "+
+				"on cluster ID (%s)"), pOpts.ClusterID)
+		} else if strings.HasPrefix(string(output), rbdTaskRemoveCmdPermissionDeniedMessage) {
+			klog.Infof(util.Log(ctx, "permission denied to Ceph MGR-based RBD image deletion "+
 				"on cluster ID (%s)"), pOpts.ClusterID)
 		} else {
 			klog.Errorf(util.Log(ctx, "unexpected error related to Ceph MGR-based RBD image deletion "+

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -185,12 +185,14 @@ func rbdManagerTaskDeleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.C
 			strings.Contains(string(output), rbdTaskRemoveCmdInvalidString2) {
 			klog.Infof(util.Log(ctx, "cluster with cluster ID (%s) does not support Ceph manager based rbd image"+
 				" deletion (minimum ceph version required is v14.2.3)"), pOpts.ClusterID)
-			return false, err
 		} else if strings.HasPrefix(string(output), rbdTaskRemoveCmdAccessDeniedMessage) {
 			klog.Infof(util.Log(ctx, "access denied to Ceph MGR-based RBD image deletion "+
 				"on cluster ID (%s)"), pOpts.ClusterID)
-			return false, err
+		} else {
+			klog.Errorf(util.Log(ctx, "unexpected error related to Ceph MGR-based RBD image deletion "+
+				"on cluster ID (%s): %s"), pOpts.ClusterID, output)
 		}
+		return false, err
 	}
 
 	return true, err


### PR DESCRIPTION
# Describe what this PR does #

While running tests with csi-sanity against the rbd provisioner, deletion of volumes fails (on a Ceph Nano deployment) with the following useless error:

```
I1029 08:33:51.613080       1 controllerserver.go:371] ID: 24 Req-ID: 0001-0024-b9d62327-c3fd-4028-a1f0-48e6dbd66675-0000000000000001-cad48e19-fa26-11e9-bc00-0242ac110007 deleting image csi-vol-cad48e19-fa26-11e9-bc00-0242ac110007
I1029 08:33:51.613101       1 rbd_util.go:144] ID: 24 Req-ID: 0001-0024-b9d62327-c3fd-4028-a1f0-48e6dbd66675-0000000000000001-cad48e19-fa26-11e9-bc00-0242ac110007 rbd: status csi-vol-cad48e19-fa26-11e9-bc00-0242ac110007 using mon 172.17.0.4:3300, pool rbd
W1029 08:33:51.693675       1 rbd_util.go:166] ID: 24 Req-ID: 0001-0024-b9d62327-c3fd-4028-a1f0-48e6dbd66675-0000000000000001-cad48e19-fa26-11e9-bc00-0242ac110007 rbd: no watchers on csi-vol-cad48e19-fa26-11e9-bc00-0242ac110007
I1029 08:33:51.693710       1 rbd_util.go:213] ID: 24 Req-ID: 0001-0024-b9d62327-c3fd-4028-a1f0-48e6dbd66675-0000000000000001-cad48e19-fa26-11e9-bc00-0242ac110007 rbd: rm csi-vol-cad48e19-fa26-11e9-bc00-0242ac110007 using mon 172.17.0.4:3300, pool rbd
E1029 08:33:52.935852       1 rbd_util.go:225] ID: 24 Req-ID: 0001-0024-b9d62327-c3fd-4028-a1f0-48e6dbd66675-0000000000000001-cad48e19-fa26-11e9-bc00-0242ac110007 failed to delete rbd image: exit status 1, command output: 
E1029 08:33:52.935909       1 controllerserver.go:373] ID: 24 Req-ID: 0001-0024-b9d62327-c3fd-4028-a1f0-48e6dbd66675-0000000000000001-cad48e19-fa26-11e9-bc00-0242ac110007 failed to delete rbd image: rbd/csi-vol-cad48e19-fa26-11e9-bc00-0242ac110007 with error: exit status 1
E1029 08:33:52.935986       1 utils.go:161] ID: 24 Req-ID: 0001-0024-b9d62327-c3fd-4028-a1f0-48e6dbd66675-0000000000000001-cad48e19-fa26-11e9-bc00-0242ac110007 GRPC error: rpc error: code = Internal desc = exit status 1
```

It seems that this error is returned by Ceph MGR and is not recognized by the provisioner. This PR adds additional logging to the provisioner so that `exit status 1` is replaced with something more  useful.