### PR TITLE
Update readme to add new ceph-csi releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ in the Kubernetes documentation.
 | Ceph CSI Release/Branch | Container image name         | Image Tag |
 | ----------------------- | ---------------------------- | --------- |
 | Master (Branch)         | quay.io/cephcsi/cephcsi      | canary    |
+| v1.2.2 (Release)        | quay.io/cephcsi/cephcsi      | v1.2.2    |
+| v1.2.1 (Release)        | quay.io/cephcsi/cephcsi      | v1.2.1    |
 | v1.2.0 (Release)        | quay.io/cephcsi/cephcsi      | v1.2.0    |
 | v1.1.0 (Release)        | quay.io/cephcsi/cephcsi      | v1.1.0    |
 | v1.0.0 (Branch)         | quay.io/cephcsi/cephfsplugin | v1.0.0    |


### PR DESCRIPTION
we have new releases i.e `1.2.1` and `1.2.2`, This PR updated the readme to point to the same

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>