### PR TITLE
add optional TARGET=.. parameter for 'make containerized-test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ ifdef BASE_IMAGE
 BASE_IMAGE_ARG = --build-arg BASE_IMAGE=$(BASE_IMAGE)
 endif
 
+# passing TARGET=static-check on the 'make containerized-test' commandline will
+# run the selected target instead of 'make test' in the container. Obviously
+# other targets can be passed as well, making it easier for developers to run
+# single tests.
+TARGET ?= test
+
 SELINUX := $(shell getenforce 2>/dev/null)
 ifeq ($(SELINUX),Enforcing)
 	SELINUX_VOL_FLAG = :z
@@ -82,7 +88,7 @@ containerized-build: .devel-container-id
 	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make cephcsi
 
 containerized-test: .test-container-id
-	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make test
+	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make $(TARGET)
 
 # create a (cached) container image with dependencied for building cephcsi
 .devel-container-id: scripts/Dockerfile.devel


### PR DESCRIPTION
Running the containerized-tests is relatively time consuming as it runs
all the tests. By adding a TARGET=.. option to the Makefile, it is now
possible to run a selected test, for example:

    make containerized-test TARGET=static-check

This reduces the time the tests take, so it is more friendly to the
developers while addressing problems.

When no TARGET=.. parameter is passed, the default tests are run.