### PR TITLE
DOC: Added document for DCO and commit message

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
+documentation before submitting a Pull Request!
+Thank you for contributing to ceph-csi! -->
+
 # Describe what this PR does #
 
 Provide some context for the reviewer

--- a/docs/DCO
+++ b/docs/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -76,6 +76,64 @@ for code contributions.
 
 Please read the [coding guidelines](coding.md) document before submitting a PR.
 
+#### Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
+
+Contributors sign-off that they adhere to these requirements by adding a
+Signed-off-by line to commit messages. For example:
+
+```text
+subsystem: This is my commit message
+
+More details on what this commit does
+
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+If you have already made a commit and forgot to include the sign-off, you can
+amend your last commit to add the sign-off with the following command, which
+can then be force pushed.
+
+```console
+git commit --amend -s
+```
+
+We use a [DCO bot](https://github.com/apps/dco) to enforce the DCO on each pull
+request and branch commits.
+
+#### Commit Messages
+
+We follow a rough convention for commit messages that is designed to answer two
+questions: what changed and why? The subject line should feature the what and
+the body of the commit should describe the why.
+
+```text
+cephfs: update cephfs resize
+
+use cephfs resize to resize subvolume
+
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+The format can be described more formally as follows:
+
+```text
+<subsystem>: <what changed>
+<BLANK LINE>
+<why this change was made>
+<BLANK LINE>
+<footer>
+```
+
+The first line is the subject and should be no longer than 70 characters, the
+second line is always blank, and other lines should be wrapped at 80 characters.
+This allows the message to be easier to read on GitHub as well as in various
+git tools.
+
 Here is a short guide on how to work on a new patch.  In this example, we will
 work on a patch called *hellopatch*:
 


### PR DESCRIPTION
# Describe what this PR does #

Added document on the standard user needs to follow when writing the commit message and to include sign-off in the commit message.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

## Related issues ##

Updates #773 
