### PR TITLE
Add 'make containerized-test' target to release-v2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,12 @@ cephcsi:
 	if [ ! -d ./vendor ]; then (go mod tidy && go mod vendor); fi
 	GOOS=linux GOARCH=$(GOARCH) go build -mod vendor -a -ldflags '$(LDFLAGS)' -o _output/cephcsi ./cmd/
 
-.PHONY: containerized-build
+.PHONY: containerized-build containerized-test
 containerized-build: .devel-container-id
 	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make -C /go/src/github.com/ceph/ceph-csi cephcsi
+
+containerized-test: .test-container-id
+	$(CONTAINER_CMD) run --rm -v $(PWD):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):test make test
 
 # create a (cached) container image with dependencied for building cephcsi
 .devel-container-id: scripts/Dockerfile.devel
@@ -81,8 +84,15 @@ containerized-build: .devel-container-id
 	$(CONTAINER_CMD) build -t $(CSI_IMAGE_NAME):devel -f ./scripts/Dockerfile.devel .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):devel > .devel-container-id
 
+# create a (cached) container image with dependencied for testing cephcsi
+.test-container-id: scripts/Dockerfile.test
+	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
+	$(CONTAINER_CMD) build -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
+	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
+
 image-cephcsi:
 	$(CONTAINER_CMD) build -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg GOLANG_VERSION=1.13.8 --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) $(BASE_IMAGE_ARG)
+
 
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) tag $(CSI_IMAGE) $(CSI_IMAGE)-$(GOARCH)
@@ -91,8 +101,10 @@ push-image-cephcsi: image-cephcsi
 	if [ $(GOARCH) = amd64 ]; then $(CONTAINER_CMD) push $(CSI_IMAGE); fi
 
 clean:
-	go clean -r -x
+	go clean -mod=vendor -r -x
 	rm -f deploy/cephcsi/image/cephcsi
 	rm -f _output/cephcsi
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
 	$(RM) .devel-container-id
+	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
+	$(RM) .test-container-id

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -1,0 +1,43 @@
+# Container image for running the Ceph-CSI tests
+#
+# This container is based on Fedora so that recent versions of tools can easily
+# be installed.
+#
+# Production containers are based one ceph/ceph:latest, which use CentOS as
+# Operating System, so generated binaries and versions of dependencies may be a
+# little different.
+#
+
+FROM fedora:latest
+
+ARG GOLANGCI_VERSION=v1.21.0
+ARG GOSEC_VERSION=2.0.0
+ARG GOPATH=/go
+
+ENV \
+ GOPATH=${GOPATH} \
+ GO111MODULE=on \
+ PATH="${GOPATH}/bin:${PATH}"
+
+
+RUN dnf -y install \
+	git \
+	make \
+	golang \
+	gcc \
+	librados-devel \
+	librbd-devel \
+	rubygems \
+	ShellCheck \
+	yamllint \
+    && dnf -y update \
+    && dnf -y clean all \
+    && gem install mdl \
+    && curl -sf "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" \
+       | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
+    && curl -sfL "https://raw.githubusercontent.com/securego/gosec/master/install.sh" \
+       | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}" \
+    && curl -L https://git.io/get_helm.sh | bash \
+    && true
+
+WORKDIR /go/src/github.com/ceph/ceph-csi

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -31,10 +31,9 @@ function copy_image_to_cluster() {
 # install minikube
 function install_minikube() {
     if type minikube >/dev/null 2>&1; then
-        local version
-        version=$(minikube version)
-        read -ra version <<<"${version}"
-        version=${version[2]}
+        local mk_version version
+        read -ra mk_version <<<"$(minikube version)"
+        version=${mk_version[2]}
         if [[ "${version}" != "${MINIKUBE_VERSION}" ]]; then
             echo "installed minikube version ${version} is not matching requested version ${MINIKUBE_VERSION}"
             exit 1


### PR DESCRIPTION
The CentOS CI job fails on release-v2.1 because `make containerized-test` errors out. This PR adds the missing target to the `Makefile` and fixes the ShellCheck issues in scripts/minikube.sh.

Backports-of: 3c6054ddf9 58c2a3f15