### PR TITLE
doc: update coding doc to correct import order

### DIFF
--- a/docs/coding.md
+++ b/docs/coding.md
@@ -23,9 +23,9 @@ We use the following convention for specifying imports:
 ```
 <import standard library packages>
 
-<import third-party packages>
-
 <import ceph-csi packages>
+
+<import third-party packages>
 ```
 
 Example:
@@ -37,10 +37,10 @@ import (
  "strings"
  "time"
 
+ "github.com/ceph/ceph-csi/internal/util"
+
  "github.com/pborman/uuid"
  "github.com/pkg/errors"
-
- "github.com/ceph/ceph-csi/internal/util"
 )
 ```
 


### PR DESCRIPTION
Updated coding doc to correct the import order
as per the standard. More info can be found on
https://github.com/golang/go/wiki/CodeReviewComments#imports.

Note:- codebase is having proper order, the only issue is in the documentation.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
