### PR TITLE
cephfs: fix IneffAssign warnings in resizeVolume()

### DIFF
--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -144,10 +144,7 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, cr *util.Crede
 // subvolume. If the command is not available as a fallback it will use
 // CreateVolume to resize the subvolume.
 func resizeVolume(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, volID volumeID, bytesQuota int64) error {
-	supported := false
-	ok := false
-
-	if supported, ok = resizeSupportedList[volOptions.ClusterID]; supported || !ok {
+	if supported, ok := resizeSupportedList[volOptions.ClusterID]; supported || !ok {
 		args := []string{
 			"fs",
 			"subvolume",


### PR DESCRIPTION
IneffAssign warns about the two following statements:

Line 147: warning: ineffectual assignment to supported (ineffassign)
Line 148: warning: ineffectual assignment to ok (ineffassign)

Reported-by: https://goreportcard.com/report/github.com/ceph/ceph-csi
Updates: #975

Signed-off-by: Yug Gupta <ygupta@redhat.com>