### PR TITLE
ci: track jjb jobs by a jjb/session=<uuid> label

### DIFF
--- a/deploy/jjb-deploy.yaml
+++ b/deploy/jjb-deploy.yaml
@@ -1,33 +1,45 @@
 ---
-apiVersion: batch/v1
-kind: Job
+kind: Template
+apiVersion: v1
 metadata:
-  labels:
-    app: jjb
-  name: jjb-deploy
-spec:
-  ttlSecondsAfterFinished: 0
-  backoffLimit: 1
-  template:
-    labels:
-      app: jjb
+  name: my-template
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      labels:
+        app: jjb
+        jjb/session: "${SESSION}"
+      name: jjb-deploy
     spec:
-      containers:
-        - name: jjb
-          image: 172.30.254.79:5000/ceph-csi/jjb:latest
-          env:
-            - name: GIT_REPO
-              value: https://github.com/ceph/ceph-csi
-            - name: GIT_REF
-              value: ci/centos
-            - name: MAKE_TARGET
-              value: deploy
-          volumeMounts:
+      ttlSecondsAfterFinished: 0
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: jjb-deploy
+            jjb/session: "${SESSION}"
+        spec:
+          containers:
+            - name: jjb
+              image: 172.30.254.79:5000/ceph-csi/jjb:latest
+              env:
+                - name: GIT_REPO
+                  value: https://github.com/ceph/ceph-csi
+                - name: GIT_REF
+                  value: ci/centos
+                - name: MAKE_TARGET
+                  value: deploy
+              volumeMounts:
+                - name: etc-jj
+                  mountPath: /etc/jenkins_jobs
+                  readOnly: true
+          volumes:
             - name: etc-jj
-              mountPath: /etc/jenkins_jobs
-              readOnly: true
-      volumes:
-        - name: etc-jj
-          configMap:
-            name: jenkins-jobs
-      restartPolicy: Never
+              configMap:
+                name: jenkins-jobs
+          restartPolicy: Never
+parameters:
+  - name: SESSION
+    description: unique ID for the session to track the pod for the job
+    required: true

--- a/deploy/jjb-validate.yaml
+++ b/deploy/jjb-validate.yaml
@@ -1,23 +1,35 @@
 ---
-apiVersion: batch/v1
-kind: Job
+kind: Template
+apiVersion: v1
 metadata:
-  labels:
-    app: jjb-validate
   name: jjb-validate
-spec:
-  ttlSecondsAfterFinished: 0
-  backoffLimit: 1
-  template:
-    labels:
-      app: jjb-validate
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      labels:
+        app: jjb-validate
+        jjb/session: "${SESSION}"
+      name: jjb-validate
     spec:
-      containers:
-        - name: jjb-validate
-          image: 172.30.254.79:5000/ceph-csi/jjb:latest
-          env:
-            - name: GIT_REPO
-              value: https://github.com/ceph/ceph-csi
-            - name: GIT_REF
-              value: ci/centos
-      restartPolicy: Never
+      ttlSecondsAfterFinished: 0
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app: jjb-validate
+            jjb/session: "${SESSION}"
+        spec:
+          containers:
+            - name: jjb-validate
+              image: 172.30.254.79:5000/ceph-csi/jjb:latest
+              env:
+                - name: GIT_REPO
+                  value: https://github.com/ceph/ceph-csi
+                - name: GIT_REF
+                  value: ci/centos
+          restartPolicy: Never
+parameters:
+  - name: SESSION
+    description: unique ID for the session to track the pod for the job
+    required: true

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -11,11 +11,11 @@
           days-to-keep: 7
           artifact-days-to-keep: 7
     dsl: |
-      def GIT_REPO = 'http://github.com/ceph/ceph-csi'
+      def GIT_REPO = 'https://github.com/ceph/ceph-csi'
       def GIT_BRANCH = 'ci/centos'
 
       if (params.ghprbPullId != null) {
-          GIT_BRANCH = "pr/${ghprbPullId}/head"
+          GIT_BRANCH = "pull/${ghprbPullId}/head"
       }
 
       node {

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -32,10 +32,7 @@
       - github-pull-request:
           status-context: ci/centos/jjb-validate
           trigger-phrase: '/(re)?test ((all)|(ci/centos/jjb-validate))'
-          # FIXME: re-enable permit-all, disable only-trigger-phrase
-          # See https://github.com/ceph/ceph-csi/issues/1111
-          # permit-all: true
-          only-trigger-phrase: true
+          permit-all: true
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false
           cron: 'H/5 * * * *'


### PR DESCRIPTION
# Describe what this PR does #

By using a template, it becomes possible to identify the Pod that has
been started by the Batch Job.

This prevents the script from getting the logs from an incorrect (old)
container.

## Related issues ##

Fixes: #1111
