### PR TITLE
rbd: change image pull policy

### DIFF
--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -58,7 +58,7 @@ spec:
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock
-          imagePullPolicy: Always
+          imagePullPolicy: "IfNotPresent"
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
unlike other containers, image pull policy of
csi-snapshotter was set to "Always", which can
be changed to pull only if not present.

Signed-off-by: Yug Gupta <ygupta@redhat.com>

