### PR TITLE
E2E: Add option to deploy ceph-csi in different namespace

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -72,7 +72,7 @@ are available while running tests:
 
 | flag              | description                                                                   |
 | ----------------- | ----------------------------------------------------------------------------- |
-| deploy-timeout    | Timeout to wait for created kubernetes resources (default: 10)                |
+| deploy-timeout    | Timeout to wait for created kubernetes resources (default: 10 minutes)        |
 | deploy-cephfs     | Deploy cephfs csi driver as part of E2E (default: true)                       |
 | deploy-rbd        | Deploy rbd csi driver as part of E2E (default: true)                          |
 | cephcsi-namespace | The namespace in which cephcsi driver will be created (default: "default")    |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -70,12 +70,16 @@ $./minikube.sh clean
 In addition to standard go tests parameters, the following custom parameters
 are available while running tests:
 
-| flag           | description                                                                   |
-| -------------- | ----------------------------------------------------------------------------- |
-| deploy-timeout | Timeout to wait for created kubernetes resources (default: 10)                |
-| kubeconfig     | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config) |
-| timeout        | Panic test binary after duration d (default 0, timeout disabled)              |
-| v              | Verbose: print additional output                                              |
+| flag              | description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| deploy-timeout    | Timeout to wait for created kubernetes resources (default: 10)                |
+| deploy-cephfs     | Deploy cephfs csi driver as part of E2E (default: true)                       |
+| deploy-rbd        | Deploy rbd csi driver as part of E2E (default: true)                          |
+| cephcsi-namespace | The namespace in which cephcsi driver will be created (default: "default")    |
+| rook-namespace    | The namespace in which rook operator is installed (default: "rook-ceph")      |
+| kubeconfig        | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config) |
+| timeout           | Panic test binary after duration d (default 0, timeout disabled)              |
+| v                 | Verbose: print additional output                                              |
 
 ## Running E2E
 

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -71,7 +71,9 @@ var _ = Describe("cephfs", func() {
 	BeforeEach(func() {
 		c = f.ClientSet
 		createConfigMap(cephfsDirPath, f.ClientSet, f)
-		deployCephfsPlugin()
+		if deployCephFS {
+			deployCephfsPlugin()
+		}
 		createCephfsSecret(f.ClientSet, f)
 	})
 
@@ -82,7 +84,9 @@ var _ = Describe("cephfs", func() {
 			// log node plugin
 			logsCSIPods("app=csi-cephfsplugin", c)
 		}
-		deleteCephfsPlugin()
+		if deployCephFS {
+			deleteCephfsPlugin()
+		}
 		deleteConfigMap(cephfsDirPath)
 		deleteResource(cephfsExamplePath + "secret.yaml")
 		deleteResource(cephfsExamplePath + "storageclass.yaml")

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -2,13 +2,9 @@ package e2e
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo" // nolint
 
-	v1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
@@ -29,42 +25,86 @@ var (
 
 func deployCephfsPlugin() {
 	// delete objects deployed by rook
-	framework.RunKubectlOrDie("delete", "--ignore-not-found=true", "-f", cephfsDirPath+cephfsProvisionerRBAC, fmt.Sprintf("--namespace=%s", cephCSINamespace))
-	framework.RunKubectlOrDie("delete", "--ignore-not-found=true", "-f", cephfsDirPath+cephfsNodePluginRBAC, fmt.Sprintf("--namespace=%s", cephCSINamespace))
-	// deploy provisioner
-	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisioner, fmt.Sprintf("--namespace=%s", cephCSINamespace))
-	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisionerRBAC, fmt.Sprintf("--namespace=%s", cephCSINamespace))
-	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisionerPSP, fmt.Sprintf("--namespace=%s", cephCSINamespace))
-	// deploy nodeplugin
-	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePlugin, fmt.Sprintf("--namespace=%s", cephCSINamespace))
-	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePluginRBAC, fmt.Sprintf("--namespace=%s", cephCSINamespace))
-	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePluginPSP, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+
+	data, err := replaceNamespaceInTemplate(cephfsDirPath + cephfsProvisionerRBAC)
+	if err != nil {
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsProvisionerRBAC, err)
+	}
+	_, err = framework.RunKubectlInput(data, "--ignore-not-found=true", ns, "delete", "-f", "-")
+	if err != nil {
+		e2elog.Logf("failed to delete provisioner rbac %s %v", cephfsDirPath+cephfsProvisionerRBAC, err)
+	}
+
+	data, err = replaceNamespaceInTemplate(cephfsDirPath + cephfsNodePluginRBAC)
+	if err != nil {
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsNodePluginRBAC, err)
+	}
+	_, err = framework.RunKubectlInput(data, "delete", "--ignore-not-found=true", ns, "-f", "-")
+
+	if err != nil {
+		e2elog.Logf("failed to delete nodeplugin rbac %s %v", cephfsDirPath+cephfsNodePluginRBAC, err)
+	}
+
+	createORDeleteCephfsResouces("create")
 }
 
 func deleteCephfsPlugin() {
-	_, err := framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisioner, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+	createORDeleteCephfsResouces("delete")
+}
+
+func createORDeleteCephfsResouces(action string) {
+	data, err := replaceNamespaceInTemplate(cephfsDirPath + cephfsProvisioner)
 	if err != nil {
-		e2elog.Logf("failed to delete cephfs provisioner %v", err)
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsProvisioner, err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisionerRBAC, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+	_, err = framework.RunKubectlInput(data, action, ns, "-f", "-")
 	if err != nil {
-		e2elog.Logf("failed to delete cephfs provisioner rbac %v", err)
+		e2elog.Logf("failed to %s cephfs provisioner %v", action, err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisionerPSP, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+
+	data, err = replaceNamespaceInTemplate(cephfsDirPath + cephfsProvisionerRBAC)
 	if err != nil {
-		e2elog.Logf("failed to delete cephfs provisioner psp %v", err)
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsProvisionerRBAC, err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsNodePlugin, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+	_, err = framework.RunKubectlInput(data, action, ns, "-f", "-")
 	if err != nil {
-		e2elog.Logf("failed to delete cephfs nodeplugin %v", err)
+		e2elog.Logf("failed to %s cephfs provisioner rbac %v", action, err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsNodePluginRBAC, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+
+	data, err = replaceNamespaceInTemplate(cephfsDirPath + cephfsProvisionerPSP)
 	if err != nil {
-		e2elog.Logf("failed to delete cephfs nodeplugin rbac %v", err)
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsProvisionerPSP, err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsNodePluginPSP, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+	_, err = framework.RunKubectlInput(data, action, ns, "-f", "-")
 	if err != nil {
-		e2elog.Logf("failed to delete cephfs nodeplugin psp %v", err)
+		e2elog.Logf("failed to %s cephfs provisioner psp %v", action, err)
+	}
+
+	data, err = replaceNamespaceInTemplate(cephfsDirPath + cephfsNodePlugin)
+	if err != nil {
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsNodePlugin, err)
+	}
+	_, err = framework.RunKubectlInput(data, action, ns, "-f", "-")
+	if err != nil {
+		e2elog.Logf("failed to %s cephfs nodeplugin %v", action, err)
+	}
+
+	data, err = replaceNamespaceInTemplate(cephfsDirPath + cephfsNodePluginRBAC)
+	if err != nil {
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsNodePluginRBAC, err)
+	}
+	_, err = framework.RunKubectlInput(data, action, ns, "-f", "-")
+	if err != nil {
+		e2elog.Logf("failed to %s cephfs nodeplugin rbac %v", action, err)
+	}
+
+	data, err = replaceNamespaceInTemplate(cephfsDirPath + cephfsNodePluginPSP)
+	if err != nil {
+		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsNodePluginPSP, err)
+	}
+	_, err = framework.RunKubectlInput(data, action, ns, "-f", "-")
+	if err != nil {
+		e2elog.Logf("failed to %s cephfs nodeplugin psp %v", action, err)
 	}
 }
 
@@ -74,23 +114,16 @@ var _ = Describe("cephfs", func() {
 	// deploy cephfs CSI
 	BeforeEach(func() {
 		c = f.ClientSet
-		createConfigMap(cephfsDirPath, f.ClientSet, f)
 		if deployCephFS {
 			if cephCSINamespace != defaultNs {
-				// create namespace
-				ns := &v1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: cephCSINamespace,
-					},
-				}
-				_, err := c.CoreV1().Namespaces().Create(ns)
-				if err != nil && !apierrs.IsAlreadyExists(err) {
+				err := createNamespace(c, cephCSINamespace)
+				if err != nil {
 					Fail(err.Error())
 				}
 			}
-
 			deployCephfsPlugin()
 		}
+		createConfigMap(cephfsDirPath, f.ClientSet, f)
 		createCephfsSecret(f.ClientSet, f)
 	})
 
@@ -107,11 +140,7 @@ var _ = Describe("cephfs", func() {
 		if deployCephFS {
 			deleteCephfsPlugin()
 			if cephCSINamespace != defaultNs {
-				err := c.CoreV1().Namespaces().Delete(cephCSINamespace, nil)
-				if err != nil && !apierrs.IsNotFound(err) {
-					Fail(err.Error())
-				}
-				err = framework.WaitForNamespacesDeleted(c, []string{cephCSINamespace}, time.Duration(deployTimeout)*time.Minute)
+				err := deleteNamespace(c, cephCSINamespace)
 				if err != nil {
 					Fail(err.Error())
 				}

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/gomega" // nolint
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,37 +19,37 @@ var (
 )
 
 func deployVault(c kubernetes.Interface, deployTimeout int) {
-	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultServicePath)
-	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultPSPPath)
-	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultRBACPath)
-	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultConfigPath)
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultServicePath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultPSPPath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultRBACPath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
+	framework.RunKubectlOrDie("create", "-f", vaultExamplePath+vaultConfigPath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
 
 	opt := metav1.ListOptions{
 		LabelSelector: "app=vault",
 	}
 
-	pods, err := c.CoreV1().Pods("default").List(opt)
+	pods, err := c.CoreV1().Pods(cephCSINamespace).List(opt)
 	Expect(err).Should(BeNil())
 	Expect(len(pods.Items)).Should(Equal(1))
 	name := pods.Items[0].Name
-	err = waitForPodInRunningState(name, "default", c, deployTimeout)
+	err = waitForPodInRunningState(name, cephCSINamespace, c, deployTimeout)
 	Expect(err).Should(BeNil())
 }
 
 func deleteVault() {
-	_, err := framework.RunKubectl("delete", "-f", vaultExamplePath+vaultServicePath)
+	_, err := framework.RunKubectl("delete", "-f", vaultExamplePath+vaultServicePath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
 	if err != nil {
 		e2elog.Logf("failed to delete vault statefull set %v", err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultRBACPath)
+	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultRBACPath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
 	if err != nil {
 		e2elog.Logf("failed to delete vault statefull set %v", err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultConfigPath)
+	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultConfigPath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
 	if err != nil {
 		e2elog.Logf("failed to delete vault config map %v", err)
 	}
-	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultPSPPath)
+	_, err = framework.RunKubectl("delete", "-f", vaultExamplePath+vaultPSPPath, fmt.Sprintf("--namespace=%s", cephCSINamespace))
 	if err != nil {
 		e2elog.Logf("failed to delete vault psp %v", err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -15,9 +15,11 @@ import (
 )
 
 var (
-	deployTimeout int
-	deployCephFS  bool
-	deployRBD     bool
+	deployTimeout    int
+	deployCephFS     bool
+	deployRBD        bool
+	cephCSINamespace string
+	rookNamespace    string
 )
 
 func init() {
@@ -26,7 +28,8 @@ func init() {
 	flag.IntVar(&deployTimeout, "deploy-timeout", 10, "timeout to wait for created kubernetes resources")
 	flag.BoolVar(&deployCephFS, "deploy-cephfs", true, "deploy cephfs csi driver")
 	flag.BoolVar(&deployRBD, "deploy-rbd", true, "deploy rbd csi driver")
-
+	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
+	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
 	setDefaultKubeconfig()
 
 	// Register framework flags, then handle flags

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -16,12 +16,16 @@ import (
 
 var (
 	deployTimeout int
+	deployCephFS  bool
+	deployRBD     bool
 )
 
 func init() {
 	log.SetOutput(GinkgoWriter)
 
 	flag.IntVar(&deployTimeout, "deploy-timeout", 10, "timeout to wait for created kubernetes resources")
+	flag.BoolVar(&deployCephFS, "deploy-cephfs", true, "deploy cephfs csi driver")
+	flag.BoolVar(&deployRBD, "deploy-rbd", true, "deploy rbd csi driver")
 
 	setDefaultKubeconfig()
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -58,4 +58,5 @@ func handleFlags() {
 	framework.RegisterClusterFlags(flag.CommandLine)
 	testing.Init()
 	flag.Parse()
+	initResouces()
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -14,14 +14,6 @@ import (
 	config "k8s.io/kubernetes/test/e2e/framework/config"
 )
 
-var (
-	deployTimeout    int
-	deployCephFS     bool
-	deployRBD        bool
-	cephCSINamespace string
-	rookNamespace    string
-)
-
 func init() {
 	log.SetOutput(GinkgoWriter)
 

--- a/e2e/log.go
+++ b/e2e/log.go
@@ -25,11 +25,10 @@ import (
 )
 
 func logsCSIPods(label string, c clientset.Interface) {
-	ns := "default"
 	opt := metav1.ListOptions{
 		LabelSelector: label,
 	}
-	podList, err := c.CoreV1().Pods(ns).List(opt)
+	podList, err := c.CoreV1().Pods(cephCSINamespace).List(opt)
 	if err != nil {
 		e2elog.Logf("failed to list pods with selector %s %v", label, err)
 		return

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -74,7 +74,9 @@ var _ = Describe("RBD", func() {
 	BeforeEach(func() {
 		c = f.ClientSet
 		createConfigMap(rbdDirPath, f.ClientSet, f)
-		deployRBDPlugin()
+		if deployRBD {
+			deployRBDPlugin()
+		}
 		createRBDStorageClass(f.ClientSet, f, make(map[string]string))
 		createRBDSecret(f.ClientSet, f)
 		deployVault(f.ClientSet, deployTimeout)
@@ -87,7 +89,9 @@ var _ = Describe("RBD", func() {
 			// log node plugin
 			logsCSIPods("app=csi-rbdplugin", c)
 		}
-		deleteRBDPlugin()
+		if deployRBD {
+			deleteRBDPlugin()
+		}
 		deleteConfigMap(rbdDirPath)
 		deleteResource(rbdExamplePath + "secret.yaml")
 		deleteResource(rbdExamplePath + "storageclass.yaml")

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -94,7 +94,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock bool) e
 		LabelSelector: "app=rook-ceph-tools",
 	}
 
-	fsID, e := execCommandInPod(f, "ceph fsid", rookNS, &listOpt)
+	fsID, e := execCommandInPod(f, "ceph fsid", rookNamespace, &listOpt)
 	if e != "" {
 		return fmt.Errorf("failed to get fsid from ceph cluster %s", e)
 	}
@@ -104,7 +104,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock bool) e
 	// create rbd image
 	cmd := fmt.Sprintf("rbd create %s --size=%d --pool=replicapool --image-feature=layering", rbdImageName, 4096)
 
-	_, e = execCommandInPod(f, cmd, rookNS, &listOpt)
+	_, e = execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	if e != "" {
 		return fmt.Errorf("failed to create rbd image %s", e)
 	}
@@ -113,7 +113,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock bool) e
 	opt["pool"] = "replicapool"
 	opt["staticVolume"] = "true"
 
-	pv := getStaticPV(pvName, rbdImageName, size, "csi-rbd-secret", "default", sc, "rbd.csi.ceph.com", isBlock, opt)
+	pv := getStaticPV(pvName, rbdImageName, size, "csi-rbd-secret", cephCSINamespace, sc, "rbd.csi.ceph.com", isBlock, opt)
 
 	_, err := c.CoreV1().PersistentVolumes().Create(pv)
 	if err != nil {
@@ -155,6 +155,6 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock bool) e
 	}
 
 	cmd = fmt.Sprintf("rbd rm %s --pool=replicapool", rbdImageName)
-	execCommandInPod(f, cmd, rookNS, &listOpt)
+	execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	return nil
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -36,6 +36,13 @@ const (
 )
 
 var (
+	// cli flags
+	deployTimeout    int
+	deployCephFS     bool
+	deployRBD        bool
+	cephCSINamespace string
+	rookNamespace    string
+
 	vaultAddr = fmt.Sprintf("http://vault.%s.svc.cluster.local:8200", cephCSINamespace)
 	poll      = 2 * time.Second
 )

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	defaultNs     = "default"
-	vaultSecretNs = "/secret/ceph-csi/" // nolint: gosec, #nosec
+	vaultSecretNs = "/secret/ceph-csi/" // nolint: gosec
 )
 
 var (

--- a/scripts/travis-functest.sh
+++ b/scripts/travis-functest.sh
@@ -11,7 +11,6 @@ sudo scripts/minikube.sh cephcsi
 sudo scripts/minikube.sh k8s-sidecar
 sudo chown -R travis: "$HOME"/.minikube /usr/local/bin/kubectl
 # functional tests
-
-go test github.com/ceph/ceph-csi/e2e --deploy-timeout=10 -timeout=30m -v
+go test github.com/ceph/ceph-csi/e2e --deploy-timeout=10 -timeout=30m --cephcsi-namespace=cephcsi-e2e-$RANDOM -v
 
 sudo scripts/minikube.sh clean


### PR DESCRIPTION
This PR has changes to deploy ceph-csi in a different namespace and also provides an option to enable/disable plugin installation in E2E, which also helps in enabling helm templates testing in CI

fixes: #723