### PR TITLE
cleanup: avoid comparing errors directly

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"regexp"
@@ -177,7 +178,7 @@ func waitForDeploymentComplete(name, ns string, c clientset.Interface, t int) er
 		return false, nil
 	})
 
-	if err == wait.ErrWaitTimeout {
+	if errors.Is(err, wait.ErrWaitTimeout) {
 		err = fmt.Errorf("%s", reason)
 	}
 	if err != nil {

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -19,6 +19,7 @@ package rbd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -257,7 +258,7 @@ func waitForrbdImage(ctx context.Context, backoff wait.Backoff, volOptions *rbdV
 		return !used, nil
 	})
 	// return error if rbd image has not become available for the specified timeout
-	if err == wait.ErrWaitTimeout {
+	if errors.Is(err, wait.ErrWaitTimeout) {
 		return fmt.Errorf("rbd image %s is still being used", imagePath)
 	}
 	// return error if any other errors were encountered during waiting for the image to become available

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -267,7 +267,7 @@ func rbdStatus(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) (boo
 	output = string(cmd)
 
 	if err, ok := err.(*exec.Error); ok {
-		if err.Err == exec.ErrNotFound {
+		if errors.Is(err.Err, exec.ErrNotFound) {
 			klog.Errorf(util.Log(ctx, "rbd cmd not found"))
 			// fail fast if command not found
 			return false, output, err

--- a/internal/util/nodecache.go
+++ b/internal/util/nodecache.go
@@ -62,7 +62,7 @@ func (nc *NodeCache) ForAll(pattern string, destObj interface{}, f ForAllFunc) e
 	cachePath := path.Join(nc.BasePath, nc.CacheDir)
 	for _, file := range files {
 		err = decodeObj(cachePath, pattern, file, destObj)
-		if err == errDec {
+		if errors.Is(err, errDec) {
 			continue
 		} else if err == nil {
 			if err = f(strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))); err != nil {


### PR DESCRIPTION
    
    Go 1.13 contains support for error wrapping. To support wrapping,
    fmt.Errorf now has a %w verb for creating wrapped errors, and three
    new functions in the errors package ( errors.Unwrap, errors.Is and
    errors.As) simplify unwrapping and inspecting wrapped errors.
    
    With this change, If we currently compare errors using ==, we have to
    use errors.Is instead. Example:
    
    if err == io.ErrUnexpectedEOF
    
    becomes
    
    if errors.Is(err, io.ErrUnexpectedEOF)
    
    https://tip.golang.org/doc/go1.13#error_wrapping


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

