### PR TITLE
Fix helm clean in functional test

### DIFF
--- a/scripts/travis-helmtest.sh
+++ b/scripts/travis-helmtest.sh
@@ -21,5 +21,5 @@ go test github.com/ceph/ceph-csi/e2e -mod=vendor --deploy-timeout=10 -timeout=30
 
 #cleanup
 scripts/install-helm.sh cleanup-cephcsi
-scripts/install-helm.sh cleanup
+scripts/install-helm.sh clean
 sudo scripts/minikube.sh clean


### PR DESCRIPTION
The command to helm cleanup script in functional tests was incorrect this fixes the same.

Signed-off-by: Madhu Rajanna <madhupr0gmail.com>

