### PR TITLE
ci: do not automatically run jjb-validate on PRs

### DIFF
--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -32,7 +32,10 @@
       - github-pull-request:
           status-context: ci/centos/jjb-validate
           trigger-phrase: '/(re)?test ((all)|(ci/centos/jjb-validate))'
-          permit-all: true
+          # FIXME: re-enable permit-all, disable only-trigger-phrase
+          # See https://github.com/ceph/ceph-csi/issues/1111
+          # permit-all: true
+          only-trigger-phrase: true
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false
           cron: 'H/5 * * * *'


### PR DESCRIPTION
# Describe what this PR does #

The jjb-validate job is not correct, it does not always return the
results of the PR.

Prevent triggering the job automatically, and only have it run when
someone leaves the `/test ci/centos/jjb-validate` comment.

## Is there anything that requires special attention ##

Once the job has been corrected, it should be enabled again too.

## Related issues ##

Updates: #1111