### PR TITLE
ci: require ci/centos/containerized-tests for merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
+      - "status-success=ci/centos/containerized-tests"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:
@@ -40,6 +41,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
+      - "status-success=ci/centos/containerized-tests"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,12 +92,6 @@ jobs:
         - ./scripts/build-multi-arch-image.sh || travis_terminate 1;
 
     - stage: build testing
-      name: containerized test (Fedora) and build (CentOS)
-      script:
-        - make containerized-test || travis_terminate 1;
-        - make containerized-build || travis_terminate 1;
-
-    - stage: build testing
       name: cephcsi on Arm64
       arch: arm64
       script:


### PR DESCRIPTION
# Describe what this PR does #

The ci/centos/containerized-tests status is already set by the Jenkins
job in the CentOS CI. It can now be used to gate the automatic merging
of PRs.

Reduce the load on Travis CI, do not run the containerized-tests job
there any longer.