### PR TITLE
fixed toYaml

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -186,7 +186,7 @@ spec:
           }
 {{- if .Values.nodeplugin.affinity }}
       affinity:
-{{ toYaml .Values.nodeplugin.affinity . | indent 8 -}}
+{{ toYaml .Values.nodeplugin.affinity | indent 8 -}}
 {{- end -}}
 {{- if .Values.nodeplugin.nodeSelector }}
       nodeSelector:

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -186,7 +186,7 @@ spec:
           }
 {{- if .Values.provisioner.affinity }}
       affinity:
-{{ toYaml .Values.provisioner.affinity . | indent 8 -}}
+{{ toYaml .Values.provisioner.affinity | indent 8 -}}
 {{- end -}}
 {{- if .Values.provisioner.nodeSelector }}
       nodeSelector:

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -183,7 +183,7 @@ spec:
           }
 {{- if .Values.nodeplugin.affinity }}
       affinity:
-{{ toYaml .Values.nodeplugin.affinity . | indent 8 -}}
+{{ toYaml .Values.nodeplugin.affinity | indent 8 -}}
 {{- end -}}
 {{- if .Values.nodeplugin.nodeSelector }}
       nodeSelector:

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -183,7 +183,7 @@ spec:
           }
 {{- if .Values.provisioner.affinity }}
       affinity:
-{{ toYaml .Values.provisioner.affinity . | indent 8 -}}
+{{ toYaml .Values.provisioner.affinity | indent 8 -}}
 {{- end -}}
 {{- if .Values.provisioner.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
# Fix helm deploy error (toYaml)

`helm upgrade csi-rbd ../ceph-csi-rbd/ --namespace csi-rbd --tiller-namespace csi-rbd -f my_values.yaml`

> UPGRADE FAILED
> Error: render error in "ceph-csi-rbd/templates/provisioner-deployment.yaml": template: ceph-csi-rbd/templates/provisioner-deployment.yaml:186:3: executing "ceph-csi-rbd/templates/provisioner-deployment.yaml" at <toYaml>: wrong number of args for toYaml: want 1 got 2
> Error: UPGRADE FAILED: render error in "ceph-csi-rbd/templates/provisioner-deployment.yaml": template: ceph-csi-rbd/templates/provisioner-deployment.yaml:186:3: executing "ceph-csi-rbd/templates/provisioner-deployment.yaml" at <toYaml>: wrong number of args for toYaml: want 1 got 2

## Path

- charts/ceph-csi-cephfs/templates/
- charts/ceph-csi-rbd/templates/

### Files

charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml

```
- {{ toYaml .Values.nodeplugin.affinity . | indent 8 -}}
+ {{ toYaml .Values.nodeplugin.affinity | indent 8 -}}
```

charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml

```
- {{ toYaml .Values.provisioner.affinity . | indent 8 -}}
+ {{ toYaml .Values.provisioner.affinity | indent 8 -}}
```