### PR TITLE
Fix to use `kubectl create` not `kubectl apply` in the e2e

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -28,12 +28,15 @@ func updateCephfsDirPath(c clientset.Interface) {
 }
 
 func deployCephfsPlugin() {
+	// delete objects deployed by rook
+	framework.RunKubectlOrDie("delete", "--ignore-not-found=true", "-f", cephfsDirPath+cephfsProvisionerRBAC)
+	framework.RunKubectlOrDie("delete", "--ignore-not-found=true", "-f", cephfsDirPath+cephfsNodePluginRBAC)
 	// deploy provisioner
 	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisioner)
-	framework.RunKubectlOrDie("apply", "-f", cephfsDirPath+cephfsProvisionerRBAC)
+	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisionerRBAC)
 	// deploy nodeplugin
 	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePlugin)
-	framework.RunKubectlOrDie("apply", "-f", cephfsDirPath+cephfsNodePluginRBAC)
+	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePluginRBAC)
 }
 
 func deleteCephfsPlugin() {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -30,12 +30,15 @@ func updaterbdDirPath(c clientset.Interface) {
 }
 
 func deployRBDPlugin() {
+	// delete objects deployed by rook
+	framework.RunKubectlOrDie("delete", "--ignore-not-found=true", "-f", rbdDirPath+rbdProvisionerRBAC)
+	framework.RunKubectlOrDie("delete", "--ignore-not-found=true", "-f", rbdDirPath+rbdNodePluginRBAC)
 	// deploy provisioner
 	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdProvisioner)
-	framework.RunKubectlOrDie("apply", "-f", rbdDirPath+rbdProvisionerRBAC)
+	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdProvisionerRBAC)
 	// deploy nodeplugin
 	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdNodePlugin)
-	framework.RunKubectlOrDie("apply", "-f", rbdDirPath+rbdNodePluginRBAC)
+	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdNodePluginRBAC)
 }
 
 func deleteRBDPlugin() {


### PR DESCRIPTION
Signed-off-by: Woohyung Han <techhanx@gmail.com>

# Describe what this PR does #
Fix to use `kubectl create` not `kubectl apply` in the e2e.

## Is there anything that requires special attention ##
NONE

## Related issues ##
Fixes: #731

## Future concerns ##
NONE