### PR TITLE
ci: update golangci to v1.27.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ go: 1.13.x
 
 env:
   global:
-    - GOLANGCI_VERSION=v1.21.0
+    - GOLANGCI_VERSION=v1.27.0
     - GO111MODULE=on
     - GOSEC_VERSION=2.0.0
     - TEST_COVERAGE=stdout


### PR DESCRIPTION
There are various improvements in golangci in window of v1.21.0
to v1.27.0

Reference# https://github.com/golangci/golangci-lint/releases

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
