### PR TITLE
ci: checkout the PR when running jjb-validate

### DIFF
--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -20,7 +20,8 @@
 
       node {
         stage('checkout ci repository') {
-          git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
+          checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
+            userRemoteConfigs: [[url: "${ci_git_repo}", refspec: "${ref}"]]])
         }
         stage('validation') {
           sh './deploy/jjb.sh validate'


### PR DESCRIPTION
Using the 'git' function in groovy does not allow checking out a
non-branch, so use the 'checkout' function instead.

Currently the `ci/centos/jjb-validate` status will never succeed.
