### PR TITLE
deploy: Enable `extraCreateMetadata` for provisioner

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - "--timeout={{ .Values.provisioner.timeout }}"
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
+            - "--extra-create-metadata=true"
 {{- if .Values.topology.enabled }}
             - "--feature-gates=Topology=true"
 {{- end }}

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -53,6 +53,7 @@ spec:
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
             - "--default-fstype={{ .Values.provisioner.defaultFSType }}"
+            - "--extra-create-metadata=true"
 {{- if .Values.topology.enabled }}
             - "--feature-gates=Topology=true"
 {{- end }}

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -50,6 +50,7 @@ spec:
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
             - "--feature-gates=Topology=false"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -53,6 +53,7 @@ spec:
             - "--feature-gates=Topology=false"
             # if fstype is not specified in storageclass, ext4 is default
             - "--default-fstype=ext4"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -260,6 +260,15 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("create a PVC and validate owner", func() {
+				err := validateImageOwner(pvcPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate owner of pvc with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0)
+			})
+
 			By("create a PVC and bind it to an app", func() {
 				err := validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
@@ -1109,8 +1118,15 @@ var _ = Describe("RBD", func() {
 
 				updateConfigMap("e2e-ns")
 
+				err := validateImageOwner(pvcPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate owner of pvc with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0)
+
 				// Create a PVC and bind it to an app within the namesapce
-				err := validatePVCAndAppBinding(pvcPath, appPath, f)
+				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -232,7 +232,7 @@ func reserveVol(ctx context.Context, volOptions *volumeOptions, secret map[strin
 	imageUUID, vid.FsSubvolName, err = j.ReserveName(
 		ctx, volOptions.MetadataPool, util.InvalidPoolID,
 		volOptions.MetadataPool, util.InvalidPoolID, volOptions.RequestName,
-		volOptions.NamePrefix, "", "", volOptions.ReservedID)
+		volOptions.NamePrefix, "", "", volOptions.ReservedID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func reserveSnap(ctx context.Context, volOptions *volumeOptions, parentSubVolNam
 	imageUUID, vid.FsSnapshotName, err = j.ReserveName(
 		ctx, volOptions.MetadataPool, util.InvalidPoolID,
 		volOptions.MetadataPool, util.InvalidPoolID, snap.RequestName,
-		snap.NamePrefix, parentSubVolName, "", snap.ReservedID)
+		snap.NamePrefix, parentSubVolName, "", snap.ReservedID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -344,7 +344,7 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 
 	rbdSnap.ReservedID, rbdSnap.RbdSnapName, err = j.ReserveName(
 		ctx, rbdSnap.JournalPool, journalPoolID, rbdSnap.Pool, imagePoolID,
-		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, "", rbdSnap.ReservedID)
+		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, "", rbdSnap.ReservedID, rbdVol.Owner)
 	if err != nil {
 		return err
 	}
@@ -422,7 +422,7 @@ func reserveVol(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnapshot, cr
 
 	rbdVol.ReservedID, rbdVol.RbdImageName, err = j.ReserveName(
 		ctx, rbdVol.JournalPool, journalPoolID, rbdVol.Pool, imagePoolID,
-		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, rbdVol.ReservedID)
+		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, rbdVol.ReservedID, rbdVol.Owner)
 	if err != nil {
 		return err
 	}
@@ -542,6 +542,7 @@ func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName strin
 	if imageData != nil {
 		rbdVol.ReservedID = imageData.ImageUUID
 		rbdVol.ImageID = imageData.ImageAttributes.ImageID
+		rbdVol.Owner = imageData.ImageAttributes.Owner
 		if rbdVol.ImageID == "" {
 			err = rbdVol.storeImageID(ctx, j)
 			if err != nil {
@@ -559,7 +560,7 @@ func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName strin
 
 	rbdVol.ReservedID, rbdVol.RbdImageName, err = j.ReserveName(
 		ctx, rbdVol.JournalPool, journalPoolID, rbdVol.Pool, imagePoolID,
-		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, vi.ObjectUUID)
+		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, vi.ObjectUUID, rbdVol.Owner)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Pass extra metadata when creating volumes makes it possible to detect the Kubernetes Namespace where the PVC is created. This can then be used for fetching the Vault Token (or other configuration) from the namespace where the PVC lives.

The extra metadata is available in the parameters of the CreateVolume request, for example:
```
GRPC call: /csi.v1.Controller/CreateVolume
GRPC request: {"accessibility_requirements":{"preferred":[{"segments":{"topology.rbd.csi.ceph.com/region":"testregion","topology.rbd.csi.ceph.com/zone":"testzone"}}],"requisite":[{"segments":{"topology.rbd.csi.ceph.com/region":"testregion","topology.rbd.csi.ceph.com/zone":"testzone"}}]},"capacity_range":{"required_bytes":1073741824},"name":"pvc-a18380b9-d9b7-46df-be26-693e0530c715","parameters":{"clusterID":"fa4b2e2b-ceb9-4db2-a96b-162a815a31a9","csi.storage.k8s.io/pv/name":"pvc-a18380b9-d9b7-46df-be26-693e0530c715","csi.storage.k8s.io/pvc/name":"rbd-pvc","csi.storage.k8s.io/pvc/namespace":"rbd-7887","encrypted":"true","imageFeatures":"layering","pool":"replicapool"},"secrets":"***stripped***","volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext4","mount_flags":["discard"]}},"access_mode":{"mode":1}}]}
```

See-also: #1305

