### PR TITLE
examples: rbd/storageclass.yaml causes Python excetion with yamllint

### DIFF
--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -40,8 +40,8 @@ parameters:
    # mounter: rbd-nbd
 
    # Instruct the plugin it has to encrypt the volume
-   # By default it is disabled. Valid values are “true” or “false”.
-   # A string is expected here, i.e. “true”, not true.
+   # By default it is disabled. Valid values are "true" or "false".
+   # A string is expected here, i.e. "true", not true.
    # encrypted: "true"
 
    # Use external key management system for encryption passphrases by specifying


### PR DESCRIPTION
# Describe what this PR does #

While running the 'make test' target and have 'yamllint' available, the test fails with the following exception:

```
yamllint -s -d {extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: charts/*/templates/*.yaml} ./examples/rbd/storageclass.yaml
Traceback (most recent call last):
  File "/usr/local/bin/yamllint", line 11, in <module>
    sys.exit(run())
  File "/usr/local/lib/python3.6/site-packages/yamllint/cli.py", line 181, in run
    problems = linter.run(f, conf, filepath)
  File "/usr/local/lib/python3.6/site-packages/yamllint/linter.py", line 237, in run
    content = input.read()
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1947: ordinal not in range(128)
```

The quotes used in the comments seem to be non-ascii characters. Replacing these with standard " makes the test pass again.

## Is there anything that requires special attention ##

This problem occurred while running tests in a container based on the Ceph image (CentOS-7) with Python 3. Travis CI might still use Python 2 for yamllint, and hide the problem.

## Related issues ##

Updates: #890
