### PR TITLE
journal: remove SetNamespace setter function

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -110,11 +110,8 @@ func (fs *Driver) Run(conf *util.Config, cachePersister util.CachePersister) {
 		CSIInstanceID = conf.InstanceID
 	}
 	// Create an instance of the volume journal
-	volJournal = journal.NewCSIVolumeJournal(CSIInstanceID)
+	volJournal = journal.NewCSIVolumeJournalWithNamespace(CSIInstanceID, radosNamespace)
 
-	// Update namespace for storing keys into a specific namespace on RADOS, in the CephFS
-	// metadata pool
-	volJournal.SetNamespace(radosNamespace)
 	// Initialize default library driver
 
 	fs.cd = csicommon.NewCSIDriver(conf.DriverName, util.DriverVersion, conf.NodeID)

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -176,6 +176,14 @@ func NewCSISnapshotJournal(suffix string) *CSIJournal {
 	}
 }
 
+// NewCSIVolumeJournalWithNamespace returns an instance of CSIJournal for
+// volumes using a predetermined namespace value.
+func NewCSIVolumeJournalWithNamespace(suffix, ns string) *CSIJournal {
+	j := NewCSIVolumeJournal(suffix)
+	j.namespace = ns
+	return j
+}
+
 // GetNameForUUID returns volume name
 func (cj *CSIJournal) GetNameForUUID(prefix, uid string, isSnapshot bool) string {
 	if prefix == "" {
@@ -186,11 +194,6 @@ func (cj *CSIJournal) GetNameForUUID(prefix, uid string, isSnapshot bool) string
 		}
 	}
 	return prefix + uid
-}
-
-// SetNamespace sets the namespace in which all RADOS objects would be created
-func (cj *CSIJournal) SetNamespace(ns string) {
-	cj.namespace = ns
 }
 
 // ImageData contains image name and stored CSI properties


### PR DESCRIPTION

# Describe what this PR does #

The SetNamespace setter function was called only once, immediately after
the creation of a volume journal object in cephfs only.
Remove this function so that it is no longer implied that this field can
be mutated after the journal is created. In its place, use an extended
"constructor" NewCSIVolumeJournalWithNamespace that takes a namespace
value at create-time only.

Another journal refactor to clean up the api and prepare a bit for integrating go-ceph for omap support in the journal package.


## Is there anything that requires special attention ##

Do you have any questions? n/a

Is the change backward compatible? yes 

Are there concerns around backward compatibility? no
