### PR TITLE
build: use CURDIR instead of PWD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,10 @@ cephcsi: check-env
 
 .PHONY: containerized-build containerized-test
 containerized-build: .devel-container-id
-	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make cephcsi
+	$(CONTAINER_CMD) run --rm -v $(CURDIR):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make cephcsi
 
 containerized-test: .test-container-id
-	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make $(TARGET) GIT_SINCE=$(GIT_SINCE)
+	$(CONTAINER_CMD) run --rm -v $(CURDIR):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make $(TARGET) GIT_SINCE=$(GIT_SINCE)
 
 # create a (cached) container image with dependencied for building cephcsi
 .devel-container-id: scripts/Dockerfile.devel


### PR DESCRIPTION
# Describe what this PR does #

`make -C ${GOPATH/src/github.com/ceph/ceph-csi container...` commands
fail as the PWD variable gets substituted with the path where `make` is
called, not with the path of the Makefile that is passed with the -C
option.

The CURDIR variable is expended to the correct path, so `make -C ...`
works for all make targets now.
