### PR TITLE
Reduce encryption KMS configuration SC parameters

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -31,9 +31,15 @@ csiConfig: []
 # Ref: https://github.com/ceph/ceph-csi/blob/master/docs/deploy-rbd.md
 # Example:
 # encryptionKMSConfig:
-#   - encryptionKMSID: "<kms-id>"
-#     <kms-specific-configs>
-encryptionKMSConfig: []
+#   vault-unique-id-1:
+#     encryptionKMSType: vault
+#     vaultAddress: https://vault.example.com
+#     vaultAuthPath: /v1/auth/kubernetes/login
+#     vaultRole: csi-kubernetes
+#     vaultPassphraseRoot: /v1/secret
+#     vaultPassphrasePath: ceph-csi/
+#     vaultCAVerify: "false"
+encryptionKMSConfig: {}
 
 nodeplugin:
   name: nodeplugin

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -54,8 +54,7 @@ make image-cephcsi
 | `csi.storage.k8s.io/provisioner-secret-namespace`, `csi.storage.k8s.io/node-stage-secret-namespace` | yes (for Kubernetes) | namespaces of the above Secret objects                                                                                                                                                                                  |
 | `mounter`                                                                                           | no                   | if set to `rbd-nbd`, use `rbd-nbd` on nodes that have `rbd-nbd` and `nbd` kernel modules to map rbd images                                                                                                              |
 | `encrypted`                                                                                         | no                   | disabled by default, use `"true"` to enable LUKS encryption on pvc and `"false"` to disable it. **Do not change for existing storageclasses**                                                                           |
-| `encryptionKMS`                                                                                     | no                   | specifies key management system for encrypytion. Currently supports `vault`                                                                                                                                             |
-| `encryptionKMSID`                                                                                   | no                   | required if `encryptionKMS` is set to `vault` to specify a unique identifier for vault configuration                                                                                                                    |
+| `encryptionKMSID`                                                                                   | no                   | required if encryption is enabled and a kms is used to store passphrases                                                                                                                                                |
 
 **NOTE:** An accompanying CSI configuration file, needs to be provided to the
 running pods. Refer to [Creating CSI configuration](../examples/README.md#creating-csi-configuration)
@@ -223,14 +222,19 @@ To further improve security robustness it is possible to use unique passphrases
 generated for each volume and stored in a Key Management System (KMS). Currently
 HashiCorp Vault is the only KMS supported.
 
-To use Vault as KMS set `encryptionKMS` to `vault` and `encryptionKMSID` to a
-unique identifier for Vault configuration. You will also need to create vault
-configuration similar to the [example](../examples/rbd/kms-config.yaml)
-and use same `encryptionKMSID`. In order for ceph-csi to be able to access the
-configuration you will need to have it mounted to csi-rbdplugin containers in
-both daemonset (so kms client can be instantiated to encrypt/decrypt volumes)
-and deployment pods (so kms client can be instantiated to delete passphrase on
-volume delete) `ceph-csi-encryption-kms-config` config map.
+To use Vault as KMS set `encryptionKMSID` to a unique identifier for Vault
+configuration. You will also need to create vault configuration similar to the
+[example](../examples/rbd/kms-config.yaml) and use same `encryptionKMSID`.
+Configuration must include `encryptionKMSType: "vault"`. In order for ceph-csi
+to be able to access the configuration you will need to have it mounted to
+csi-rbdplugin containers in both daemonset (so kms client can be instantiated to
+encrypt/decrypt volumes) and deployment pods (so kms client can be instantiated
+to delete passphrase on volume delete) `ceph-csi-encryption-kms-config` config
+map.
+
+> Note: kms configuration must be a map of string values only
+> (`map[string]string`) so for numerical and boolean values make sure to put
+> quotes around.
 
 #### Configuring HashiCorp Vault
 

--- a/docs/design/proposals/encrypted-pvc.md
+++ b/docs/design/proposals/encrypted-pvc.md
@@ -63,10 +63,9 @@ requirement by using dm-crypt module through cryptsetup cli interface.
 
 * StorageClass extended with following parameters:
   1. `encrypted` ("true" or "false")
-  1. `encryptionKMS` (string representing kms of choice)
+  1. `encryptionKMSID` (string representing kms configuration of choice)
   ceph-csi plugin may support different kms vendors with different type of
   authentication
-  1. `encryptionKMSID` (string representing kms configuration)
 
 * New KMS Configuration created.
 
@@ -103,10 +102,9 @@ parameters:
    # Encrypt volumes
    encrypted: "true"
 
-   # The type of kms we want to connect to: Barbican, aws kms or others can be
-   # supported
-   encryptionKMS: vault
-   # String representing a KMS configuration
+   # Use external key management system for encryption passphrases by specifying
+   # a unique ID matching KMS ConfigMap. The ID is only used for correlation to
+   # config map entry.
    encryptionKMSID: <kms-id>
 
 reclaimPolicy: Delete
@@ -120,12 +118,12 @@ apiVersion: v1
 kind: ConfigMap
 data:
   config.json: |-
-    [
-      {
-        "kmsID": "<kms-id>",
+    {
+      "<kms-id>": {
+        "encryptionKMSType": "kmsType",
         kms specific config...
       }
-    ]
+    }
 metadata:
   name: ceph-csi-encryption-kms-config
 ```

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -145,7 +145,6 @@ var _ = Describe("RBD", func() {
 				deleteResource(rbdExamplePath + "storageclass.yaml")
 				scOpts := map[string]string{
 					"encrypted":       "true",
-					"encryptionKMS":   "vault",
 					"encryptionKMSID": "vault-test",
 				}
 				createRBDStorageClass(f.ClientSet, f, scOpts)

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -3,16 +3,16 @@ apiVersion: v1
 kind: ConfigMap
 data:
   config.json: |-
-    [
-      {
-        "encryptionKMSID": "vault-test",
+    {
+      "vault-test": {
+        "encryptionKMSType": "vault",
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
         "vaultAuthPath": "/v1/auth/kubernetes/login",
         "vaultRole": "csi-kubernetes",
         "vaultPassphraseRoot": "/v1/secret",
         "vaultPassphrasePath": "ceph-csi/",
-        "vaultCAVerify": false
+        "vaultCAVerify": "false"
       }
-    ]
+    }
 metadata:
   name: ceph-csi-encryption-kms-config

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -44,11 +44,9 @@ parameters:
    # A string is expected here, i.e. “true”, not true.
    # encrypted: "true"
 
-   # Use external key management system for encryption passphrases
-   # encryptionKMS: vault
-
-   # String representing KMS configuration. Should be unique and match ID in
-   # KMS ConfigMap. The ID is only used for correlation to config map entry.
+   # Use external key management system for encryption passphrases by specifying
+   # a unique ID matching KMS ConfigMap. The ID is only used for correlation to
+   # config map entry.
    # encryptionKMSID: <kms-config-id>
 reclaimPolicy: Delete
 allowVolumeExpansion: true

--- a/pkg/rbd/rbd_journal.go
+++ b/pkg/rbd/rbd_journal.go
@@ -162,12 +162,12 @@ func checkVolExists(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials
 		return false, err
 	}
 
-	encryptionKmsConfig := ""
+	kmsID := ""
 	if rbdVol.Encrypted {
-		encryptionKmsConfig = rbdVol.KMS.KmsConfig()
+		kmsID = rbdVol.KMS.GetID()
 	}
 	imageUUID, err := volJournal.CheckReservation(ctx, rbdVol.Monitors, cr, rbdVol.Pool,
-		rbdVol.RequestName, "", encryptionKmsConfig)
+		rbdVol.RequestName, "", kmsID)
 	if err != nil {
 		return false, err
 	}
@@ -237,12 +237,12 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, cr *util.Credentials
 // reserveVol is a helper routine to request a rbdVolume name reservation and generate the
 // volume ID for the generated name
 func reserveVol(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials) error {
-	encryptionKmsConfig := ""
+	kmsID := ""
 	if rbdVol.Encrypted {
-		encryptionKmsConfig = rbdVol.KMS.KmsConfig()
+		kmsID = rbdVol.KMS.GetID()
 	}
 	imageUUID, err := volJournal.ReserveName(ctx, rbdVol.Monitors, cr, rbdVol.Pool,
-		rbdVol.RequestName, "", encryptionKmsConfig)
+		rbdVol.RequestName, "", kmsID)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/voljournal.go
+++ b/pkg/util/voljournal.go
@@ -416,8 +416,8 @@ func (cj *CSIJournal) GetObjectUUIDData(ctx context.Context, monitors string, cr
 		cj.cephUUIDDirectoryPrefix+objectUUID, cj.encryptKMSKey)
 	if err != nil {
 		if _, ok := err.(ErrKeyNotFound); !ok {
-			klog.Errorf(Log(ctx, "=> GetObjectUUIDData encryptedKMS failed: %s (%s)"), cj.cephUUIDDirectoryPrefix+objectUUID, err)
-			return "", "", "", err
+			return "", "", "", fmt.Errorf("OMapVal for %s/%s failed to get encryption KMS value: %s",
+				pool, cj.cephUUIDDirectoryPrefix+objectUUID, err)
 		}
 		// ErrKeyNotFound means no encryption KMS was used
 	}


### PR DESCRIPTION
 * moves KMS type from StorageClass into KMS configuration itself
 * updates omapval used to identify KMS to only it's ID without the type

why?

1. when using multiple KMS configurations (not currently supported)
automated parsing of kms configuration will be failing because some
entries in configs won't comply with the requested type
2. less options are needed in the StorageClass and less data used to
identify the KMS

Signed-off-by: Vasyl Purchel vasyl.purchel@workday.com
Signed-off-by: Andrea Baglioni andrea.baglioni@workday.com