### PR TITLE
travis: run deploy as final stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,17 @@ before_script:
   # only the arm64 fallback repo is unsigned and needs --allow-unauthenticated
   - sudo apt-get -y --allow-unauthenticated install librados-dev librbd-dev
 
+# Two stages for testing, each stage runs its jobs in parallel, but stages are
+# run after each other, unless the last stage fails.
+# Only run the deploy stage on push (not pull_request) events.
+stages:
+  - build testing
+  - e2e testing
+  - name: deploy
+    if: type = push
+
 jobs:
   include:
-    # two stages for testing, each stage runs its jobs in parallel, but stages
-    # are run after each other, unless the last stage fails
-    # - build testing
-    # - e2e testing
     - stage: build testing
       name: static-check-make
       install:
@@ -132,8 +137,6 @@ jobs:
         - make image-cephcsi || travis_terminate 1;
         - scripts/travis-helmtest.sh v1.17.0 || travis_terminate 1;
 
-deploy:
-  - provider: script
-    on:  # yamllint disable-line rule:truthy
-      all_branches: true
-    script: ./deploy.sh
+    - stage: deploy
+      name: push artifacts to repositories
+      script: ./deploy.sh


### PR DESCRIPTION
# Describe what this PR does #

The `deploy:` section is executed as part of each successful job. That
means the container images are built and pushed many times during
testing after a push/merge event on the master branch.

By creating a deploy stage and listing it after the tests, it is
guaranteed to run only once after all tests have succeeded. By adding a
condition to only run the stage on the master branch for push events,
the images should only get built+pushed after a PR has been merged into
the master branch.

See-also: https://docs.travis-ci.com/user/conditional-builds-stages-jobs#Specifying-conditions