### PR TITLE
ci: Add Rule to auto merge the PR based on label and >=1 approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,23 @@ pull_request_rules:
         strict: smart
       dismiss_reviews: {}
       delete_head_branch: {}
+  - name: automatic merge PR having ready-to-merge label
+    conditions:
+      - label!=DNM
+      - label=ready-to-merge
+      - base=master
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "status-success=continuous-integration/travis-ci/pr"
+      - "status-success=DCO"
+      - "status-success=commitlint"
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: merge
+        strict: smart
+      dismiss_reviews: {}
+      delete_head_branch: {}
   - name: backport patches to release v1.2.0 branch
     conditions:
       - base=master

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -200,6 +200,10 @@ need to be met before it will be merged:
   * The 24 working hours counts hours occuring Mon-Fri in the local timezone
   * of the submitter
 * Each PR must be fully updated to master and tests must have passed
+* If the PR is having trivial changes or the reviewer is confident enough that
+  PR doesn't need a second review, the reviewer can set `ready-to-merge` label
+  on the PR. The bot will merge the PR if it's having one approval and the
+  label `ready-to-merge`
 
 When the criteria are met, a project maintainer can merge your changes into
 the project's master branch.


### PR DESCRIPTION
If the PR is having trivial changes or the reviewer is confident enough that PR doesn't need a second review, the reviewer can set `ready-to-merge` label on the PR. The bot will merge the PR if it's having one approval and the label `ready-to-merge`

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

