### PR TITLE
Fix regression when using non-admin Ceph user/credentials

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -425,6 +425,39 @@ func createRBDSecret(c kubernetes.Interface, f *framework.Framework) {
 	sc.Namespace = cephCSINamespace
 	_, err := c.CoreV1().Secrets(cephCSINamespace).Create(&sc)
 	Expect(err).Should(BeNil())
+
+	err = updateSecretForEncryption(c)
+	Expect(err).Should(BeNil())
+}
+
+// updateSecretForEncryption is an hack to update the secrets created by rook to
+// include the encyption key
+// TODO in cephcsi we need to create own users in ceph cluster and use it for E2E
+func updateSecretForEncryption(c kubernetes.Interface) error {
+	secrets, err := c.CoreV1().Secrets(rookNamespace).Get(rbdProvisionerSecretName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	secrets.Data["encryptionPassphrase"] = []byte("test_passphrase")
+
+	_, err = c.CoreV1().Secrets(rookNamespace).Update(secrets)
+	if err != nil {
+		return err
+	}
+
+	secrets, err = c.CoreV1().Secrets(rookNamespace).Get(rbdNodePluginSecretName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	secrets.Data["encryptionPassphrase"] = []byte("test_passphrase")
+
+	_, err = c.CoreV1().Secrets(rookNamespace).Update(secrets)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func deleteResource(scPath string) {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -33,6 +33,14 @@ import (
 const (
 	defaultNs     = "default"
 	vaultSecretNs = "/secret/ceph-csi/" // nolint: gosec
+
+	// rook created cephfs user
+	cephfsNodePluginSecretName  = "rook-csi-cephfs-node"        // nolint: gosec
+	cephfsProvisionerSecretName = "rook-csi-cephfs-provisioner" // nolint: gosec
+
+	// rook created rbd user
+	rbdNodePluginSecretName  = "rook-csi-rbd-node"        // nolint: gosec
+	rbdProvisionerSecretName = "rook-csi-rbd-provisioner" // nolint: gosec
 )
 
 var (
@@ -260,9 +268,14 @@ func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, en
 	scPath := fmt.Sprintf("%s/%s", cephfsExamplePath, "storageclass.yaml")
 	sc := getStorageClass(scPath)
 	sc.Parameters["fsName"] = "myfs"
-	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = cephCSINamespace
-	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-namespace"] = cephCSINamespace
-	sc.Parameters["csi.storage.k8s.io/node-stage-secret-namespace"] = cephCSINamespace
+	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = rookNamespace
+	sc.Parameters["csi.storage.k8s.io/provisioner-secret-name"] = cephfsProvisionerSecretName
+
+	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-namespace"] = rookNamespace
+	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-name"] = cephfsProvisionerSecretName
+
+	sc.Parameters["csi.storage.k8s.io/node-stage-secret-namespace"] = rookNamespace
+	sc.Parameters["csi.storage.k8s.io/node-stage-secret-name"] = cephfsNodePluginSecretName
 
 	if enablePool {
 		sc.Parameters["pool"] = "myfs-data0"
@@ -284,9 +297,14 @@ func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, param
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc := getStorageClass(scPath)
 	sc.Parameters["pool"] = "replicapool"
-	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = cephCSINamespace
-	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-namespace"] = cephCSINamespace
-	sc.Parameters["csi.storage.k8s.io/node-stage-secret-namespace"] = cephCSINamespace
+	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = rookNamespace
+	sc.Parameters["csi.storage.k8s.io/provisioner-secret-name"] = rbdProvisionerSecretName
+
+	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-namespace"] = rookNamespace
+	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-name"] = rbdProvisionerSecretName
+
+	sc.Parameters["csi.storage.k8s.io/node-stage-secret-namespace"] = rookNamespace
+	sc.Parameters["csi.storage.k8s.io/node-stage-secret-name"] = rbdNodePluginSecretName
 
 	opt := metav1.ListOptions{
 		LabelSelector: "app=rook-ceph-tools",

--- a/pkg/rbd/rbd_util.go
+++ b/pkg/rbd/rbd_util.go
@@ -165,7 +165,7 @@ func createImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 
 func (rv *rbdVolume) getIoctx(cr *util.Credentials) (*rados.IOContext, error) {
 	if rv.conn == nil {
-		conn, err := connPool.Get(rv.Pool, rv.Monitors, cr.KeyFile)
+		conn, err := connPool.Get(rv.Pool, rv.Monitors, cr.ID, cr.KeyFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get connection")
 		}

--- a/pkg/util/conn_pool.go
+++ b/pkg/util/conn_pool.go
@@ -95,14 +95,14 @@ func (cp *ConnPool) Destroy() {
 	}
 }
 
-func (cp *ConnPool) generateUniqueKey(pool, monitors, keyfile string) (string, error) {
+func (cp *ConnPool) generateUniqueKey(pool, monitors, user, keyfile string) (string, error) {
 	// the keyfile can be unique for operations, contents will be the same
 	key, err := ioutil.ReadFile(keyfile) // nolint: gosec, #nosec
 	if err != nil {
 		return "", errors.Wrapf(err, "could not open keyfile %s", keyfile)
 	}
 
-	return fmt.Sprintf("%s|%s|%s", pool, monitors, string(key)), nil
+	return fmt.Sprintf("%s|%s|%s|%s", pool, monitors, user, string(key)), nil
 }
 
 // getExisting returns the existing rados.Conn associated with the unique key.
@@ -120,8 +120,8 @@ func (cp *ConnPool) getConn(unique string) *rados.Conn {
 // Get returns a rados.Conn for the given arguments. Creates a new rados.Conn in
 // case there is none in the pool. Use the returned unique string to reduce the
 // reference count with ConnPool.Put(unique).
-func (cp *ConnPool) Get(pool, monitors, keyfile string) (*rados.Conn, error) {
-	unique, err := cp.generateUniqueKey(pool, monitors, keyfile)
+func (cp *ConnPool) Get(pool, monitors, user, keyfile string) (*rados.Conn, error) {
+	unique, err := cp.generateUniqueKey(pool, monitors, user, keyfile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate unique for connection")
 	}
@@ -135,7 +135,7 @@ func (cp *ConnPool) Get(pool, monitors, keyfile string) (*rados.Conn, error) {
 
 	// construct and connect a new rados.Conn
 	args := []string{"-m", monitors, "--keyfile=" + keyfile}
-	conn, err = rados.NewConn()
+	conn, err = rados.NewConnWithUser(user)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating a new connection failed")
 	}

--- a/pkg/util/conn_pool_test.go
+++ b/pkg/util/conn_pool_test.go
@@ -34,8 +34,8 @@ const (
 // working Ceph cluster to connect to.
 //
 // This is mostly a copy of ConnPool.Get()
-func (cp *ConnPool) fakeGet(pool, monitors, keyfile string) (*rados.Conn, string, error) {
-	unique, err := cp.generateUniqueKey(pool, monitors, keyfile)
+func (cp *ConnPool) fakeGet(pool, monitors, user, keyfile string) (*rados.Conn, string, error) {
+	unique, err := cp.generateUniqueKey(pool, monitors, user, keyfile)
 	if err != nil {
 		return nil, "", err
 	}
@@ -91,7 +91,7 @@ func TestConnPool(t *testing.T) {
 	var unique string
 
 	t.Run("fakeGet", func(t *testing.T) {
-		conn, unique, err = cp.fakeGet("pool", "monitors", keyfile)
+		conn, unique, err = cp.fakeGet("pool", "monitors", "user", keyfile)
 		if err != nil {
 			t.Errorf("failed to get connection: %v", err)
 		}
@@ -115,7 +115,7 @@ func TestConnPool(t *testing.T) {
 
 	t.Run("doubleFakeGet", func(t *testing.T) {
 		// after a 2nd get, there should still be a single conn in cp.conns
-		_, _, err = cp.fakeGet("pool", "monitors", keyfile)
+		_, _, err = cp.fakeGet("pool", "monitors", "user", keyfile)
 		if err != nil {
 			t.Errorf("failed to get connection: %v", err)
 		}


### PR DESCRIPTION
Connect to the Ceph cluster by passing the user-id stored in the util.Credentials.
Before, the user-id was not passed, and so the default (admin) user was used to connect. This causes problems if the credentials belong to a different user.

Updated E2E to use a normal user other than admin user, who is having access to create and mount cephfs PVC and create and map rbd PVC

Fixes: #904