### PR TITLE
ci: remove jjb Pods after job finished

### DIFF
--- a/deploy/jjb.sh
+++ b/deploy/jjb.sh
@@ -63,6 +63,7 @@ oc logs "${jjb_pod}"
 
 # delete the job, so a next run can create it again
 oc process -f "jjb-${CMD}.yaml" -p=SESSION="${SESSION}" | oc delete --wait -f -
+oc delete pod "${jjb_pod}"
 
 # return the exit status of the pod
 [ "${status}" = 'Succeeded' ]


### PR DESCRIPTION
# Describe what this PR does #

Currently the number of Pods is growing in the OpenShift Console. The
pods are all Completed, so not running anymore, but there is also no
need to keep them around.

## Is there anything that requires special attention ##

A `jjb-validate` pod gets created for each PR in the `ci/centos` branch, and a `jjb-deploy` pod is created once a PR is merged. These pods linger around and can be deleted (did so manually now).
