### PR TITLE
Fix default kubeconfig working correctly in e2e test

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -24,12 +26,23 @@ func init() {
 
 	flag.BoolVar(&rookRequired, "deploy-rook", true, "deploy rook on kubernetes")
 	flag.IntVar(&deployTimeout, "deploy-timeout", 10, "timeout to wait for created kubernetes resources")
+
+	setDefaultKubeconfig()
+
 	// Register framework flags, then handle flags
 	framework.HandleFlags()
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
 	formRookURL(RookVersion)
 	fmt.Println("timeout for deploytimeout ", deployTimeout)
+}
+
+func setDefaultKubeconfig() {
+	_, exists := os.LookupEnv("KUBECONFIG")
+	if !exists {
+		defaultKubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		os.Setenv("KUBECONFIG", defaultKubeconfig)
+	}
 }
 
 // removeCephCSIResource is a temporary fix for CI to remove the ceph-csi resources deployed by rook


### PR DESCRIPTION
## Describe what this PR does #
Kuberentes e2e framework get kubeconfig information from
KUBECONFIG environment variable. set the variable by default.

## Is there anything that requires special attention ##
NONE

## Related issues ##
Fixes: #721

## Future concerns ##
NONE