### PR TITLE
tests: in case 'go test' is run in a container, skip TestGetPIDLimit()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ env:
     - MINIKUBE_VERSION=v1.6.0
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
+    # set CEPH_CSI_RUN_ALL_TESTS to non-empty to run all tests
+    - CEPH_CSI_RUN_ALL_TESTS=true
 
 before_install:
   - mkdir -p $GOPATH/bin

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -66,6 +66,10 @@ tests:
 
 `$ make test`
 
+Certain unit tests may require extended permissions or other external resources
+that are not available by default. To run these tests as well, export the
+environment variable `CEPH_CSI_RUN_ALL_TESTS=1` before running the tests.
+
 You will need to provide unit tests and functional tests for your changes
 wherever applicable.
 

--- a/pkg/util/pidlimit_test.go
+++ b/pkg/util/pidlimit_test.go
@@ -17,12 +17,18 @@ limitations under the License.
 package util
 
 import (
+	"os"
 	"testing"
 )
 
 // minimal test to check if GetPIDLimit() returns an int
 // changing the limit require root permissions, not tested
-func TestGetPIDLimix(t *testing.T) {
+func TestGetPIDLimit(t *testing.T) {
+	runTest := os.Getenv("CEPH_CSI_RUN_ALL_TESTS")
+	if runTest == "" {
+		t.Skip("not running test that requires root permissions and cgroup support")
+	}
+
 	limit, err := GetPIDLimit()
 
 	if err != nil {


### PR DESCRIPTION
# Describe what this PR does #

In (standard, non-privileged) container environments the /sys/fs/cgroup
mountpoint is not available. This would cause the tests to fail, as
TestGetPIDLimit() tries to write to the cgroup configuration.

## Is there anything that requires special attention ##

The test will work when run as root on a privileged container or
directly on a host (as Travis CI does).

## Related issues ##

Updates: #890
