### PR TITLE
Convert journal package omap to use go ceph

### DIFF
--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package journal
+
+import (
+	"context"
+
+	"github.com/ceph/ceph-csi/internal/util"
+
+	"github.com/ceph/go-ceph/rados"
+	"k8s.io/klog"
+)
+
+func getOneOMapValue(
+	ctx context.Context,
+	conn *Connection,
+	poolName, namespace, oMapName, oMapKey string) (string, error) {
+	// fetch and configure the rados ioctx
+	ioctx, err := conn.conn.GetIoctx(poolName)
+	if err != nil {
+		return "", omapPoolError(poolName, err)
+	}
+	defer ioctx.Destroy()
+
+	if namespace != "" {
+		ioctx.SetNamespace(namespace)
+	}
+
+	pairs, err := ioctx.GetOmapValues(
+		oMapName, // oid (name of object)
+		"",       // startAfter (ignored)
+		oMapKey,  // filterPrefix - match only keys with this prefix
+		1,        // maxReturn - fetch no more than N values
+	)
+	switch err {
+	case nil:
+	case rados.ErrNotFound:
+		klog.Errorf(
+			util.Log(ctx, "omap not found (pool=%q, namespace=%q, name=%q, key=%q): %v"),
+			poolName, namespace, oMapName, oMapKey, err)
+		return "", util.NewErrKeyNotFound(oMapKey, err)
+	default:
+		return "", err
+	}
+
+	result, found := pairs[oMapKey]
+	if !found {
+		klog.Errorf(
+			util.Log(ctx, "key not found in omap (pool=%q, namespace=%q, name=%q, key=%q): %v"),
+			poolName, namespace, oMapName, oMapKey, err)
+		return "", util.NewErrKeyNotFound(oMapKey, nil)
+	}
+	klog.Infof(
+		util.Log(ctx, "XXX key found in omap! (pool=%q, namespace=%q, name=%q, key=%q): %v"),
+		poolName, namespace, oMapName, oMapKey, result)
+	return string(result), nil
+}
+
+func removeOneOMapKey(
+	ctx context.Context,
+	conn *Connection,
+	poolName, namespace, oMapName, oMapKey string) error {
+	// fetch and configure the rados ioctx
+	ioctx, err := conn.conn.GetIoctx(poolName)
+	if err != nil {
+		return omapPoolError(poolName, err)
+	}
+	defer ioctx.Destroy()
+
+	if namespace != "" {
+		ioctx.SetNamespace(namespace)
+	}
+
+	err = ioctx.RmOmapKeys(oMapName, []string{oMapKey})
+	if err != nil {
+		klog.Errorf(
+			util.Log(ctx, "failed removing omap key (pool=%q, namespace=%q, name=%q, key=%q): %v"),
+			poolName, namespace, oMapName, oMapKey, err)
+	} else {
+		klog.Infof(
+			util.Log(ctx, "XXX removed omap key (pool=%q, namespace=%q, name=%q, key=%q, ): %v"),
+			poolName, namespace, oMapName, oMapKey, err)
+	}
+	return err
+}
+
+func setOneOMapKey(
+	ctx context.Context,
+	conn *Connection,
+	poolName, namespace, oMapName, oMapKey, keyValue string) error {
+	// fetch and configure the rados ioctx
+	ioctx, err := conn.conn.GetIoctx(poolName)
+	if err != nil {
+		return omapPoolError(poolName, err)
+	}
+	defer ioctx.Destroy()
+
+	if namespace != "" {
+		ioctx.SetNamespace(namespace)
+	}
+
+	pairs := map[string][]byte{
+		oMapKey: []byte(keyValue),
+	}
+	err = ioctx.SetOmap(oMapName, pairs)
+	if err != nil {
+		klog.Errorf(
+			util.Log(ctx, "failed setting omap key (pool=%q, namespace=%q, name=%q, key=%q, value=%q): %v"),
+			poolName, namespace, oMapName, oMapKey, keyValue, err)
+	} else {
+		klog.Infof(
+			util.Log(ctx, "XXX set omap key (pool=%q, namespace=%q, name=%q, key=%q, value=%q): %v"),
+			poolName, namespace, oMapName, oMapKey, keyValue, err)
+	}
+	return err
+}
+
+func omapPoolError(poolName string, err error) error {
+	if err == rados.ErrNotFound {
+		return util.NewErrPoolNotFound(poolName, err)
+	}
+	return err
+}

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -105,10 +105,10 @@ func removeMapKeys(
 	return err
 }
 
-func setOneOMapKey(
+func setOMapKeys(
 	ctx context.Context,
 	conn *Connection,
-	poolName, namespace, oMapName, oMapKey, keyValue string) error {
+	poolName, namespace, oid string, pairs map[string]string) error {
 	// fetch and configure the rados ioctx
 	ioctx, err := conn.conn.GetIoctx(poolName)
 	if err != nil {
@@ -120,20 +120,21 @@ func setOneOMapKey(
 		ioctx.SetNamespace(namespace)
 	}
 
-	pairs := map[string][]byte{
-		oMapKey: []byte(keyValue),
+	bpairs := make(map[string][]byte, len(pairs))
+	for k, v := range pairs {
+		bpairs[k] = []byte(v)
 	}
-	err = ioctx.SetOmap(oMapName, pairs)
+	err = ioctx.SetOmap(oid, bpairs)
 	if err != nil {
 		klog.Errorf(
-			util.Log(ctx, "failed setting omap key (pool=%q, namespace=%q, name=%q, key=%q, value=%q): %v"),
-			poolName, namespace, oMapName, oMapKey, keyValue, err)
-	} else {
-		klog.Infof(
-			util.Log(ctx, "XXX set omap key (pool=%q, namespace=%q, name=%q, key=%q, value=%q): %v"),
-			poolName, namespace, oMapName, oMapKey, keyValue, err)
+			util.Log(ctx, "failed setting omap keys (pool=%q, namespace=%q, name=%q, pairs=%+v): %v"),
+			poolName, namespace, oid, pairs, err)
+		return err
 	}
-	return err
+	klog.V(4).Infof(
+		util.Log(ctx, "set omap keys (pool=%q, namespace=%q, name=%q): %+v)"),
+		poolName, namespace, oid, pairs)
+	return nil
 }
 
 func omapPoolError(poolName string, err error) error {

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -77,10 +77,10 @@ func getOMapValues(
 	return results, nil
 }
 
-func removeOneOMapKey(
+func removeMapKeys(
 	ctx context.Context,
 	conn *Connection,
-	poolName, namespace, oMapName, oMapKey string) error {
+	poolName, namespace, oid string, keys []string) error {
 	// fetch and configure the rados ioctx
 	ioctx, err := conn.conn.GetIoctx(poolName)
 	if err != nil {
@@ -92,15 +92,15 @@ func removeOneOMapKey(
 		ioctx.SetNamespace(namespace)
 	}
 
-	err = ioctx.RmOmapKeys(oMapName, []string{oMapKey})
+	err = ioctx.RmOmapKeys(oid, keys)
 	if err != nil {
 		klog.Errorf(
-			util.Log(ctx, "failed removing omap key (pool=%q, namespace=%q, name=%q, key=%q): %v"),
-			poolName, namespace, oMapName, oMapKey, err)
+			util.Log(ctx, "failed removing omap keys (pool=%q, namespace=%q, name=%q): %v"),
+			poolName, namespace, oid, err)
 	} else {
-		klog.Infof(
-			util.Log(ctx, "XXX removed omap key (pool=%q, namespace=%q, name=%q, key=%q, ): %v"),
-			poolName, namespace, oMapName, oMapKey, err)
+		klog.V(4).Infof(
+			util.Log(ctx, "removed omap keys (pool=%q, namespace=%q, name=%q): %+v"),
+			poolName, namespace, oid, keys)
 	}
 	return err
 }

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -411,8 +411,8 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 	}
 
 	// delete the request name key (last, inverse of create order)
-	err := removeOneOMapKey(ctx, conn, csiJournalPool, cj.namespace, cj.csiDirectory,
-		cj.csiNameKeyPrefix+reqName)
+	err := removeMapKeys(ctx, conn, csiJournalPool, cj.namespace, cj.csiDirectory,
+		[]string{cj.csiNameKeyPrefix + reqName})
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed removing oMap key %s (%s)"), cj.csiNameKeyPrefix+reqName, err)
 		return err

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -211,14 +211,21 @@ type Connection struct {
 	// connection metadata
 	monitors string
 	cr       *util.Credentials
+	// cached cluster connection (required by go-ceph)
+	conn *util.ClusterConnection
 }
 
 // Connect establishes a new connection to a ceph cluster for journal metadata.
 func (cj *Config) Connect(monitors string, cr *util.Credentials) (*Connection, error) {
+	cc := &util.ClusterConnection{}
+	if err := cc.Connect(monitors, cr); err != nil {
+		return nil, err
+	}
 	conn := &Connection{
 		config:   cj,
 		monitors: monitors,
 		cr:       cr,
+		conn:     cc,
 	}
 	return conn, nil
 }
@@ -257,7 +264,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 	}
 
 	// check if request name is already part of the directory omap
-	objUUIDAndPool, err := util.GetOMapValue(ctx, conn.monitors, conn.cr, journalPool, cj.namespace, cj.csiDirectory,
+	objUUIDAndPool, err := getOneOMapValue(ctx, conn, journalPool, cj.namespace, cj.csiDirectory,
 		cj.csiNameKeyPrefix+reqName)
 	if err != nil {
 		// error should specifically be not found, for volume to be absent, any other error
@@ -389,7 +396,7 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 	}
 
 	// delete the request name key (last, inverse of create order)
-	err := util.RemoveOMapKey(ctx, conn.monitors, conn.cr, csiJournalPool, cj.namespace, cj.csiDirectory,
+	err := removeOneOMapKey(ctx, conn, csiJournalPool, cj.namespace, cj.csiDirectory,
 		cj.csiNameKeyPrefix+reqName)
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed removing oMap key %s (%s)"), cj.csiNameKeyPrefix+reqName, err)
@@ -495,7 +502,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 		nameKeyVal = volUUID
 	}
 
-	err = util.SetOMapKeyValue(ctx, conn.monitors, conn.cr, journalPool, cj.namespace, cj.csiDirectory,
+	err = setOneOMapKey(ctx, conn, journalPool, cj.namespace, cj.csiDirectory,
 		cj.csiNameKeyPrefix+reqName, nameKeyVal)
 	if err != nil {
 		return "", "", err
@@ -514,14 +521,14 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	// 	and also CSI journal pool, when only the VolumeID is passed in (e.g DeleteVolume/DeleteSnapshot,
 	// 	VolID during CreateSnapshot).
 	// Update UUID directory to store CSI request name
-	err = util.SetOMapKeyValue(ctx, conn.monitors, conn.cr, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
+	err = setOneOMapKey(ctx, conn, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
 		cj.csiNameKey, reqName)
 	if err != nil {
 		return "", "", err
 	}
 
 	// Update UUID directory to store image name
-	err = util.SetOMapKeyValue(ctx, conn.monitors, conn.cr, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
+	err = setOneOMapKey(ctx, conn, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
 		cj.csiImageKey, imageName)
 	if err != nil {
 		return "", "", err
@@ -529,7 +536,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 
 	// Update UUID directory to store encryption values
 	if kmsConf != "" {
-		err = util.SetOMapKeyValue(ctx, conn.monitors, conn.cr, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
+		err = setOneOMapKey(ctx, conn, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
 			cj.encryptKMSKey, kmsConf)
 		if err != nil {
 			return "", "", err
@@ -542,7 +549,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 		journalPoolIDStr := hex.EncodeToString(buf64)
 
 		// Update UUID directory to store CSI journal pool name (prefer ID instead of name to be pool rename proof)
-		err = util.SetOMapKeyValue(ctx, conn.monitors, conn.cr, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
+		err = setOneOMapKey(ctx, conn, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
 			cj.csiJournalPool, journalPoolIDStr)
 		if err != nil {
 			return "", "", err
@@ -551,7 +558,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 
 	if snapSource {
 		// Update UUID directory to store source volume UUID in case of snapshots
-		err = util.SetOMapKeyValue(ctx, conn.monitors, conn.cr, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
+		err = setOneOMapKey(ctx, conn, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix+volUUID,
 			cj.cephSnapSourceKey, parentName)
 		if err != nil {
 			return "", "", err
@@ -584,7 +591,7 @@ func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID
 	}
 
 	// TODO: fetch all omap vals in one call, than make multiple listomapvals
-	imageAttributes.RequestName, err = util.GetOMapValue(ctx, conn.monitors, conn.cr, pool, cj.namespace,
+	imageAttributes.RequestName, err = getOneOMapValue(ctx, conn, pool, cj.namespace,
 		cj.cephUUIDDirectoryPrefix+objectUUID, cj.csiNameKey)
 	if err != nil {
 		return nil, err
@@ -592,7 +599,7 @@ func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID
 
 	// image key was added at some point, so not all volumes will have this key set
 	// when ceph-csi was upgraded
-	imageAttributes.ImageName, err = util.GetOMapValue(ctx, conn.monitors, conn.cr, pool, cj.namespace,
+	imageAttributes.ImageName, err = getOneOMapValue(ctx, conn, pool, cj.namespace,
 		cj.cephUUIDDirectoryPrefix+objectUUID, cj.csiImageKey)
 	if err != nil {
 		// if the key was not found, assume the default key + UUID
@@ -610,7 +617,7 @@ func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID
 		}
 	}
 
-	imageAttributes.KmsID, err = util.GetOMapValue(ctx, conn.monitors, conn.cr, pool, cj.namespace,
+	imageAttributes.KmsID, err = getOneOMapValue(ctx, conn, pool, cj.namespace,
 		cj.cephUUIDDirectoryPrefix+objectUUID, cj.encryptKMSKey)
 	if err != nil {
 		// ErrKeyNotFound means no encryption KMS was used
@@ -622,7 +629,7 @@ func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID
 		}
 	}
 
-	journalPoolIDStr, err := util.GetOMapValue(ctx, conn.monitors, conn.cr, pool, cj.namespace,
+	journalPoolIDStr, err := getOneOMapValue(ctx, conn, pool, cj.namespace,
 		cj.cephUUIDDirectoryPrefix+objectUUID, cj.csiJournalPool)
 	if err != nil {
 		if _, ok := err.(util.ErrKeyNotFound); !ok {
@@ -639,7 +646,7 @@ func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID
 	}
 
 	if snapSource {
-		imageAttributes.SourceName, err = util.GetOMapValue(ctx, conn.monitors, conn.cr, pool, cj.namespace,
+		imageAttributes.SourceName, err = getOneOMapValue(ctx, conn, pool, cj.namespace,
 			cj.cephUUIDDirectoryPrefix+objectUUID, cj.cephSnapSourceKey)
 		if err != nil {
 			return nil, err

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -22,10 +22,12 @@ type ErrKeyNotFound struct {
 	err     error
 }
 
+// NewErrKeyNotFound returns a new ErrKeyNotFound error.
 func NewErrKeyNotFound(keyName string, err error) ErrKeyNotFound {
 	return ErrKeyNotFound{keyName, err}
 }
 
+// Error returns the error string for ErrKeyNotFound.
 func (e ErrKeyNotFound) Error() string {
 	return e.err.Error()
 }
@@ -36,6 +38,7 @@ type ErrObjectExists struct {
 	err        error
 }
 
+// Error returns the error string for ErrObjectExists.
 func (e ErrObjectExists) Error() string {
 	return e.err.Error()
 }
@@ -46,6 +49,7 @@ type ErrObjectNotFound struct {
 	err      error
 }
 
+// Error returns the error string for ErrObjectNotFound.
 func (e ErrObjectNotFound) Error() string {
 	return e.err.Error()
 }
@@ -57,6 +61,7 @@ type ErrSnapNameConflict struct {
 	err         error
 }
 
+// Error returns the error string for ErrSnapNameConflict.
 func (e ErrSnapNameConflict) Error() string {
 	return e.err.Error()
 }
@@ -72,10 +77,12 @@ type ErrPoolNotFound struct {
 	Err  error
 }
 
+// Error returns the error string for ErrPoolNotFound.
 func (e ErrPoolNotFound) Error() string {
 	return e.Err.Error()
 }
 
+// NewErrPoolNotFound returns a new ErrPoolNotFound error.
 func NewErrPoolNotFound(pool string, err error) ErrPoolNotFound {
 	return ErrPoolNotFound{pool, err}
 }

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -22,6 +22,10 @@ type ErrKeyNotFound struct {
 	err     error
 }
 
+func NewErrKeyNotFound(keyName string, err error) ErrKeyNotFound {
+	return ErrKeyNotFound{keyName, err}
+}
+
 func (e ErrKeyNotFound) Error() string {
 	return e.err.Error()
 }
@@ -70,4 +74,8 @@ type ErrPoolNotFound struct {
 
 func (e ErrPoolNotFound) Error() string {
 	return e.Err.Error()
+}
+
+func NewErrPoolNotFound(pool string, err error) ErrPoolNotFound {
+	return ErrPoolNotFound{pool, err}
 }

--- a/scripts/golangci.yml
+++ b/scripts/golangci.yml
@@ -149,8 +149,6 @@ linters-settings:
     # TODO: decrease complexity with refacoring the code
     min-complexity: 40
   dogsled:
-    # voljournal.GetObjectUUIDData currently returns 4 values of which some may
-    # not always be useful
     max-blank-identifiers: 3
 
 linters:


### PR DESCRIPTION
# Describe what this PR does #

Change the way the journal package interacts with omaps by switching from cli based functions to the api bindings of go-ceph. The first few patches basically do one-to-one switch overs of the calls used in voljournal.go. Subsequent patches change the internal interfaces to use the natural batching that the api calls give us, allowing the setting, fetching, or removal of multiple keys in one api call.



## Is there anything that requires special attention ##

Do you have any questions? n/a

Is the change backward compatible?
In theory it should behave exactly as before.

Are there concerns around backward compatibility?
Now that CI is passing, there shouldn't be, but any missed changes can be handled as fixes.

## Related issues ##



Fixes: #434

## Future concerns ##

This series does not handle changing everything in journal to go-ceph. There's more to be done here. 
I did not clean up any functions that are now unused in util. I plan to do that in a follow up pr.