### PR TITLE
util: add MountOptionsAdd() to add mount options

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -205,3 +205,35 @@ func Mount(source, target, fstype string, options []string) error {
 	dummyMount := mount.New("")
 	return dummyMount.Mount(source, target, fstype, options)
 }
+
+// MountOptionsAdd adds the `add` mount options to the `options` and returns a
+// new string. In case `add` is already present in the `options`, `add` is not
+// added again.
+func MountOptionsAdd(options string, add ...string) string {
+	opts := strings.Split(options, ",")
+	newOpts := []string{}
+	// clean original options from empty strings
+	for _, opt := range opts {
+		if opt != "" {
+			newOpts = append(newOpts, opt)
+		}
+	}
+
+	for _, opt := range add {
+		if opt != "" && !contains(newOpts, opt) {
+			newOpts = append(newOpts, opt)
+		}
+	}
+
+	return strings.Join(newOpts, ",")
+}
+
+func contains(s []string, key string) bool {
+	for _, v := range s {
+		if v == key {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -156,3 +156,83 @@ func TestKernelVersion(t *testing.T) {
 		t.Error("version ends with \\x00 byte(s)")
 	}
 }
+
+func TestMountOptionsAdd(t *testing.T) {
+	moaTests := []struct {
+		name         string
+		mountOptions string
+		option       []string
+		result       string
+	}{
+		{
+			"add option to empty string",
+			"",
+			[]string{"new_option"},
+			"new_option",
+		},
+		{
+			"add empty option to string",
+			"orig_option",
+			[]string{""},
+			"orig_option",
+		},
+		{
+			"add empty option to empty string",
+			"",
+			[]string{""},
+			"",
+		},
+		{
+			"add option to single option string",
+			"orig_option",
+			[]string{"new_option"},
+			"orig_option,new_option",
+		},
+		{
+			"add option to multi option string",
+			"orig_option,2nd_option",
+			[]string{"new_option"},
+			"orig_option,2nd_option,new_option",
+		},
+		{
+			"add redundant option to multi option string",
+			"orig_option,2nd_option",
+			[]string{"2nd_option"},
+			"orig_option,2nd_option",
+		},
+		{
+			"add option to multi option string starting with ,",
+			",orig_option,2nd_option",
+			[]string{"new_option"},
+			"orig_option,2nd_option,new_option",
+		},
+		{
+			"add option to multi option string with trailing ,",
+			"orig_option,2nd_option,",
+			[]string{"new_option"},
+			"orig_option,2nd_option,new_option",
+		},
+		{
+			"add options to multi option string",
+			"orig_option,2nd_option,",
+			[]string{"new_option", "another_option"},
+			"orig_option,2nd_option,new_option,another_option",
+		},
+		{
+			"add options (one redundant) to multi option string",
+			"orig_option,2nd_option,",
+			[]string{"new_option", "2nd_option", "another_option"},
+			"orig_option,2nd_option,new_option,another_option",
+		},
+	}
+
+	for _, moaTest := range moaTests {
+		mt := moaTest
+		t.Run(moaTest.name, func(t *testing.T) {
+			result := MountOptionsAdd(mt.mountOptions, mt.option...)
+			if result != mt.result {
+				t.Errorf("MountOptionsAdd(): %v, want %v", result, mt.result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #

There are a few occasions where the mount-options string is modified. This is not always done cleanly and could cause weird issues (fuse cephfs not allowing empty options).

The new util function MountOptionsAdd() takes a string, and adds the option in case it does not exist yet. It makes sure to return a correctly formatted (`,` separated, none at the start, nor end) string.

## Is there anything that requires special attention ##

Idea while reviewing #1169 that does some more mount option string manipulations and corrections.
