### PR TITLE
Log error message for cephfs

### DIFF
--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -147,10 +147,12 @@ func loadAvailableMounters(conf *util.Config) error {
 	kernelMounterProbe := exec.Command("mount.ceph")
 
 	err := kernelMounterProbe.Run()
-	if err == nil {
+	if err != nil {
+		klog.Errorf("failed to run mount.ceph %v", err)
+	} else {
 		// fetch the current running kernel info
 		utsname := unix.Utsname{}
-		err := unix.Uname(&utsname)
+		err = unix.Uname(&utsname)
 		if err != nil {
 			return err
 		}
@@ -164,7 +166,10 @@ func loadAvailableMounters(conf *util.Config) error {
 		}
 	}
 
-	if fuseMounterProbe.Run() == nil {
+	err = fuseMounterProbe.Run()
+	if err != nil {
+		klog.Errorf("failed to run ceph-fuse %v", err)
+	} else {
 		klog.V(1).Infof("loaded mounter: %s", volumeMounterFuse)
 		availableMounters = append(availableMounters, volumeMounterFuse)
 	}


### PR DESCRIPTION
If the loading of cephfs fuse or the mount.ceph command fails log the error message.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>