### PR TITLE
build: fix kubelet issue#60987

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -242,9 +242,8 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	err = os.Remove(targetPath)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, status.Error(codes.Internal, err.Error())
+	if err := util.CleanPath(targetPath); err != nil {
+		klog.V(3).Infof("remove targetPath: %v with error: %v", targetPath, err)
 	}
 
 	klog.V(4).Infof(util.Log(ctx, "cephfs: successfully unbinded volume %s from %s"), req.GetVolumeId(), targetPath)
@@ -270,6 +269,10 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	// Unmount the volume
 	if err = unmountVolume(ctx, stagingTargetPath); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if err := util.CleanPath(stagingTargetPath); err != nil {
+		klog.V(3).Infof("remove stagingTargetPath: %v with error: %v", stagingTargetPath, err)
 	}
 
 	klog.V(4).Infof(util.Log(ctx, "cephfs: successfully unmounted volume %s from %s"), req.GetVolumeId(), stagingTargetPath)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -193,3 +193,8 @@ func Mount(source, target, fstype string, options []string) error {
 	dummyMount := mount.New("")
 	return dummyMount.Mount(source, target, fstype, options)
 }
+
+// remove the parent path of targetPath
+func CleanPath(targetPath string) error {
+	return os.RemoveAll(path.Dir(targetPath))
+}

--- a/internal/util/util_linux_test.go
+++ b/internal/util/util_linux_test.go
@@ -1,0 +1,70 @@
+// +build linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestCleanPath(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test_2",
+			args: args{
+				path: fmt.Sprintf("%s/pvc-9ae9405c-7fb3-11ea-80b3-246e968d4b38/mount", os.TempDir()),
+			},
+			want: fmt.Sprintf("%s/pvc-9ae9405c-7fb3-11ea-80b3-246e968d4b38", os.TempDir()),
+		}, {
+			name: "test_4",
+			args: args{
+				path: fmt.Sprintf("%s/pvc-8ae9405c-7fb3-11ea-80b3-246e968d4b38/globalmount", os.TempDir()),
+			},
+			want: fmt.Sprintf("%s/pvc-8ae9405c-7fb3-11ea-80b3-246e968d4b38", os.TempDir()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := os.MkdirAll(tt.args.path, 0777)
+			if err != nil {
+				t.Errorf("create a path[%s] for preparing test enviroment fail, err: %v", tt.args.path, err)
+			}
+
+			if _, err := os.Stat(tt.args.path); err != nil {
+				t.Errorf("preparing test enviroment fail, the path[%s] not exist err: %v", tt.args.path, err)
+			}
+
+			if err := CleanPath(tt.args.path); err != nil {
+				t.Errorf("CleanPath fail, path:%s, want %v", tt.args.path, tt.want)
+			}
+
+			if _, err := os.Stat(tt.want); err != nil {
+				if !os.IsNotExist(err) {
+					t.Errorf("CleanPath fail, and the expected path[%s] still exist, err: %v", tt.want, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a Pod which has used PVC is deleted from kubuernetes cluster
we can get a error message repeatedly(Orphaned pod "1f415e-...-4b38"
found, but volume paths are still present on disk) from kubelet log.
this error message is caused by kubelet because it cannot clean the
parent path of targetPath when Pod is deleted from cluster
(targetPath like:
/var/lib/kubelet/pods/9cda187a-7fb3-11ea-80b3-246e968d4b38/volumes/kubernetes.io~csi/pvc-9ae9405c-7fb3-11ea-80b3-246e968d4b38/mount
). Ceph CSI can remove the parent path of targetPath first instead of
waiting kubelet to fix this issue.

Signed-off-by: chengyu-l <chengyu_l@126.com>
