### PR TITLE
CSI: Use EmptyDir to store provisioner socker and run all containers as privileged in daemonset pod

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -33,6 +33,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
           image: "{{ .Values.nodeplugin.registrar.image.repository }}:{{ .Values.nodeplugin.registrar.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.registrar.image.pullPolicy }}
           args:
@@ -129,6 +134,8 @@ spec:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
 {{- if .Values.nodeplugin.httpMetrics.enabled }}
         - name: liveness-prometheus
+          securityContext:
+            privileged: true
           image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           args:

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -164,9 +164,9 @@ spec:
 {{- end }}
       volumes:
         - name: socket-dir
-          hostPath:
-            path: {{ .Values.socketDir }}
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: host-sys
           hostPath:
             path: /sys

--- a/charts/ceph-csi-cephfs/templates/provisioner-statefulset.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-statefulset.yaml
@@ -142,9 +142,9 @@ spec:
 {{- end }}
       volumes:
         - name: socket-dir
-          hostPath:
-            path: {{ .Values.socketDir }}
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: host-sys
           hostPath:
             path: /sys

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -34,6 +34,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
           image: "{{ .Values.nodeplugin.registrar.image.repository }}:{{ .Values.nodeplugin.registrar.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.registrar.image.pullPolicy }}
           args:
@@ -126,6 +131,8 @@ spec:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
 {{- if .Values.nodeplugin.httpMetrics.enabled }}
         - name: liveness-prometheus
+          securityContext:
+            privileged: true
           image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           args:

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -179,9 +179,9 @@ spec:
 {{- end }}
       volumes:
         - name: socket-dir
-          hostPath:
-            path: {{ .Values.socketDir }}
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: host-dev
           hostPath:
             path: /dev

--- a/charts/ceph-csi-rbd/templates/provisioner-statefulset.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-statefulset.yaml
@@ -159,9 +159,9 @@ spec:
 {{- end }}
       volumes:
         - name: socket-dir
-          hostPath:
-            path: {{ .Values.socketDir }}
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: host-dev
           hostPath:
             path: /dev

--- a/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin-provisioner.yaml
@@ -133,9 +133,9 @@ spec:
           imagePullPolicy: "IfNotPresent"
       volumes:
         - name: socket-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: host-sys
           hostPath:
             path: /sys

--- a/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/v1.13/csi-cephfsplugin.yaml
@@ -19,6 +19,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
@@ -102,6 +107,8 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
+          securityContext:
+            privileged: true
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"

--- a/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin-provisioner.yaml
@@ -149,9 +149,9 @@ spec:
           imagePullPolicy: "IfNotPresent"
       volumes:
         - name: socket-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: host-sys
           hostPath:
             path: /sys

--- a/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/v1.14+/csi-cephfsplugin.yaml
@@ -19,6 +19,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
@@ -101,6 +106,8 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
+          securityContext:
+            privileged: true
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin-provisioner.yaml
@@ -156,9 +156,9 @@ spec:
           hostPath:
             path: /lib/modules
         - name: socket-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/rbd.csi.ceph.com
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config

--- a/deploy/rbd/kubernetes/v1.13/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/v1.13/csi-rbdplugin.yaml
@@ -20,6 +20,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
@@ -94,6 +99,8 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
+          securityContext:
+            privileged: true
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin-provisioner.yaml
@@ -173,9 +173,9 @@ spec:
           hostPath:
             path: /lib/modules
         - name: socket-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/rbd.csi.ceph.com
-            type: DirectoryOrCreate
+          emptyDir: {
+            medium: "Memory"
+          }
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config

--- a/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/v1.14+/csi-rbdplugin.yaml
@@ -20,6 +20,11 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - "--v=5"
@@ -98,6 +103,8 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
+          securityContext:
+            privileged: true
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"


### PR DESCRIPTION
currently, we are making use of host path directory to store the provisioner socket, as this
the socket is not needed by anyone else other than containers inside the provisioner pod using the empty directory to store this socket is the best option.

On systems with SELinux enabled, non-privileged containers can't access data of privileged containers. Since the socket is exposed by privileged containers, all sidecars must be privileged too. This is needed only for containers running in daemonset as we are using bidirectional mounts in daemonset