### PR TITLE
created struct for keeping the state of a staging transaction

### DIFF
--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -55,13 +55,6 @@ func (cs *ControllerServer) createBackingVolume(ctx context.Context, volOptions 
 		klog.Errorf(util.Log(ctx, "failed to create volume %s: %v"), volOptions.RequestName, err)
 		return status.Error(codes.Internal, err.Error())
 	}
-	defer func() {
-		if err != nil {
-			if errDefer := purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions); errDefer != nil {
-				klog.Warningf(util.Log(ctx, "failed purging volume: %s (%s)"), volOptions.RequestName, errDefer)
-			}
-		}
-	}()
 
 	return nil
 }

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -45,6 +45,18 @@ type NodeServer struct {
 	VolumeLocks *util.VolumeLocks
 }
 
+// stageTransaction struct represents the state a transaction was when it either completed
+// or failed
+// this transaction state can be used to rollback the transaction
+type stageTransaction struct {
+	// isStagePathCreated represents whether the mount path to stage the volume on was created or not
+	isStagePathCreated bool
+	// isMounted represents if the volume was mounted or not
+	isMounted bool
+	// isEncrypted represents if the volume was encrypted or not
+	isEncrypted bool
+}
+
 // NodeStageVolume mounts the volume to a staging path on the node.
 // Implementation notes:
 // - stagingTargetPath is the directory passed in the request where the volume needs to be staged
@@ -143,10 +155,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 
 	volOptions.VolID = volID
-
-	isMounted := false
-	isEncrypted := false
-	isStagePathCreated := false
+	transaction := stageTransaction{}
 	devicePath := ""
 
 	// Stash image details prior to mapping the image (useful during Unstage as it has no
@@ -157,13 +166,13 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	defer func() {
 		if err != nil {
-			ns.undoStagingTransaction(ctx, req, devicePath, isStagePathCreated, isMounted, isEncrypted)
+			ns.undoStagingTransaction(ctx, req, devicePath, transaction)
 		}
 	}()
 
 	// perform the actual staging and if this fails, have undoStagingTransaction
 	// cleans up for us
-	isStagePathCreated, isMounted, isEncrypted, err = ns.stageTransaction(ctx, req, volOptions, staticVol)
+	transaction, err = ns.stageTransaction(ctx, req, volOptions, staticVol)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -173,17 +182,15 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, volOptions *rbdVolume, staticVol bool) (bool, bool, bool, error) {
-	isStagePathCreated := false
-	isMounted := false
-	isEncrypted := false
+func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, volOptions *rbdVolume, staticVol bool) (stageTransaction, error) {
+	transaction := stageTransaction{}
 
 	var err error
 
 	var cr *util.Credentials
 	cr, err = util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
-		return isStagePathCreated, isMounted, isEncrypted, err
+		return transaction, err
 	}
 	defer cr.DeleteCredentials()
 
@@ -191,7 +198,7 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	var devicePath string
 	devicePath, err = attachRBDImage(ctx, volOptions, cr)
 	if err != nil {
-		return isStagePathCreated, isMounted, isEncrypted, err
+		return transaction, err
 	}
 
 	klog.V(4).Infof(util.Log(ctx, "rbd image: %s/%s was successfully mapped at %s\n"),
@@ -200,9 +207,9 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	if volOptions.Encrypted {
 		devicePath, err = ns.processEncryptedDevice(ctx, volOptions, devicePath, cr)
 		if err != nil {
-			return isStagePathCreated, isMounted, isEncrypted, err
+			return transaction, err
 		}
-		isEncrypted = true
+		transaction.isEncrypted = true
 	}
 
 	stagingTargetPath := getStagingTargetPath(req)
@@ -210,29 +217,29 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	err = ns.createStageMountPoint(ctx, stagingTargetPath, isBlock)
 	if err != nil {
-		return isStagePathCreated, isMounted, isEncrypted, err
+		return transaction, err
 	}
 
-	isStagePathCreated = true
+	transaction.isStagePathCreated = true
 
 	// nodeStage Path
 	err = ns.mountVolumeToStagePath(ctx, req, staticVol, stagingTargetPath, devicePath)
 	if err != nil {
-		return isStagePathCreated, isMounted, isEncrypted, err
+		return transaction, err
 	}
-	isMounted = true
+	transaction.isMounted = true
 
 	// #nosec - allow anyone to write inside the target path
 	err = os.Chmod(stagingTargetPath, 0777)
 
-	return isStagePathCreated, isMounted, isEncrypted, err
+	return transaction, err
 }
 
-func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, devicePath string, isStagePathCreated, isMounted, isEncrypted bool) {
+func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, devicePath string, transaction stageTransaction) {
 	var err error
 
 	stagingTargetPath := getStagingTargetPath(req)
-	if isMounted {
+	if transaction.isMounted {
 		err = ns.mounter.Unmount(stagingTargetPath)
 		if err != nil {
 			klog.Errorf(util.Log(ctx, "failed to unmount stagingtargetPath: %s with error: %v"), stagingTargetPath, err)
@@ -241,7 +248,7 @@ func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeS
 	}
 
 	// remove the file/directory created on staging path
-	if isStagePathCreated {
+	if transaction.isStagePathCreated {
 		err = os.Remove(stagingTargetPath)
 		if err != nil {
 			klog.Errorf(util.Log(ctx, "failed to remove stagingtargetPath: %s with error: %v"), stagingTargetPath, err)
@@ -253,7 +260,7 @@ func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeS
 
 	// Unmapping rbd device
 	if devicePath != "" {
-		err = detachRBDDevice(ctx, devicePath, volID, isEncrypted)
+		err = detachRBDDevice(ctx, devicePath, volID, transaction.isEncrypted)
 		if err != nil {
 			klog.Errorf(util.Log(ctx, "failed to unmap rbd device: %s for volume %s with error: %v"), devicePath, volID, err)
 			// continue on failure to delete the stash file, as kubernetes will fail to delete the staging path otherwise

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -115,11 +115,11 @@ var (
 )
 
 // createImage creates a new ceph image with provision and volume options.
-func createImage(ctx context.Context, pOpts *rbdVolume, volSz int64, cr *util.Credentials) error {
+func createImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) error {
 	var output []byte
 
 	image := pOpts.RbdImageName
-	volSzMiB := fmt.Sprintf("%dM", volSz)
+	volSzMiB := fmt.Sprintf("%dM", util.RoundOffVolSize(pOpts.VolSize))
 
 	logMsg := "rbd: create %s size %s format 2 (features: %s) using mon %s, pool %s "
 	if pOpts.DataPool != "" {
@@ -861,12 +861,12 @@ func cleanupRBDImageMetadataStash(path string) error {
 }
 
 // resizeRBDImage resizes the given volume to new size
-func resizeRBDImage(rbdVol *rbdVolume, newSize int64, cr *util.Credentials) error {
+func resizeRBDImage(rbdVol *rbdVolume, cr *util.Credentials) error {
 	var output []byte
 
 	mon := rbdVol.Monitors
 	image := rbdVol.RbdImageName
-	volSzMiB := fmt.Sprintf("%dM", newSize)
+	volSzMiB := fmt.Sprintf("%dM", util.RoundOffVolSize(rbdVol.VolSize))
 
 	args := []string{"resize", image, "--size", volSzMiB, "--pool", rbdVol.Pool, "--id", cr.ID, "-m", mon, "--keyfile=" + cr.KeyFile}
 	output, err := execCommand("rbd", args)


### PR DESCRIPTION
# Describe what this PR does #

As a follow-up on #758 I did some cleaning up on the way `NodeStageVolume` transactions can be rolled back if they fail halfway staging. By using a struct keeping state of the transaction, the code is a little cleaner and can be extended in the future more easily.

## Future concerns ##

I think a lot more cleaning up can be done to normalise code paths in the future.