### PR TITLE
CentOS CI: add job for validating the ci/centos branch

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,30 @@
+---
+# rules are documented at https://commitlint.js.org/#/reference-rules
+# each rule has a n arry of three values:
+# - 0, 1, 2 (rule is disabled, warning or error)
+# - always/never
+# - value
+rules:
+  # the subject may not exceed 72 characters
+  header-max-length: [2, always, 72]
+  # the subject may not end with a "."
+  header-full-stop: [2, never, "."]
+  # we do not use scopes for commit messages
+  scope-empty: [1, always]
+  # valid types/prefixes, see docs/development-guide.md
+  type-enum:
+    - 1
+    - always
+    - - build
+      - cephfs
+      - ci
+      - cleanup
+      - deploy
+      - doc
+      - e2e
+      - helm
+      - journal
+      - rbd
+      - rebase
+      - revert
+      - util

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.test-container-id

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+# Copyright 2020 The Ceph-CSI Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CONTAINER_CMD?=$(shell docker version >/dev/null 2>&1 && echo docker)
+ifeq ($(CONTAINER_CMD),)
+    CONTAINER_CMD=$(shell podman version >/dev/null 2>&1 && echo podman)
+endif
+CPUS?=$(shell nproc --ignore=1)
+CPUSET?=--cpuset-cpus=0-${CPUS}
+
+CSI_IMAGE_NAME=$(if $(ENV_CSI_IMAGE_NAME),$(ENV_CSI_IMAGE_NAME),quay.io/cephcsi/cephcsi)
+
+# passing TARGET=static-check on the 'make containerized-test' commandline will
+# run the selected target instead of 'make test' in the container. Obviously
+# other targets can be passed as well, making it easier for developers to run
+# single tests.
+TARGET ?= lint-all
+
+# Pass GIT_SINCE for the range of commits to test. Used with the commitlint
+# target.
+GIT_SINCE := origin/ci/centos
+
+SELINUX := $(shell getenforce 2>/dev/null)
+ifeq ($(SELINUX),Enforcing)
+	SELINUX_VOL_FLAG = :z
+endif
+
+.PHONY: test
+test:
+	$(MAKE) containerized-test TARGET=lint-all
+	$(MAKE) containerized-test TARGET=commitlint
+
+.PHONY: lint-all lint-shell lint-markdown lint-yaml commitlint
+lint-all: lint-shell lint-markdown lint-yaml
+
+lint-shell:
+	./scripts/lint-extras.sh lint-shell
+
+lint-markdown:
+	./scripts/lint-extras.sh lint-markdown
+
+lint-yaml:
+	./scripts/lint-extras.sh lint-yaml
+
+commitlint:
+	commitlint --from $(GIT_SINCE)
+
+.PHONY: containerized-test
+containerized-test: .test-container-id
+	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make $(TARGET) GIT_SINCE=$(GIT_SINCE)
+
+# create a (cached) container image with dependencies for testing the CI jobs
+.test-container-id: scripts/Dockerfile.test
+	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
+	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
+	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
+
+clean:
+	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
+	$(RM) .test-container-id

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - a Jenkins Pipeline is used to reserve bare metal system(s), and run jobs on
   those systems
 
-# Repository/Branch Structure
+## Repository/Branch Structure
 
 This is the `ci/centos` branch, where all the scripts for the Jenkins jobs are
 maintained. The tests that are executed by the jobs are part of the normal
@@ -47,7 +47,6 @@ they can be run. Importing is done with the `jenkins-jobs` command, which runs
 in a `jjb` container. To build the container, and provide the configuration for
 Jenkins Job Builder, see the [documentation in the `deploy/`
 directory](deploy/README.md).
-
 
 [ceph_csi_ci]: https://jenkins-ceph-csi.apps.ci.centos.org
 [app_ci_centos_org]: https://console.apps.ci.centos.org:8443/console/project/ceph-csi

--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -7,9 +7,11 @@ def base = ''
 
 node('cico-workspace') {
 	stage('checkout ci repository') {
-		git url: "${ci_git_repo}",
-			branch: "${ci_git_branch}",
-			changelog: false
+		if (params.ghprbPullId != null) {
+			ref = "pull/${ghprbPullId}/head"
+		}
+		checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
+			userRemoteConfigs: [[url: "${ci_git_repo}", refspec: "${ref}"]]])
 	}
 
 	stage('reserve bare-metal machine') {
@@ -30,9 +32,6 @@ node('cico-workspace') {
 
 	try {
 		stage('prepare bare-metal machine') {
-			if (params.ghprbPullId != null) {
-				ref = "pull/${ghprbPullId}/head"
-			}
 			if (params.ghprbTargetBranch != null) {
 				base = "--base=${ghprbTargetBranch}"
 			}

--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -3,6 +3,7 @@ def cico_retry_interval = 60
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def ref = 'ci/centos'
+def base = ''
 
 node('cico-workspace') {
 	stage('checkout ci repository') {
@@ -32,8 +33,11 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/head"
 			}
+			if (params.ghprbTargetBranch != null) {
+				base = "--base=${ghprbTargetBranch}"
+			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh root@${CICO_NODE}:'
-			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref}"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref} ${base}"
 		}
 		stage('test') {
 			sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make"'

--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -1,0 +1,48 @@
+def cico_retries = 16
+def cico_retry_interval = 60
+def ci_git_repo = 'https://github.com/ceph/ceph-csi'
+def ci_git_branch = 'ci/centos'
+def ref = 'ci/centos'
+
+node('cico-workspace') {
+	stage('checkout ci repository') {
+		git url: "${ci_git_repo}",
+			branch: "${ci_git_branch}",
+			changelog: false
+	}
+
+	stage('reserve bare-metal machine') {
+		def firstAttempt = true
+		retry(30) {
+			if (!firstAttempt) {
+				sleep(time: 5, unit: "MINUTES")
+			}
+			firstAttempt = false
+			cico = sh(
+				script: "cico node get -f value -c hostname -c comment --retry-count ${cico_retries} --retry-interval ${cico_retry_interval}",
+				returnStdout: true
+			).trim().tokenize(' ')
+			env.CICO_NODE = "${cico[0]}.ci.centos.org"
+			env.CICO_SSID = "${cico[1]}"
+		}
+	}
+
+	try {
+		stage('prepare bare-metal machine') {
+			if (params.ghprbPullId != null) {
+				ref = "pull/${ghprbPullId}/head"
+			}
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh root@${CICO_NODE}:'
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref}"
+		}
+		stage('test') {
+			sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make"'
+		}
+	}
+
+	finally {
+		stage('return bare-metal machine') {
+			sh 'cico node done ${CICO_SSID}'
+		}
+	}
+}

--- a/ci-job-validation.yaml
+++ b/ci-job-validation.yaml
@@ -1,0 +1,34 @@
+---
+- job:
+    name: ci-job-validation
+    project-type: pipeline
+    sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-csi
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-csi
+            branches:
+              - ci/centos
+      script-path: ci-job-validation.groovy
+      lightweight-checkout: true
+    triggers:
+      - github-pull-request:
+          status-context: ci/centos/job-validation
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/job-validation))'
+          permit-all: true
+          # TODO: set github-hooks to true when it is configured in GitHub
+          github-hooks: false
+          cron: 'H/5 * * * *'
+          white-list-target-branches:
+            - ci/centos
+          admin-list:
+            - nixpanic
+          org-list:
+            - ceph

--- a/deploy/jjb-buildconfig.yaml
+++ b/deploy/jjb-buildconfig.yaml
@@ -7,7 +7,7 @@ metadata:
     app: jjb
 spec:
   tags:
-  - name: latest
+    - name: latest
 ---
 apiVersion: v1
 kind: BuildConfig

--- a/deploy/jjb-deploy.yaml
+++ b/deploy/jjb-deploy.yaml
@@ -13,21 +13,21 @@ spec:
       app: jjb
     spec:
       containers:
-      - name: jjb
-        image: 172.30.254.79:5000/ceph-csi/jjb:latest
-        env:
-        - name: GIT_REPO
-          value: https://github.com/ceph/ceph-csi
-        - name: GIT_REF
-          value: ci/centos
-        - name: MAKE_TARGET
-          value: deploy
-        volumeMounts:
-        - name: etc-jj
-          mountPath: /etc/jenkins_jobs
-          readOnly: true
+        - name: jjb
+          image: 172.30.254.79:5000/ceph-csi/jjb:latest
+          env:
+            - name: GIT_REPO
+              value: https://github.com/ceph/ceph-csi
+            - name: GIT_REF
+              value: ci/centos
+            - name: MAKE_TARGET
+              value: deploy
+          volumeMounts:
+            - name: etc-jj
+              mountPath: /etc/jenkins_jobs
+              readOnly: true
       volumes:
-      - name: etc-jj
-        configMap:
-          name: jenkins-jobs
+        - name: etc-jj
+          configMap:
+            name: jenkins-jobs
       restartPolicy: Never

--- a/deploy/jjb-validate.yaml
+++ b/deploy/jjb-validate.yaml
@@ -13,11 +13,11 @@ spec:
       app: jjb-validate
     spec:
       containers:
-      - name: jjb-validate
-        image: 172.30.254.79:5000/ceph-csi/jjb:latest
-        env:
-        - name: GIT_REPO
-          value: https://github.com/ceph/ceph-csi
-        - name: GIT_REF
-          value: ci/centos
+        - name: jjb-validate
+          image: 172.30.254.79:5000/ceph-csi/jjb:latest
+          env:
+            - name: GIT_REPO
+              value: https://github.com/ceph/ceph-csi
+            - name: GIT_REF
+              value: ci/centos
       restartPolicy: Never

--- a/jjb-deploy.yaml
+++ b/jjb-deploy.yaml
@@ -15,4 +15,4 @@
         }
       }
     triggers:
-    - github
+      - github

--- a/jjb-deploy.yaml
+++ b/jjb-deploy.yaml
@@ -14,5 +14,11 @@
           sh './deploy/jjb.sh deploy'
         }
       }
+    scm:
+      git:
+        url: https://github.com/ceph/ceph-csi
+        branches:
+          - ci/centos
     triggers:
-      - github
+      - pollscm:
+          cron: "H/5 * * * *"

--- a/jjb-validate.yaml
+++ b/jjb-validate.yaml
@@ -17,6 +17,6 @@
     triggers:
       - github-pull-request:
           admin-list:
-          - nixpanic
+            - nixpanic
           org-list:
-          - ceph
+            - ceph

--- a/jjb-validate.yaml
+++ b/jjb-validate.yaml
@@ -3,9 +3,21 @@
     name: jjb-validate
     project-type: pipeline
     sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-csi
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
     dsl: |
       def GIT_REPO = 'http://github.com/ceph/ceph-csi'
       def GIT_BRANCH = 'ci/centos'
+
+      if (params.ghprbPullId != null) {
+          GIT_BRANCH = "pr/${ghprbPullId}/head"
+      }
+
       node {
         stage('checkout ci repository') {
           git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
@@ -16,6 +28,14 @@
       }
     triggers:
       - github-pull-request:
+          status-context: ci/centos/jjb-validate
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/jjb-validate))'
+          permit-all: true
+          # TODO: set github-hooks to true when it is configured in GitHub
+          github-hooks: false
+          cron: 'H/5 * * * *'
+          white-list-target-branches:
+            - ci/centos
           admin-list:
             - nixpanic
           org-list:

--- a/prepare.sh
+++ b/prepare.sh
@@ -17,8 +17,9 @@ opts=$(getopt \
     --options "" \
     -- "$@"
 )
+ret=$?
 
-if [ $? -ne 0 ]
+if [ ${ret} -ne 0 ]
 then
     echo "Try '--help' for more information." 
     exit 1   

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -o pipefail
+
 # In case no value is specified, default values will be used.
 gitrepo="https://github.com/ceph/ceph-csi"
 workdir="tip/"
@@ -21,38 +23,38 @@ ret=$?
 
 if [ ${ret} -ne 0 ]
 then
-    echo "Try '--help' for more information." 
-    exit 1   
+    echo "Try '--help' for more information."
+    exit 1
 fi
 
-eval set -- ${opts}
+eval set -- "${opts}"
 
 while true; do
     case "${1}" in
-    --help)  
+    --help)
         shift
         echo "Options:"
         echo "--help|-h                 specify the flags"
         echo "--ref                     specify the reference of pr"
         echo "--workdir                 specify the working directory"
-        echo "--gitrepo                 specify the git repository" 
+        echo "--gitrepo                 specify the git repository"
         echo " "
         echo "Sample Usage:"
         echo "./prepare.sh --gitrepo=https://github.com/example --workdir=/opt/build --ref=pull/123/head"
         exit 0
         ;;
-    --gitrepo)  
+    --gitrepo)
         shift
         gitrepo=${1}
         ;;
-    --workdir)  
+    --workdir)
         shift
         workdir=${1}
         ;;
-    --ref)  
+    --ref)
         shift
         ref=${1}
-        echo ${ref}      
+        echo "${ref}"
         ;;
     --)
         shift
@@ -66,7 +68,7 @@ set -x
 
 yum -y install git podman
 
-git clone --depth=1 ${gitrepo} ${workdir}
-cd ${workdir}
+git clone --depth=1 "${gitrepo}" "${workdir}"
+cd "${workdir}"
 git fetch --depth=1 origin "${ref}:tip/${ref}"
 git checkout "tip/${ref}"

--- a/prepare.sh
+++ b/prepare.sh
@@ -6,11 +6,13 @@ set -e -o pipefail
 gitrepo="https://github.com/ceph/ceph-csi"
 workdir="tip/"
 ref="master"
+base="master"
 
 ARGUMENT_LIST=(
     "ref"
     "workdir"
     "gitrepo"
+    "base"
 )
 
 opts=$(getopt \
@@ -38,6 +40,7 @@ while true; do
         echo "--ref                     specify the reference of pr"
         echo "--workdir                 specify the working directory"
         echo "--gitrepo                 specify the git repository"
+        echo "--base                    specify the base branch to checkout"
         echo " "
         echo "Sample Usage:"
         echo "./prepare.sh --gitrepo=https://github.com/example --workdir=/opt/build --ref=pull/123/head"
@@ -56,6 +59,10 @@ while true; do
         ref=${1}
         echo "${ref}"
         ;;
+    --base)
+        shift
+        base=${1}
+        ;;
     --)
         shift
         break
@@ -68,7 +75,7 @@ set -x
 
 yum -y install git podman
 
-git clone --depth=1 "${gitrepo}" "${workdir}"
+git clone --depth=1 --branch="${base}" "${gitrepo}" "${workdir}"
 cd "${workdir}"
-git fetch --depth=1 origin "${ref}:tip/${ref}"
+git fetch origin "${ref}:tip/${ref}"
 git checkout "tip/${ref}"

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # In case no value is specified, default values will be used.
 gitrepo="https://github.com/ceph/ceph-csi"

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -1,0 +1,47 @@
+# Container image for running the Ceph-CSI tests
+#
+# This container is based on Fedora so that recent versions of tools can easily
+# be installed.
+#
+# Production containers are based one ceph/ceph:latest, which use CentOS as
+# Operating System, so generated binaries and versions of dependencies may be a
+# little different.
+#
+
+FROM fedora:latest
+
+ARG GOLANGCI_VERSION=v1.21.0
+ARG GOSEC_VERSION=2.0.0
+ARG GOPATH=/go
+
+ENV \
+ GOPATH=${GOPATH} \
+ GO111MODULE=on \
+ PATH="${GOPATH}/bin:/opt/commitlint/node_modules/.bin:${PATH}"
+
+RUN dnf -y install \
+	git \
+	make \
+	golang \
+	gcc \
+	librados-devel \
+	librbd-devel \
+	rubygems \
+	ShellCheck \
+	yamllint \
+	npm \
+    && dnf -y update \
+    && dnf -y clean all \
+    && gem install mdl \
+    && curl -sf "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" \
+       | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
+    && curl -sfL "https://raw.githubusercontent.com/securego/gosec/master/install.sh" \
+       | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}" \
+    && curl -L https://git.io/get_helm.sh | bash \
+    && mkdir /opt/commitlint && pushd /opt/commitlint \
+    && npm init -y \
+    && npm install @commitlint/cli \
+    && popd \
+    && true
+
+WORKDIR /go/src/github.com/ceph/ceph-csi

--- a/scripts/lint-extras.sh
+++ b/scripts/lint-extras.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# vim: set ts=4 sw=4 et :
+
+# This script will be used to lint non-go files
+# Usage: ./scripts/lint-extras.sh <command>
+# Available commands are [lint-shell lint-yaml lint-markdown lint-helmlint-all ]
+set -e
+
+# Run checks from root of the repo
+scriptdir="$(dirname "$(realpath "$0")")"
+cd "$scriptdir/.."
+
+# run_check <file_regex> <checker_exe> [optional args to checker...]
+# Pass empty regex when no regex is needed
+function run_check() {
+    local regex="$1"
+    shift
+    local exe="$1"
+    shift
+
+    if [ -x "$(command -v "${exe}")" ]; then
+        if [ -z "${regex}" ]; then
+            "$exe" "$@"
+        else
+            find . -path ./vendor -prune -o -regextype egrep -iregex "$regex" -print0 |
+                xargs -0rt -n1 "$exe" "$@"
+        fi
+    elif [ "$all_required" -eq 0 ]; then
+        echo "Warning: $exe not found... skipping some tests."
+    else
+        echo "FAILED: All checks required, but $exe not found!"
+        exit 1
+    fi
+}
+
+all_required=0
+
+function lint_markdown() {
+    # markdownlint: https://github.com/markdownlint/markdownlint
+    # https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+    # Install via: gem install mdl
+    run_check '.*\.md' mdl --style scripts/mdl-style.rb
+}
+
+function lint_shell() {
+    # Install via: dnf install shellcheck
+    run_check '.*\.(ba)?sh' shellcheck --external-sources
+    run_check '.*\.(ba)?sh' bash -n
+}
+
+function lint_yaml() {
+    # Install via: pip install yamllint
+    # disable yamlint check for helm charts
+    run_check '.*\.ya?ml' yamllint -s -d "{extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: charts/*/templates/*.yaml}"
+}
+
+function lint_helm() {
+    # Install via: https://github.com/helm/helm/blob/master/docs/install.md
+    run_check '' helm lint --namespace=test charts/*
+}
+
+function lint_all() {
+    # runs all checks
+    all_required=1
+    lint_shell
+    lint_yaml
+    lint_markdown
+    lint_helm
+}
+case "${1:-}" in
+lint-shell)
+    lint_shell
+    ;;
+lint-yaml)
+    lint_yaml
+    ;;
+lint-markdown)
+    lint_markdown
+    ;;
+lint-helm)
+    lint_helm
+    ;;
+lint-all)
+    lint_all
+    ;;
+*)
+    echo " $0 [command]
+Available Commands:
+  lint-shell             Lint shell files
+  lint-yaml              Lint yaml files
+  lint-markdown          Lint markdown files
+  lint-helm              Lint helm charts
+  lint-all               Run lint on all non-go files
+" >&2
+    ;;
+esac

--- a/scripts/mdl-style.rb
+++ b/scripts/mdl-style.rb
@@ -1,0 +1,9 @@
+all
+
+#Refer below url for more information about the markdown rules.
+#https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+
+rule 'MD013', :code_blocks => false, :tables => false
+
+exclude_rule 'MD040' # Fenced code blocks should have a language specified
+exclude_rule 'MD041' # First line in file should be a top level header


### PR DESCRIPTION
This PR adds validation for MarkDown, shell-scripts and yaml files in the ci/centos branch when a PR is created/updated.

While working on this, many files needed corrections. These corrections are required for the new jobs to succeed.

After a merge in the ci/centos branch is done, the jjb-deploy job will deploy the contents to the CentOS CI so that next PRs will get tested with the new configuration/jobs.