### PR TITLE
ci: Enable stale bot on issues.

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -10,7 +10,7 @@ exemptLabels:
   - release requirement
 
 # Set to true to ignore issues in a project (defaults to false)
-exemptProjects: true
+exemptProjects: false
 
 # Set to true to ignore issues in a milestone (defaults to false)
 exemptMilestones: true


### PR DESCRIPTION
The stale bot was disabled in existing configuration and this PR enables it.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

