### PR TITLE
build: add an option to compile in a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ _output
 # docker build
 deploy/cephcsi/image/cephcsi
 
+# build container
+.devel-container-id
+
 # git merge files
 *.orig
 *.patch

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,10 @@ jobs:
         - make go-test
         - make mod-check || travis_terminate 1;
 
+    - name: containerized build
+      script:
+        - make containerized-build || travis_terminate 1;
+
     - name: cephcsi with kube 1.14.10
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -36,8 +36,11 @@ it is **highly** encouraged to:
 
 ### Building Ceph-CSI
 
-To build ceph-csi run:
+To build ceph-csi locally run:
 `$ make`
+
+To build ceph-csi in a container:
+`$ make containerized-build`
 
 The built binary will be present under `_output/` directory.
 

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -1,0 +1,11 @@
+FROM ceph/ceph:v14
+
+ENV GOPATH=/go
+
+RUN yum -y install \
+	golang \
+	make \
+	librados-devel \
+	librbd-devel \
+    && yum -y update \
+    && true


### PR DESCRIPTION
# Describe what this PR does #

This makes it possible to build on any platform that supports Linux
containers. The container image used for building is created once, or on
updating the `scripts/Dockerfile.devel` and is cached afterwards.

To build the executable in a container, use `make containerized-build`
and everything will be done automatically. The executable will also be
available on the usual location.

## Related issues ##

Closes: #385 - old stale PR with similar intentions
Updates: #872 - this might make it possible to build on MacOS again

## Future concerns ##

Make this the default build target?