### PR TITLE
[Experimental] Add RBD mirroring support based on image snapshots

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/ceph:v14.2
+FROM ceph/daemon-base:latest-master-devel
 LABEL maintainers="Ceph-CSI Authors"
 LABEL description="Ceph-CSI Plugin"
 

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -36,7 +36,8 @@ spec:
       serviceAccount: rbd-csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.4.0
+          # to get feature in PR https://github.com/kubernetes-csi/external-provisioner/pull/399
+          image: quay.io/k8scsi/csi-provisioner:canary
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -44,6 +45,7 @@ spec:
             - "--retry-interval-start=500ms"
             - "--enable-leader-election=true"
             - "--leader-election-type=leases"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock
@@ -68,7 +70,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.1.0
+          image: quay.io/k8scsi/csi-attacher:canary
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -24,6 +24,7 @@ parameters:
    # RBD image features, CSI creates image with image-format 2
    # CSI RBD currently supports only `layering` feature.
    imageFeatures: layering
+   mirrored: "true"
 
    # The secrets have to contain Ceph credentials with required access
    # to the 'pool'.

--- a/pkg/cephfs/fsjournal.go
+++ b/pkg/cephfs/fsjournal.go
@@ -133,7 +133,7 @@ func reserveVol(ctx context.Context, volOptions *volumeOptions, secret map[strin
 	defer cr.DeleteCredentials()
 
 	imageUUID, vid.FsSubvolName, err = volJournal.ReserveName(ctx, volOptions.Monitors, cr,
-		volOptions.MetadataPool, volOptions.RequestName, volOptions.NamePrefix, "", "")
+		volOptions.MetadataPool, volOptions.RequestName, volOptions.NamePrefix, "", "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rbd/rbd_attach.go
+++ b/pkg/rbd/rbd_attach.go
@@ -183,7 +183,9 @@ func attachRBDImage(ctx context.Context, volOptions *rbdVolume, cr *util.Credent
 
 	devicePath, found := waitForPath(ctx, volOptions.Pool, image, 1, useNBD)
 	if !found {
-		backoff := wait.Backoff{
+		// TODO: With mirroring there is already a watcher on the image (possibly the mirror deamon), hence checking
+		// for watchers as a defense against existing clients will not work
+		/*backoff := wait.Backoff{
 			Duration: rbdImageWatcherInitDelay,
 			Factor:   rbdImageWatcherFactor,
 			Steps:    rbdImageWatcherSteps,
@@ -193,7 +195,7 @@ func attachRBDImage(ctx context.Context, volOptions *rbdVolume, cr *util.Credent
 
 		if err != nil {
 			return "", err
-		}
+		}*/
 		devicePath, err = createPath(ctx, volOptions, cr)
 	}
 


### PR DESCRIPTION
This commit is fully experimental, with a hack/slash approach to get
RBD mirroring working.

The RBD mirroring mode of snapshot based mirroring is enabled in
this commit, using under development Ceph Octopus release.

The basic design is to name the images with the pvc name-namespace
as its header, and to trigger seraching for such an image when the
CreateVolume parameters specify "mirrored", instead of first creating
the the image.

Signed-off-by: ShyamsundarR <srangana@redhat.com>