### PR TITLE
Make sure go.mod is correct/updated when vendor/ updates are done

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ go-test:
 	./scripts/test-go.sh
 
 mod-check:
-	go mod verify
+	@echo 'running: go mod verify'
+	@go mod verify && [ "$(shell sha512sum go.mod)" = "`sha512sum go.mod`" ] || ( echo "ERROR: go.mod was modified by 'go mod verify'" && false )
 
 static-check:
 	./scripts/lint-go.sh

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20200413115906-b5235f65be36 // indirect
-	google.golang.org/grpc v1.26.0
 	gopkg.in/square/go-jose.v2 v2.5.0 // indirect
 	k8s.io/api v0.18.0
 	k8s.io/apimachinery v0.18.0


### PR DESCRIPTION
`go mod verify` does not fail when all modules under vendor/ are
updated. However it does update `go.mod` in case there is some
inconsistency.

By adding this additional verification in `make mod-check`, future
updates to vendor/ will require a correct go.mod as well.