### PR TITLE
Add ContentSource to the CreateVolume response

### DIFF
--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -162,6 +162,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 				VolumeId:      rbdVol.VolID,
 				CapacityBytes: rbdVol.VolSize,
 				VolumeContext: req.GetParameters(),
+				ContentSource: req.GetVolumeContentSource(),
 			},
 		}, nil
 	}
@@ -203,6 +204,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			VolumeId:      rbdVol.VolID,
 			CapacityBytes: rbdVol.VolSize,
 			VolumeContext: req.GetParameters(),
+			ContentSource: req.GetVolumeContentSource(),
 		},
 	}, nil
 }


### PR DESCRIPTION
if PVC is created from a snapshot, external-provisioner expects the volume ContentSource to be set in Create VolumeResponse

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

See https://github.com/rook/rook/issues/4624 for more info