### PR TITLE
set priorityclassName for cephcsi pods

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -27,6 +27,9 @@ spec:
         heritage: {{ .Release.Service }}
     spec:
       serviceAccountName: {{ include "ceph-csi-cephfs.serviceAccountName.nodeplugin" . }}
+{{- if .Values.nodeplugin.priorityClassName }}
+      priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
+{{- end }}
       hostNetwork: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -42,6 +42,9 @@ spec:
               topologyKey: "kubernetes.io/hostname"
 {{- end }}
       serviceAccountName: {{ include "ceph-csi-cephfs.serviceAccountName.provisioner" . }}
+{{- if .Values.provisioner.priorityClassName }}
+      priorityClassName: {{ .Values.provisioner.priorityClassName }}
+{{- end }}
       containers:
         - name: csi-provisioner
           image: "{{ .Values.provisioner.provisioner.image.repository }}:{{ .Values.provisioner.provisioner.image.tag }}"

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -39,6 +39,10 @@ nodeplugin:
   # if you are using ceph-fuse client set this value to OnDelete
   updateStrategy: RollingUpdate
 
+  # set user created priorityclassName for csi plugin pods. default is
+  # system-node-critical which is highest priority
+  priorityClassName: system-node-critical
+
   httpMetrics:
     # Metrics only available for cephcsi/cephcsi => 1.2.0
     # Specifies whether http metrics should be exposed
@@ -104,6 +108,10 @@ provisioner:
   replicaCount: 3
   # Timeout for waiting for creation or deletion of a volume
   timeout: 60s
+
+  # set user created priorityclassName for csi provisioner pods. default is
+  # system-cluster-critical which is less priority than system-node-critical
+  priorityClassName: system-cluster-critical
 
   httpMetrics:
     # Metrics only available for cephcsi/cephcsi => 1.2.0

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -29,6 +29,9 @@ spec:
       serviceAccountName: {{ include "ceph-csi-rbd.serviceAccountName.nodeplugin" . }}
       hostNetwork: true
       hostPID: true
+{{- if .Values.nodeplugin.priorityClassName }}
+      priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
+{{- end }}
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -42,6 +42,9 @@ spec:
               topologyKey: "kubernetes.io/hostname"
 {{- end }}
       serviceAccountName: {{ include "ceph-csi-rbd.serviceAccountName.provisioner" . }}
+{{- if .Values.provisioner.priorityClassName }}
+      priorityClassName: {{ .Values.provisioner.priorityClassName }}
+{{- end }}
       containers:
         - name: csi-provisioner
           image: "{{ .Values.provisioner.provisioner.image.repository }}:{{ .Values.provisioner.provisioner.image.tag }}"

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -48,6 +48,9 @@ logLevel: 5
 
 nodeplugin:
   name: nodeplugin
+  # set user created priorityclassName for csi plugin pods. default is
+  # system-node-critical which is high priority
+  priorityClassName: system-node-critical
   # if you are using rbd-nbd client set this value to OnDelete
   updateStrategy: RollingUpdate
 
@@ -130,6 +133,10 @@ provisioner:
   # skip image flattening if kernel support mapping of rbd images
   # which has the deep-flatten feature
   # skipForceFlatten: false
+
+  # set user created priorityclassName for csi provisioner pods. default is
+  # system-cluster-critical which is less priority than system-node-critical
+  priorityClassName: system-cluster-critical
 
   httpMetrics:
     # Metrics only available for cephcsi/cephcsi => 1.2.0

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -40,6 +40,7 @@ spec:
                       - csi-cephfsplugin-provisioner
               topologyKey: "kubernetes.io/hostname"
       serviceAccount: cephfs-csi-provisioner
+      priorityClassName: system-cluster-critical
       containers:
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -13,6 +13,7 @@ spec:
         app: csi-cephfsplugin
     spec:
       serviceAccount: cephfs-csi-nodeplugin
+      priorityClassName: system-node-critical
       hostNetwork: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -40,6 +40,7 @@ spec:
                       - csi-rbdplugin-provisioner
               topologyKey: "kubernetes.io/hostname"
       serviceAccount: rbd-csi-provisioner
+      priorityClassName: system-cluster-critical
       containers:
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -15,6 +15,7 @@ spec:
       serviceAccount: rbd-csi-nodeplugin
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
set system-cluster-critical priority class on provisioner pods. the system-cluster-critical is having the lowest priority compared to node-critical.

set system-node-critical priority on the plugin pods, as its the highest priority, and this needs to be applied on plugin pods as its critical for storage in the cluster.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>