### PR TITLE
Handle Delete operation if pool not found (bp #815)

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -207,6 +207,15 @@ var _ = Describe("cephfs", func() {
 
 				})
 
+				// Make sure this should be last testcase in this file, because
+				// it deletes pool
+				By("Create a PVC and Delete PVC when backend pool deleted", func() {
+					err := pvcDeleteWhenPoolNotFound(pvcPath, true, f)
+					if err != nil {
+						Fail(err.Error())
+					}
+				})
+
 			})
 
 		})

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -325,6 +325,15 @@ var _ = Describe("RBD", func() {
 					Fail(err.Error())
 				}
 			})
+
+			// Make sure this should be last testcase in this file, because
+			// it deletes pool
+			By("Create a PVC and Delete PVC when backend pool deleted", func() {
+				err := pvcDeleteWhenPoolNotFound(pvcPath, false, f)
+				if err != nil {
+					Fail(err.Error())
+				}
+			})
 		})
 	})
 

--- a/pkg/cephfs/cephfs_util.go
+++ b/pkg/cephfs/cephfs_util.go
@@ -84,10 +84,10 @@ func getMetadataPool(ctx context.Context, monitors string, cr *util.Credentials,
 		}
 	}
 
-	return "", fmt.Errorf("fsName (%s) not found in Ceph cluster", fsName)
+	return "", util.ErrPoolNotFound{Pool: fsName, Err: fmt.Errorf("fsName (%s) not found in Ceph cluster", fsName)}
 }
 
-// CephFilesystemDetails is a representation of the main json structure returned by 'ceph fs dump'
+// CephFilesystemDump is a representation of the main json structure returned by 'ceph fs dump'
 type CephFilesystemDump struct {
 	Filesystems []CephFilesystemDetails `json:"filesystems"`
 }
@@ -114,5 +114,5 @@ func getFsName(ctx context.Context, monitors string, cr *util.Credentials, fscID
 		}
 	}
 
-	return "", fmt.Errorf("fscID (%d) not found in Ceph cluster", fscID)
+	return "", util.ErrPoolNotFound{Pool: string(fscID), Err: fmt.Errorf("fscID (%d) not found in Ceph cluster", fscID)}
 }

--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -231,6 +231,12 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	// Find the volume using the provided VolumeID
 	volOptions, vID, err := newVolumeOptionsFromVolID(ctx, string(volID), nil, secrets)
 	if err != nil {
+		// if error is ErrPoolNotFound, the pool is already deleted we dont
+		// need to worry about deleting subvolume or omap data, return success
+		if _, ok := err.(util.ErrPoolNotFound); ok {
+			klog.Warningf(util.Log(ctx, "failed to get backend volume for %s: %v"), string(volID), err)
+			return &csi.DeleteVolumeResponse{}, nil
+		}
 		// if error is ErrKeyNotFound, then a previous attempt at deletion was complete
 		// or partially complete (subvolume and imageOMap are garbage collected already), hence
 		// return success as deletion is complete

--- a/pkg/util/cephcmds.go
+++ b/pkg/util/cephcmds.go
@@ -114,7 +114,7 @@ func GetPoolName(ctx context.Context, monitors string, cr *Credentials, poolID i
 		}
 	}
 
-	return "", fmt.Errorf("pool ID (%d) not found in Ceph cluster", poolID)
+	return "", ErrPoolNotFound{string(poolID), fmt.Errorf("pool ID (%d) not found in Ceph cluster", poolID)}
 }
 
 // SetOMapKeyValue sets the given key and value into the provided Ceph omap name

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -56,3 +56,13 @@ type ErrSnapNameConflict struct {
 func (e ErrSnapNameConflict) Error() string {
 	return e.err.Error()
 }
+
+// ErrPoolNotFound is returned when pool is not found
+type ErrPoolNotFound struct {
+	Pool string
+	Err  error
+}
+
+func (e ErrPoolNotFound) Error() string {
+	return e.Err.Error()
+}


### PR DESCRIPTION
If the backend rbd or cephfs pool is already deleted we need to return success to the  DeleteVolume RPC call to make it idempotent.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 8dcb6a6105f5f890c5f4e86e1208774262847070)
