### PR TITLE
build: prevent error message when 'go' is unavailable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ LDFLAGS += -X $(GO_PROJECT)/internal/util.DriverVersion=$(CSI_IMAGE_VERSION)
 
 # set GOARCH explicitly for cross building, default to native architecture
 ifndef GOARCH
-GOARCH := $(shell go env GOARCH)
+GOARCH := $(shell go env GOARCH 2>/dev/null)
 endif
 
 ifdef BASE_IMAGE


### PR DESCRIPTION
# Describe what this PR does #

In case the `go` executable is not available, any `make` command shows
the error `go: command not found` even when running the actual task in a
container (that will have `go` available).

So, redirect the error message to `/dev/null`. In case `go` is really
not available in the build environment, the `check-env` make target will
report it.