### PR TITLE
Update golang to 1.13.9

### DIFF
--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -1,12 +1,18 @@
 FROM ceph/ceph:v15
 
 ENV GOPATH=/go \
-	GO111MODULE=on
+ GOROOT=/usr/local/go \
+ GO111MODULE=on
+
+RUN mkdir -p /usr/local/go && \
+ curl https://storage.googleapis.com/golang/go1.13.9.linux-amd64.tar.gz | tar xzf - -C /usr/local/go --strip-components=1
+
+ENV PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
 
 RUN yum -y install \
-	golang \
 	git \
 	make \
+	gcc \
 	librados-devel \
 	librbd-devel \
     && yum -y update \


### PR DESCRIPTION
The attempt here is update the golang to latest version . 

Its necessary as we have a failure mentioned @ https://github.com/ceph/ceph-csi/pull/917#issuecomment-609998502 . May be updating to `1.13.9` is enough. 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

