### PR TITLE
travis: test functionality of travis with github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 services:
   - docker
 
-language: go
+language:go
 branches:
   only:
     - master


### PR DESCRIPTION
Github considers all the checks as passed even in the case when there is an error
in travis.yml and ci doesn't run. This results in auto merging of the code without a valid
CI run, trying to repro the same by introducing a parsing error in travis.yml.
Please not, that this is a just a repro attempt, it doesn't fix #1011

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

