### PR TITLE
ci: Use bionic dist for test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 ---
 # need for docker build
 sudo: true
-dist: xenial
+dist: bionic
 
 addons:
   apt:
     packages:
-      - realpath
+      - coreutils
       - ruby
       - socat
 services:
@@ -41,7 +41,7 @@ before_install:
 before_script:
   - curl https://download.ceph.com/keys/release.asc | sudo apt-key add -
   - sudo apt-add-repository
-    "deb https://download.ceph.com/debian-nautilus xenial main"
+    "deb https://download.ceph.com/debian-nautilus $(lsb_release -sc) main"
   # Ceph does not guarantee arm64 builds, fallback to ceph 14.2.5
   # yamllint disable rule:line-length
   - test "$(arch)" != "aarch64" || sudo apt-add-repository
@@ -99,6 +99,7 @@ jobs:
 
     - stage: build testing
       name: cephcsi on Arm64
+      dist: xenial   # There are no arm64 builds available in bionic repo
       arch: arm64
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -78,7 +78,8 @@ fi
 K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-"BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,ExpandCSIVolumes=true"}
 
 #extra-config for kube https://minikube.sigs.k8s.io/docs/reference/configuration/kubernetes/
-EXTRA_CONFIG=${EXTRA_CONFIG:-"--extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy"}
+EXTRA_CONFIG=${EXTRA_CONFIG:-"--extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy \
+  --extra-config=kubelet.resolv-conf=/run/systemd/resolve/resolv.conf"}
 
 #extra Rook configuration
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}


### PR DESCRIPTION
# Describe what this PR does #
As bionic uses a newer version of linux we'd also be using a newer version of krbd.

## Is there anything that requires special attention ##
No.

Do you have any questions?
No.

Is the change backward compatible?
Yes.

Are there concerns around backward compatibility?
No.

Provide any external context for the change, if any.

## Related issues ##

This is required for using the rados namespace with krbd
#798 

## Future concerns ##
I'm not sure if it's okay to let the arm64 still be using xenial.
