### PR TITLE
Fix issue for ro mount option

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -61,6 +61,7 @@ spec:
             - "--nodeserver=true"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
+            - "--forcecephkernelclient=false"
             - "--drivername=cephfs.csi.ceph.com"
             - "--metadatastorage=k8s_configmap"
             # If topology based provisioning is desired, configure required

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -11,6 +11,11 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
+const (
+	// force use the kernel client in E2E
+	useKernelClient = true
+)
+
 var (
 	cephfsProvisioner     = "csi-cephfsplugin-provisioner.yaml"
 	cephfsProvisionerRBAC = "csi-provisioner-rbac.yaml"
@@ -82,6 +87,8 @@ func createORDeleteCephfsResouces(action string) {
 	}
 
 	data, err = replaceNamespaceInTemplate(cephfsDirPath + cephfsNodePlugin)
+
+	data = strings.ReplaceAll(data, "forcecephkernelclient=false", fmt.Sprintf("forcecephkernelclient=%t", useKernelClient))
 	if err != nil {
 		e2elog.Logf("failed to read content from %s %v", cephfsDirPath+cephfsNodePlugin, err)
 	}

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -168,12 +168,12 @@ var _ = Describe("cephfs", func() {
 			}
 
 			By("create a storage class with pool and a PVC then Bind it to an app", func() {
-				createCephfsStorageClass(f.ClientSet, f, true)
+				createCephfsStorageClass(f.ClientSet, f, true, nil)
 				validatePVCAndAppBinding(pvcPath, appPath, f)
 				deleteResource(cephfsExamplePath + "storageclass.yaml")
 			})
 
-			createCephfsStorageClass(f.ClientSet, f, false)
+			createCephfsStorageClass(f.ClientSet, f, false, nil)
 
 			By("create and delete a PVC", func() {
 				By("create a PVC and Bind it to an app", func() {
@@ -266,6 +266,21 @@ var _ = Describe("cephfs", func() {
 						}
 					}
 
+				})
+
+				By("create storage class with mountoption ro", func() {
+					mountFlag := "ro"
+					deleteResource(cephfsExamplePath + "storageclass.yaml")
+					createCephfsStorageClass(f.ClientSet, f, false, map[string]string{"mountOptions": mountFlag})
+
+					mountFlags := []string{mountFlag}
+					err := checkMountOptions(pvcPath, appPath, f, mountFlags)
+					if err != nil {
+						Fail(err.Error())
+					}
+					// cleanup and undo changes made by the test
+					deleteResource(cephfsExamplePath + "storageclass.yaml")
+					createCephfsStorageClass(f.ClientSet, f, false, nil)
 				})
 
 				// Make sure this should be last testcase in this file, because

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -562,6 +562,21 @@ var _ = Describe("RBD", func() {
 				createRBDStorageClass(f.ClientSet, f, nil, nil)
 			})
 
+			By("create storage class with mountoption ro", func() {
+				mountFlag := "ro"
+				deleteResource(rbdExamplePath + "storageclass.yaml")
+				createRBDStorageClass(f.ClientSet, f, map[string]string{"mountOptions": mountFlag}, nil)
+
+				mountFlags := []string{mountFlag}
+				err := checkMountOptions(pvcPath, appPath, f, mountFlags)
+				if err != nil {
+					Fail(err.Error())
+				}
+				// cleanup and undo changes made by the test
+				deleteResource(rbdExamplePath + "storageclass.yaml")
+				createRBDStorageClass(f.ClientSet, f, nil, nil)
+			})
+
 			// Make sure this should be last testcase in this file, because
 			// it deletes pool
 			By("Create a PVC and Delete PVC when backend pool deleted", func() {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo" // nolint
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
@@ -568,10 +569,62 @@ var _ = Describe("RBD", func() {
 				createRBDStorageClass(f.ClientSet, f, map[string]string{"mountOptions": mountFlag}, nil)
 
 				mountFlags := []string{mountFlag}
+				// check the mountpoint as ro flag
 				err := checkMountOptions(pvcPath, appPath, f, mountFlags)
 				if err != nil {
 					Fail(err.Error())
 				}
+
+				// create pvc and app pod. check app pod is able to write data
+				// to mount point
+				totalCount := 3
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					Fail(err.Error())
+				}
+				pvc.Namespace = f.UniqueName
+				app, err := loadApp(appPath)
+				if err != nil {
+					Fail(err.Error())
+				}
+				app.Namespace = f.UniqueName
+				// create pvc and app
+				for i := 0; i < totalCount; i++ {
+					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					label := map[string]string{
+						"app": name,
+					}
+					app.Labels = label
+					err := createPVCAndApp(name, f, pvc, app, deployTimeout)
+					if err != nil {
+						Fail(err.Error())
+					}
+				}
+
+				for i := 0; i < totalCount; i++ {
+					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					opt := metav1.ListOptions{
+						LabelSelector: fmt.Sprintf("app=%s", name),
+					}
+
+					filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
+					_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo 'Hello World' > %s", filePath), app.Namespace, &opt)
+					readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
+					if !strings.Contains(stdErr, readOnlyErr) {
+						Fail(stdErr)
+					}
+				}
+
+				// delete pvc and app
+				for i := 0; i < totalCount; i++ {
+					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					err := deletePVCAndApp(name, f, pvc, app)
+					if err != nil {
+						Fail(err.Error())
+					}
+
+				}
+
 				// cleanup and undo changes made by the test
 				deleteResource(rbdExamplePath + "storageclass.yaml")
 				createRBDStorageClass(f.ClientSet, f, nil, nil)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -265,7 +265,7 @@ func getStorageClass(path string) scv1.StorageClass {
 // 	return sc
 // }
 
-func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, enablePool bool, mountOption map[string]string) {
+func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, enablePool bool, parameters map[string]string) {
 	scPath := fmt.Sprintf("%s/%s", cephfsExamplePath, "storageclass.yaml")
 	sc := getStorageClass(scPath)
 	sc.Parameters["fsName"] = "myfs"
@@ -291,10 +291,8 @@ func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, en
 	sc.Namespace = cephCSINamespace
 	sc.Parameters["clusterID"] = fsID
 
-	for key, val := range mountOption {
-		if key == "mountOption" {
-			sc.MountOptions = append(sc.MountOptions, val)
-		}
+	for key, val := range parameters {
+		sc.Parameters[key] = val
 	}
 	_, err := c.StorageV1().StorageClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
 	Expect(err).Should(BeNil())

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -321,10 +321,16 @@ func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, scOpt
 	}
 	sc.Namespace = cephCSINamespace
 
-	if scOptions["volumeBindingMode"] == "WaitForFirstConsumer" {
-		value := scv1.VolumeBindingWaitForFirstConsumer
-		sc.VolumeBindingMode = &value
+	for key, val := range scOptions {
+		if key == "WaitForFirstConsumer" {
+			value := scv1.VolumeBindingWaitForFirstConsumer
+			sc.VolumeBindingMode = &value
+		}
+		if key == "mountOptions" {
+			sc.MountOptions = append(sc.MountOptions, val)
+		}
 	}
+
 	_, err := c.StorageV1().StorageClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
 	Expect(err).Should(BeNil())
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -265,7 +265,7 @@ func getStorageClass(path string) scv1.StorageClass {
 // 	return sc
 // }
 
-func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, enablePool bool) {
+func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, enablePool bool, mountOption map[string]string) {
 	scPath := fmt.Sprintf("%s/%s", cephfsExamplePath, "storageclass.yaml")
 	sc := getStorageClass(scPath)
 	sc.Parameters["fsName"] = "myfs"
@@ -290,6 +290,12 @@ func createCephfsStorageClass(c kubernetes.Interface, f *framework.Framework, en
 	fsID = strings.Trim(fsID, "\n")
 	sc.Namespace = cephCSINamespace
 	sc.Parameters["clusterID"] = fsID
+
+	for key, val := range mountOption {
+		if key == "mountOption" {
+			sc.MountOptions = append(sc.MountOptions, val)
+		}
+	}
 	_, err := c.StorageV1().StorageClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
 	Expect(err).Should(BeNil())
 }

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -213,6 +213,11 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		err = os.Chmod(targetPath, 0777)
 		if err != nil {
 			klog.Errorf(util.Log(ctx, "failed to change targetpath permission for volume %s: %v"), volID, err)
+
+			uErr := unmountVolume(ctx, targetPath)
+			if uErr != nil {
+				klog.Errorf(util.Log(ctx, "failed to unmount target path %s for volume %s: %v"), targetPath, volID, uErr)
+			}
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -208,11 +208,13 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	klog.V(4).Infof(util.Log(ctx, "cephfs: successfully bind-mounted volume %s to %s"), volID, targetPath)
 
-	// #nosec - allow anyone to write inside the target path
-	err = os.Chmod(targetPath, 0777)
-	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to change targetpath permission for volume %s: %v"), volID, err)
-		return nil, status.Error(codes.Internal, err.Error())
+	if !csicommon.Contains(mountOptions, "ro") {
+		// #nosec - allow anyone to write inside the target path
+		err = os.Chmod(targetPath, 0777)
+		if err != nil {
+			klog.Errorf(util.Log(ctx, "failed to change targetpath permission for volume %s: %v"), volID, err)
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/cephfs/nodeserver.go
+++ b/pkg/cephfs/nodeserver.go
@@ -201,7 +201,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// It's not, mount now
 
-	if err = bindMount(ctx, req.GetStagingTargetPath(), req.GetTargetPath(), req.GetReadonly(), mountOptions); err != nil {
+	if err = bindMount(ctx, req.GetStagingTargetPath(), req.GetTargetPath(), mountOptions); err != nil {
 		klog.Errorf(util.Log(ctx, "failed to bind-mount volume %s: %v"), volID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"sync"
 
-	csicommon "github.com/ceph/ceph-csi/pkg/csi-common"
 	"github.com/ceph/ceph-csi/pkg/util"
 
 	"golang.org/x/sys/unix"
@@ -322,7 +321,7 @@ func bindMount(ctx context.Context, from, to string, mntOptions []string) error 
 		return fmt.Errorf("failed to bind-mount %s to %s: %v", from, to, err)
 	}
 
-	if csicommon.Contains(mntOptions, "ro") {
+	if util.Contains(mntOptions, "ro") {
 		mntOptionSli += ",remount"
 		if err := execCommandErr(ctx, "mount", "-o", mntOptionSli, to); err != nil {
 			return fmt.Errorf("failed read-only remount of %s: %v", to, err)

--- a/pkg/cephfs/volumemounter.go
+++ b/pkg/cephfs/volumemounter.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 
+	csicommon "github.com/ceph/ceph-csi/pkg/csi-common"
 	"github.com/ceph/ceph-csi/pkg/util"
 
 	"golang.org/x/sys/unix"
@@ -315,13 +316,13 @@ func (m *kernelMounter) mount(ctx context.Context, mountPoint string, cr *util.C
 
 func (m *kernelMounter) name() string { return "Ceph kernel client" }
 
-func bindMount(ctx context.Context, from, to string, readOnly bool, mntOptions []string) error {
+func bindMount(ctx context.Context, from, to string, mntOptions []string) error {
 	mntOptionSli := strings.Join(mntOptions, ",")
 	if err := execCommandErr(ctx, "mount", "-o", mntOptionSli, from, to); err != nil {
 		return fmt.Errorf("failed to bind-mount %s to %s: %v", from, to, err)
 	}
 
-	if readOnly {
+	if csicommon.Contains(mntOptions, "ro") {
 		mntOptionSli += ",remount"
 		if err := execCommandErr(ctx, "mount", "-o", mntOptionSli, to); err != nil {
 			return fmt.Errorf("failed read-only remount of %s: %v", to, err)

--- a/pkg/csi-common/nodeserver-default.go
+++ b/pkg/csi-common/nodeserver-default.go
@@ -175,33 +175,3 @@ func (ns *DefaultNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.No
 		},
 	}, nil
 }
-
-// ConstructMountOptions returns only unique mount options in slice
-func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) []string {
-	if m := volCap.GetMount(); m != nil {
-		hasOption := func(options []string, opt string) bool {
-			for _, o := range options {
-				if o == opt {
-					return true
-				}
-			}
-			return false
-		}
-		for _, f := range m.MountFlags {
-			if !hasOption(mountOptions, f) {
-				mountOptions = append(mountOptions, f)
-			}
-		}
-	}
-	return mountOptions
-}
-
-// Contains checks the opt is present in mountOptions
-func Contains(mountOptions []string, opt string) bool {
-	for _, mnt := range mountOptions {
-		if mnt == opt {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/csi-common/nodeserver-default.go
+++ b/pkg/csi-common/nodeserver-default.go
@@ -195,3 +195,13 @@ func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) 
 	}
 	return mountOptions
 }
+
+// Contains checks the opt is present in mountOptions
+func Contains(mountOptions []string, opt string) bool {
+	for _, mnt := range mountOptions {
+		if mnt == opt {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -409,11 +409,11 @@ func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeS
 	}
 
 	opt := []string{"_netdev"}
-	opt = csicommon.ConstructMountOptions(opt, req.GetVolumeCapability())
+	opt = util.ConstructMountOptions(opt, req.GetVolumeCapability())
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 
 	rOnly := "ro"
-	if csicommon.Contains(opt, rOnly) {
+	if util.Contains(opt, rOnly) {
 		readOnly = true
 	}
 
@@ -437,7 +437,7 @@ func (ns *NodeServer) mountVolume(ctx context.Context, stagingPath string, req *
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	targetPath := req.GetTargetPath()
 
-	mountOptions = csicommon.ConstructMountOptions(mountOptions, req.GetVolumeCapability())
+	mountOptions = util.ConstructMountOptions(mountOptions, req.GetVolumeCapability())
 
 	klog.V(4).Infof(util.Log(ctx, "target %v\nisBlock %v\nfstype %v\nstagingPath %v\nreadonly %v\nmountflags %v\n"),
 		targetPath, isBlock, fsType, stagingPath, readOnly, mountOptions)

--- a/pkg/util/mount.go
+++ b/pkg/util/mount.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"strings"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+// ConstructMountOptions returns only unique mount options in slice
+func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) []string {
+	if m := volCap.GetMount(); m != nil {
+		hasOption := func(options []string, opt string) bool {
+			for _, o := range options {
+				if o == opt {
+					return true
+				}
+			}
+			return false
+		}
+		for _, f := range m.MountFlags {
+			if !hasOption(mountOptions, f) {
+				mountOptions = append(mountOptions, f)
+			}
+		}
+	}
+	return mountOptions
+}
+
+// Contains checks the opt is present in mountOptions
+func Contains(mountOptions []string, opt string) bool {
+	for _, mnt := range mountOptions {
+		if mnt == opt {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckROMountFlag checks the options has the `ro flag`
+func CheckROMountFlag(options map[string]string, param, flag string) bool {
+	if o, ok := options[param]; ok {
+		mOpt := strings.Split(o, ",")
+		for _, m := range mOpt {
+			if m == flag {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/util/mount_test.go
+++ b/pkg/util/mount_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"testing"
+)
+
+func TestCheckROMountFlag(t *testing.T) {
+	type args struct {
+		options map[string]string
+		param   string
+		flag    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"Testing cephfs fuse ro mount option",
+			args{
+				options: map[string]string{"fuseMountOptions": "debug"},
+				param:   "fuseMountOptions",
+				flag:    "ro",
+			},
+			false,
+		},
+
+		{
+			"Testing cephfs kernel ro mount option",
+			args{
+				options: map[string]string{"kernelMountOptions": "readdir_max_bytes=1048576,norbytes,ro"},
+				param:   "kernelMountOptions",
+				flag:    "ro",
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckROMountFlag(ts.args.options, ts.args.param, ts.args.flag); got != ts.want {
+				t.Errorf("CheckROMountFlag() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	type args struct {
+		mountOptions []string
+		opt          string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"Testing mount options contains string",
+			args{
+				mountOptions: []string{"debug", "ro"},
+				opt:          "ro"},
+			true,
+		},
+		{"Testing mount options doesnt contains string",
+			args{
+				mountOptions: []string{"debug", "ro"},
+				opt:          "_netdev"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		ts := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Contains(ts.args.mountOptions, ts.args.opt); got != ts.want {
+				t.Errorf("Contains() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -144,7 +144,7 @@ install_cephcsi_helm_charts() {
     done
 
     # install ceph-csi-cephfs and ceph-csi-rbd charts
-    "${HELM}" install "${SCRIPT_DIR}"/../charts/ceph-csi-cephfs --name ${CEPHFS_CHART_NAME} --namespace ${NAMESPACE} --set provisioner.fullnameOverride=csi-cephfsplugin-provisioner --set nodeplugin.fullnameOverride=csi-cephfsplugin --set configMapName=ceph-csi-config --set provisioner.podSecurityPolicy.enabled=true --set nodeplugin.podSecurityPolicy.enabled=true
+    "${HELM}" install "${SCRIPT_DIR}"/../charts/ceph-csi-cephfs --name ${CEPHFS_CHART_NAME} --namespace ${NAMESPACE} --set provisioner.fullnameOverride=csi-cephfsplugin-provisioner --set nodeplugin.fullnameOverride=csi-cephfsplugin --set configMapName=ceph-csi-config --set provisioner.podSecurityPolicy.enabled=true --set nodeplugin.podSecurityPolicy.enabled=true --set nodeplugin.forcecephkernelclient=true
 
     check_deployment_status app=ceph-csi-cephfs ${NAMESPACE}
     check_daemonset_status app=ceph-csi-cephfs ${NAMESPACE}


### PR DESCRIPTION

# Describe what this PR does #

Added an e2e for testing the PVC and pod mounting created with storage class with mount options `ro`.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Provide some context for the reviewer
with current code, the PVC created with storage-class which is having `ro` as mount option is failing to mount the PVC to the app pod.

## Is there anything that requires special attention ##

Do you have any questions?
No

Is the change backward compatible?
Yes

Are there concerns around backward compatibility?
No

fixes https://github.com/ceph/ceph-csi/issues/953
fixes https://github.com/ceph/ceph-csi/issues/952