### PR TITLE
doc: remove weekly bug triage call details as its nolonger active.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,6 @@ if you are interested to contribute to this repo.
 
 Please submit an issue at: [Issues](https://github.com/ceph/ceph-csi/issues)
 
-## Weekly Bug Triage call
-
-We conduct weekly bug triage calls at our slack channel on Tuesdays.
-More details are available [here](https://github.com/ceph/ceph-csi/issues/463)
 
 ## Dev standup
 


### PR DESCRIPTION
Its been few months we didnt host this call, so there is no point
in keeping it in the doc

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
