### PR TITLE
add make target for containerized tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,9 @@ jobs:
         - make go-test
         - make mod-check || travis_terminate 1;
 
-    - name: containerized build
+    - name: containerized test (Fedora) and build (CentOS)
       script:
+        - make containerized-test || travis_terminate 1;
         - make containerized-build || travis_terminate 1;
 
     - name: cephcsi with kube 1.14.10

--- a/Makefile
+++ b/Makefile
@@ -65,15 +65,24 @@ cephcsi:
 	if [ ! -d ./vendor ]; then (go mod tidy && go mod vendor); fi
 	GOOS=linux GOARCH=$(GOARCH) go build -mod vendor -a -ldflags '$(LDFLAGS)' -o _output/cephcsi ./cmd/
 
-.PHONY: containerized-build
+.PHONY: containerized-build containerized-test
 containerized-build: .devel-container-id
 	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make -C /go/src/github.com/ceph/ceph-csi cephcsi
+
+containerized-test: .test-container-id
+	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make test
 
 # create a (cached) container image with dependencied for building cephcsi
 .devel-container-id: scripts/Dockerfile.devel
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
 	$(CONTAINER_CMD) build -t $(CSI_IMAGE_NAME):devel -f ./scripts/Dockerfile.devel .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):devel > .devel-container-id
+
+# create a (cached) container image with dependencied for testing cephcsi
+.test-container-id: scripts/Dockerfile.test
+	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
+	$(CONTAINER_CMD) build -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
+	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 
 image-cephcsi: cephcsi
 	cp _output/cephcsi deploy/cephcsi/image/cephcsi
@@ -87,8 +96,10 @@ push-image-cephcsi: image-cephcsi
 	if [ $(GOARCH) = amd64 ]; then $(CONTAINER_CMD) push $(CSI_IMAGE); fi
 
 clean:
-	go clean -r -x
+	go clean -mod=vendor -r -x
 	rm -f deploy/cephcsi/image/cephcsi
 	rm -f _output/cephcsi
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
 	$(RM) .devel-container-id
+	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
+	$(RM) .test-container-id

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -1,0 +1,43 @@
+# Container image for running the Ceph-CSI tests
+#
+# This container is based on Fedora so that recent versions of tools can easily
+# be installed.
+#
+# Production containers are based one ceph/ceph:latest, which use CentOS as
+# Operating System, so generated binaries and versions of dependencies may be a
+# little different.
+#
+
+FROM fedora:latest
+
+ARG GOLANGCI_VERSION=v1.21.0
+ARG GOSEC_VERSION=2.0.0
+ARG GOPATH=/go
+
+ENV \
+ GOPATH=${GOPATH} \
+ GO111MODULE=on \
+ PATH="${GOPATH}/bin:${PATH}"
+
+
+RUN dnf -y install \
+	git \
+	make \
+	golang \
+	gcc \
+	librados-devel \
+	librbd-devel \
+	rubygems \
+	ShellCheck \
+	yamllint \
+    && dnf -y update \
+    && dnf -y clean all \
+    && gem install mdl \
+    && curl -sf "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" \
+       | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
+    && curl -sfL "https://raw.githubusercontent.com/securego/gosec/master/install.sh" \
+       | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}" \
+    && curl -L https://git.io/get_helm.sh | bash \
+    && true
+
+WORKDIR /go/src/github.com/ceph/ceph-csi

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -31,10 +31,9 @@ function copy_image_to_cluster() {
 # install minikube
 function install_minikube() {
     if type minikube >/dev/null 2>&1; then
-        local version
-        version=$(minikube version)
-        read -ra version <<<"${version}"
-        version=${version[2]}
+        local mk_version version
+        read -ra mk_version <<<"$(minikube version)"
+        version=${mk_version[2]}
         if [[ "${version}" != "${MINIKUBE_VERSION}" ]]; then
             echo "installed minikube version ${version} is not matching requested version ${MINIKUBE_VERSION}"
             exit 1


### PR DESCRIPTION
# Describe what this PR does #

`make containerized-test` has been added as a make target. This runs the
'make test' target in a container. All test dependencies are installed
in the container once, and the container is kept around for running
`make containerized-test` subsequently.

The test container is based on Fedora:latest so that all test tools get
easily installed and are available in a recent version. The production
container is based on the Ceph container which has CentOS as Operating
System and therefor a more stable (too old) toolset.

## Future concerns ##

Ideally the e2e tests will also run inside a container. However deploying k8s in a container, and rook for the e2e tests is a huge hurdle to take.

Closes: #890
