### PR TITLE
Adds per volume encryption with Vault integration

### DIFF
--- a/charts/ceph-csi-rbd/templates/encryptionkms-configmap.yaml
+++ b/charts/ceph-csi-rbd/templates/encryptionkms-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.kmsConfigMapName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config.json: |-
+{{ toJson .Values.encryptionKMSConfig | indent 4 -}}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -121,6 +121,8 @@ spec:
               readOnly: true
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
+            - name: ceph-csi-encryption-kms-config
+              mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins
               mountPropagation: "Bidirectional"
@@ -189,6 +191,9 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}
+        - name: ceph-csi-encryption-kms-config
+          configMap:
+            name: {{ .Values.kmsConfigMapName | quote }}
         - name: keys-tmp-dir
           emptyDir: {
             medium: "Memory"

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -148,6 +148,8 @@ spec:
               readOnly: true
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
+            - name: ceph-csi-encryption-kms-config
+              mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
           resources:
@@ -193,6 +195,9 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}
+        - name: ceph-csi-encryption-kms-config
+          configMap:
+            name: {{ .Values.kmsConfigMapName | quote }}
         - name: keys-tmp-dir
           emptyDir: {
             medium: "Memory"

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -27,6 +27,14 @@ serviceAccounts:
 #       - "<MONValue2>"
 csiConfig: []
 
+# Configuration for the encryption KMS
+# Ref: https://github.com/ceph/ceph-csi/blob/master/docs/deploy-rbd.md
+# Example:
+# encryptionKMSConfig:
+#   - encryptionKMSID: "<kms-id>"
+#     <kms-specific-configs>
+encryptionKMSConfig: []
+
 nodeplugin:
   name: nodeplugin
   # if you are using rbd-nbd client set this value to OnDelete
@@ -248,3 +256,5 @@ pluginDir: /var/lib/kubelet/plugins
 driverName: rbd.csi.ceph.com
 # Name of the configmap used for state
 configMapName: ceph-csi-config-rbd
+# Name of the configmap used for encryption kms configuration
+kmsConfigMapName: ceph-csi-encryption-kms-config

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -140,6 +140,8 @@ spec:
               readOnly: true
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
+            - name: ceph-csi-encryption-kms-config
+              mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
@@ -179,6 +181,9 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config
+        - name: ceph-csi-encryption-kms-config
+          configMap:
+            name: ceph-csi-encryption-kms-config
         - name: keys-tmp-dir
           emptyDir: {
             medium: "Memory"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -96,6 +96,8 @@ spec:
               readOnly: true
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
+            - name: ceph-csi-encryption-kms-config
+              mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins
               mountPropagation: "Bidirectional"
@@ -158,6 +160,9 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config
+        - name: ceph-csi-encryption-kms-config
+          configMap:
+            name: ceph-csi-encryption-kms-config
         - name: keys-tmp-dir
           emptyDir: {
             medium: "Memory"

--- a/docs/design/proposals/encrypted-pvc.md
+++ b/docs/design/proposals/encrypted-pvc.md
@@ -1,0 +1,131 @@
+# Encrypted Persistent Volume Claims
+
+## Proposal
+
+Subject of this proposal is to add support for encryption of RBD volumes in
+Ceph-CSI.
+
+Some but not all the benefits of this approach:
+
+* guarantee encryption in transit to rbd without using messenger v2
+* extra security layer to application with special regulatory needs
+* at rest encryption can be disabled to selectively allow encryption only where
+  required
+
+## Document Terminology
+
+* volume encryption: encryption of a volume attached by rbd
+* encryption at rest: encryption of physical disk done by ceph
+* LUKS: Linux Unified Key Setup: stores all of the needed setup information for
+  dm-crypt on the disk
+* dm-crypt: linux kernel device-mapper crypto target
+* cryptsetup: the command line tool to interface with dm-crypt
+
+## Proposed Solution
+
+The proposed solution in this document, is to address the volume encryption
+requirement by using dm-crypt module through cryptsetup cli interface.
+
+### Implementation Summary
+
+* Encryption is implemented using cryptsetup with LUKS extension.
+  A good introduction to LUKS and dm-crypt in general can be found
+  [here](https://wiki.archlinux.org/index.php/Dm-crypt/Device_encryption#Encrypting_devices_with_cryptsetup)
+  Functions to implement necessary interaction are implemented in a separate
+  `cryptsetup.go` file.
+  * LuksFormat
+  * LuksOpen
+  * LuksClose
+  * LuksStatus
+
+* `CreateVolume`: refactored to prepare for encryption (tag image that it
+  requires encryption later), before returning, if encrypted volume option is
+  set.
+* `NodeStageVolume`: refactored to call `encryptDevice` method on the very first
+  volume attach request
+* `NodeStageVolume`: refactored to open encrypted device (`openEncryptedDevice`)
+* `openEncryptedDevice`: looks up for a passphrase matching the volume id,
+  returns the new device path in the form: `/dev/mapper/luks-<volume_id>`.
+  On the woker node where the attach is scheduled:
+
+  ```shell
+  $ lsblk
+  NAME                            MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINT
+  sda                               8:0    0   10G  0 disk
+  └─sda1                            8:1    0   10G  0 part  /
+  sdb                               8:16   0   20G  0 disk
+  rbd0                            253:0    0    1G  0 disk
+  └─luks-pvc-8a710f4c934811e9 252:0    0 1020M  0 crypt /var/lib/kubelet/pods/9eaceaef-936c-11e9-b396-005056af3de0/volumes/kubernetes.io~csi/pvc-8a710f4c934811e9/mount
+  ```
+
+* `detachRBDDevice`: calls `LuksClose` function to remove the LUKS mapping
+  before detaching the volume.
+
+* StorageClass extended with following parameters:
+  1. `encrypted` ("true" or "false")
+  1. `encryptionKMS` (string representing kms of choice)
+  ceph-csi plugin may support different kms vendors with different type of
+  authentication
+  1. `encryptionKMSID` (string representing kms configuration)
+
+* New KMS Configuration created.
+
+#### Annotated YAML for RBD StorageClass
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: csi-rbd
+provisioner: rbd.csi.ceph.com
+parameters:
+   # String representing Ceph cluster configuration
+   clusterID: <cluster-id>
+   # ceph pool
+   pool: rbd
+
+   # RBD image features, CSI creates image with image-format 2
+   # CSI RBD currently supports only `layering` feature.
+   imageFeatures: layering
+
+   # The secrets have to contain Ceph credentials with required access
+   # to the 'pool'.
+   csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
+   csi.storage.k8s.io/provisioner-secret-namespace: default
+   csi.storage.k8s.io/controller-expand-secret-name: csi-rbd-secret
+   csi.storage.k8s.io/controller-expand-secret-namespace: default
+   csi.storage.k8s.io/node-stage-secret-name: csi-rbd-secret
+   csi.storage.k8s.io/node-stage-secret-namespace: default
+   # Specify the filesystem type of the volume. If not specified,
+   # csi-provisioner will set default as `ext4`.
+   csi.storage.k8s.io/fstype: ext4
+
+   # Encrypt volumes
+   encrypted: "true"
+
+   # The type of kms we want to connect to: Barbican, aws kms or others can be
+   # supported
+   encryptionKMS: vault
+   # String representing a KMS configuration
+   encryptionKMSID: <kms-id>
+
+reclaimPolicy: Delete
+```
+
+And kms configuration:
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  config.json: |-
+    [
+      {
+        "kmsID": "<kms-id>",
+        kms specific config...
+      }
+    ]
+metadata:
+  name: ceph-csi-encryption-kms-config
+```

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -1,0 +1,54 @@
+package e2e
+
+import (
+	. "github.com/onsi/gomega" // nolint
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+)
+
+var (
+	vaultExamplePath = "../examples/kms/vault/"
+	vaultServicePath = "vault.yaml"
+	vaultPSPPath     = "vault-psp.yaml"
+	vaultRBACPath    = "csi-vaulttokenreview-rbac.yaml"
+	vaultConfigPath  = "kms-config.yaml"
+)
+
+func deployVault(c kubernetes.Interface, deployTimeout int) {
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultServicePath)
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultPSPPath)
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultRBACPath)
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultConfigPath)
+
+	opt := metav1.ListOptions{
+		LabelSelector: "app=vault",
+	}
+
+	pods, err := c.CoreV1().Pods("default").List(opt)
+	Expect(err).Should(BeNil())
+	Expect(len(pods.Items)).Should(Equal(1))
+	name := pods.Items[0].Name
+	err = waitForPodInRunningState(name, "default", c, deployTimeout)
+	Expect(err).Should(BeNil())
+}
+
+func deleteVault() {
+	_, err := framework.RunKubectl("delete", "-f", vaultExamplePath+vaultServicePath)
+	if err != nil {
+		e2elog.Logf("failed to delete vault statefull set %v", err)
+	}
+	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultRBACPath)
+	if err != nil {
+		e2elog.Logf("failed to delete vault statefull set %v", err)
+	}
+	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultConfigPath)
+	if err != nil {
+		e2elog.Logf("failed to delete vault config map %v", err)
+	}
+	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultPSPPath)
+	if err != nil {
+		e2elog.Logf("failed to delete vault psp %v", err)
+	}
+}

--- a/examples/kms/vault/csi-vaulttokenreview-rbac.yaml
+++ b/examples/kms/vault/csi-vaulttokenreview-rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-csi-vault-token-review
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-csi-vault-token-review
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create", "get", "list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-csi-vault-token-review
+subjects:
+  - kind: ServiceAccount
+    name: rbd-csi-vault-token-review
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: rbd-csi-vault-token-review
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  config.json: |-
+    [
+      {
+        "encryptionKMSID": "vault-test",
+        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultAuthPath": "/v1/auth/kubernetes/login",
+        "vaultRole": "csi-kubernetes",
+        "vaultPassphraseRoot": "/v1/secret",
+        "vaultPassphrasePath": "ceph-csi/",
+        "vaultCAVerify": false
+      }
+    ]
+metadata:
+  name: ceph-csi-encryption-kms-config

--- a/examples/kms/vault/vault-psp.yaml
+++ b/examples/kms/vault/vault-psp.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: rbd-csi-vault-token-review-psp
+spec:
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'secret'
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: default
+  name: rbd-csi-vault-token-review-psp
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['rbd-csi-vault-token-review-psp']
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-csi-vault-token-review-psp
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: rbd-csi-vault-token-review
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: rbd-csi-vault-token-review-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -1,0 +1,150 @@
+# HashiCorp Vault configuration for minikube
+# This is not part of ceph-csi project, used only
+# for e2e testing of integration with such KMS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  labels:
+    app: vault-api
+spec:
+  ports:
+    - name: vault-api
+      port: 8200
+  clusterIP: None
+  selector:
+    app: vault
+    role: server
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault
+  labels:
+    app: vault
+    role: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vault
+      role: server
+  template:
+    metadata:
+      labels:
+        app: vault
+        role: server
+    spec:
+      containers:
+        - name: vault
+          image: vault
+          securityContext:
+            runAsUser: 100
+          env:
+            - name: VAULT_DEV_ROOT_TOKEN_ID
+              value: sample_root_token_id
+            - name: SKIP_SETCAP
+              value: any
+          livenessProbe:
+            exec:
+              command:
+                - pidof
+                - vault
+            initialDelaySeconds: 5
+            timeoutSeconds: 2
+          ports:
+            - containerPort: 8200
+              name: vault-api
+---
+apiVersion: v1
+items:
+  - apiVersion: v1
+    data:
+      init-vault.sh: |
+        set -x -e
+
+        timeout 300 sh -c 'until vault status; do sleep 5; done'
+
+        # login into vault to retrieve token
+        vault login ${VAULT_DEV_ROOT_TOKEN_ID}
+
+        # enable kubernetes auth method under specific path:
+        vault auth enable -path="/${CLUSTER_IDENTIFIER}" kubernetes
+
+        # write configuration to use your cluster
+        vault write auth/${CLUSTER_IDENTIFIER}/config \
+          token_reviewer_jwt=@${SERVICE_ACCOUNT_TOKEN_PATH}/token \
+          kubernetes_host="${K8S_HOST}" \
+          kubernetes_ca_cert=@${SERVICE_ACCOUNT_TOKEN_PATH}/ca.crt
+
+        # create policy to use keys related to the cluster
+        vault policy write "${CLUSTER_IDENTIFIER}" - << EOS
+        path "secret/data/ceph-csi/*" {
+          capabilities = ["create", "update", "delete", "read"]
+        }
+
+        path "secret/metadata/ceph-csi/*" {
+          capabilities = ["read", "delete"]
+        }
+        EOS
+
+        # create a role
+        vault write "auth/${CLUSTER_IDENTIFIER}/role/${PLUGIN_ROLE}" \
+            bound_service_account_names="${SERVICE_ACCOUNTS}" \
+            bound_service_account_namespaces="${SERVICE_ACCOUNTS_NAMESPACE}" \
+            policies="${CLUSTER_IDENTIFIER}"
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      name: init-scripts
+kind: List
+metadata: {}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-init-job
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: vault-init-job
+    spec:
+      serviceAccount: rbd-csi-vault-token-review
+      volumes:
+        - name: init-scripts-volume
+          configMap:
+            name: init-scripts
+      containers:
+        - name: vault-init-job
+          image: vault
+          volumeMounts:
+            - mountPath: /init-scripts
+              name: init-scripts-volume
+          env:
+            - name: HOME
+              value: /tmp
+            - name: CLUSTER_IDENTIFIER
+              value: kubernetes
+            - name: SERVICE_ACCOUNT_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount
+            - name: K8S_HOST
+              value: https://kubernetes.default.svc.cluster.local
+            - name: PLUGIN_ROLE
+              value: csi-kubernetes
+            - name: SERVICE_ACCOUNTS
+              value: rbd-csi-nodeplugin,rbd-csi-provisioner
+            - name: SERVICE_ACCOUNTS_NAMESPACE
+              value: default
+            - name: VAULT_ADDR
+              value: http://vault.default.svc.cluster.local:8200/
+            - name: VAULT_DEV_ROOT_TOKEN_ID
+              value: sample_root_token_id
+          command:
+            - /bin/sh
+            - /init-scripts/init-vault.sh
+      restartPolicy: Never

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -43,6 +43,13 @@ parameters:
    # By default it is disabled. Valid values are “true” or “false”.
    # A string is expected here, i.e. “true”, not true.
    # encrypted: "true"
+
+   # Use external key management system for encryption passphrases
+   # encryptionKMS: vault
+
+   # String representing KMS configuration. Should be unique and match ID in
+   # KMS ConfigMap. The ID is only used for correlation to config map entry.
+   # encryptionKMSID: <kms-config-id>
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 mountOptions:

--- a/pkg/cephfs/fsjournal.go
+++ b/pkg/cephfs/fsjournal.go
@@ -58,7 +58,7 @@ func checkVolExists(ctx context.Context, volOptions *volumeOptions, secret map[s
 	defer cr.DeleteCredentials()
 
 	imageUUID, err := volJournal.CheckReservation(ctx, volOptions.Monitors, cr,
-		volOptions.MetadataPool, volOptions.RequestName, "")
+		volOptions.MetadataPool, volOptions.RequestName, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func reserveVol(ctx context.Context, volOptions *volumeOptions, secret map[strin
 	defer cr.DeleteCredentials()
 
 	imageUUID, err := volJournal.ReserveName(ctx, volOptions.Monitors, cr,
-		volOptions.MetadataPool, volOptions.RequestName, "")
+		volOptions.MetadataPool, volOptions.RequestName, "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cephfs/volumeoptions.go
+++ b/pkg/cephfs/volumeoptions.go
@@ -221,7 +221,7 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 		return nil, nil, err
 	}
 
-	volOptions.RequestName, _, err = volJournal.GetObjectUUIDData(ctx, volOptions.Monitors, cr,
+	volOptions.RequestName, _, _, err = volJournal.GetObjectUUIDData(ctx, volOptions.Monitors, cr,
 		volOptions.MetadataPool, vi.ObjectUUID, false)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/rbd/rbd_journal.go
+++ b/pkg/rbd/rbd_journal.go
@@ -115,7 +115,7 @@ func checkSnapExists(ctx context.Context, rbdSnap *rbdSnapshot, cr *util.Credent
 	}
 
 	snapUUID, err := snapJournal.CheckReservation(ctx, rbdSnap.Monitors, cr, rbdSnap.Pool,
-		rbdSnap.RequestName, rbdSnap.RbdImageName)
+		rbdSnap.RequestName, rbdSnap.RbdImageName, "")
 	if err != nil {
 		return false, err
 	}
@@ -162,8 +162,12 @@ func checkVolExists(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials
 		return false, err
 	}
 
+	encryptionKmsConfig := ""
+	if rbdVol.Encrypted {
+		encryptionKmsConfig = rbdVol.KMS.KmsConfig()
+	}
 	imageUUID, err := volJournal.CheckReservation(ctx, rbdVol.Monitors, cr, rbdVol.Pool,
-		rbdVol.RequestName, "")
+		rbdVol.RequestName, "", encryptionKmsConfig)
 	if err != nil {
 		return false, err
 	}
@@ -211,7 +215,7 @@ func checkVolExists(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials
 // volume ID for the generated name
 func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, cr *util.Credentials) error {
 	snapUUID, err := snapJournal.ReserveName(ctx, rbdSnap.Monitors, cr, rbdSnap.Pool,
-		rbdSnap.RequestName, rbdSnap.RbdImageName)
+		rbdSnap.RequestName, rbdSnap.RbdImageName, "")
 	if err != nil {
 		return err
 	}
@@ -233,8 +237,12 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, cr *util.Credentials
 // reserveVol is a helper routine to request a rbdVolume name reservation and generate the
 // volume ID for the generated name
 func reserveVol(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials) error {
+	encryptionKmsConfig := ""
+	if rbdVol.Encrypted {
+		encryptionKmsConfig = rbdVol.KMS.KmsConfig()
+	}
 	imageUUID, err := volJournal.ReserveName(ctx, rbdVol.Monitors, cr, rbdVol.Pool,
-		rbdVol.RequestName, "")
+		rbdVol.RequestName, "", encryptionKmsConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/vault.go
+++ b/pkg/util/vault.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2019 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const (
+	// path to service account token that will be used to authenticate with Vault
+	// #nosec
+	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	// vault configuration defaults
+	vaultDefaultAuthPath       = "/v1/auth/kubernetes/login"
+	vaultDefaultRole           = "csi-kubernetes"
+	vaultDefaultNamespace      = ""
+	vaultDefaultPassphraseRoot = "/v1/secret"
+	vaultDefaultPassphrasePath = ""
+
+	// vault request headers
+	vaultTokenHeader     = "X-Vault-Token" // nolint: gosec, #nosec
+	vaultNamespaceHeader = "X-Vault-Namespace"
+)
+
+/*
+kmsKMS represents a Hashicorp Vault KMS configuration
+
+Example JSON structure in the KMS config is,
+[
+	{
+		"encryptionKMSID": "local_vault_unique_identifier",
+		"vaultAddress": "https://127.0.0.1:8500",
+		"vaultAuthPath": "/v1/auth/kubernetes/login",
+		"vaultRole": "csi-kubernetes",
+		"vaultNamespace": "",
+		"vaultPassphraseRoot": "/v1/secret",
+		"vaultPassphrasePath": "",
+		"vaultCAVerify": true,
+		"vaultCAFromSecret": "vault-ca"
+	},
+	...
+]
+*/
+type VaultKMS struct {
+	EncryptionKMSID     string `json:"encryptionKMSID"`
+	VaultAddress        string `json:"vaultAddress"`
+	VaultAuthPath       string `json:"vaultAuthPath"`
+	VaultRole           string `json:"vaultRole"`
+	VaultNamespace      string `json:"vaultNamespace"`
+	VaultPassphraseRoot string `json:"vaultPassphraseRoot"`
+	VaultPassphrasePath string `json:"vaultPassphrasePath"`
+	VaultCAVerify       bool   `json:"vaultCAVerify"`
+	VaultCAFromSecret   string `json:"vaultCAFromSecret"`
+	vaultCA             *x509.CertPool
+}
+
+// InitVaultKMS returns an interface to HashiCorp Vault KMS
+func InitVaultKMS(opts, secrets map[string]string) (EncryptionKMS, error) {
+	var config []VaultKMS
+
+	vaultID, ok := opts["encryptionKMSID"]
+	if !ok {
+		return nil, fmt.Errorf("missing encryptionKMSID for vault as encryption KMS")
+	}
+
+	// #nosec
+	content, err := ioutil.ReadFile(kmsConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching vault configuration for vault ID (%s): (%s)",
+			vaultID, err)
+	}
+
+	err = json.Unmarshal(content, &config)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal failed: %v. raw buffer response: %s",
+			err, string(content))
+	}
+
+	for i := range config {
+		vault := &config[i]
+		if vault.EncryptionKMSID != vaultID {
+			continue
+		}
+		if vault.VaultAddress == "" {
+			return nil, fmt.Errorf("missing vaultAddress for vault as encryption KMS")
+		}
+		if vault.VaultAuthPath == "" {
+			vault.VaultAuthPath = vaultDefaultAuthPath
+		}
+		if vault.VaultRole == "" {
+			vault.VaultRole = vaultDefaultRole
+		}
+		if vault.VaultNamespace == "" {
+			vault.VaultNamespace = vaultDefaultNamespace
+		}
+		if vault.VaultPassphraseRoot == "" {
+			vault.VaultPassphraseRoot = vaultDefaultPassphraseRoot
+		}
+		if vault.VaultPassphrasePath == "" {
+			vault.VaultPassphrasePath = vaultDefaultPassphrasePath
+		}
+		if vault.VaultCAFromSecret != "" {
+			caPEM, ok := secrets[vault.VaultCAFromSecret]
+			if !ok {
+				return nil, fmt.Errorf("missing vault CA in secret %s", vault.VaultCAFromSecret)
+			}
+			roots := x509.NewCertPool()
+			ok = roots.AppendCertsFromPEM([]byte(caPEM))
+			if !ok {
+				return nil, fmt.Errorf("failed loading CA bundle for vault from secret %s",
+					vault.VaultCAFromSecret)
+			}
+			vault.vaultCA = roots
+		}
+		return vault, nil
+	}
+
+	return nil, fmt.Errorf("missing configuration for vault ID (%s)", vaultID)
+}
+
+// KmsConfig returns KMS configuration: "<kms-type>|<kms-id>"
+func (kms *VaultKMS) KmsConfig() string {
+	return fmt.Sprintf("vault|%s", kms.EncryptionKMSID)
+}
+
+// GetPassphrase returns passphrase from Vault
+func (kms *VaultKMS) GetPassphrase(key string) (string, error) {
+	var passphrase string
+	resp, err := kms.request("GET", kms.getKeyDataURI(key), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve passphrase for %s from vault: %s",
+			key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return "", MissingPassphrase{fmt.Errorf("passphrase for %s not found", key)}
+	}
+	err = kms.processError(resp, fmt.Sprintf("get passphrase for %s", key))
+	if err != nil {
+		return "", err
+	}
+
+	// parse resp as JSON and retrieve vault token
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return "", fmt.Errorf("failed parsing passphrase for %s from response: %s",
+			key, err)
+	}
+	data, ok := result["data"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("failed parsing data for get passphrase request for %s", key)
+	}
+	data, ok = data["data"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("failed parsing data.data for get passphrase request for %s", key)
+	}
+	passphrase, ok = data["passphrase"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed parsing passphrase for get passphrase request for %s", key)
+	}
+
+	return passphrase, nil
+}
+
+// SavePassphrase saves new passphrase in Vault
+func (kms *VaultKMS) SavePassphrase(key, value string) error {
+	data, err := json.Marshal(map[string]map[string]string{
+		"data": {
+			"passphrase": value,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("passphrase request data is broken: %s", err)
+	}
+
+	resp, err := kms.request("POST", kms.getKeyDataURI(key), data)
+	if err != nil {
+		return fmt.Errorf("failed to POST passphrase for %s to vault: %s", key, err)
+	}
+	defer resp.Body.Close()
+	err = kms.processError(resp, "save passphrase")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeletePassphrase deletes passphrase from Vault
+func (kms *VaultKMS) DeletePassphrase(key string) error {
+	vaultToken, err := kms.getAccessToken()
+	if err != nil {
+		return fmt.Errorf("could not retrieve vault token to delete the passphrase at %s: %s",
+			key, err)
+	}
+
+	resp, err := kms.send("DELETE", kms.getKeyMetadataURI(key), &vaultToken, nil)
+	if err != nil {
+		return fmt.Errorf("delete passphrase at %s request to vault failed: %s", key, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		err = kms.processError(resp, "delete passphrase")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (kms *VaultKMS) getKeyDataURI(key string) string {
+	return kms.VaultPassphraseRoot + "/data/" + kms.VaultPassphrasePath + key
+}
+
+func (kms *VaultKMS) getKeyMetadataURI(key string) string {
+	return kms.VaultPassphraseRoot + "/metadata/" + kms.VaultPassphrasePath + key
+}
+
+/*
+getVaultAccessToken retrieves vault token using kubernetes authentication:
+ 1. read jwt service account token from well known location
+ 2. request token from vault using service account jwt token
+Vault will verify service account jwt token with Kubernetes and return token
+if the requester is allowed
+*/
+func (kms *VaultKMS) getAccessToken() (string, error) {
+	saToken, err := ioutil.ReadFile(serviceAccountTokenPath)
+	if err != nil {
+		return "", fmt.Errorf("service account token could not be read: %s", err)
+	}
+	data, err := json.Marshal(map[string]string{
+		"role": kms.VaultRole,
+		"jwt":  string(saToken),
+	})
+	if err != nil {
+		return "", fmt.Errorf("vault token request data is broken: %s", err)
+	}
+	resp, err := kms.send("POST", kms.VaultAuthPath, nil, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve vault token: %s", err)
+	}
+	defer resp.Body.Close()
+
+	err = kms.processError(resp, "retrieve vault token")
+	if err != nil {
+		return "", err
+	}
+	// parse resp as JSON and retrieve vault token
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return "", fmt.Errorf("failed parsing vaultToken from response: %s", err)
+	}
+
+	auth, ok := result["auth"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("failed parsing vault token auth data")
+	}
+	vaultToken, ok := auth["client_token"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed parsing vault client_token")
+	}
+
+	return vaultToken, nil
+}
+
+func (kms *VaultKMS) processError(resp *http.Response, action string) error {
+	if resp.StatusCode >= 200 || resp.StatusCode < 300 {
+		return nil
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to %s (%v), error body parsing failed: %s",
+			action, resp.StatusCode, err)
+	}
+	return fmt.Errorf("failed to %s (%v): %s", action, resp.StatusCode, body)
+}
+
+func (kms *VaultKMS) request(method, path string, data []byte) (*http.Response, error) {
+	vaultToken, err := kms.getAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	return kms.send(method, path, &vaultToken, data)
+}
+
+func (kms *VaultKMS) send(method, path string, token *string, data []byte) (*http.Response, error) {
+	tlsConfig := &tls.Config{}
+	if !kms.VaultCAVerify {
+		tlsConfig.InsecureSkipVerify = true
+	}
+	if kms.vaultCA != nil {
+		tlsConfig.RootCAs = kms.vaultCA
+	}
+	netTransport := &http.Transport{TLSClientConfig: tlsConfig}
+	client := &http.Client{Transport: netTransport}
+
+	var dataToSend io.Reader
+	if data != nil {
+		dataToSend = strings.NewReader(string(data))
+	}
+
+	req, err := http.NewRequest(method, kms.VaultAddress+path, dataToSend)
+	if err != nil {
+		return nil, fmt.Errorf("could not create a Vault request: %s", err)
+	}
+
+	if kms.VaultNamespace != "" {
+		req.Header.Set(vaultNamespaceHeader, kms.VaultNamespace)
+	}
+	if token != nil {
+		req.Header.Set(vaultTokenHeader, *token)
+	}
+
+	return client.Do(req)
+}


### PR DESCRIPTION
- adds proposal document for PVC encryption from PR448
- adds per-volume encription by generating encryption passphrase for each volume and storing it in a KMS
- adds HashiCorp Vault integration as a KMS for encryption passphrases (#420)
- avoids encrypting volume second time if it was already encrypted but no file system created (#744)
- avoids unnecessary checks if volume is a mapped device when encryption was not requested (#744)
- prevents resizing encrypted volumes (it is not currently supported)
- prevents creating snapshots from encrypted volumes to prevent attack on encryption key (security guard until re-encryption of volumes implemented)

Signed-off-by: Vasyl Purchel vasyl.purchel@workday.com
Signed-off-by: Andrea Baglioni andrea.baglioni@workday.com

Fixes: #420 
Fixes: #744