### PR TITLE
Upgrade: csi-node-driver-registrar from v1.1.0 to v1.2.0

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -95,7 +95,7 @@ nodeplugin:
   registrar:
     image:
       repository: quay.io/k8scsi/csi-node-driver-registrar
-      tag: v1.1.0
+      tag: v1.2.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -95,7 +95,7 @@ nodeplugin:
   registrar:
     image:
       repository: quay.io/k8scsi/csi-node-driver-registrar
-      tag: v1.1.0
+      tag: v1.2.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin.yaml
@@ -19,7 +19,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin.yaml
@@ -19,7 +19,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin.yaml
@@ -22,7 +22,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
@@ -22,7 +22,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -120,7 +120,7 @@ k8s-sidecar)
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v1.2.0 "${K8S_IMAGE_REPO}"/csi-attacher:v1.2.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v1.1.0 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.1
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.1.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.1.0
+    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.2.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.2.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0 "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0
     ;;
 clean)


### PR DESCRIPTION
Upgrade: csi-node-driver-registrar from v1.1.0 to v1.2.0

See https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v1.2.0
See https://github.com/kubernetes-csi/node-driver-registrar/blob/v1.2.0/CHANGELOG-1.2.md