### PR TITLE
Replace rbd-image metadata commands with go-ceph implementation

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -172,7 +172,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 	if found {
 		if rbdVol.Encrypted {
-			err = ensureEncryptionMetadataSet(ctx, cr, rbdVol)
+			err = rbdVol.ensureEncryptionMetadataSet(rbdImageRequiresEncryption)
 			if err != nil {
 				klog.Errorf(util.Log(ctx, err.Error()))
 				return nil, err
@@ -224,7 +224,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	if rbdVol.Encrypted {
-		err = ensureEncryptionMetadataSet(ctx, cr, rbdVol)
+		err = rbdVol.ensureEncryptionMetadataSet(rbdImageRequiresEncryption)
 		if err != nil {
 			klog.Errorf(util.Log(ctx, "failed to save encryption status, deleting image %s"),
 				rbdVol.RbdImageName)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -201,6 +201,13 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	}
 	defer cr.DeleteCredentials()
 
+	err = volOptions.Connect(cr)
+	if err != nil {
+		klog.Errorf(util.Log(ctx, "failed to connect to volume %v: %v"), volOptions.RbdImageName, err)
+		return transaction, err
+	}
+	defer volOptions.Destroy()
+
 	// Mapping RBD image
 	var devicePath string
 	devicePath, err = attachRBDImage(ctx, volOptions, cr)
@@ -212,7 +219,7 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 		req.GetVolumeId(), volOptions.Pool, devicePath)
 
 	if volOptions.Encrypted {
-		devicePath, err = ns.processEncryptedDevice(ctx, volOptions, devicePath, cr)
+		devicePath, err = ns.processEncryptedDevice(ctx, volOptions, devicePath)
 		if err != nil {
 			return transaction, err
 		}
@@ -703,9 +710,9 @@ func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 	}, nil
 }
 
-func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rbdVolume, devicePath string, cr *util.Credentials) (string, error) {
+func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rbdVolume, devicePath string) (string, error) {
 	imageSpec := volOptions.Pool + "/" + volOptions.RbdImageName
-	encrypted, err := util.CheckRbdImageEncrypted(ctx, cr, volOptions.Monitors, imageSpec)
+	encrypted, err := volOptions.checkRbdImageEncrypted(ctx)
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed to get encryption status for rbd image %s: %v"),
 			imageSpec, err)
@@ -723,15 +730,14 @@ func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rb
 
 		switch existingFormat {
 		case "":
-			err = encryptDevice(ctx, volOptions, cr, devicePath)
+			err = encryptDevice(ctx, volOptions, devicePath)
 			if err != nil {
 				return "", fmt.Errorf("failed to encrypt rbd image %s: %v", imageSpec, err)
 			}
 		case "crypt":
 			klog.Warningf(util.Log(ctx, "rbd image %s is encrypted, but encryption state was not updated"),
 				imageSpec)
-			err = util.SaveRbdImageEncryptionStatus(
-				ctx, cr, volOptions.Monitors, imageSpec, rbdImageEncrypted)
+			err = volOptions.ensureEncryptionMetadataSet(rbdImageEncrypted)
 			if err != nil {
 				return "", fmt.Errorf("failed to update encryption state for rbd image %s", imageSpec)
 			}
@@ -752,7 +758,7 @@ func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rb
 	return devicePath, nil
 }
 
-func encryptDevice(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials, devicePath string) error {
+func encryptDevice(ctx context.Context, rbdVol *rbdVolume, devicePath string) error {
 	passphrase, err := util.GetCryptoPassphrase(ctx, rbdVol.VolID, rbdVol.KMS)
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed to get crypto passphrase for %s/%s: %v"),
@@ -766,10 +772,13 @@ func encryptDevice(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials,
 		return err
 	}
 
-	imageSpec := rbdVol.Pool + "/" + rbdVol.RbdImageName
-	err = util.SaveRbdImageEncryptionStatus(ctx, cr, rbdVol.Monitors, imageSpec, rbdImageEncrypted)
+	err = rbdVol.ensureEncryptionMetadataSet(rbdImageEncrypted)
+	if err != nil {
+		klog.Error(util.Log(ctx, err.Error()))
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func openEncryptedDevice(ctx context.Context, volOptions *rbdVolume, devicePath string) (string, error) {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -163,19 +163,19 @@ volume names as requested by the CSI drivers. Hence, these need to be invoked on
 respective CSI snapshot or volume name based locks are held, as otherwise racy access to these
 omaps may end up leaving the omaps in an inconsistent state.
 */
-func (rbdVol *rbdVolume) Exists(ctx context.Context) (bool, error) {
-	err := validateRbdVol(rbdVol)
+func (rv *rbdVolume) Exists(ctx context.Context) (bool, error) {
+	err := validateRbdVol(rv)
 	if err != nil {
 		return false, err
 	}
 
 	kmsID := ""
-	if rbdVol.Encrypted {
-		kmsID = rbdVol.KMS.GetID()
+	if rv.Encrypted {
+		kmsID = rv.KMS.GetID()
 	}
 
-	imageData, err := volJournal.CheckReservation(ctx, rbdVol.Monitors, rbdVol.conn.Creds, rbdVol.JournalPool,
-		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID)
+	imageData, err := volJournal.CheckReservation(ctx, rv.Monitors, rv.conn.Creds, rv.JournalPool,
+		rv.RequestName, rv.NamePrefix, "", kmsID)
 	if err != nil {
 		return false, err
 	}
@@ -184,51 +184,51 @@ func (rbdVol *rbdVolume) Exists(ctx context.Context) (bool, error) {
 	}
 
 	imageUUID := imageData.ImageUUID
-	rbdVol.RbdImageName = imageData.ImageAttributes.ImageName
+	rv.RbdImageName = imageData.ImageAttributes.ImageName
 
 	// check if topology constraints match what is found
-	rbdVol.Topology, err = util.MatchTopologyForPool(rbdVol.TopologyPools,
-		rbdVol.TopologyRequirement, imageData.ImagePool)
+	rv.Topology, err = util.MatchTopologyForPool(rv.TopologyPools, rv.TopologyRequirement,
+		imageData.ImagePool)
 	if err != nil {
 		// TODO check if need any undo operation here, or ErrVolNameConflict
 		return false, err
 	}
 	// update Pool, if it was topology constrained
-	if rbdVol.Topology != nil {
-		rbdVol.Pool = imageData.ImagePool
+	if rv.Topology != nil {
+		rv.Pool = imageData.ImagePool
 	}
 
 	// NOTE: Return volsize should be on-disk volsize, not request vol size, so
 	// save it for size checks before fetching image data
-	requestSize := rbdVol.VolSize
+	requestSize := rv.VolSize
 	// Fetch on-disk image attributes and compare against request
-	err = updateVolWithImageInfo(ctx, rbdVol, rbdVol.conn.Creds)
+	err = updateVolWithImageInfo(ctx, rv, rv.conn.Creds)
 	if err != nil {
 		if _, ok := err.(ErrImageNotFound); ok {
-			err = volJournal.UndoReservation(ctx, rbdVol.Monitors, rbdVol.conn.Creds, rbdVol.JournalPool, rbdVol.Pool,
-				rbdVol.RbdImageName, rbdVol.RequestName)
+			err = volJournal.UndoReservation(ctx, rv.Monitors, rv.conn.Creds, rv.JournalPool, rv.Pool,
+				rv.RbdImageName, rv.RequestName)
 			return false, err
 		}
 		return false, err
 	}
 
 	// size checks
-	if rbdVol.VolSize < requestSize {
+	if rv.VolSize < requestSize {
 		err = fmt.Errorf("image with the same name (%s) but with different size already exists",
-			rbdVol.RbdImageName)
-		return false, ErrVolNameConflict{rbdVol.RbdImageName, err}
+			rv.RbdImageName)
+		return false, ErrVolNameConflict{rv.RbdImageName, err}
 	}
 	// TODO: We should also ensure image features and format is the same
 
 	// found a volume already available, process and return it!
-	rbdVol.VolID, err = util.GenerateVolID(ctx, rbdVol.Monitors, rbdVol.conn.Creds, imageData.ImagePoolID, rbdVol.Pool,
-		rbdVol.ClusterID, imageUUID, volIDVersion)
+	rv.VolID, err = util.GenerateVolID(ctx, rv.Monitors, rv.conn.Creds, imageData.ImagePoolID, rv.Pool,
+		rv.ClusterID, imageUUID, volIDVersion)
 	if err != nil {
 		return false, err
 	}
 
 	klog.V(4).Infof(util.Log(ctx, "found existing volume (%s) with image name (%s) for request (%s)"),
-		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.RequestName)
+		rv.VolID, rv.RbdImageName, rv.RequestName)
 
 	return true, nil
 }

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -197,30 +197,6 @@ func createImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 	return nil
 }
 
-// Open the rbdVolume after it has been connected.
-func (rv *rbdVolume) open() (*librbd.Image, error) {
-	if rv.RbdImageName == "" {
-		var vi util.CSIIdentifier
-		err := vi.DecomposeCSIID(rv.VolID)
-		if err != nil {
-			err = fmt.Errorf("error decoding volume ID (%s) (%s)", rv.VolID, err)
-			return nil, ErrInvalidVolID{err}
-		}
-		rv.RbdImageName = volJournal.GetNameForUUID(rv.NamePrefix, vi.ObjectUUID, false)
-	}
-
-	ioctx, err := rv.conn.GetIoctx(rv.Pool)
-	if err != nil {
-		return nil, err
-	}
-
-	image, err := librbd.OpenImage(ioctx, rv.RbdImageName, librbd.NoSnapshot)
-	if err != nil {
-		return nil, err
-	}
-	return image, nil
-}
-
 // rbdStatus checks if there is watcher on the image.
 // It returns true if there is a watcher on the image, otherwise returns false.
 func rbdStatus(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) (bool, string, error) {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -389,21 +389,22 @@ func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID str
 
 // genVolFromVolID generates a rbdVolume structure from the provided identifier, updating
 // the structure with elements from on-disk image metadata as well
-func genVolFromVolID(ctx context.Context, rbdVol *rbdVolume, volumeID string, cr *util.Credentials, secrets map[string]string) error {
+func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials, secrets map[string]string) (*rbdVolume, error) {
 	var (
 		options map[string]string
 		vi      util.CSIIdentifier
+		rbdVol  *rbdVolume
 	)
 	options = make(map[string]string)
 
 	// rbdVolume fields that are not filled up in this function are:
 	//		Mounter, MultiNodeWritable
-	rbdVol.VolID = volumeID
+	rbdVol = &rbdVolume{VolID: volumeID}
 
 	err := vi.DecomposeCSIID(rbdVol.VolID)
 	if err != nil {
 		err = fmt.Errorf("error decoding volume ID (%s) (%s)", err, rbdVol.VolID)
-		return ErrInvalidVolID{err}
+		return nil, ErrInvalidVolID{err}
 	}
 
 	rbdVol.ClusterID = vi.ClusterID
@@ -411,26 +412,31 @@ func genVolFromVolID(ctx context.Context, rbdVol *rbdVolume, volumeID string, cr
 
 	rbdVol.Monitors, _, err = getMonsAndClusterID(ctx, options)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	rbdVol.Pool, err = util.GetPoolName(ctx, rbdVol.Monitors, cr, vi.LocationID)
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	err = rbdVol.Connect(cr)
+	if err != nil {
+		return nil, err
 	}
 	rbdVol.JournalPool = rbdVol.Pool
 
 	imageAttributes, err := volJournal.GetImageAttributes(ctx, rbdVol.Monitors, cr,
 		rbdVol.Pool, vi.ObjectUUID, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if imageAttributes.KmsID != "" {
 		rbdVol.Encrypted = true
 		rbdVol.KMS, err = util.GetKMS(imageAttributes.KmsID, secrets)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 	rbdVol.RequestName = imageAttributes.RequestName
@@ -441,13 +447,13 @@ func genVolFromVolID(ctx context.Context, rbdVol *rbdVolume, volumeID string, cr
 		rbdVol.JournalPool, err = util.GetPoolName(ctx, rbdVol.Monitors, cr, imageAttributes.JournalPoolID)
 		if err != nil {
 			// TODO: If pool is not found we may leak the image (as DeleteVolume will return success)
-			return err
+			return nil, err
 		}
 	}
 
 	err = updateVolWithImageInfo(ctx, rbdVol, cr)
 
-	return err
+	return rbdVol, err
 }
 
 func execCommand(command string, args []string) ([]byte, error) {

--- a/internal/util/conn_pool.go
+++ b/internal/util/conn_pool.go
@@ -95,14 +95,14 @@ func (cp *ConnPool) Destroy() {
 	}
 }
 
-func (cp *ConnPool) generateUniqueKey(pool, monitors, user, keyfile string) (string, error) {
+func (cp *ConnPool) generateUniqueKey(monitors, user, keyfile string) (string, error) {
 	// the keyfile can be unique for operations, contents will be the same
 	key, err := ioutil.ReadFile(keyfile) // nolint: gosec, #nosec
 	if err != nil {
 		return "", errors.Wrapf(err, "could not open keyfile %s", keyfile)
 	}
 
-	return fmt.Sprintf("%s|%s|%s|%s", pool, monitors, user, string(key)), nil
+	return fmt.Sprintf("%s|%s|%s", monitors, user, string(key)), nil
 }
 
 // getExisting returns the existing rados.Conn associated with the unique key.
@@ -118,10 +118,10 @@ func (cp *ConnPool) getConn(unique string) *rados.Conn {
 }
 
 // Get returns a rados.Conn for the given arguments. Creates a new rados.Conn in
-// case there is none in the pool. Use the returned unique string to reduce the
-// reference count with ConnPool.Put(unique).
-func (cp *ConnPool) Get(pool, monitors, user, keyfile string) (*rados.Conn, error) {
-	unique, err := cp.generateUniqueKey(pool, monitors, user, keyfile)
+// case there is none. Use the returned rados.Conn to reduce the reference
+// count with ConnPool.Put(unique).
+func (cp *ConnPool) Get(monitors, user, keyfile string) (*rados.Conn, error) {
+	unique, err := cp.generateUniqueKey(monitors, user, keyfile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate unique for connection")
 	}

--- a/internal/util/conn_pool_test.go
+++ b/internal/util/conn_pool_test.go
@@ -34,8 +34,8 @@ const (
 // working Ceph cluster to connect to.
 //
 // This is mostly a copy of ConnPool.Get()
-func (cp *ConnPool) fakeGet(pool, monitors, user, keyfile string) (*rados.Conn, string, error) {
-	unique, err := cp.generateUniqueKey(pool, monitors, user, keyfile)
+func (cp *ConnPool) fakeGet(monitors, user, keyfile string) (*rados.Conn, string, error) {
+	unique, err := cp.generateUniqueKey(monitors, user, keyfile)
 	if err != nil {
 		return nil, "", err
 	}
@@ -91,7 +91,7 @@ func TestConnPool(t *testing.T) {
 	var unique string
 
 	t.Run("fakeGet", func(t *testing.T) {
-		conn, unique, err = cp.fakeGet("pool", "monitors", "user", keyfile)
+		conn, unique, err = cp.fakeGet("monitors", "user", keyfile)
 		if err != nil {
 			t.Errorf("failed to get connection: %v", err)
 		}
@@ -115,7 +115,7 @@ func TestConnPool(t *testing.T) {
 
 	t.Run("doubleFakeGet", func(t *testing.T) {
 		// after a 2nd get, there should still be a single conn in cp.conns
-		_, _, err = cp.fakeGet("pool", "monitors", "user", keyfile)
+		_, _, err = cp.fakeGet("monitors", "user", keyfile)
 		if err != nil {
 			t.Errorf("failed to get connection: %v", err)
 		}

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	"github.com/ceph/go-ceph/rados"
+	"github.com/pkg/errors"
+)
+
+type ClusterConnection struct {
+	// connection
+	conn *rados.Conn
+
+	// FIXME: temporary reference for credentials. Remove this when go-ceph
+	// is used for operations.
+	Creds *Credentials
+}
+
+var (
+	// large interval and timeout, it should be longer than the maximum
+	// time an operation can take (until refcounting of the connections is
+	// available)
+	cpInterval = 15 * time.Minute
+	cpExpiry   = 10 * time.Minute
+	connPool   = NewConnPool(cpInterval, cpExpiry)
+)
+
+// rbdVol.Connect() connects to the Ceph cluster and sets rbdVol.conn for further usage.
+func (cc *ClusterConnection) Connect(monitors string, cr *Credentials) error {
+	if cc.conn == nil {
+		conn, err := connPool.Get(monitors, cr.ID, cr.KeyFile)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get connection")
+		}
+
+		cc.conn = conn
+
+		// FIXME: remove .Creds from ClusterConnection
+		cc.Creds = cr
+	}
+
+	return nil
+}
+
+func (cc *ClusterConnection) Destroy() {
+	if cc.conn != nil {
+		connPool.Put(cc.conn)
+	}
+}
+
+func (cc *ClusterConnection) GetIoctx(pool string) (*rados.IOContext, error) {
+	if cc.conn == nil {
+		return nil, errors.New("cluster is not connected yet")
+	}
+
+	ioctx, err := cc.conn.OpenIOContext(pool)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open IOContext for pool %s", pool)
+	}
+
+	return ioctx, nil
+}

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -36,9 +36,6 @@ const (
 	mapperFilePrefix     = "luks-rbd-"
 	mapperFilePathPrefix = "/dev/mapper"
 
-	// image metadata key for encryption
-	encryptionMetaKey = ".rbd.csi.ceph.com/encrypted"
-
 	// Encryption passphrase location in K8s secrets
 	encryptionPassphraseKey = "encryptionPassphrase"
 	kmsTypeKey              = "encryptionKMSType"
@@ -247,28 +244,4 @@ func DeviceEncryptionStatus(ctx context.Context, devicePath string) (mappedDevic
 	}
 	// Identified as LUKS, but failed to identify a mapped device
 	return "", "", fmt.Errorf("mapped device not found in path %s", devicePath)
-}
-
-// CheckRbdImageEncrypted verifies if rbd image was encrypted when created
-func CheckRbdImageEncrypted(ctx context.Context, cr *Credentials, monitors, imageSpec string) (string, error) {
-	value, err := GetImageMeta(ctx, cr, monitors, imageSpec, encryptionMetaKey)
-	if err != nil {
-		klog.Errorf(Log(ctx, "checking image %s encrypted state metadata failed: %s"), imageSpec, err)
-		return "", err
-	}
-
-	encrypted := strings.TrimSpace(value)
-	klog.V(4).Infof(Log(ctx, "image %s encrypted state metadata reports %q"), imageSpec, encrypted)
-	return encrypted, nil
-}
-
-// SaveRbdImageEncryptionStatus sets image metadata for encryption status
-func SaveRbdImageEncryptionStatus(ctx context.Context, cr *Credentials, monitors, imageSpec, status string) error {
-	err := SetImageMeta(ctx, cr, monitors, imageSpec, encryptionMetaKey, status)
-	if err != nil {
-		err = fmt.Errorf("failed to save image metadata encryption status for %s: %v", imageSpec, err.Error())
-		klog.Errorf(Log(ctx, err.Error()))
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
# Describe what this PR does #

Improve performance of volume creation by replacing command execution (and reconnecting to the cluster) by using the go-ceph bindings and re-using the connection to the cluster.

This also removes passing credentials to the metadata helper functions. Later updates can remove them even more, and reduce them to a single `RbdVolume.Connect(credentials)` call.