### PR TITLE
Upgrade: csi-resizer from v0.3.0 to v0.4.0

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -203,7 +203,7 @@ provisioner:
     enabled: true
     image:
       repository: quay.io/k8scsi/csi-resizer
-      tag: v0.3.0
+      tag: v0.4.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -203,7 +203,7 @@ provisioner:
     enabled: true
     image:
       repository: quay.io/k8scsi/csi-resizer
-      tag: v0.3.0
+      tag: v0.4.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
@@ -52,7 +52,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.3.0
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
@@ -86,7 +86,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.3.0
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -121,7 +121,7 @@ k8s-sidecar)
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v1.1.0 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.1
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.1.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.1.0
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-resizer:v0.3.0 "${K8S_IMAGE_REPO}"/csi-resizer:v0.3.0
+    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0 "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0
     ;;
 clean)
     minikube delete


### PR DESCRIPTION
Upgrade: csi-resizer from v0.3.0 to v0.4.0

See https://github.com/kubernetes-csi/external-resizer/releases/tag/v0.4.0
See https://github.com/kubernetes-csi/external-resizer/blob/v0.4.0/CHANGELOG-0.4.md
