### PR TITLE
Revert back the ceph base image

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,6 +1,6 @@
 ARG SRC_DIR="/go/src/github.com/ceph/ceph-csi/"
 ARG GO_ARCH
-ARG BASE_IMAGE=ceph/ceph:v15
+ARG BASE_IMAGE=ceph/ceph:v14.2
 
 FROM ${BASE_IMAGE} as builder
 
@@ -17,7 +17,7 @@ ARG GOROOT=/usr/local/go
 RUN mkdir -p ${GOROOT} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
-RUN dnf install libcephfs-devel librados-devel librbd-devel /usr/bin/cc make -y
+RUN yum install libcephfs-devel librados-devel librbd-devel /usr/bin/cc make -y
 
 ENV GOROOT=${GOROOT} \
     GOPATH=/go \


### PR DESCRIPTION
as we are facing the xfs issue as the xfsprogs version has changed in ceph:v15 base image.
due to this cephcsi is not working in older kernel versions

updates: #966 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

