### PR TITLE
Cleanup the containerized-build Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ cephcsi:
 
 .PHONY: containerized-build
 containerized-build: .devel-container-id
-	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make -C /go/src/github.com/ceph/ceph-csi cephcsi
+	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make cephcsi
 
 # create a (cached) container image with dependencied for building cephcsi
 .devel-container-id: scripts/Dockerfile.devel

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -1,13 +1,14 @@
 FROM ceph/ceph:v15
 
+ARG GOROOT=/usr/local/go
+
 ENV GOPATH=/go \
- GOROOT=/usr/local/go \
- GO111MODULE=on
+ GOROOT=${GOROOT} \
+ GO111MODULE=on \
+ PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 
 RUN mkdir -p /usr/local/go && \
- curl https://storage.googleapis.com/golang/go1.13.9.linux-amd64.tar.gz | tar xzf - -C /usr/local/go --strip-components=1
-
-ENV PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
+ curl https://storage.googleapis.com/golang/go1.13.9.linux-amd64.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
 RUN dnf -y install \
 	git \

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -18,3 +18,5 @@ RUN dnf -y install \
 	librbd-devel \
     && dnf -y update \
     && true
+
+WORKDIR "/go/src/github.com/ceph/ceph-csi"

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -9,11 +9,11 @@ RUN mkdir -p /usr/local/go && \
 
 ENV PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
 
-RUN yum -y install \
+RUN dnf -y install \
 	git \
 	make \
 	gcc \
 	librados-devel \
 	librbd-devel \
-    && yum -y update \
+    && dnf -y update \
     && true


### PR DESCRIPTION
This cleans up a few minor things in the `scripts/Dockerfile.devel`:

- use `dnf` instead of `yum` as the Ceph base images now uses CentOS 8
- hardcode the GOROOT `/usr/local/go` path only once
- set `WORKINGDIR` so that `make` commands do not need to pass the path