### PR TITLE
cephfs: use new 'ceph fs resize' command when available

### DIFF
--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -357,7 +357,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 
 	RoundOffSize := util.RoundOffBytes(req.GetCapacityRange().GetRequiredBytes())
 
-	if err = resizeVolume(ctx, volOptions, cr, volumeID(volIdentifier.FsSubvolName), RoundOffSize); err != nil {
+	if err = createVolume(ctx, volOptions, cr, volumeID(volIdentifier.FsSubvolName), RoundOffSize); err != nil {
 		klog.Errorf(util.Log(ctx, "failed to expand volume %s: %v"), volumeID(volIdentifier.FsSubvolName), err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/cephfs/volume.go
+++ b/pkg/cephfs/volume.go
@@ -38,12 +38,6 @@ var (
 	// Subvolume group create gets called every time the plugin loads, though it doesn't result in error
 	// its unnecessary
 	cephfsInit = false
-
-	// resizeSupportedList stores the mapping for clusterID and resize is
-	// supported in the particular cluster
-	resizeSupportedList = make(map[string]bool)
-
-	inValidCommmand = "no valid command found"
 )
 
 func getCephRootVolumePathLocalDeprecated(volID volumeID) string {
@@ -142,48 +136,6 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, cr *util.Crede
 	}
 
 	return nil
-}
-
-// resizeVolume will try to use ceph fs subvolume resize command to resize the
-// subvolume. If the command is not available as a fallback it will use
-// CreateVolume to resize the subvolume.
-func resizeVolume(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, volID volumeID, bytesQuota int64) error {
-	supported := false
-	ok := false
-
-	if supported, ok = resizeSupportedList[volOptions.ClusterID]; supported || !ok {
-		args := []string{
-			"fs",
-			"subvolume",
-			"resize",
-			volOptions.FsName,
-			string(volID),
-			strconv.FormatInt(bytesQuota, 10),
-			"--group_name",
-			csiSubvolumeGroup,
-			"-m", volOptions.Monitors,
-			"-c", util.CephConfigPath,
-			"-n", cephEntityClientPrefix + cr.ID,
-			"--keyfile=" + cr.KeyFile,
-		}
-
-		err := execCommandErr(
-			ctx,
-			"ceph",
-			args[:]...)
-
-		if err == nil {
-			resizeSupportedList[volOptions.ClusterID] = true
-			return nil
-		}
-		// Incase the error is other than invalid command return error to the caller.
-		if !strings.Contains(err.Error(), inValidCommmand) {
-			klog.Errorf(util.Log(ctx, "failed to resize subvolume %s(%s) in fs %s"), string(volID), err, volOptions.FsName)
-			return err
-		}
-	}
-	resizeSupportedList[volOptions.ClusterID] = false
-	return createVolume(ctx, volOptions, cr, volID, bytesQuota)
 }
 
 func mountCephRoot(ctx context.Context, volID volumeID, volOptions *volumeOptions, adminCr *util.Credentials) error {


### PR DESCRIPTION
This reverts commit 9022d899eb6fd464f0be33701d8160ecd1317467.

Unfortunately this mentioned commit got merged onto release-v2.1 branch which was not intended. It was supposed to go with v2.1 canary image. Reverting the commit here.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

