### PR TITLE
examples/rbd-block: use a container image that is supported

### DIFF
--- a/examples/rbd/raw-block-pod.yaml
+++ b/examples/rbd/raw-block-pod.yaml
@@ -5,10 +5,9 @@ metadata:
   name: pod-with-raw-block-volume
 spec:
   containers:
-    - name: fc-container
-      image: fedora:26
-      command: ["/bin/sh", "-c"]
-      args: ["tail -f /dev/null"]
+    - name: centos
+      image: centos:latest
+      command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data
           devicePath: /dev/xvda


### PR DESCRIPTION
Fedora 26 has been End-Of-Life for a long time already, is should not be
used anymore. Instead use the latest CentOS image that gets regular
updates. The Ceph base image used by Ceph-CSI is also based on CentOS,
so uses would be familiar with the available tools.

Also use "sleep infinity" instead of a weird 'tail -f /dev/null' hack.