### PR TITLE
reduce default worker-threads for csi-provisioner

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -41,6 +41,7 @@ spec:
             - "--leader-election-type=leases"
             - "--retry-interval-start=500ms"
             - "--feature-gates=Topology=true"
+            - "--worker-threads=5"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock


### PR DESCRIPTION
Have various testing on small and medium size cluster,  default worker-threads=100 will cause multiple grpc errors from API during PVC dynamic provisioning, as the result PVC creation randomly spent 15 to 60 mins. Reducing worker-threads helps eliminate the API errors.
