### PR TITLE
util: fix golint warnings in csiconfig, volid

### DIFF
--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -23,6 +23,14 @@ import (
 	"strings"
 )
 
+// clusterInfo strongly typed JSON spec for the below JSON structure
+type clusterInfo struct {
+	// ClusterID is used for unique identification
+	ClusterID string `json:"clusterID"`
+	// Monitors is monitor list for corresponding cluster ID
+	Monitors []string `json:"monitors"`
+}
+
 /*
 Mons returns a comma separated MON list from the csi config for the given clusterID
 Expected JSON structure in the passed in config file is,
@@ -39,13 +47,6 @@ Expected JSON structure in the passed in config file is,
 	...
 ]
 */
-
-// clusterInfo strongly typed JSON spec for the above JSON structure
-type clusterInfo struct {
-	ClusterID string   `json:"clusterID"`
-	Monitors  []string `json:"monitors"`
-}
-
 func Mons(pathToConfig, clusterID string) (string, error) {
 	var config []clusterInfo
 

--- a/internal/util/volid.go
+++ b/internal/util/volid.go
@@ -52,6 +52,11 @@ type CSIIdentifier struct {
 // This maximum comes from the CSI spec on max bytes allowed in the various CSI ID fields
 const maxVolIDLen = 128
 
+const (
+	knownFieldSize = 64
+	uuidSize       = 36
+)
+
 /*
 ComposeCSIID composes a CSI ID from passed in parameters.
 Version 1 of the encoding scheme is as follows,
@@ -64,11 +69,6 @@ Version 1 of the encoding scheme is as follows,
 	Total of constant field lengths, including '-' field separators would hence be,
 	4+1+4+1+1+16+1+36 = 64
 */
-const (
-	knownFieldSize = 64
-	uuidSize       = 36
-)
-
 func (ci CSIIdentifier) ComposeCSIID() (string, error) {
 	buf16 := make([]byte, 2)
 	buf64 := make([]byte, 8)


### PR DESCRIPTION
golint warns about the following statements:

- ceph-csi/internal/util/csiconfig.go
  Line 49: warning: exported function Mons should have comment or be unexported (golint)

- ceph-csi/pkg/util/volid.go :
  Line 72: warning: exported method CSIIdentifier.ComposeCSIID should have comment
  or be unexported (golint)

Reported-by: https://goreportcard.com/report/github.com/ceph/ceph-csi
Updates: #975

Signed-off-by: Yug Gupta <ygupta@redhat.com>