### PR TITLE
journal: remove SetCSIDirectorySuffix to simplify journal creation

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -109,11 +109,8 @@ func (fs *Driver) Run(conf *util.Config, cachePersister util.CachePersister) {
 	if conf.InstanceID != "" {
 		CSIInstanceID = conf.InstanceID
 	}
-	// Get an instance of the volume journal
-	volJournal = journal.NewCSIVolumeJournal()
-
-	// Update keys with CSI instance suffix
-	volJournal.SetCSIDirectorySuffix(CSIInstanceID)
+	// Create an instance of the volume journal
+	volJournal = journal.NewCSIVolumeJournal(CSIInstanceID)
 
 	// Update namespace for storing keys into a specific namespace on RADOS, in the CephFS
 	// metadata pool

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -147,9 +147,9 @@ type CSIJournal struct {
 }
 
 // NewCSIVolumeJournal returns an instance of CSIJournal for volumes
-func NewCSIVolumeJournal() *CSIJournal {
+func NewCSIVolumeJournal(suffix string) *CSIJournal {
 	return &CSIJournal{
-		csiDirectory:            "csi.volumes",
+		csiDirectory:            "csi.volumes." + suffix,
 		csiNameKeyPrefix:        "csi.volume.",
 		cephUUIDDirectoryPrefix: "csi.volume.",
 		csiNameKey:              "csi.volname",
@@ -162,9 +162,9 @@ func NewCSIVolumeJournal() *CSIJournal {
 }
 
 // NewCSISnapshotJournal returns an instance of CSIJournal for snapshots
-func NewCSISnapshotJournal() *CSIJournal {
+func NewCSISnapshotJournal(suffix string) *CSIJournal {
 	return &CSIJournal{
-		csiDirectory:            "csi.snaps",
+		csiDirectory:            "csi.snaps." + suffix,
 		csiNameKeyPrefix:        "csi.snap.",
 		cephUUIDDirectoryPrefix: "csi.snap.",
 		csiNameKey:              "csi.snapname",
@@ -186,11 +186,6 @@ func (cj *CSIJournal) GetNameForUUID(prefix, uid string, isSnapshot bool) string
 		}
 	}
 	return prefix + uid
-}
-
-// SetCSIDirectorySuffix sets the given suffix for the csiDirectory omap
-func (cj *CSIJournal) SetCSIDirectorySuffix(suffix string) {
-	cj.csiDirectory = cj.csiDirectory + "." + suffix
 }
 
 // SetNamespace sets the namespace in which all RADOS objects would be created

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -103,13 +103,9 @@ func (r *Driver) Run(conf *util.Config, cachePersister util.CachePersister) {
 		CSIInstanceID = conf.InstanceID
 	}
 
-	// Get an instance of the volume and snapshot journal keys
-	volJournal = journal.NewCSIVolumeJournal()
-	snapJournal = journal.NewCSISnapshotJournal()
-
-	// Update keys with CSI instance suffix
-	volJournal.SetCSIDirectorySuffix(CSIInstanceID)
-	snapJournal.SetCSIDirectorySuffix(CSIInstanceID)
+	// Create instances of the volume and snapshot journal
+	volJournal = journal.NewCSIVolumeJournal(CSIInstanceID)
+	snapJournal = journal.NewCSISnapshotJournal(CSIInstanceID)
 
 	// Initialize default library driver
 	r.cd = csicommon.NewCSIDriver(conf.DriverName, util.DriverVersion, conf.NodeID)


### PR DESCRIPTION
# Describe what this PR does #

The function SetCSIDirectorySuffix was used only one per (long-lived,
gloabl) journal object. It is simpler to construct the journal objects
with this needed parameter:
1. As it is required to function and non-optional AFAICT
2. Removes the temptation to mutate global object
3. Reduces LOC with exact same functionality
4. SetCSIDirectorySuffix would not behave correctly if called a 2nd time
   anyway.

Point 4. means that if you called the function twice to change the
suffix when you previously had "csi.volumes.alice", you'd get
"csi.volumes.alice.bob" instead of "csi.volumes.bob" what one would
expect.

This is partly done in preparation to make the journal get/set/or-otherwise-make-use-of go-ceph for omap.


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->



Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions? n/a

Is the change backward compatible? yes - refactoring only

Are there concerns around backward compatibility? n/a

