### PR TITLE
Use go modules from ./vendor in test scripts

### DIFF
--- a/scripts/gosec.sh
+++ b/scripts/gosec.sh
@@ -3,6 +3,9 @@
 set -o pipefail
 
 if [[ -x "$(command -v gosec)" ]]; then
+  # gosec does not support -mod=vendor, so fallback to non-module support and
+  # assume all dependencies are available in ./vendor already
+  export GO111MODULE=off
   find cmd pkg -type d -print0 | xargs --null gosec
 else
   echo "WARNING: gosec not found, skipping security tests" >&2

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-GOPACKAGES="$(go list ./... | grep -v vendor | grep -v e2e)"
+GOPACKAGES="$(go list -mod=vendor ./... | grep -v -e vendor -e e2e)"
 COVERFILE="${GO_COVER_DIR}/profile.cov"
 
 # no special options, exec to go test w/ all pkgs
 if [[ ${TEST_EXITFIRST} != "yes" && -z ${TEST_COVERAGE} ]]; then
 	# shellcheck disable=SC2086
-	exec go test ${GOPACKAGES}
+	exec go test -mod=vendor -v ${GOPACKAGES}
 fi
 
 # our options are set so we need to handle each go package one
@@ -20,7 +20,7 @@ failed=0
 for gopackage in ${GOPACKAGES}; do
 	echo "--- testing: ${gopackage} ---"
 	# shellcheck disable=SC2086
-	go test ${GOTESTOPTS} "${gopackage}" || ((failed += 1))
+	go test -mod=vendor -v ${GOTESTOPTS} "${gopackage}" || ((failed += 1))
 	if [[ -f cover.out ]]; then
 		# Append to coverfile
 		grep -v "^mode: count" cover.out >>"${COVERFILE}"


### PR DESCRIPTION
# Describe what this PR does #

The test script do not use `-mod=vendor` and will download all dependencies even if they are available in the `./vendor` directory.

This is annoying for developers that want to run the tests, as downloading all dependencies takes time and costs bandwidth.

In addition to the above, `go get` expects a recent version of git to be available, but the version in the Ceph container (CentOS-7) is too old. `go get` fails to download any dependency that is not available yet.

## Related issues ##

Updates: #890