### PR TITLE
Make fetching the kernel version a utility function

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -111,6 +111,9 @@ func main() {
 		fmt.Println("Go Version:", runtime.Version())
 		fmt.Println("Compiler:", runtime.Compiler)
 		fmt.Printf("Platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		if kv, err := util.KernelVersion(); err == nil {
+			fmt.Println("Kernel:", kv)
+		}
 		os.Exit(0)
 	}
 

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/ceph/ceph-csi/internal/util"
 
-	"golang.org/x/sys/unix"
 	"k8s.io/klog"
 )
 
@@ -151,12 +150,10 @@ func loadAvailableMounters(conf *util.Config) error {
 		klog.Errorf("failed to run mount.ceph %v", err)
 	} else {
 		// fetch the current running kernel info
-		utsname := unix.Utsname{}
-		err = unix.Uname(&utsname)
-		if err != nil {
-			return err
+		release, kvErr := util.KernelVersion()
+		if kvErr != nil {
+			return kvErr
 		}
-		release := string(utsname.Release[:64])
 
 		if conf.ForceKernelCephFS || kernelSupportsQuota(release) {
 			klog.V(1).Infof("loaded mounter: %s", volumeMounterKernel)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -148,7 +148,7 @@ func KernelVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(utsname.Release[:]), nil
+	return strings.TrimRight(string(utsname.Release[:]), "\x00"), nil
 }
 
 // GenerateVolID generates a volume ID based on passed in parameters and version, to be returned

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -137,6 +138,17 @@ func ValidateDriverName(driverName string) error {
 		err = errors.Wrap(err, msg)
 	}
 	return err
+}
+
+// KernelVersion returns the version of the running Unix (like) system from the
+// 'utsname' structs 'release' component.
+func KernelVersion() (string, error) {
+	utsname := unix.Utsname{}
+	err := unix.Uname(&utsname)
+	if err != nil {
+		return "", err
+	}
+	return string(utsname.Release[:]), nil
 }
 
 // GenerateVolID generates a volume ID based on passed in parameters and version, to be returned

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -142,3 +142,13 @@ func TestRoundOffVolSize(t *testing.T) {
 		})
 	}
 }
+
+func TestKernelVersion(t *testing.T) {
+	version, err := KernelVersion()
+	if err != nil {
+		t.Errorf("failed to get kernel version: %s", err)
+	}
+	if version == "" {
+		t.Error("version is empty, this is unexpected?!")
+	}
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package util
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -150,5 +151,8 @@ func TestKernelVersion(t *testing.T) {
 	}
 	if version == "" {
 		t.Error("version is empty, this is unexpected?!")
+	}
+	if strings.HasSuffix(version, "\x00") {
+		t.Error("version ends with \\x00 byte(s)")
 	}
 }


### PR DESCRIPTION
# Describe what this PR does #

It is useful to have the kernel version logged while starting binaries.
Some functionality depends on the version of the kernel, debugging
issues related to this will be easier.

For this, moving the version checking from CephFS into its own function.

It seems that convering the release component from the unix.Utsrelease
type leaves some trailing "\x00" characters.

While splitting the string to compare kernel versions, these additional
characters might prevent converting the string to an int. Strip the
additional characters before returning the string.

Note:
  "\x00" characters are not visible when printing to a file or screen.
  They can be seen in hex-editors, or sending the output through 'xxd'.

## Related issues ##

Fixes: #1167