### PR TITLE
build: add option to compile e2e.test in a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # build directory
 _output
 
+# e2e test executable
+e2e.test
+
 # docker build
 deploy/cephcsi/image/cephcsi
 


### PR DESCRIPTION
# Describe what this PR does #

Run `make containerized-build TARGET=e2e.test` to build the e2e.test
executable in a container. This makes it possible for environments to
only have the dependencies for the runtime installed (most notably Ceph
shared libraries) and, run the e2e tests directly.

## Related issues ##

This should make #1083 a little easier as fewer dependencies need to be installed.
