### PR TITLE
Add commitlint to containerized-test

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,30 @@
+---
+# rules are documented at https://commitlint.js.org/#/reference-rules
+# each rule has a n arry of three values:
+# - 0, 1, 2 (rule is disabled, warning or error)
+# - always/never
+# - value
+rules:
+  # the subject may not exceed 72 characters
+  header-max-length: [2, always, 72]
+  # the subject may not end with a "."
+  header-full-stop: [2, never, "."]
+  # we do not use scopes for commit messages
+  scope-empty: [1, always]
+  # valid types/prefixes, see docs/development-guide.md
+  type-enum:
+    - 1
+    - always
+    - - build
+      - cephfs
+      - ci
+      - cleanup
+      - deploy
+      - doc
+      - e2e
+      - helm
+      - journal
+      - rbd
+      - rebase
+      - revert
+      - util

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ endif
 # single tests.
 TARGET ?= test
 
+# Pass GIT_SINCE for the range of commits to test. Used with the commitlint
+# target.
+GIT_SINCE := origin/master
+
 SELINUX := $(shell getenforce 2>/dev/null)
 ifeq ($(SELINUX),Enforcing)
 	SELINUX_VOL_FLAG = :z
@@ -60,7 +64,7 @@ endif
 
 all: cephcsi
 
-.PHONY: go-test static-check mod-check go-lint lint-extras gosec
+.PHONY: go-test static-check mod-check go-lint lint-extras gosec commitlint
 test: go-test static-check mod-check
 static-check: check-env go-lint lint-extras gosec
 
@@ -98,6 +102,9 @@ func-test:
 check-env:
 	@./scripts/check-env.sh
 
+commitlint:
+	commitlint --from $(GIT_SINCE)
+
 .PHONY: cephcsi
 cephcsi: check-env
 	if [ ! -d ./vendor ]; then (go mod tidy && go mod vendor); fi
@@ -108,7 +115,7 @@ containerized-build: .devel-container-id
 	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make cephcsi
 
 containerized-test: .test-container-id
-	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make $(TARGET)
+	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make $(TARGET) GIT_SINCE=$(GIT_SINCE)
 
 # create a (cached) container image with dependencied for building cephcsi
 .devel-container-id: scripts/Dockerfile.devel

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -17,8 +17,7 @@ ARG GOPATH=/go
 ENV \
  GOPATH=${GOPATH} \
  GO111MODULE=on \
- PATH="${GOPATH}/bin:${PATH}"
-
+ PATH="${GOPATH}/bin:/opt/commitlint/node_modules/.bin:${PATH}"
 
 RUN dnf -y install \
 	git \
@@ -30,6 +29,7 @@ RUN dnf -y install \
 	rubygems \
 	ShellCheck \
 	yamllint \
+	npm \
     && dnf -y update \
     && dnf -y clean all \
     && gem install mdl \
@@ -38,6 +38,10 @@ RUN dnf -y install \
     && curl -sfL "https://raw.githubusercontent.com/securego/gosec/master/install.sh" \
        | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}" \
     && curl -L https://git.io/get_helm.sh | bash \
+    && mkdir /opt/commitlint && pushd /opt/commitlint \
+    && npm init -y \
+    && npm install @commitlint/cli \
+    && popd \
     && true
 
 WORKDIR /go/src/github.com/ceph/ceph-csi


### PR DESCRIPTION
# Describe what this PR does #

The `commitlint` command can be used to verify the subject of commit
messages, so it is added to the $PATH of the test container.

The rules are documented at https://commitlint.js.org/#/reference-rules
and can easily be added to the configuration.

When passing `GIT_SINCE` as an argument, the commits from then on
(defaults to origin/master) are used. A CI job can pass the base branch
or ID so a range of patches gets checked.

To test the last four commits, one can run:

    $ make containerized-test TARGET=commitlint GIT_SINCE=HEAD~4

A CI job can pass the base branch where the PR is expected to get merged.

## Related issues ##

Updates: #1057 - still needs a configuration in `.travis.yaml`
See-also: #1036 - contains the list of valid `types`

## Future concerns ##

This can easily be run in the CentOS CI, but we may want to run it in Travis CI instead
