### PR TITLE
Support Arm64 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
     - DEP_VERSION=v0.5.4
 
 before_install:
+  - mkdir -p $GOPATH/bin
   - curl
     https://raw.githubusercontent.com/golang/dep/${DEP_VERSION}/install.sh|sh
 
@@ -75,6 +76,17 @@ jobs:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;
         - scripts/travis-functest.sh v1.17.0 || travis_terminate 1;
+
+    - name: cephcsi on Arm64
+      arch: arm64
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        # No CI test job is availabe for Arm64 now due to below issues
+        # - k8s-csi sidecar images for Arm64 are not available
+        # - Travis Arm64 CI job runs inside unprivileged LXD which blocks
+        #   launching minikube test environment
+        - travis_terminate 0    # deploy only on x86
 
 deploy:
   - provider: script

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Independent CSI plugins are provided to support RBD and CephFS backed volumes,
   refer [cephfs doc](https://github.com/ceph/ceph-csi/blob/master/docs/deploy-cephfs.md).
 - For example usage of RBD and CephFS CSI plugins, see examples in `examples/`.
 
+NOTE:
+
+- Ceph CSI **`Arm64`** support is experimental.
+
 ## Project status
 
 Status: **GA**

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -2,12 +2,14 @@ FROM ceph/ceph:v14.2
 LABEL maintainers="Ceph-CSI Authors"
 LABEL description="Ceph-CSI Plugin"
 
+# To support cross building, do NOT RUN native binaries here.
+# If we have to run native binaries, qemu-user-static must be installed on
+# build host and mounted to container.
+
 # Removing ceph-iscsi repo to workaround the repo issue while upgrading
 #RUN rm -f /etc/yum.repos.d/ceph-iscsi.repo && yum -y update && yum clean all
 ENV CSIBIN=/usr/local/bin/cephcsi
 
 COPY cephcsi $CSIBIN
-
-RUN chmod +x $CSIBIN
 
 ENTRYPOINT ["/usr/local/bin/cephcsi"]

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -44,16 +44,17 @@ function install_minikube() {
     fi
 
     echo "Installing minikube. Version: ${MINIKUBE_VERSION}"
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-amd64 && chmod +x minikube && mv minikube /usr/local/bin/
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-"${MINIKUBE_ARCH}" && chmod +x minikube && mv minikube /usr/local/bin/
 }
 
 function install_kubectl() {
     # Download kubectl, which is a requirement for using minikube.
     echo "Installing kubectl. Version: ${KUBE_VERSION}"
-    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBE_VERSION}"/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
+    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBE_VERSION}"/bin/linux/"${MINIKUBE_ARCH}"/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
 }
 
 # configure minikube
+MINIKUBE_ARCH=${MINIKUBE_ARCH:-"amd64"}
 MINIKUBE_VERSION=${MINIKUBE_VERSION:-"latest"}
 KUBE_VERSION=${KUBE_VERSION:-"v1.14.2"}
 MEMORY=${MEMORY:-"3000"}


### PR DESCRIPTION
### **This change log is obsolete. Please see https://github.com/ceph/ceph-csi/pull/707#issuecomment-558032838 for latest change log.**

Support multi-arch images

    Add jobs to build arm64 image and support multi-arch docker image.
    By multi-arch it means "docker pull cephcsi/cephcsi:canary" will
    download amd64 or arm64 image per host archtecture automatically.
    Architecture dependent images are named as cephcsi/cephcsi-amd64
    and cephcsi/cephcsi-arm64.
    
    Major changes:
    - Add travis job "build arm64 image" which runs on travis arm64 nodes
      to build cephcsi image for arm64.
    - Add travis job "push image manifest" which pushes multi-arch image
      manifest to docker registry.
    - Update Makefile to tag and push architecture dependent image with
      architecture appended in name (e.g, cephcsi/cephcsi-amd64:canary)
    - Add Makefile target "push-manifest-cephcsi" to push image manifest
      and support multi arch.
    - Add ENV_DOCKER_REGISTRY variable to configure docker registry
      for hosting built image, rather than hard coded quay.io.
    
    NOTES:
    - CI test jobs are disabled on Arm now build due to minikube issue.
    - Job "push-manifest-cephcsi" runs for every PR. It should only run
      when patch merges. Though it does nothing for normal PR (deploy.sh
      checks ${TRAVIS_PULL_REQUEST}), it still needs booting, installing
      packages, etc, which costs about 1 minute.
    - In current jobs, docker image is pushed if one test succeeds and
      runs deployment, even if other tests fails. After applying this
      patch, architecure image is handled same, pushed when any test
      succeeds. But multi-arch manifest is pushed only after all tests
      succeed, any broken test will block pushing multi-arch manifest.

CI test log
https://travis-ci.org/cyb70289/ceph-csi/builds/608636375