### PR TITLE
util: use go-ceph instead of "rados" command for GetPoolID()

### DIFF
--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -285,7 +285,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 		}
 		savedImagePoolID = int64(binary.BigEndian.Uint64(buf64))
 
-		savedImagePool, err = util.GetPoolName(ctx, conn.monitors, conn.cr, savedImagePoolID)
+		savedImagePool, err = util.GetPoolName(conn.monitors, conn.cr, savedImagePoolID)
 		if err != nil {
 			if _, ok := err.(util.ErrPoolNotFound); ok {
 				err = conn.UndoReservation(ctx, journalPool, "", "", reqName)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -385,7 +385,7 @@ func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID str
 		return err
 	}
 
-	rbdSnap.Pool, err = util.GetPoolName(ctx, rbdSnap.Monitors, cr, vi.LocationID)
+	rbdSnap.Pool, err = util.GetPoolName(rbdSnap.Monitors, cr, vi.LocationID)
 	if err != nil {
 		return err
 	}
@@ -408,7 +408,7 @@ func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID str
 
 	// convert the journal pool ID to name, for use in DeleteSnapshot cases
 	if imageAttributes.JournalPoolID != util.InvalidPoolID {
-		rbdSnap.JournalPool, err = util.GetPoolName(ctx, rbdSnap.Monitors, cr, imageAttributes.JournalPoolID)
+		rbdSnap.JournalPool, err = util.GetPoolName(rbdSnap.Monitors, cr, imageAttributes.JournalPoolID)
 		if err != nil {
 			// TODO: If pool is not found we may leak the image (as DeleteSnapshot will return success)
 			return err
@@ -448,7 +448,7 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 		return nil, err
 	}
 
-	rbdVol.Pool, err = util.GetPoolName(ctx, rbdVol.Monitors, cr, vi.LocationID)
+	rbdVol.Pool, err = util.GetPoolName(rbdVol.Monitors, cr, vi.LocationID)
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 
 	// convert the journal pool ID to name, for use in DeleteVolume cases
 	if imageAttributes.JournalPoolID >= 0 {
-		rbdVol.JournalPool, err = util.GetPoolName(ctx, rbdVol.Monitors, cr, imageAttributes.JournalPoolID)
+		rbdVol.JournalPool, err = util.GetPoolName(rbdVol.Monitors, cr, imageAttributes.JournalPoolID)
 		if err != nil {
 			// TODO: If pool is not found we may leak the image (as DeleteVolume will return success)
 			return nil, err

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -89,7 +89,7 @@ func getPools(ctx context.Context, monitors string, cr *Credentials) ([]cephStor
 
 // GetPoolID fetches the ID of the pool that matches the passed in poolName
 // parameter
-func GetPoolID(ctx context.Context, monitors string, cr *Credentials, poolName string) (int64, error) {
+func GetPoolID(monitors string, cr *Credentials, poolName string) (int64, error) {
 	conn, err := connPool.Get(monitors, cr.ID, cr.KeyFile)
 	if err != nil {
 		return 0, err
@@ -127,14 +127,14 @@ func GetPoolName(ctx context.Context, monitors string, cr *Credentials, poolID i
 // the passed in pools
 // TODO this should take in a list and return a map[string(poolname)]int64(poolID)
 func GetPoolIDs(ctx context.Context, monitors, journalPool, imagePool string, cr *Credentials) (int64, int64, error) {
-	journalPoolID, err := GetPoolID(ctx, monitors, cr, journalPool)
+	journalPoolID, err := GetPoolID(monitors, cr, journalPool)
 	if err != nil {
 		return InvalidPoolID, InvalidPoolID, err
 	}
 
 	imagePoolID := journalPoolID
 	if imagePool != journalPool {
-		imagePoolID, err = GetPoolID(ctx, monitors, cr, imagePool)
+		imagePoolID, err = GetPoolID(monitors, cr, imagePool)
 		if err != nil {
 			return InvalidPoolID, InvalidPoolID, err
 		}

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -92,15 +92,15 @@ func getPools(ctx context.Context, monitors string, cr *Credentials) ([]cephStor
 func GetPoolID(monitors string, cr *Credentials, poolName string) (int64, error) {
 	conn, err := connPool.Get(monitors, cr.ID, cr.KeyFile)
 	if err != nil {
-		return 0, err
+		return InvalidPoolID, err
 	}
 	defer connPool.Put(conn)
 
 	id, err := conn.GetPoolByName(poolName)
 	if err == rados.ErrNotFound {
-		return 0, ErrPoolNotFound{poolName, fmt.Errorf("pool (%s) not found in Ceph cluster", poolName)}
+		return InvalidPoolID, ErrPoolNotFound{poolName, fmt.Errorf("pool (%s) not found in Ceph cluster", poolName)}
 	} else if err != nil {
-		return 0, err
+		return InvalidPoolID, err
 	}
 
 	return id, nil

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -108,7 +108,7 @@ func GetPoolID(monitors string, cr *Credentials, poolName string) (int64, error)
 
 // GetPoolName fetches the pool whose pool ID is equal to the requested poolID
 // parameter
-func GetPoolName(ctx context.Context, monitors string, cr *Credentials, poolID int64) (string, error) {
+func GetPoolName(monitors string, cr *Credentials, poolID int64) (string, error) {
 	conn, err := connPool.Get(monitors, cr.ID, cr.KeyFile)
 	if err != nil {
 		return "", err

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -19,7 +19,6 @@ package util
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -51,40 +50,6 @@ func ExecCommand(program string, args ...string) (stdout, stderr []byte, err err
 	}
 
 	return stdoutBuf.Bytes(), nil, nil
-}
-
-// cephStoragePoolSummary strongly typed JSON spec for osd ls pools output
-type cephStoragePoolSummary struct {
-	Name   string `json:"poolname"`
-	Number int64  `json:"poolnum"`
-}
-
-// GetPools fetches a list of pools from a cluster
-func getPools(ctx context.Context, monitors string, cr *Credentials) ([]cephStoragePoolSummary, error) {
-	// ceph <options> -f json osd lspools
-	// JSON out: [{"poolnum":<int64>,"poolname":<string>}]
-
-	stdout, _, err := ExecCommand(
-		"ceph",
-		"-m", monitors,
-		"--id", cr.ID,
-		"--keyfile="+cr.KeyFile,
-		"-c", CephConfigPath,
-		"-f", "json",
-		"osd", "lspools")
-	if err != nil {
-		klog.Errorf(Log(ctx, "failed getting pool list from cluster (%s)"), err)
-		return nil, err
-	}
-
-	var pools []cephStoragePoolSummary
-	err = json.Unmarshal(stdout, &pools)
-	if err != nil {
-		klog.Errorf(Log(ctx, "failed to parse JSON output of pool list from cluster (%s)"), err)
-		return nil, fmt.Errorf("unmarshal of pool list failed: %+v.  raw buffer response: %s", err, string(stdout))
-	}
-
-	return pools, nil
 }
 
 // GetPoolID fetches the ID of the pool that matches the passed in poolName

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -145,7 +145,7 @@ func GenerateVolID(ctx context.Context, monitors string, cr *Credentials, locati
 	var err error
 
 	if locationID == InvalidPoolID {
-		locationID, err = GetPoolID(ctx, monitors, cr, pool)
+		locationID, err = GetPoolID(monitors, cr, pool)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Describe what this PR does #

Remove an other command execution and replace it by using go-ceph.

GetPoolID() did not return ErrPoolNotFound in case the pool could not be
found. This has been addressed as well, so that looking for an existing
pool behaves the same for checking by Name or ID.

Also remove unused context.Context parameter from GetPoolID().
