### PR TITLE
Remove testing of unmaintained k8s versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,20 +110,6 @@ jobs:
         - travis_terminate 0    # deploy only on x86
 
     - stage: e2e testing
-      name: cephcsi with kube 1.14.10
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.14.10 || travis_terminate 1;
-
-    - stage: e2e testing
-      name: cephcsi with kube 1.15.6
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.15.6 || travis_terminate 1;
-
-    - stage: e2e testing
       name: cephcsi with kube 1.17.0
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,18 +110,18 @@ jobs:
         - travis_terminate 0    # deploy only on x86
 
     - stage: e2e testing
-      name: cephcsi with kube 1.17.0
+      name: cephcsi with kube 1.17.5
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.17.0 || travis_terminate 1;
+        - scripts/travis-functest.sh v1.17.5 || travis_terminate 1;
 
     - stage: e2e testing
-      name: cephcsi helm charts with kube 1.17.0
+      name: cephcsi helm charts with kube 1.17.5
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-helmtest.sh v1.17.0 || travis_terminate 1;
+        - scripts/travis-helmtest.sh v1.17.5 || travis_terminate 1;
 
     - stage: deploy
       name: push artifacts to repositories

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,13 @@ jobs:
         - travis_terminate 0    # deploy only on x86
 
     - stage: e2e testing
+      name: cephcsi with kube 1.16.9
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-functest.sh v1.16.9 || travis_terminate 1;
+
+    - stage: e2e testing
       name: cephcsi with kube 1.17.5
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;


### PR DESCRIPTION
# Describe what this PR does #

Version 1.18.x is currently out, and the k8s community does not maintain
versions 1.14 and 1.15 anymore. No need to test on versions that users
should not deploy.

See-also: [Kubernetes Patch Releases](https://github.com/kubernetes/sig-release/blob/master/releases/patch-releases.md#timelines)

Fixes: #1023

