### PR TITLE
Add _netdev as default mount options for both cepfs and rbd

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -121,6 +121,8 @@ spec:
               mountPropagation: "Bidirectional"
             - mountPath: /dev
               name: host-dev
+            - mountPath: /run/mount
+              name: host-mount
             - mountPath: /sys
               name: host-sys
             - mountPath: /lib/modules
@@ -180,6 +182,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: host-mount
+          hostPath:
+            path: /run/mount
         - name: lib-modules
           hostPath:
             path: /lib/modules

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
@@ -34,6 +34,8 @@ spec:
   allowedHostPaths:
     - pathPrefix: '/dev'
       readOnly: false
+    - pathPrefix: '/run/mount'
+      readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
     - pathPrefix: '/lib/modules'

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -111,6 +111,8 @@ spec:
             - name: socket-dir
               mountPath: /csi
             - mountPath: /dev
+              name: host-mount
+            - mountPath: /run/mount
               name: host-dev
             - mountPath: /sys
               name: host-sys
@@ -175,6 +177,9 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
+        - name: host-mount
+          hostPath:
+            path: /run/mount
         - name: host-sys
           hostPath:
             path: /sys

--- a/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
@@ -34,6 +34,8 @@ spec:
   allowedHostPaths:
     - pathPrefix: '/dev'
       readOnly: false
+    - pathPrefix: '/run/mount'
+      readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
     - pathPrefix: '/lib/modules'

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -101,6 +101,8 @@ spec:
               readOnly: true
             - name: host-dev
               mountPath: /dev
+            - name: host-mount
+              mountPath: /run/mount
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
@@ -155,6 +157,9 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
+        - name: host-mount
+          hostPath:
+            path: /run/mount
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
@@ -28,6 +28,8 @@ spec:
   allowedHostPaths:
     - pathPrefix: '/dev'
       readOnly: false
+    - pathPrefix: '/run/mount'
+      readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
     - pathPrefix: '/lib/modules'

--- a/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
@@ -28,6 +28,8 @@ spec:
   allowedHostPaths:
     - pathPrefix: '/dev'
       readOnly: false
+    - pathPrefix: '/run/mount'
+      readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
     - pathPrefix: '/lib/modules'

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -89,6 +89,8 @@ spec:
               name: host-dev
             - mountPath: /sys
               name: host-sys
+            - mountPath: /run/mount
+              name: host-mount
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
@@ -147,6 +149,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: host-mount
+          hostPath:
+            path: /run/mount
         - name: lib-modules
           hostPath:
             path: /lib/modules

--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -36,6 +36,7 @@ import (
 const (
 	volumeMounterFuse   = "fuse"
 	volumeMounterKernel = "kernel"
+	netDev              = "_netdev"
 )
 
 var (
@@ -229,6 +230,7 @@ func mountFuse(ctx context.Context, mountPoint string, cr *util.Credentials, vol
 	if volOptions.FuseMountOptions != "" {
 		args = append(args, ","+volOptions.FuseMountOptions)
 	}
+
 	if volOptions.FsName != "" {
 		args = append(args, "--client_mds_namespace="+volOptions.FsName)
 	}
@@ -288,6 +290,11 @@ func mountKernel(ctx context.Context, mountPoint string, cr *util.Credentials, v
 	if volOptions.KernelMountOptions != "" {
 		optionsStr += fmt.Sprintf(",%s", volOptions.KernelMountOptions)
 	}
+
+	if !strings.Contains(volOptions.KernelMountOptions, netDev) {
+		optionsStr += fmt.Sprintf(",%s", netDev)
+	}
+
 	args = append(args, "-o", optionsStr)
 
 	return execCommandErr(ctx, "mount", args[:]...)

--- a/pkg/csi-common/nodeserver-default.go
+++ b/pkg/csi-common/nodeserver-default.go
@@ -170,3 +170,23 @@ func (ns *DefaultNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.No
 		},
 	}, nil
 }
+
+// ConstructMountOptions returns only unique mount options in slice
+func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) []string {
+	if m := volCap.GetMount(); m != nil {
+		hasOption := func(options []string, opt string) bool {
+			for _, o := range options {
+				if o == opt {
+					return true
+				}
+			}
+			return false
+		}
+		for _, f := range m.MountFlags {
+			if !hasOption(mountOptions, f) {
+				mountOptions = append(mountOptions, f)
+			}
+		}
+	}
+	return mountOptions
+}


### PR DESCRIPTION
Add _netdev as default mount options in plugins. This value will be added at both node stage and node publish for RBD, NBD and ceph kernel client.
  As cephfs fuse doesn't support this value, this is added only during the node publish.

Add run host path to daemonset pods. `/run/mount` need to be shared between the host and csi-plugin containers for `/run/mount/utab` this is required to ensure that the network is not stopped prior to unmounting the network devices.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Resolves #756