### PR TITLE
use temp folder to push helm charts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,6 +5,7 @@ source "$(dirname "${0}")/scripts/build_step.inc.sh"
 
 push_helm_charts() {
 	PACKAGE=$1
+	CHARTDIR=$2
 	VERSION=${ENV_CSI_IMAGE_VERSION//v/} # Set version (without v prefix)
 
 	# update information in Chart.yaml if the branch is not master
@@ -23,13 +24,14 @@ push_helm_charts() {
 		fi
 	fi
 
-	mkdir -p tmp/csi-charts/docs/"$PACKAGE"
-	pushd tmp/csi-charts/docs/"$PACKAGE" >/dev/null
+	mkdir -p "$CHARTDIR/csi-charts/docs/$PACKAGE"
+	cp -R "./charts/ceph-csi-$PACKAGE" "$CHARTDIR/csi-charts/docs/$PACKAGE"
+	pushd "$CHARTDIR/csi-charts/docs/$PACKAGE" >/dev/null
 	helm init --client-only
-	helm package ../../../../charts/ceph-csi-"$PACKAGE"
+	helm package "ceph-csi-$PACKAGE"
 	popd >/dev/null
 
-	pushd tmp/csi-charts/docs >/dev/null
+	pushd "$CHARTDIR/csi-charts/docs" >/dev/null
 	helm repo index .
 	git add --all :/ && git commit -m "Update for helm charts $PACKAGE-$VERSION"
 	git push https://"$GITHUB_TOKEN"@github.com/ceph/csi-charts
@@ -93,8 +95,9 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
 
 	build_push_images
 
-	mkdir -p tmp
-	pushd tmp >/dev/null
+	CSI_CHARTS_DIR=$(mktemp -d)
+
+	pushd "$CSI_CHARTS_DIR" >/dev/null
 
 	curl -L https://git.io/get_helm.sh | bash
 
@@ -105,8 +108,10 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
 	popd >/dev/null
 
 	build_step "pushing RBD helm charts"
-	push_helm_charts rbd
+	push_helm_charts rbd "$CSI_CHARTS_DIR"
 	build_step "pushing CephFS helm charts"
-	push_helm_charts cephfs
+	push_helm_charts cephfs "$CSI_CHARTS_DIR"
 	build_step_log "finished deployment!"
+
+	[ -n "${CSI_CHARTS_DIR}" ] && rm -rf "${CSI_CHARTS_DIR}"
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -96,10 +96,7 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
 	mkdir -p tmp
 	pushd tmp >/dev/null
 
-	build_step "installing helm"
-	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get >get_helm.sh
-	chmod 700 get_helm.sh
-	./get_helm.sh
+	curl -L https://git.io/get_helm.sh | bash
 
 	build_step "cloning ceph/csi-charts repository"
 	git clone https://github.com/ceph/csi-charts


### PR DESCRIPTION
install helm directly from the script instead of storing it in a temp file and then executing it.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

fixes https://github.com/ceph/ceph-csi/issues/980