### PR TITLE
Upgrade: csi-snapshotter from v1.2.1 to v1.2.2

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -212,7 +212,7 @@ provisioner:
   snapshotter:
     image:
       repository: quay.io/k8scsi/csi-snapshotter
-      tag: v1.2.1
+      tag: v1.2.2
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
@@ -51,7 +51,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.1.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
@@ -52,7 +52,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.2.1
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -118,7 +118,7 @@ cephcsi)
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v1.2.0 "${K8S_IMAGE_REPO}"/csi-attacher:v1.2.0
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v1.1.0 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.1
+    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.2.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.2.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0 "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0


### PR DESCRIPTION
Upgrade: csi-snapshotter from v1.2.1 to v1.2.2

See https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v1.2.2
See https://github.com/kubernetes-csi/external-snapshotter/blob/v1.2.2/CHANGELOG-1.2.md