### PR TITLE
ci: Enable stale bot to auto close the old issues

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -23,8 +23,8 @@ limitPerRun: 5
 
 # Specify configuration settings that are specific to issues
 issues:
-  daysUntilStale: 60
-  daysUntilClose: 7
+  daysUntilStale: 7
+  daysUntilClose: 25
   markComment: >
     This issue has been automatically marked as stale because it has not had
     recent activity. It will be closed in a week if no further activity occurs.


### PR DESCRIPTION
atm, the daysUntilStale is 60 which is really huge and it
will take some time to trigger the bot itself and come into
action. This PR reduce or make stale bot active on cases (7days)
to reduce the huge backlog and set daysUntilClose to 25 days for now.
It gives enough window for issues to be revisited.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
