### PR TITLE
move voljournal.go to a new package

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/klog"
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -55,7 +56,7 @@ var (
 
 	// volJournal is used to maintain RADOS based journals for CO generated
 	// VolumeName to backing CephFS subvolumes
-	volJournal *util.CSIJournal
+	volJournal *journal.CSIJournal
 )
 
 // NewDriver returns new ceph driver
@@ -109,7 +110,7 @@ func (fs *Driver) Run(conf *util.Config, cachePersister util.CachePersister) {
 		CSIInstanceID = conf.InstanceID
 	}
 	// Get an instance of the volume journal
-	volJournal = util.NewCSIVolumeJournal()
+	volJournal = journal.NewCSIVolumeJournal()
 
 	// Update keys with CSI instance suffix
 	volJournal.SetCSIDirectorySuffix(CSIInstanceID)

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -18,6 +18,7 @@ package rbd
 
 import (
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -50,8 +51,8 @@ var (
 
 	// volJournal and snapJournal are used to maintain RADOS based journals for CO generated
 	// VolumeName to backing RBD images
-	volJournal  *util.CSIJournal
-	snapJournal *util.CSIJournal
+	volJournal  *journal.CSIJournal
+	snapJournal *journal.CSIJournal
 )
 
 // NewDriver returns new rbd driver
@@ -103,8 +104,8 @@ func (r *Driver) Run(conf *util.Config, cachePersister util.CachePersister) {
 	}
 
 	// Get an instance of the volume and snapshot journal keys
-	volJournal = util.NewCSIVolumeJournal()
-	snapJournal = util.NewCSISnapshotJournal()
+	volJournal = journal.NewCSIVolumeJournal()
+	snapJournal = journal.NewCSISnapshotJournal()
 
 	// Update keys with CSI instance suffix
 	volJournal.SetCSIDirectorySuffix(CSIInstanceID)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -145,7 +146,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	default:
 		var vi util.CSIIdentifier
-		var imageAttributes *util.ImageAttributes
+		var imageAttributes *journal.ImageAttributes
 		err = vi.DecomposeCSIID(volID)
 		if err != nil {
 			err = fmt.Errorf("error decoding volume ID (%s) (%s)", err, volID)

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -57,6 +57,10 @@ func (e ErrSnapNameConflict) Error() string {
 	return e.err.Error()
 }
 
+func NewErrSnapNameConflict(name string, err error) ErrSnapNameConflict {
+	return ErrSnapNameConflict{name, err}
+}
+
 // ErrPoolNotFound is returned when pool is not found
 type ErrPoolNotFound struct {
 	Pool string


### PR DESCRIPTION
# Describe what this PR does #


This new journal package isolates journal logic from the rest of util
and helps draw bright lines between what is a generic utility function
and what is csi journal logic.
    
Done partly as preparation for making use of go-ceph in journal.
   
No functional changes are made except to update references to allow the
code to compile.
    

## Related issues ##

Precursor to work expected for issue #434 

## Future concerns ##

This is expected to isolate and help make clear what changes are needed in the journal related code so we can swap the omap functions to be based on go-ceph rather than subprocesses.
