### PR TITLE
e2e: fix IneffAssign warnings in checkPVSelectorValuesForPVC()

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1330,10 +1330,9 @@ func checkPVSelectorValuesForPVC(f *framework.Framework, pvc *v1.PersistentVolum
 		Fail("Found empty NodeSelectorTerms in PV")
 	}
 
+	rFound := false
+	zFound := false
 	for _, expression := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions {
-		rFound := false
-		zFound := false
-
 		switch expression.Key {
 		case nodeCSIRegionLabel:
 			if rFound {


### PR DESCRIPTION
IneffAssign warns about the two following statements:

  Line 1342: warning: ineffectual assignment to rFound (ineffassign)
  Line 1350: warning: ineffectual assignment to zFound (ineffassign)

rFound and zFound should be set before entering the loop, otherwise the
initial value will overwrite the updated value on each iteration.

Reported-by: https://goreportcard.com/report/github.com/ceph/ceph-csi
Updates: #975
