### PR TITLE
rbd: default nouuid if the formattype is xfs

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -407,6 +407,9 @@ func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeS
 	}
 
 	opt := []string{"_netdev"}
+	if fsType == "xfs" {
+		opt = append(opt, "nouuid")
+	}
 	opt = csicommon.ConstructMountOptions(opt, req.GetVolumeCapability())
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 


### PR DESCRIPTION
The problem happens when multiple PVCs with the same UUID are attached/mounted on a node. This can happen after creating a PVC from a snapshot or cloning a PVC.

make nouuid as the default mount option if
the format type is xfs to avoid mounting
issues.

updates: #966

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
