### PR TITLE
Update csi-provisioner from v1.4.0 to v1.6.0

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -132,7 +132,7 @@ provisioner:
   provisioner:
     image:
       repository: quay.io/k8scsi/csi-provisioner
-      tag: v1.4.0
+      tag: v1.6.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -142,7 +142,7 @@ provisioner:
   provisioner:
     image:
       repository: quay.io/k8scsi/csi-provisioner
-      tag: v1.4.0
+      tag: v1.6.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccount: cephfs-csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.4.0
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccount: rbd-csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.4.0
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -135,7 +135,7 @@ k8s-sidecar)
     echo "copying the kubernetes sidecar images"
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1 "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0
+    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.6.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.6.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.3.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.3.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0 "${K8S_IMAGE_REPO}"/csi-resizer:v0.4.0
     ;;


### PR DESCRIPTION
# Describe what this PR does #

All external-provisioner versions < 1.4.0 are deprecated and will stop functioning in Kubernetes v1.20. See #323 and k/k#80978 for more details. Upgrade your external-provisioner to v1.4+ before Kubernetes v1.20.

See https://github.com/kubernetes-csi/external-provisioner/releases/tag/v1.5.0
See https://github.com/kubernetes-csi/external-provisioner/blob/release-1.5/CHANGELOG-1.5.md

See https://github.com/kubernetes-csi/external-provisioner/releases/tag/v1.6.0
See https://github.com/kubernetes-csi/external-provisioner/blob/release-1.6/CHANGELOG-1.6.md



## Is there anything that requires special attention ##

From #767 we postpone the upgrade into v1.5.0 due to its breaking changes; BTW it is now v1.6.0 so shall we catch it up?

