### PR TITLE
util/cephcmds: have GetOMapValue() return ErrPoolNotFound

### DIFF
--- a/pkg/util/cephcmds.go
+++ b/pkg/util/cephcmds.go
@@ -182,6 +182,11 @@ func GetOMapValue(ctx context.Context, monitors string, cr *Credentials, poolNam
 			return "", ErrKeyNotFound{poolName + "/" + oMapName + "/" + oMapKey, err}
 		}
 
+		if strings.Contains(stdoutanderr, "error opening pool "+
+			poolName+": (2) No such file or directory") {
+			return "", ErrPoolNotFound{poolName, err}
+		}
+
 		// log other errors for troubleshooting assistance
 		klog.Errorf(Log(ctx, "failed getting omap value for key (%s) from omap (%s) in pool (%s): (%v)"),
 			oMapKey, oMapName, poolName, err)


### PR DESCRIPTION
On occasion the e2e tests fail as there is an unexpected error while
deleting an RBD image. The particular tests forcefully removes the pool
where the RBD image is stored. Deleting a volume that has been removed
already (or when its parent pool has been wiped), should succeed.

By catching the error that a pool does not exist (anymore), the
provisioner responds to the DeleteVolume request with succes.