### PR TITLE
Fix multi architecture image building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,11 @@ jobs:
         - make mod-check
 
     - stage: build testing
+      name: Build multi-architecture image for amd64 and arm64
+      script:
+        - travis_wait ./build-multi-arch-image.sh || travis_terminate 1;
+
+    - stage: build testing
       name: containerized test (Fedora) and build (CentOS)
       script:
         - make containerized-test || travis_terminate 1;

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ ifndef GOARCH
 GOARCH := $(shell go env GOARCH)
 endif
 
+ifdef BASE_IMAGE
+BASE_IMAGE_ARG = --build-arg BASE_IMAGE=$(BASE_IMAGE)
+endif
+
 SELINUX := $(shell getenforce 2>/dev/null)
 ifeq ($(SELINUX),Enforcing)
 	SELINUX_VOL_FLAG = :z
@@ -93,7 +97,7 @@ containerized-test: .test-container-id
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 
 image-cephcsi:
-	$(CONTAINER_CMD) build -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg GOLANG_VERSION=1.13.8 --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH)
+	$(CONTAINER_CMD) build -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg GOLANG_VERSION=1.13.8 --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) $(BASE_IMAGE_ARG)
 
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) tag $(CSI_IMAGE) $(CSI_IMAGE)-$(GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),canary)
 CSI_IMAGE=$(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION)
 
 $(info cephcsi image settings: $(CSI_IMAGE_NAME) version $(CSI_IMAGE_VERSION))
-ifeq ($(origin GIT_COMMIT), undefined)
+ifndef GIT_COMMIT
 GIT_COMMIT=$(shell git rev-list -1 HEAD)
 endif
 
@@ -34,7 +34,7 @@ LDFLAGS += -X $(GO_PROJECT)/pkg/util.GitCommit=$(GIT_COMMIT)
 LDFLAGS += -X $(GO_PROJECT)/pkg/util.DriverVersion=$(CSI_IMAGE_VERSION)
 
 # set GOARCH explicitly for cross building, default to native architecture
-ifeq ($(origin GOARCH), undefined)
+ifndef GOARCH
 GOARCH := $(shell go env GOARCH)
 endif
 
@@ -93,7 +93,7 @@ containerized-test: .test-container-id
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 
 image-cephcsi:
-	$(CONTAINER_CMD) build -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg GOLANG_VERSION=1.13.8 --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(shell git rev-list -1 HEAD) --build-arg ARCH=$(ARCH)
+	$(CONTAINER_CMD) build -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg GOLANG_VERSION=1.13.8 --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH)
 
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) tag $(CSI_IMAGE) $(CSI_IMAGE)-$(GOARCH)

--- a/build-multi-arch-image.sh
+++ b/build-multi-arch-image.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -xe
+# "docker manifest" requires experimental feature enabled
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# ceph base image used for building multi architecture images
+dockerfile="deploy/cephcsi/image/Dockerfile"
+baseimg=$(awk -F = '/^ARG BASE_IMAGE=/ {print $NF}' "${dockerfile}")
+
+# get image digest per architecture
+# {
+#   "arch": "amd64",
+#   "digest": "sha256:XXX"
+# }
+# {
+#   "arch": "arm64",
+#   "digest": "sha256:YYY"
+# }
+manifests=$(docker manifest inspect "${baseimg}" | jq '.manifests[] | {arch: .platform.architecture, digest: .digest}')
+# qemu-user-static is to enable an execution of different multi-architecture containers by QEMU
+# more info at https://github.com/multiarch/qemu-user-static
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+# build and push per arch images
+for ARCH in amd64 arm64; do
+	ifs=$IFS
+	IFS=
+	digest=$(awk -v ARCH=${ARCH} '{if (archfound) {print $NF; exit 0}}; {archfound=($0 ~ "arch.*"ARCH)}' <<<"${manifests}")
+	IFS=$ifs
+	sed -i "s|\(^FROM.*\)${baseimg}.*$|\1${baseimg}@${digest}|" "${dockerfile}"
+	GOARCH=${ARCH} make image-cephcsi
+done

--- a/build-multi-arch-image.sh
+++ b/build-multi-arch-image.sh
@@ -26,6 +26,6 @@ for ARCH in amd64 arm64; do
 	IFS=
 	digest=$(awk -v ARCH=${ARCH} '{if (archfound) {print $NF; exit 0}}; {archfound=($0 ~ "arch.*"ARCH)}' <<<"${manifests}")
 	IFS=$ifs
-	sed -i "s|\(^FROM.*\)${baseimg}.*$|\1${baseimg}@${digest}|" "${dockerfile}"
-	GOARCH=${ARCH} make image-cephcsi
+	base_img=${baseimg}@${digest}
+	GOARCH=${ARCH} BASE_IMAGE=${base_img} make image-cephcsi
 done

--- a/deploy.sh
+++ b/deploy.sh
@@ -67,7 +67,7 @@ build_push_images() {
 		digest=$(awk -v ARCH=${ARCH} '{if (archfound) {print $NF; exit 0}}; {archfound=($0 ~ "arch.*"ARCH)}' <<<"${manifests}")
 		IFS=$ifs
 		sed -i "s|\(^FROM.*\)${baseimg}.*$|\1${baseimg}@${digest}|" "${dockerfile}"
-		ARCH=${ARCH} make push-image-cephcsi
+		GOARCH=${ARCH} make push-image-cephcsi
 	done
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -67,8 +67,8 @@ build_push_images() {
 		IFS=
 		digest=$(awk -v ARCH=${ARCH} '{if (archfound) {print $NF; exit 0}}; {archfound=($0 ~ "arch.*"ARCH)}' <<<"${manifests}")
 		IFS=$ifs
-		sed -i "s|\(^FROM.*\)${baseimg}.*$|\1${baseimg}@${digest}|" "${dockerfile}"
-		GOARCH=${ARCH} make push-image-cephcsi
+		base_image=${baseimg}@${digest}
+		GOARCH=${ARCH} BASE_IMAGE=${base_image} make push-image-cephcsi
 	done
 }
 

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -11,13 +11,13 @@ ARG GO_ARCH
 ARG SRC_DIR
 ARG GIT_COMMIT
 ARG GOROOT=/usr/local/go
-RUN dnf install libcephfs-devel librados-devel librbd-devel /usr/bin/cc  make -y
 
 RUN mkdir -p ${GOROOT} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
+RUN dnf install libcephfs-devel librados-devel librbd-devel /usr/bin/cc make -y
 
-ENV GOROOT=$GOROOT \
+ENV GOROOT=${GOROOT} \
     GOPATH=/go \
     CGO_ENABLED=1 \
     GIT_COMMIT="${GIT_COMMIT}" \
@@ -40,8 +40,8 @@ FROM ceph/ceph:v15
 ARG SRC_DIR
 
 LABEL maintainers="Ceph-CSI Authors" \
-    version=$CSI_IMAGE_VERSION \
-    architecture=$GO_ARCH \
+    version=${CSI_IMAGE_VERSION} \
+    architecture=${GO_ARCH} \
     description="Ceph-CSI Plugin"
 
 COPY --from=0 ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,15 +1,49 @@
+ARG SRC_DIR="/go/src/github.com/ceph/ceph-csi/"
+ARG GO_ARCH
 FROM ceph/ceph:v15
-LABEL maintainers="Ceph-CSI Authors"
-LABEL description="Ceph-CSI Plugin"
 
-# To support cross building, do NOT RUN native binaries here.
-# If we have to run native binaries, qemu-user-static must be installed on
-# build host and mounted to container.
+LABEL stage="build"
 
-# Removing ceph-iscsi repo to workaround the repo issue while upgrading
-#RUN rm -f /etc/yum.repos.d/ceph-iscsi.repo && yum -y update && yum clean all
-ENV CSIBIN=/usr/local/bin/cephcsi
+ARG GOLANG_VERSION=1.13.9
+ARG CSI_IMAGE_NAME=quay.io/cephcsi/cephcsi
+ARG CSI_IMAGE_VERSION=canary
+ARG GO_ARCH
+ARG SRC_DIR
+ARG GIT_COMMIT
+ARG GOROOT=/usr/local/go
+RUN dnf install libcephfs-devel librados-devel librbd-devel /usr/bin/cc  make -y
 
-COPY cephcsi $CSIBIN
+RUN mkdir -p ${GOROOT} && \
+    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
+
+
+ENV GOROOT=$GOROOT \
+    GOPATH=/go \
+    CGO_ENABLED=1 \
+    GIT_COMMIT="${GIT_COMMIT}" \
+    ENV_CSI_IMAGE_VERSION="${CSI_IMAGE_VERSION}" \
+    ENV_CSI_IMAGE_NAME="${CSI_IMAGE_NAME}" \
+    PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
+
+
+WORKDIR ${SRC_DIR}
+
+# Copy source directories
+COPY . ${SRC_DIR}
+
+# Build executable
+RUN make cephcsi
+
+#-- Final container
+FROM ceph/ceph:v15
+
+ARG SRC_DIR
+
+LABEL maintainers="Ceph-CSI Authors" \
+    version=$CSI_IMAGE_VERSION \
+    architecture=$GO_ARCH \
+    description="Ceph-CSI Plugin"
+
+COPY --from=0 ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi
 
 ENTRYPOINT ["/usr/local/bin/cephcsi"]

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,6 +1,8 @@
 ARG SRC_DIR="/go/src/github.com/ceph/ceph-csi/"
 ARG GO_ARCH
-FROM ceph/ceph:v15
+ARG BASE_IMAGE=ceph/ceph:v15
+
+FROM ${BASE_IMAGE} as builder
 
 LABEL stage="build"
 
@@ -35,7 +37,7 @@ COPY . ${SRC_DIR}
 RUN make cephcsi
 
 #-- Final container
-FROM ceph/ceph:v15
+FROM ${BASE_IMAGE}
 
 ARG SRC_DIR
 
@@ -44,6 +46,6 @@ LABEL maintainers="Ceph-CSI Authors" \
     architecture=${GO_ARCH} \
     description="Ceph-CSI Plugin"
 
-COPY --from=0 ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi
+COPY --from=builder ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi
 
 ENTRYPOINT ["/usr/local/bin/cephcsi"]


### PR DESCRIPTION
Fix multi-architecture image building
    
 Add support for multi-architecture build for cephcsi. with multistage docker build
 we can build a cephcsi binary for both arm64 and amd64 architecture.
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Fixes: #856