### PR TITLE
ci: add configuration for "Semantic Pull Request" bot

### DIFF
--- a/.github/semantic.yaml
+++ b/.github/semantic.yaml
@@ -1,0 +1,44 @@
+---
+# Always validate the PR title, and ignore the commits
+# titleOnly: true
+
+# Always validate all commits, and ignore the PR title
+commitsOnly: true
+
+# Always validate the PR title AND all the commits
+# titleAndCommits: true
+
+# Require at least one commit to be valid
+# this is only relevant when using commitsOnly: true or titleAndCommits: true,
+# which validate all commits by default
+# anyCommit: true
+
+# Allow use of Merge commits (eg on github: "Merge branch 'master' into
+# feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: false
+
+##
+## We do not use scopes, list is empty.
+##
+# You can define a list of valid scopes
+# scopes:
+#  - scope1
+#  - scope2
+
+# By default types specified in commitizen/conventional-commit-types is used.
+##
+## We override the types by components we have.
+##
+types:
+  - cephfs
+  - rbd
+  - doc
+  - util
+  - journal
+  - helm
+  - build
+  - ci
+  - e2e
+  - cleanup
+  - revert


### PR DESCRIPTION
# Describe what this PR does #

The "Semantic Pull Request" bot has been enabled as replacement for [https://github.com/z0al/commitlint-bot](commitlint-bot) that is not being maintained anymore. It requires some configuration before it can be practically used with Ceph-CSI.

## Is there anything that requires special attention ##

This configuration enforces the format of commits that are part of a
Pull Request. The title of the PR can be checked as well, that will not
be required for now.

The format of a subject of all commit messages needs to be:

    <component>: <description>

For example:

    ci: add configuration for "Semantic Pull Request" bot

The valid components in the commit message are listed in the
.github/semantic.yaml file as 'types'.

See-also: https://github.com/zeke/semantic-pull-requests#semantic-pull-requests
See-also: https://www.conventionalcommits.org