### PR TITLE
ci: pass ghprPullId in make-containerized-build job

### DIFF
--- a/make-containerized-build.yaml
+++ b/make-containerized-build.yaml
@@ -11,6 +11,10 @@
             - ci/centos
       script-path: make-containerized-build.groovy
       lightweight-checkout: true
+    parameters:
+      - string:
+          name: ghprbPullId
+          default: ''
     triggers:
       - github-pull-request:
           admin-list:

--- a/make-containerized-build.yaml
+++ b/make-containerized-build.yaml
@@ -17,6 +17,7 @@
           default: ''
     triggers:
       - github-pull-request:
+          cron: 'H/5 * * * *'
           admin-list:
           - nixpanic
           org-list:


### PR DESCRIPTION
# Describe what this PR does #

In case the environment variable is not set at all (as opposed to
empty), the following error is reported while running the job:

    groovy.lang.MissingPropertyException: No such property: ghprbPullId for class: groovy.lang.Binding

Also, add a cron schedule to check every 5 minutes for a new PR to run the
make-containerized-build job.

## Related issues ##

Updates: #1029
