### PR TITLE
Insert backend storage name into volumeAttributes

### DIFF
--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -96,10 +96,12 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// TODO return error message if requested vol size greater than found volume return error
 
 	if vID != nil {
+		volumeContext := req.GetParameters()
+		volumeContext["subvolumeName"] = vID.FsSubvolName
 		volume := &csi.Volume{
 			VolumeId:      vID.VolumeID,
 			CapacityBytes: volOptions.Size,
-			VolumeContext: req.GetParameters(),
+			VolumeContext: volumeContext,
 		}
 		if volOptions.Topology != nil {
 			volume.AccessibleTopology =
@@ -136,10 +138,12 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	klog.V(4).Infof(util.Log(ctx, "cephfs: successfully created backing volume named %s for request name %s"),
 		vID.FsSubvolName, requestName)
 
+	volumeContext := req.GetParameters()
+	volumeContext["subvolumeName"] = vID.FsSubvolName
 	volume := &csi.Volume{
 		VolumeId:      vID.VolumeID,
 		CapacityBytes: volOptions.Size,
-		VolumeContext: req.GetParameters(),
+		VolumeContext: volumeContext,
 	}
 	if volOptions.Topology != nil {
 		volume.AccessibleTopology =

--- a/pkg/rbd/controllerserver.go
+++ b/pkg/rbd/controllerserver.go
@@ -176,6 +176,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		volumeContext := req.GetParameters()
 		volumeContext["pool"] = rbdVol.Pool
 		volumeContext["journalPool"] = rbdVol.JournalPool
+		volumeContext["imageName"] = rbdVol.RbdImageName
 		volume := &csi.Volume{
 			VolumeId:      rbdVol.VolID,
 			CapacityBytes: rbdVol.VolSize,
@@ -233,6 +234,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volumeContext := req.GetParameters()
 	volumeContext["pool"] = rbdVol.Pool
 	volumeContext["journalPool"] = rbdVol.JournalPool
+	volumeContext["imageName"] = rbdVol.RbdImageName
 	volume := &csi.Volume{
 		VolumeId:      rbdVol.VolID,
 		CapacityBytes: rbdVol.VolSize,


### PR DESCRIPTION
1. insert "imageName" field to pv with storage rbd
2. insert "subvolumeName" field to pv with storage cephfs

# Describe what this PR does #

Make dynamically provisioned volumes (PVC-PV-ceph) recognizably related

## Related issues ##

#780 

