### PR TITLE
Support externally managed configmap.

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csiplugin-configmap.yaml
+++ b/charts/ceph-csi-cephfs/templates/csiplugin-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externallyManagedConfigmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,3 +13,4 @@ metadata:
 data:
   config.json: |-
 {{ toJson .Values.csiConfig | indent 4 -}}
+{{- end }}

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -187,6 +187,11 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}
+{{- if .Values.configMapKey }}
+            items:
+              - key: {{ .Values.configMapKey | quote }}
+                path: config.json
+{{- end }}
         - name: keys-tmp-dir
           emptyDir: {
             medium: "Memory"

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -173,6 +173,11 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}
+{{- if .Values.configMapKey }}
+            items:
+              - key: {{ .Values.configMapKey | quote }}
+                path: config.json
+{{- end }}
         - name: keys-tmp-dir
           emptyDir: {
             medium: "Memory"

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -183,3 +183,7 @@ pluginDir: /var/lib/kubelet/plugins
 driverName: cephfs.csi.ceph.com
 # Name of the configmap used for state
 configMapName: ceph-csi-config-cephfs
+# Key to use in the Configmap if not config.json
+configMapKey:
+# Use an externally provided configmap
+externallyManagedConfigmap: false

--- a/charts/ceph-csi-rbd/templates/csiplugin-configmap.yaml
+++ b/charts/ceph-csi-rbd/templates/csiplugin-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externallyManagedConfigmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,3 +13,4 @@ metadata:
 data:
   config.json: |-
 {{ toJson .Values.csiConfig | indent 4 -}}
+{{- end }}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -186,6 +186,11 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}
+{{- if .Values.configMapKey }}
+            items:
+              - key: {{ .Values.configMapKey | quote }}
+                path: config.json
+{{- end }}
         - name: ceph-csi-encryption-kms-config
           configMap:
             name: {{ .Values.kmsConfigMapName | quote }}

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -190,6 +190,11 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}
+{{- if .Values.configMapKey }}
+            items:
+              - key: {{ .Values.configMapKey | quote }}
+                path: config.json
+{{- end }}
         - name: ceph-csi-encryption-kms-config
           configMap:
             name: {{ .Values.kmsConfigMapName | quote }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -200,5 +200,9 @@ pluginDir: /var/lib/kubelet/plugins
 driverName: rbd.csi.ceph.com
 # Name of the configmap used for state
 configMapName: ceph-csi-config-rbd
+# Key to use in the Configmap if not config.json
+configMapKey:
+# Use an externally provided configmap
+externallyManagedConfigmap: false
 # Name of the configmap used for encryption kms configuration
 kmsConfigMapName: ceph-csi-encryption-kms-config


### PR DESCRIPTION
This PR enables an externally managed configmap to be use with the csi driver.

This works with the rook-ceph operator

## Related issues ##
fixes https://github.com/ceph/ceph-csi/issues/927
