### PR TITLE
scripts: add -mod=vendor to go run in check-env.sh

### DIFF
--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -41,7 +41,7 @@ if [ -n "$(command -v go)" ]; then
 	# in case of a failed execution, the user will be informed about
 	# the missing packages based on whether they are on rpm or debian
 	# based systems.
-	if ! go run "${LIBCHECK}" > /dev/null; then
+	if ! go run -mod=vendor "${LIBCHECK}" > /dev/null; then
 		if [ -n "${RPM_CMD}" ]; then
 			echo "Packages libcephfs-devel librbd-devel librados-devel need to be installed"
 		elif [ -n "${DPKG_CMD}" ]; then


### PR DESCRIPTION


# Describe what this PR does #

Without -mod=vendor running go run in this script may take more
resources than needed to execute. This also makes it consistent go build
(and alike) are invoked in the other scripts and the Makefile.



## Is there anything that requires special attention ##

Do you have any questions? nein

Is the change backward compatible? yep

Are there concerns around backward compatibility? nope

## Related issues ##

Fixes: #1171


## Future concerns ##

n/a