### PR TITLE
prepare: exit when passed incorrect parameters

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -18,6 +18,12 @@ opts=$(getopt \
     -- "$@"
 )
 
+if [ $? -ne 0 ]
+then
+    echo "Try '--help' for more information." 
+    exit 1   
+fi
+
 eval set -- ${opts}
 
 while true; do


### PR DESCRIPTION
Now script does not continue execution
when an invalid argument is passed.

Signed-off-by: Yug Gupta <ygupta@redhat.com>