### PR TITLE
deploy: log steps while tasks are running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
     - stage: build testing
       name: Build multi-architecture image for amd64 and arm64
       script:
-        - travis_wait ./scripts/build-multi-arch-image.sh || travis_terminate 1;
+        - ./scripts/build-multi-arch-image.sh || travis_terminate 1;
 
     - stage: build testing
       name: containerized test (Fedora) and build (CentOS)

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
     - stage: build testing
       name: Build multi-architecture image for amd64 and arm64
       script:
-        - travis_wait ./build-multi-arch-image.sh || travis_terminate 1;
+        - travis_wait ./scripts/build-multi-arch-image.sh || travis_terminate 1;
 
     - stage: build testing
       name: containerized test (Fedora) and build (CentOS)

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,4 +136,4 @@ deploy:
   - provider: script
     on:  # yamllint disable-line rule:truthy
       all_branches: true
-    script: travis_wait ./deploy.sh
+    script: ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# shellcheck source=scripts/build_step.inc.sh
+source "$(dirname "${0}")/scripts/build_step.inc.sh"
+
 push_helm_charts() {
 	PACKAGE=$1
 	VERSION=${ENV_CSI_IMAGE_VERSION//v/} # Set version (without v prefix)
@@ -60,6 +63,7 @@ build_push_images() {
 	manifests=$(docker manifest inspect "${baseimg}" | jq '.manifests[] | {arch: .platform.architecture, digest: .digest}')
 	# qemu-user-static is to enable an execution of different multi-architecture containers by QEMU
 	# more info at https://github.com/multiarch/qemu-user-static
+	build_step "docker run multiarch/qemu-user-static container"
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	# build and push per arch images
 	for ARCH in amd64 arm64; do
@@ -68,7 +72,9 @@ build_push_images() {
 		digest=$(awk -v ARCH=${ARCH} '{if (archfound) {print $NF; exit 0}}; {archfound=($0 ~ "arch.*"ARCH)}' <<<"${manifests}")
 		IFS=$ifs
 		base_image=${baseimg}@${digest}
+		build_step "make push-image-cephcsi for ${ARCH}"
 		GOARCH=${ARCH} BASE_IMAGE=${base_image} make push-image-cephcsi
+		build_step_log "done: make push-image-cephcsi for ${ARCH} (ret=${?})"
 	done
 }
 
@@ -80,6 +86,7 @@ else
 fi
 
 if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+	build_step "log in to quay.io as user ${QUAY_IO_USERNAME}"
 	"${CONTAINER_CMD:-docker}" login -u "${QUAY_IO_USERNAME}" -p "${QUAY_IO_PASSWORD}" quay.io
 
 	set -xe
@@ -89,15 +96,20 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
 	mkdir -p tmp
 	pushd tmp >/dev/null
 
+	build_step "installing helm"
 	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get >get_helm.sh
 	chmod 700 get_helm.sh
 	./get_helm.sh
 
+	build_step "cloning ceph/csi-charts repository"
 	git clone https://github.com/ceph/csi-charts
 
 	mkdir -p csi-charts/docs
 	popd >/dev/null
 
+	build_step "pushing RBD helm charts"
 	push_helm_charts rbd
+	build_step "pushing CephFS helm charts"
 	push_helm_charts cephfs
+	build_step_log "finished deployment!"
 fi

--- a/scripts/build-multi-arch-image.sh
+++ b/scripts/build-multi-arch-image.sh
@@ -3,6 +3,8 @@ set -xe
 # "docker manifest" requires experimental feature enabled
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+cd "$(dirname "${0}")/.."
+
 # ceph base image used for building multi architecture images
 dockerfile="deploy/cephcsi/image/Dockerfile"
 baseimg=$(awk -F = '/^ARG BASE_IMAGE=/ {print $NF}' "${dockerfile}")

--- a/scripts/build-multi-arch-image.sh
+++ b/scripts/build-multi-arch-image.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# shellcheck source=scripts/build_step.inc.sh
+source "$(dirname "${0}")/build_step.inc.sh"
+
 set -xe
 # "docker manifest" requires experimental feature enabled
 export DOCKER_CLI_EXPERIMENTAL=enabled
@@ -21,6 +25,7 @@ baseimg=$(awk -F = '/^ARG BASE_IMAGE=/ {print $NF}' "${dockerfile}")
 manifests=$(docker manifest inspect "${baseimg}" | jq '.manifests[] | {arch: .platform.architecture, digest: .digest}')
 # qemu-user-static is to enable an execution of different multi-architecture containers by QEMU
 # more info at https://github.com/multiarch/qemu-user-static
+build_step "starting multiarch/qemu-user-static container"
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 # build and push per arch images
 for ARCH in amd64 arm64; do
@@ -29,5 +34,6 @@ for ARCH in amd64 arm64; do
 	digest=$(awk -v ARCH=${ARCH} '{if (archfound) {print $NF; exit 0}}; {archfound=($0 ~ "arch.*"ARCH)}' <<<"${manifests}")
 	IFS=$ifs
 	base_img=${baseimg}@${digest}
+	build_step "make image-cephcsi for ${ARCH}"
 	GOARCH=${ARCH} BASE_IMAGE=${base_img} make image-cephcsi
 done

--- a/scripts/build_step.inc.sh
+++ b/scripts/build_step.inc.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# variables used for logging build steps, use build_step() and
+# build_step_done() for setting or clearing them.
+BUILD_STEP_FILE="$(mktemp)"
+BUILD_STEP_PID=''
+BUILD_STEP_DELAY='1m'
+
+build_step_log() {
+	echo "$(date) -- ${*}"
+}
+
+# start a build step, and log every
+build_step() {
+	echo "${*}" > "${BUILD_STEP_FILE}"
+	build_step_log "starting: $(cat "${BUILD_STEP_FILE}")"
+	[ -n "${BUILD_STEP_PID}" ] && return
+	while sleep "${BUILD_STEP_DELAY}"
+	do
+		build_step_log "running: $(cat "${BUILD_STEP_FILE}")"
+	done & BUILD_STEP_PID=${!}
+}
+
+# clean up the logging of build steps
+build_steps_cleanup() {
+	[ -n "${BUILD_STEP_PID}" ] && kill "${BUILD_STEP_PID}"
+	rm -f "${BUILD_STEP_FILE}"
+	BUILD_STEP_PID=''
+}
+
+# automatically stop build step logging and cleanup temporary file
+trap build_steps_cleanup EXIT
+

--- a/scripts/lint-text.sh
+++ b/scripts/lint-text.sh
@@ -44,7 +44,7 @@ fi
 run_check '.*\.md' mdl --style scripts/mdl-style.rb
 
 # Install via: dnf install shellcheck
-run_check '.*\.(ba)?sh' shellcheck
+run_check '.*\.(ba)?sh' shellcheck --external-sources
 run_check '.*\.(ba)?sh' bash -n
 
 # Install via: pip install yamllint


### PR DESCRIPTION
# Describe what this PR does #

By repeated logging of the current step, Travis CI should receive some
terminal activity and is expected to not timeout anymore.

## Related issues ##

Fixes: #982
