### PR TITLE
cephfs: add kernel version detection for mounting with client

### DIFF
--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -78,8 +78,8 @@ func kernelSupportsQuota(release string) error {
 	}
 
 	quotaSupport := []kernelSupport{
-		kernelSupport{4, 17, 0, 0, "", false},       // standard 4.17+ versions
-		kernelSupport{3, 10, 0, 1062, ".el7", true}, // RHEL-7.7
+		{4, 17, 0, 0, "", false},       // standard 4.17+ versions
+		{3, 10, 0, 1062, ".el7", true}, // RHEL-7.7
 	}
 
 	vers := strings.Split(strings.SplitN(release, "-", 2)[0], ".")

--- a/pkg/cephfs/volumemounter_test.go
+++ b/pkg/cephfs/volumemounter_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"testing"
+)
+
+func init() {
+}
+
+func TestKernelSupportsQuota(t *testing.T) {
+	supportsQuota := []string{
+		"4.17.0",
+		"4.17.0-rc1",
+		"4.18.0-80.el8",
+		"3.10.0-1062.el7.x86_64",     // 1st backport
+		"3.10.0-1062.4.1.el7.x86_64", // updated backport
+	}
+
+	noQuota := []string{
+		"2.6.32-754.15.3.el6.x86_64", // too old
+		"3.10.0-123.el7.x86_64",      // too old for backport
+		"3.10.0-1062.4.1.el8.x86_64", // nonexisting RHEL-8 kernel
+		"3.11.0-123.el7.x86_64",      // nonexisting RHEL-7 kernel
+	}
+
+	for _, kernel := range supportsQuota {
+		err := kernelSupportsQuota(kernel)
+		if err != nil {
+			t.Errorf("support expected for %s: %v", kernel, err)
+		}
+	}
+
+	for _, kernel := range noQuota {
+		err := kernelSupportsQuota(kernel)
+		if err == nil {
+			t.Errorf("no support expected for %s: %v", kernel, err)
+		}
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #

Linux kernel 4.17.0 adds support for quota with CephFS. Without quota,
it is not possible to fullfill the requirements of the CSI Spec and
guarantee sufficient space on the filesystem for a volume. With this in
mind, usage of the kernel client is only allowed with kernel 4.17.0 or
newer.

However, some Linux vendors backport features and patches to their
Enterprise products. These kernels may have an older version, but do
support quota. One of these is the kernel that comes with RHEL-7.7.

By comparing the current running version of the Linux kernel against
known versions that support quota, we can now automatically decide to
use the kernel client, or not.

## Is there anything that requires special attention ##

Note that this does not change the 'forcekernelclient' parameter. The
parameter is still available and can be used for kernels that are not in
the 'known to support quota list'. Or users can pass the parameter to
use a CephFS kernel client that does not support quota.
