### PR TITLE
Upgrade: csi-attacher from v2.1.0 to v2.1.1

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -203,7 +203,7 @@ provisioner:
     enabled: true
     image:
       repository: quay.io/k8scsi/csi-attacher
-      tag: v2.1.0
+      tag: v2.1.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -213,7 +213,7 @@ provisioner:
     enabled: true
     image:
       repository: quay.io/k8scsi/csi-attacher
-      tag: v2.1.0
+      tag: v2.1.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -133,8 +133,7 @@ cephcsi)
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v1.2.1 "${K8S_IMAGE_REPO}"/csi-attacher:v1.2.1
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.0 "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.0
+    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1 "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.2.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.2.0


### PR DESCRIPTION
This PR follow up the missing files from ceph-csi:v2.0.1, besides:

- deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
- deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml

See https://github.com/kubernetes-csi/external-attacher/releases/tag/v2.1.1
See https://github.com/kubernetes-csi/external-attacher/blob/v2.1.1/CHANGELOG-2.1.md
