### PR TITLE
ci: add initial configuration for stale bot

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,45 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Issues or Pull Requests with these labels will never be
+# considered stale. Set to `[]` to disable
+---
+exemptLabels:
+  - keepalive
+  - security
+  - reliability
+  - release requirement
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 5
+
+# Specify configuration settings that are specific to issues
+issues:
+  daysUntilStale: 60
+  daysUntilClose: 7
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed in a week if no further activity occurs.
+    Thank you for your contributions.
+  closeComment: >
+    This issue has been automatically closed due to inactivity. Please re-open
+    if this still requires investigation.
+# Specify configuration settings that are specific to PRs
+pulls:
+  daysUntilStale: 60
+  daysUntilClose: 30
+  markComment: >
+    This pull request has been automatically marked as stale because it has not
+    had recent activity. It will be closed in a month if no further activity
+    occurs. Thank you for your contributions.
+  closeComment: >
+    This pull request has been automatically closed due to inactivity. Please
+    re-open if these changes are still required.


### PR DESCRIPTION
The rules are defined here which could enable stale bot.

Additional Ref# https://probot.github.io/apps/stale/

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


Fixes: #743 

