### PR TITLE
Update golangci-lint version to v1.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ go: 1.12.x
 
 env:
   global:
-    - GOLANGCI_VERSION=v1.17.0
+    - GOLANGCI_VERSION=v1.21.0
     - GOSEC_VERSION=2.0.0
     - TEST_COVERAGE=stdout
     - GO_METALINTER_THREADS=1

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -46,7 +46,6 @@ var (
 )
 
 func init() {
-
 	// common flags
 	flag.StringVar(&conf.Vtype, "type", "", "driver type [rbd|cephfs|liveness]")
 	flag.StringVar(&conf.Endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -136,7 +136,6 @@ func waitForDeploymentComplete(name, ns string, c clientset.Interface, t int) er
 }
 
 func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOptions) (string, string) {
-
 	cmd := []string{"/bin/sh", "-c", c}
 	podList, err := f.PodClientNS(ns).List(*opt)
 	framework.ExpectNoError(err)
@@ -523,7 +522,6 @@ func unmarshal(fileName string, obj interface{}) error {
 // createPVCAndApp creates pvc and pod
 // if name is not empty same will be set as pvc and app name
 func createPVCAndApp(name string, f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.Pod) error {
-
 	if name != "" {
 		pvc.Name = name
 		app.Name = name
@@ -540,7 +538,6 @@ func createPVCAndApp(name string, f *framework.Framework, pvc *v1.PersistentVolu
 // deletePVCAndApp delete pvc and pod
 // if name is not empty same will be set as pvc and app name
 func deletePVCAndApp(name string, f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.Pod) error {
-
 	if name != "" {
 		pvc.Name = name
 		app.Name = name
@@ -731,7 +728,6 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) {
 // }
 
 func listRBDImages(f *framework.Framework) []string {
-
 	opt := metav1.ListOptions{
 		LabelSelector: "app=rook-ceph-tools",
 	}

--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -295,7 +295,6 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 
 // ExpandVolume expand CephFS Volumes on demand based on resizer request
 func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-
 	if err := cs.validateExpandVolumeRequest(req); err != nil {
 		klog.Errorf("ControllerExpandVolumeRequest validation failed: %v", err)
 		return nil, err
@@ -335,5 +334,4 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		CapacityBytes:         RoundOffSize,
 		NodeExpansionRequired: false,
 	}, nil
-
 }

--- a/pkg/cephfs/driver.go
+++ b/pkg/cephfs/driver.go
@@ -91,7 +91,6 @@ func NewNodeServer(d *csicommon.CSIDriver, t string) *NodeServer {
 // Run start a non-blocking grpc controller,node and identityserver for
 // ceph CSI driver which can serve multiple parallel requests
 func (fs *Driver) Run(conf *util.Config, cachePersister util.CachePersister) {
-
 	// Configuration
 	PluginFolder = conf.PluginPath
 

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -163,7 +163,6 @@ func (*NodeServer) mount(ctx context.Context, volOptions *volumeOptions, req *cs
 // NodePublishVolume mounts the volume mounted to the staging path to the target
 // path
 func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-
 	mountOptions := []string{"bind"}
 	if err := util.ValidateNodePublishVolumeRequest(req); err != nil {
 		return nil, err

--- a/pkg/csi-common/driver.go
+++ b/pkg/csi-common/driver.go
@@ -88,7 +88,6 @@ func (d *CSIDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceC
 	}
 
 	d.cap = csc
-
 }
 
 // AddVolumeCapabilityAccessModes stores volume access modes

--- a/pkg/csi-common/nodeserver-default.go
+++ b/pkg/csi-common/nodeserver-default.go
@@ -81,7 +81,6 @@ func (ns *DefaultNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.N
 
 // NodeGetVolumeStats returns volume stats
 func (ns *DefaultNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-
 	var err error
 	targetPath := req.GetVolumePath()
 	if targetPath == "" {
@@ -144,7 +143,6 @@ func (ns *DefaultNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.No
 	if !ok {
 		klog.Errorf(util.Log(ctx, "failed to fetch available inodes"))
 		return nil, status.Error(codes.Unknown, "failed to fetch available inodes")
-
 	}
 	inodesFree, ok := (*(volMetrics.InodesFree)).AsInt64()
 	if !ok {
@@ -171,5 +169,4 @@ func (ns *DefaultNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.No
 			},
 		},
 	}, nil
-
 }

--- a/pkg/csi-common/server.go
+++ b/pkg/csi-common/server.go
@@ -56,7 +56,6 @@ type nonBlockingGRPCServer struct {
 
 // Start start service on endpoint
 func (s *nonBlockingGRPCServer) Start(endpoint, hstOptions string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, metrics bool) {
-
 	s.wg.Add(1)
 	go s.serve(endpoint, hstOptions, ids, cs, ns, metrics)
 }
@@ -77,7 +76,6 @@ func (s *nonBlockingGRPCServer) ForceStop() {
 }
 
 func (s *nonBlockingGRPCServer) serve(endpoint, hstOptions string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, metrics bool) {
-
 	proto, addr, err := parseEndpoint(endpoint)
 	if err != nil {
 		klog.Fatal(err.Error())

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -171,7 +171,6 @@ func panicHandler(ctx context.Context, req interface{}, info *grpc.UnaryServerIn
 			klog.Errorf("panic occurred: %v", r)
 			debug.PrintStack()
 			err = status.Errorf(codes.Internal, "panic %v", r)
-
 		}
 	}()
 	return handler(ctx, req)

--- a/pkg/liveness/liveness.go
+++ b/pkg/liveness/liveness.go
@@ -38,7 +38,6 @@ var (
 )
 
 func getLiveness(timeout time.Duration, csiConn *grpc.ClientConn) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -118,7 +118,6 @@ func (cs *ControllerServer) parseVolCreateRequest(ctx context.Context, req *csi.
 
 // CreateVolume creates the volume in backend
 func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-
 	if err := cs.validateVolumeReq(ctx, req); err != nil {
 		return nil, err
 	}

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -236,7 +236,6 @@ func (ns *NodeServer) createStageMountPoint(ctx context.Context, mountPath strin
 // NodePublishVolume mounts the volume mounted to the device path to the target
 // path
 func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-
 	err := util.ValidateNodePublishVolumeRequest(req)
 	if err != nil {
 		return nil, err
@@ -408,7 +407,6 @@ func (ns *NodeServer) createTargetMountPath(ctx context.Context, mountPath strin
 		}
 	}
 	return notMnt, err
-
 }
 
 // NodeUnpublishVolume unmounts the volume from the target path

--- a/pkg/util/nodecache.go
+++ b/pkg/util/nodecache.go
@@ -70,7 +70,6 @@ func (nc *NodeCache) ForAll(pattern string, destObj interface{}, f ForAllFunc) e
 			}
 		}
 		return err
-
 	}
 	return nil
 }
@@ -93,12 +92,10 @@ func decodeObj(fpath, pattern string, file os.FileInfo, destObj interface{}) err
 	if err = decoder.Decode(destObj); err != nil {
 		if err = fp.Close(); err != nil {
 			return errors.Wrapf(err, "failed to close file %s", file.Name())
-
 		}
 		return errors.Wrapf(err, "node-cache: couldn't decode file %s", file.Name())
 	}
 	return nil
-
 }
 
 // Create creates the metadata file in cache directory with identifier name
@@ -161,7 +158,6 @@ func (nc *NodeCache) Delete(identifier string) error {
 		}
 
 		return errors.Wrapf(err, "node-cache: error removing file %s", file)
-
 	}
 	klog.V(4).Infof("node-cache: successfully deleted metadata storage file at: %+v\n", file)
 	return nil

--- a/pkg/util/voljournal.go
+++ b/pkg/util/voljournal.go
@@ -296,7 +296,6 @@ func reserveOMapName(ctx context.Context, monitors string, cr *Credentials, pool
 	}
 
 	return "", errors.New("uuid conflicts exceeds retry threshold")
-
 }
 
 /*

--- a/scripts/golangci.yml
+++ b/scripts/golangci.yml
@@ -141,6 +141,10 @@ linters-settings:
     # make an issue if func has more lines of code than this setting and
     # it has naked returns; default is 30
     max-func-lines: 30
+  gocognit:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    # TODO: decrease complexity with refacoring the code
+    min-complexity: 40
 
 linters:
   enable-all: true
@@ -149,3 +153,6 @@ linters:
     - dupl
     - gochecknoinits
     - gochecknoglobals
+    - godox
+    - wsl
+    - funlen


### PR DESCRIPTION
Signed-off-by: Woohyung Han <techhanx@gmail.com>

# Describe what this PR does #
Update golangci-lint version to v1.21.0

## Is there anything that requires special attention ##
### Most of issue was `unnecessary trailing newline, unnecessary leading newline`. 
```
// BAD
		return err

	}
	return nil
}

// GOOD
		return err
	}
	return nil
}
```

### I disabled following linters
1. godox: Tool for detection of FIXME, TODO and other comment keywords
2. wsl: Whitespace Linter, has `assignments should only be cuddled with other assignments` rule. This rule force to cuddle all assignements. (need new line after assignements). I think It's not so cool, see following example. and we have simllary linter for detecting trailing. the `whitespace` linter to detect leading and trailing whitespace.

```go
// BAD (by wsl)
	_, err := framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisioner)
	if err != nil {
		e2elog.Logf("failed to delete cephfs provisioner %v", err)
	}
	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisionerRBAC)
	if err != nil {
		e2elog.Logf("failed to delete cephfs provisioner rbac %v", err)
	}

// GOOD
	_, err := framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisioner)
	
	if err != nil {
		e2elog.Logf("failed to delete cephfs provisioner %v", err)
	}
	
	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisionerRBAC)
	
	if err != nil {
		e2elog.Logf("failed to delete cephfs provisioner rbac %v", err)
	}
```

3. funlen: Tool for detection of long functions. I don't think this is needed for golang. golang has no column limit.



## Related issues ##
Fixes: #736



## Future concerns ##
We have one warning in the test, and this is golangci-lint issue. <https://github.com/golangci/golangci-lint/issues/827>
```
WARN [runner] Can't run linter unused: buildssa: analysis skipped: errors in package: 
(...)
```

I'm not sure about these. Please take a look these.

- We have the [gocognit](https://github.com/uudashr/gocognit) lint for `Computes and checks the cognitive complexity of functions`. But the min-complexity value with default (30) is not passed the test for now. I think we can just disable this lint, or need to refactor to pass the lint. (maybe another pull request?)
- I found yamllint not working correctly in my desktop with following error. Perhaps we need to check this too.
```shell
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: charts/*/templates/*.yaml} ./.mergify.yml 
[DEPRECATION] The trollop gem has been renamed to optimist and will no longer be supported. Please switch to optimist as soon as possible.
Error: unknown argument '-s'.
Try --help for help.
```
