### PR TITLE
travis: split static checks and continue with tests in case one fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,11 @@ jobs:
         # install helm for helm lint
         - curl -L https://git.io/get_helm.sh | bash
       script:
-        - make static-check
+        - make go-lint
+        - make go-lint-text
+        - make gosec
         - make go-test
-        - make mod-check || travis_terminate 1;
+        - make mod-check
 
     - name: containerized build
       script:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ endif
 
 all: cephcsi
 
+.PHONY: go-test static-check mod-check go-lint go-lint-text gosec
 test: go-test static-check mod-check
+static-check: go-lint go-lint-text gosec
 
 go-test:
 	./scripts/test-go.sh
@@ -52,9 +54,13 @@ go-test:
 mod-check:
 	go mod verify
 
-static-check:
+go-lint:
 	./scripts/lint-go.sh
+
+go-lint-text:
 	./scripts/lint-text.sh --require-all
+
+gosec:
 	./scripts/gosec.sh
 
 func-test:


### PR DESCRIPTION
Run all `make static-checks`, even in case one fails.