### PR TITLE
Use Error/Log when formatting is not required

### DIFF
--- a/pkg/util/conn_pool_test.go
+++ b/pkg/util/conn_pool_test.go
@@ -157,7 +157,7 @@ func TestConnPool(t *testing.T) {
 		// force expiring the ConnEntry by fetching it and adjusting .lastUsed
 		ce, exists := cp.conns[unique]
 		if !exists {
-			t.Errorf("getting the conn from cp.conns failed")
+			t.Error("getting the conn from cp.conns failed")
 		}
 		ce.lastUsed = ce.lastUsed.Add(-2 * expiry)
 

--- a/pkg/util/pidlimit_test.go
+++ b/pkg/util/pidlimit_test.go
@@ -29,13 +29,13 @@ func TestGetPIDLimix(t *testing.T) {
 		t.Errorf("no error should be returned, got: %v", err)
 	}
 	if limit == 0 {
-		t.Errorf("a PID limit of 0 is invalid")
+		t.Error("a PID limit of 0 is invalid")
 	}
 
 	// this is expected to fail when not run as root
 	err = SetPIDLimit(4096)
 	if err != nil {
-		t.Logf("failed to set PID limit, are you running as root?")
+		t.Log("failed to set PID limit, are you running as root?")
 	} else {
 		// in case it worked, reset to the previous value
 		err = SetPIDLimit(limit)


### PR DESCRIPTION
If the string formatting is not required use Error and Log.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>