### PR TITLE
Add missing env for namespace.

### DIFF
--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
@@ -72,6 +72,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
           imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
Add a missing env for the rbdplugin to get the object from the correct namespace.
The env is correctly set in the csi-cephfsplugin.yaml but missing from the rbd.