### PR TITLE
pkg/util: fix golint warnings in csiconfig, volid

### DIFF
--- a/pkg/util/csiconfig.go
+++ b/pkg/util/csiconfig.go
@@ -23,6 +23,12 @@ import (
 	"strings"
 )
 
+// clusterInfo strongly typed JSON spec for the above JSON structure
+type clusterInfo struct {
+	ClusterID string   `json:"clusterID"`
+	Monitors  []string `json:"monitors"`
+}
+
 /*
 Mons returns a comma separated MON list from the csi config for the given clusterID
 Expected JSON structure in the passed in config file is,
@@ -39,13 +45,6 @@ Expected JSON structure in the passed in config file is,
 	...
 ]
 */
-
-// clusterInfo strongly typed JSON spec for the above JSON structure
-type clusterInfo struct {
-	ClusterID string   `json:"clusterID"`
-	Monitors  []string `json:"monitors"`
-}
-
 func Mons(pathToConfig, clusterID string) (string, error) {
 	var config []clusterInfo
 


### PR DESCRIPTION
golint warns about the following statements:
- ceph-csi/pkg/util/volid.go :  
   Line 72: warning: exported method CSIIdentifier.ComposeCSIID should have comment or be unexported (golint)

Reported-by: https://goreportcard.com/report/github.com/ceph/ceph-csi
Updates: #975

Signed-off-by: Yug Gupta <ygupta@redhat.com>