### PR TITLE
Add travis_wait to deploy section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,4 +135,4 @@ deploy:
   - provider: script
     on:  # yamllint disable-line rule:truthy
       all_branches: true
-    script: ./deploy.sh
+    script: travis_wait ./deploy.sh


### PR DESCRIPTION
The deploy section is getting timeout to build and push
the images. see https://travis-ci.org/github/ceph/ceph-csi/jobs/678228818#L1617-L1622

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
