### PR TITLE
ci: use parameters set by github-pull-request-builder

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -30,7 +30,7 @@ node('cico-workspace') {
 
 	try {
 		stage('prepare bare-metal machine') {
-			if ("${ghprbPullId}".length() != 0) {
+			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/head"
 			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh root@${CICO_NODE}:'
@@ -42,7 +42,7 @@ node('cico-workspace') {
 					sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test CONTAINER_CMD=podman"'
 				}
 			},
-			build: { 
+			build: {
 				node('cico-workspace') {
 					sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman"'
 				}

--- a/containerized-tests.yaml
+++ b/containerized-tests.yaml
@@ -18,10 +18,6 @@
               - ci/centos
       script-path: containerized-tests.groovy
       lightweight-checkout: true
-    parameters:
-      - string:
-          name: ghprbPullId
-          default: ''
     triggers:
       - github-pull-request:
           status-context: ci/centos/containerized-tests


### PR DESCRIPTION
# Describe what this PR does #

The parameters are set in the environment. It seems the best way to
check if the parameters are available, is with `params.<arg> == null`.

See-also: https://www.jenkins.io/doc/book/pipeline/getting-started/#global-variable-reference#

And for the `map.key == null` at http://groovy-lang.org/syntax.html#_maps