### PR TITLE
travis: re-enable running on arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,18 +86,16 @@ jobs:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;
         - scripts/travis-functest.sh v1.17.0 || travis_terminate 1;
-     # yamllint disable rule:comments-indentation
-     # Disabled build on arm64 as we are facing issue in travis CI
-     # - name: cephcsi on Arm64
-     #   arch: arm64
-     #   script:
-     #     - scripts/skip-doc-change.sh || travis_terminate 0;
-     #    - make image-cephcsi || travis_terminate 1;
-     #    # No CI test job is availabe for Arm64 now due to below issues
-     #    # - k8s-csi sidecar images for Arm64 are not available
-     #    # - Travis Arm64 CI job runs inside unprivileged LXD which blocks
-     #    #   launching minikube test environment
-     #    - travis_terminate 0    # deploy only on x86
+    - name: cephcsi on Arm64
+      arch: arm64
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        # No CI test job is availabe for Arm64 now due to below issues
+        # - k8s-csi sidecar images for Arm64 are not available
+        # - Travis Arm64 CI job runs inside unprivileged LXD which blocks
+        #   launching minikube test environment
+        - travis_terminate 0    # deploy only on x86
 
 deploy:
   - provider: script


### PR DESCRIPTION
# Describe what this PR does #

This PR is to test if Travis CI has fixed their Ubuntu Xenial images for arm64, so the job can be enabled again.

## Is there anything that requires special attention ##

This PR might need rebasing several times, depending on when Travis CI fixes the images.

One the CI on this PR succeeds, leave an update in the [Travis CI community thread](https://travis-ci.community/t/arm64-xenial-failed-to-fetch-mongodb-amd64-repository/7639) to inform others.

## Related issues ##

Fixes: #873