### PR TITLE
Check for ENOENT errors when deleting CephFS volumes

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -165,6 +165,30 @@ var _ = Describe("cephfs", func() {
 						Fail(err.Error())
 					}
 				})
+
+				By("creating a PVC, deleting backing subvolume, and checking successful PV deletion", func() {
+					pvc, err := loadPVC(pvcPath)
+					if pvc == nil {
+						Fail(err.Error())
+					}
+					pvc.Namespace = f.UniqueName
+
+					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+					if err != nil {
+						Fail(err.Error())
+					}
+
+					err = deleteBackingCephFSVolume(f, pvc)
+					if err != nil {
+						Fail(err.Error())
+					}
+
+					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+					if err != nil {
+						Fail(err.Error())
+					}
+				})
+
 				By("Resize PVC and check application directory size", func() {
 					v, err := f.ClientSet.Discovery().ServerVersion()
 					if err != nil {

--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -243,7 +243,23 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			return cs.deleteVolumeDeprecated(ctx, req)
 		}
 
-		return nil, status.Error(codes.Internal, err.Error())
+		// All errors other than ErrVolumeNotFound should return an error back to the caller
+		if _, ok := err.(ErrVolumeNotFound); !ok {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		// If error is ErrImageNotFound then we failed to find the subvolume, but found the imageOMap
+		// to lead us to the image, hence the imageOMap needs to be garbage collected, by calling
+		// unreserve for the same
+		if acquired := cs.VolumeLocks.TryAcquire(volOptions.RequestName); !acquired {
+			return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volOptions.RequestName)
+		}
+		defer cs.VolumeLocks.Release(volOptions.RequestName)
+
+		if err = undoVolReservation(ctx, volOptions, *vID, secrets); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		return &csi.DeleteVolumeResponse{}, nil
 	}
 
 	// lock out parallel delete and create requests against the same volume name as we
@@ -263,7 +279,10 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 
 	if err = purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions); err != nil {
 		klog.Errorf(util.Log(ctx, "failed to delete volume %s: %v"), volID, err)
-		return nil, status.Error(codes.Internal, err.Error())
+		// All errors other than ErrVolumeNotFound should return an error back to the caller
+		if _, ok := err.(ErrVolumeNotFound); !ok {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	if err := undoVolReservation(ctx, volOptions, *vID, secrets); err != nil {

--- a/pkg/cephfs/errors.go
+++ b/pkg/cephfs/errors.go
@@ -35,3 +35,12 @@ type ErrNonStaticVolume struct {
 func (e ErrNonStaticVolume) Error() string {
 	return e.err.Error()
 }
+
+// ErrVolumeNotFound is returned when a subvolume is not found in CephFS
+type ErrVolumeNotFound struct {
+	err error
+}
+
+func (e ErrVolumeNotFound) Error() string {
+	return e.err.Error()
+}

--- a/pkg/cephfs/volumeoptions.go
+++ b/pkg/cephfs/volumeoptions.go
@@ -245,12 +245,12 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 		}
 	}
 
+	volOptions.ProvisionVolume = true
+
 	volOptions.RootPath, err = getVolumeRootPathCeph(ctx, &volOptions, cr, volumeID(vid.FsSubvolName))
 	if err != nil {
-		return nil, nil, err
+		return &volOptions, &vid, err
 	}
-
-	volOptions.ProvisionVolume = true
 
 	return &volOptions, &vid, nil
 }


### PR DESCRIPTION
In cases where a prior DeleteVolume deleted the backing subvolume, and was interrupted post the same, would leave behind an in-tact CSI OMap entries, but no backing image.

In such cases, detecting that the backing image is deleted and proceeding with garbage collecting the OMaps should be the way forward for future DeleteVolume calls. Current code does not honor the same, as detailed in issue #474.

This PR attempts to rectify the same, adding the required missing volume checks to the code.

Fixes #474
Signed-off-by: ShyamsundarR <srangana@redhat.com>