### PR TITLE
rbd: unmap rbd image if the mounting fails

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -562,6 +562,40 @@ var _ = Describe("RBD", func() {
 				createRBDStorageClass(f.ClientSet, f, nil, nil)
 			})
 
+			// Mount pvc to pod with invalid mount option,expected that
+			// mounting will fail
+			By("Mount pvc to pod with invalid mount option", func() {
+				deleteResource(rbdExamplePath + "storageclass.yaml")
+				createRBDStorageClass(f.ClientSet, f, map[string]string{rbdmountOptions: "debug,invalidOption"}, nil)
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					Fail(err.Error())
+				}
+				pvc.Namespace = f.UniqueName
+
+				app, err := loadApp(appPath)
+				if err != nil {
+					Fail(err.Error())
+				}
+				app.Namespace = f.UniqueName
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					Fail(err.Error())
+				}
+				// create an app and wait for 2 min for it to go to running state
+				err = createApp(f.ClientSet, app, 2)
+				if err == nil {
+					Fail("application should not go to running state due to invalid mount option")
+				}
+				err = deletePVCAndApp("", f, pvc, app)
+				if err != nil {
+					Fail(err.Error())
+				}
+
+				deleteResource(rbdExamplePath + "storageclass.yaml")
+				createRBDStorageClass(f.ClientSet, f, nil, nil)
+			})
+
 			// Make sure this should be last testcase in this file, because
 			// it deletes pool
 			By("Create a PVC and Delete PVC when backend pool deleted", func() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -42,6 +42,8 @@ const (
 	// rook created rbd user
 	rbdNodePluginSecretName  = "rook-csi-rbd-node"        // nolint: gosec
 	rbdProvisionerSecretName = "rook-csi-rbd-provisioner" // nolint: gosec
+
+	rbdmountOptions = "mountOptions"
 )
 
 var (
@@ -324,6 +326,12 @@ func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, scOpt
 	if scOptions["volumeBindingMode"] == "WaitForFirstConsumer" {
 		value := scv1.VolumeBindingWaitForFirstConsumer
 		sc.VolumeBindingMode = &value
+	}
+
+	// comma separated mount options
+	if opt, ok := scOptions[rbdmountOptions]; ok {
+		mOpt := strings.Split(opt, ",")
+		sc.MountOptions = append(sc.MountOptions, mOpt...)
 	}
 	_, err := c.StorageV1().StorageClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
 	Expect(err).Should(BeNil())

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -55,6 +55,8 @@ type stageTransaction struct {
 	isMounted bool
 	// isEncrypted represents if the volume was encrypted or not
 	isEncrypted bool
+	// devicePath represents the path where rbd device is mapped
+	devicePath string
 }
 
 // NodeStageVolume mounts the volume to a staging path on the node.
@@ -163,7 +165,6 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	volOptions.VolID = volID
 	transaction := stageTransaction{}
-	devicePath := ""
 
 	// Stash image details prior to mapping the image (useful during Unstage as it has no
 	// voloptions passed to the RPC as per the CSI spec)
@@ -173,7 +174,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	defer func() {
 		if err != nil {
-			ns.undoStagingTransaction(ctx, req, devicePath, transaction)
+			ns.undoStagingTransaction(ctx, req, transaction)
 		}
 	}()
 
@@ -207,7 +208,7 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	if err != nil {
 		return transaction, err
 	}
-
+	transaction.devicePath = devicePath
 	klog.V(4).Infof(util.Log(ctx, "rbd image: %s/%s was successfully mapped at %s\n"),
 		req.GetVolumeId(), volOptions.Pool, devicePath)
 
@@ -242,7 +243,7 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	return transaction, err
 }
 
-func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, devicePath string, transaction stageTransaction) {
+func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, transaction stageTransaction) {
 	var err error
 
 	stagingTargetPath := getStagingTargetPath(req)
@@ -266,10 +267,10 @@ func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeS
 	volID := req.GetVolumeId()
 
 	// Unmapping rbd device
-	if devicePath != "" {
-		err = detachRBDDevice(ctx, devicePath, volID, transaction.isEncrypted)
+	if transaction.devicePath != "" {
+		err = detachRBDDevice(ctx, transaction.devicePath, volID, transaction.isEncrypted)
 		if err != nil {
-			klog.Errorf(util.Log(ctx, "failed to unmap rbd device: %s for volume %s with error: %v"), devicePath, volID, err)
+			klog.Errorf(util.Log(ctx, "failed to unmap rbd device: %s for volume %s with error: %v"), transaction.devicePath, volID, err)
 			// continue on failure to delete the stash file, as kubernetes will fail to delete the staging path otherwise
 		}
 	}


### PR DESCRIPTION
There is a bug in the current code where the device path is always empty and the rbd image unmap never happens if node plugin fails to mount the rbd image to the staging path.

This is a fix to unmap the rbd image if some issue occurs after the rbd image is mapped.

Signed-off-by: Madhu Rajanna madhupr007@gmail.com

Backport of https://github.com/ceph/ceph-csi/pull/1078