### PR TITLE
travis: group build/e2e testing in stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,12 @@ before_script:
 
 jobs:
   include:
-    - name: static-check-make
+    # two stages for testing, each stage runs its jobs in parallel, but stages
+    # are run after each other, unless the last stage fails
+    # - build testing
+    # - e2e testing
+    - stage: build testing
+      name: static-check-make
       install:
         - gem install mdl
         - pip install --user --upgrade pip
@@ -75,29 +80,14 @@ jobs:
         - make go-test
         - make mod-check
 
-    - name: containerized test (Fedora) and build (CentOS)
+    - stage: build testing
+      name: containerized test (Fedora) and build (CentOS)
       script:
         - make containerized-test || travis_terminate 1;
         - make containerized-build || travis_terminate 1;
 
-    - name: cephcsi with kube 1.14.10
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.14.10 || travis_terminate 1;
-
-    - name: cephcsi with kube 1.15.6
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.15.6 || travis_terminate 1;
-
-    - name: cephcsi with kube 1.17.0
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.17.0 || travis_terminate 1;
-    - name: cephcsi on Arm64
+    - stage: build testing
+      name: cephcsi on Arm64
       arch: arm64
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;
@@ -107,7 +97,30 @@ jobs:
         # - Travis Arm64 CI job runs inside unprivileged LXD which blocks
         #   launching minikube test environment
         - travis_terminate 0    # deploy only on x86
-    - name: cephcsi helm charts with kube 1.17.0
+
+    - stage: e2e testing
+      name: cephcsi with kube 1.14.10
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-functest.sh v1.14.10 || travis_terminate 1;
+
+    - stage: e2e testing
+      name: cephcsi with kube 1.15.6
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-functest.sh v1.15.6 || travis_terminate 1;
+
+    - stage: e2e testing
+      name: cephcsi with kube 1.17.0
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-functest.sh v1.17.0 || travis_terminate 1;
+
+    - stage: e2e testing
+      name: cephcsi helm charts with kube 1.17.0
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;


### PR DESCRIPTION
This reduces the number of concurrent jobs that get executed. The "build
test" jobs are relatively quick, and give developers the 1st feedback.
Longer e2e testing now only happens once the build tests have passed.

See-also: https://docs.travis-ci.com/user/build-stages/
