### PR TITLE
Introduce build.env for single-point of configuration of environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,10 @@ before_install:
   - mkdir -p $GOPATH/bin
 
 before_script:
+  - export CV=$(source build.env ; echo ${CEPH_VERSION})
   - curl https://download.ceph.com/keys/release.asc | sudo apt-key add -
   - sudo apt-add-repository
-    "deb https://download.ceph.com/debian-nautilus $(lsb_release -sc) main"
+    "deb https://download.ceph.com/debian-${CV} $(lsb_release -sc) main"
   # yamllint enable rule:line-length
   - sudo apt-get -qq update
   # only the arm64 fallback repo is unsigned and needs --allow-unauthenticated

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - TEST_COVERAGE=stdout
     - GO_METALINTER_THREADS=1
     - GO_COVER_DIR=_output
-    - HELM_VERSION=v3.1.2
     - VM_DRIVER=none
     - MINIKUBE_VERSION=v1.6.0
     - CHANGE_MINIKUBE_NONE_USER=true
@@ -74,6 +73,7 @@ jobs:
           "https://raw.githubusercontent.com/securego/gosec/master/install.sh"
           | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}"
         # install helm for helm lint
+        - export HELM_VERSION=$(source build.env ; echo ${HELM_VERSION})
         - curl -L https://git.io/get_helm.sh
           | bash -s -- -v "${HELM_VERSION}"
         # yamllint disable rule:line-length

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ branches:
 env:
   global:
     - GO111MODULE=on
-    - GO_METALINTER_THREADS=1
     - KUBECONFIG=$HOME/.kube/config
     # set CEPH_CSI_RUN_ALL_TESTS to non-empty to run all tests
     - CEPH_CSI_RUN_ALL_TESTS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ branches:
 
 env:
   global:
-    - GOLANGCI_VERSION=v1.21.0
     - GO111MODULE=on
     - GOSEC_VERSION=2.0.0
     - TEST_COVERAGE=stdout
@@ -66,6 +65,7 @@ jobs:
         - pip install --user --upgrade pip
         - pip install --user yamllint
         # install golangci-lint
+        - export GOLANGCI_VERSION=$(source build.env ; echo ${GOLANGCI_VERSION})
         - curl -sf
           "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh"
           | bash -s -- -b $GOPATH/bin "${GOLANGCI_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ env:
     - TEST_COVERAGE=stdout
     - GO_METALINTER_THREADS=1
     - GO_COVER_DIR=_output
-    - VM_DRIVER=none
-    - MINIKUBE_VERSION=v1.6.0
-    - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
     # set CEPH_CSI_RUN_ALL_TESTS to non-empty to run all tests
     - CEPH_CSI_RUN_ALL_TESTS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ branches:
 env:
   global:
     - GO111MODULE=on
-    - TEST_COVERAGE=stdout
     - GO_METALINTER_THREADS=1
-    - GO_COVER_DIR=_output
     - KUBECONFIG=$HOME/.kube/config
     # set CEPH_CSI_RUN_ALL_TESTS to non-empty to run all tests
     - CEPH_CSI_RUN_ALL_TESTS=true
@@ -83,7 +81,7 @@ jobs:
         - make go-lint
         - make lint-extras
         - make gosec
-        - make go-test
+        - make go-test TEST_COVERAGE=stdout GO_COVER_DIR=_output/
         - make mod-check
 
     - stage: build testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ branches:
 env:
   global:
     - GO111MODULE=on
-    - GOSEC_VERSION=2.0.0
     - TEST_COVERAGE=stdout
     - GO_METALINTER_THREADS=1
     - GO_COVER_DIR=_output
@@ -70,6 +69,7 @@ jobs:
           "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh"
           | bash -s -- -b $GOPATH/bin "${GOLANGCI_VERSION}"
         # install gosec
+        - export GOSEC_VERSION=$(source build.env ; echo ${GOSEC_VERSION})
         - curl -sfL
           "https://raw.githubusercontent.com/securego/gosec/master/install.sh"
           | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ branches:
   only:
     - master
 
-go: 1.13.x
-
 env:
   global:
     - GOLANGCI_VERSION=v1.21.0
@@ -36,6 +34,9 @@ env:
     - CEPH_CSI_RUN_ALL_TESTS=true
 
 before_install:
+  - export GOLANG_VERSION=$(source build.env ; echo ${GOLANG_VERSION})
+  - gimme ${GOLANG_VERSION}
+  - source ~/.gimme/envs/go${GOLANG_VERSION}.env
   - mkdir -p $GOPATH/bin
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ containerized-test: .test-container-id
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 
 image-cephcsi:
-	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg GOLANG_VERSION=1.13.8 --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) $(BASE_IMAGE_ARG)
+	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg --build-arg GO_ARCH=$(GOARCH) $(BASE_IMAGE_ARG)
 
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) tag $(CSI_IMAGE) $(CSI_IMAGE)-$(GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,7 @@ ifndef GOARCH
 GOARCH := $(shell go env GOARCH 2>/dev/null)
 endif
 
-ifdef BASE_IMAGE
-BASE_IMAGE_ARG = --build-arg BASE_IMAGE=$(BASE_IMAGE)
-endif
+BASE_IMAGE ?= $(shell . $(CURDIR)/build.env ; echo $${BASE_IMAGE})
 
 # passing TARGET=static-check on the 'make containerized-test' or 'make
 # containerized-build' commandline will run the selected target instead of
@@ -133,7 +131,7 @@ containerized-test: .test-container-id
 # create a (cached) container image with dependencied for building cephcsi
 .devel-container-id: scripts/Dockerfile.devel
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
-	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE_NAME):devel -f ./scripts/Dockerfile.devel .
+	$(CONTAINER_CMD) build $(CPUSET) --build-arg BASE_IMAGE=$(BASE_IMAGE) -t $(CSI_IMAGE_NAME):devel -f ./scripts/Dockerfile.devel .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):devel > .devel-container-id
 
 # create a (cached) container image with dependencied for testing cephcsi
@@ -143,7 +141,7 @@ containerized-test: .test-container-id
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 
 image-cephcsi:
-	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) $(BASE_IMAGE_ARG)
+	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE)
 
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) tag $(CSI_IMAGE) $(CSI_IMAGE)-$(GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,10 @@ all: cephcsi
 test: go-test static-check mod-check
 static-check: check-env go-lint lint-extras gosec
 
+go-test: TEST_COVERAGE ?= $(shell . $(CURDIR)/build.env ; echo $${TEST_COVERAGE})
+go-test: GO_COVER_DIR ?= $(shell . $(CURDIR)/build.env ; echo $${GO_COVER_DIR})
 go-test: check-env
-	./scripts/test-go.sh
+	TEST_COVERAGE=$(TEST_COVERAGE) GO_COVER_DIR=$(GO_COVER_DIR) ./scripts/test-go.sh
 
 mod-check: check-env
 	@echo 'running: go mod verify'

--- a/Makefile
+++ b/Makefile
@@ -137,13 +137,13 @@ containerized-test: .test-container-id
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):devel > .devel-container-id
 
 # create a (cached) container image with dependencied for testing cephcsi
-.test-container-id: scripts/Dockerfile.test
+.test-container-id: build.env scripts/Dockerfile.test
 	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
 	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 
 image-cephcsi:
-	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg --build-arg GO_ARCH=$(GOARCH) $(BASE_IMAGE_ARG)
+	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) $(BASE_IMAGE_ARG)
 
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) tag $(CSI_IMAGE) $(CSI_IMAGE)-$(GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,6 @@ LDFLAGS += -X $(GO_PROJECT)/internal/util.GitCommit=$(GIT_COMMIT)
 # CSI_IMAGE_VERSION will be considered as the driver version
 LDFLAGS += -X $(GO_PROJECT)/internal/util.DriverVersion=$(CSI_IMAGE_VERSION)
 
-# set GOARCH explicitly for cross building, default to native architecture
-ifndef GOARCH
-GOARCH := $(shell go env GOARCH 2>/dev/null)
-endif
-
 BASE_IMAGE ?= $(shell . $(CURDIR)/build.env ; echo $${BASE_IMAGE})
 
 # passing TARGET=static-check on the 'make containerized-test' or 'make
@@ -142,9 +137,11 @@ containerized-test: .test-container-id
 	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 
+image-cephcsi: GOARCH ?= $(shell go env GOARCH 2>/dev/null)
 image-cephcsi:
 	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE)
 
+push-image-cephcsi: GOARCH ?= $(shell go env GOARCH 2>/dev/null)
 push-image-cephcsi: image-cephcsi
 	$(CONTAINER_CMD) tag $(CSI_IMAGE) $(CSI_IMAGE)-$(GOARCH)
 	$(CONTAINER_CMD) push $(CSI_IMAGE)-$(GOARCH)

--- a/build.env
+++ b/build.env
@@ -11,6 +11,7 @@
 
 # Ceph version to use
 BASE_IMAGE=ceph/ceph:v15
+CEPH_VERSION=nautilus
 
 # standard Golang options
 GOLANG_VERSION=1.13.9

--- a/build.env
+++ b/build.env
@@ -12,3 +12,6 @@
 # standard Golang options
 GOLANG_VERSION=1.13.9
 GO111MODULE=on
+
+# static checks and linters
+GOLANGCI_VERSION=v1.21.0

--- a/build.env
+++ b/build.env
@@ -33,3 +33,8 @@ HELM_VERSION=v3.1.2
 MINIKUBE_VERSION=v1.6.0
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
+
+# e2e settings
+# - enable CEPH_CSI_RUN_ALL_TESTS when running tests with if it has root
+#   permissions on the host
+#CEPH_CSI_RUN_ALL_TESTS=true

--- a/build.env
+++ b/build.env
@@ -16,3 +16,6 @@ GO111MODULE=on
 # static checks and linters
 GOLANGCI_VERSION=v1.21.0
 GOSEC_VERSION=2.0.0
+
+# helm chart generation, testing and publishing
+HELM_VERSION=v3.1.2

--- a/build.env
+++ b/build.env
@@ -20,6 +20,11 @@ GO111MODULE=on
 GOLANGCI_VERSION=v1.21.0
 GOSEC_VERSION=2.0.0
 
+# "go test" configuration
+# set to stdout or html to enable coverage reporting, disabled by default
+#TEST_COVERAGE=html
+#GO_COVER_DIR=_output/
+
 # helm chart generation, testing and publishing
 HELM_VERSION=v3.1.2
 

--- a/build.env
+++ b/build.env
@@ -15,3 +15,4 @@ GO111MODULE=on
 
 # static checks and linters
 GOLANGCI_VERSION=v1.21.0
+GOSEC_VERSION=2.0.0

--- a/build.env
+++ b/build.env
@@ -19,3 +19,8 @@ GOSEC_VERSION=2.0.0
 
 # helm chart generation, testing and publishing
 HELM_VERSION=v3.1.2
+
+# minikube settings
+MINIKUBE_VERSION=v1.6.0
+VM_DRIVER=none
+CHANGE_MINIKUBE_NONE_USER=true

--- a/build.env
+++ b/build.env
@@ -9,6 +9,9 @@
 # get proporly expanded.
 #
 
+# Ceph version to use
+BASE_IMAGE=ceph/ceph:v15
+
 # standard Golang options
 GOLANG_VERSION=1.13.9
 GO111MODULE=on

--- a/build.env
+++ b/build.env
@@ -1,0 +1,14 @@
+#
+# build.env
+#
+# Environment file used by scripts and tools. All (default) versions used for
+# building, testing and deploying Ceph-CSI are listed here.
+#
+# The format should be source-able by shell scripts, but do not assume only
+# shell scripts consume this file. Variables that reference variables may not
+# get proporly expanded.
+#
+
+# standard Golang options
+GOLANG_VERSION=1.13.9
+GO111MODULE=on

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,7 +40,7 @@ push_helm_charts() {
 }
 
 # Build and push images. Steps as below:
-# 1. get base image from original Dockerfile (FROM ceph/ceph:v14.2)
+# 1. get base image from ./build.env (BASE_IMAGE=ceph/ceph:v14.2)
 # 2. parse manifest to get image digest per arch (sha256:XXX, sha256:YYY)
 # 3. patch Dockerfile with amd64 base image (FROM ceph/ceph:v14.2@sha256:XXX)
 # 4. build and push amd64 image
@@ -50,8 +50,8 @@ build_push_images() {
 	# "docker manifest" requires experimental feature enabled
 	export DOCKER_CLI_EXPERIMENTAL=enabled
 
-	dockerfile="deploy/cephcsi/image/Dockerfile"
-	baseimg=$(awk -F = '/^ARG BASE_IMAGE=/ {print $NF}' "${dockerfile}")
+	build_env="build.env"
+	baseimg=$(awk -F = '/^BASE_IMAGE=/ {print $NF}' "${build_env}")
 
 	# get image digest per architecture
 	# {

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,6 +1,6 @@
 ARG SRC_DIR="/go/src/github.com/ceph/ceph-csi/"
 ARG GO_ARCH
-ARG BASE_IMAGE=ceph/ceph:v15
+ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE} as builder
 

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -19,6 +19,9 @@ RUN source /build.env && \
     mkdir -p ${GOROOT} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
+# test if the downloaded version of Golang works (different arch?)
+RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
+
 RUN dnf install libcephfs-devel librados-devel librbd-devel /usr/bin/cc make -y
 
 ENV GOROOT=${GOROOT} \

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -6,7 +6,6 @@ FROM ${BASE_IMAGE} as builder
 
 LABEL stage="build"
 
-ARG GOLANG_VERSION=1.13.9
 ARG CSI_IMAGE_NAME=quay.io/cephcsi/cephcsi
 ARG CSI_IMAGE_VERSION=canary
 ARG GO_ARCH
@@ -14,7 +13,10 @@ ARG SRC_DIR
 ARG GIT_COMMIT
 ARG GOROOT=/usr/local/go
 
-RUN mkdir -p ${GOROOT} && \
+COPY build.env /
+
+RUN source /build.env && \
+    mkdir -p ${GOROOT} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
 RUN dnf install libcephfs-devel librados-devel librbd-devel /usr/bin/cc make -y

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -7,8 +7,11 @@ ENV GOPATH=/go \
  GO111MODULE=on \
  PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 
-RUN mkdir -p /usr/local/go && \
- curl https://storage.googleapis.com/golang/go1.13.9.linux-amd64.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
+COPY build.env /
+
+RUN source /build.env \
+    && mkdir -p /usr/local/go \
+    && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
 RUN dnf -y install \
 	git \

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -1,4 +1,5 @@
-FROM ceph/ceph:v15
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 ARG GOROOT=/usr/local/go
 

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -10,7 +10,6 @@
 
 FROM fedora:latest
 
-ARG GOLANGCI_VERSION=v1.21.0
 ARG GOSEC_VERSION=2.0.0
 ARG GOPATH=/go
 
@@ -19,7 +18,10 @@ ENV \
  GO111MODULE=on \
  PATH="${GOPATH}/bin:/opt/commitlint/node_modules/.bin:${PATH}"
 
-RUN dnf -y install \
+COPY build.env /
+
+RUN source /build.env \
+    && dnf -y install \
 	git \
 	make \
 	golang \

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -10,7 +10,6 @@
 
 FROM fedora:latest
 
-ARG GOSEC_VERSION=2.0.0
 ARG GOPATH=/go
 
 ENV \

--- a/scripts/build-multi-arch-image.sh
+++ b/scripts/build-multi-arch-image.sh
@@ -10,8 +10,8 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 cd "$(dirname "${0}")/.."
 
 # ceph base image used for building multi architecture images
-dockerfile="deploy/cephcsi/image/Dockerfile"
-baseimg=$(awk -F = '/^ARG BASE_IMAGE=/ {print $NF}' "${dockerfile}")
+build_env="build.env"
+baseimg=$(awk -F = '/^BASE_IMAGE=/ {print $NF}' "${build_env}")
 
 # get image digest per architecture
 # {

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -5,7 +5,7 @@
 TEMP="/tmp/cephcsi-helm-test"
 
 HELM="helm"
-HELM_VERSION=${HELM_VERSION:-"v3.1.2"}
+HELM_VERSION=${HELM_VERSION:-"latest"}
 arch="${ARCH:-}"
 CEPHFS_CHART_NAME="ceph-csi-cephfs"
 RBD_CHART_NAME="ceph-csi-rbd"

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -30,7 +30,7 @@ for gopackage in ${GOPACKAGES}; do
 	fi
 	if [[ ${TEST_COVERAGE} = "html" && -f cover.out ]]; then
 		mkdir -p coverage
-		fn="coverage/${gopackage////-}.html"
+		fn="${GO_COVER_DIR}/${gopackage////-}.html"
 		echo " * generating coverage html: ${fn}"
 		go tool cover -html=cover.out -o "${fn}"
 	fi

--- a/scripts/travis-functest.sh
+++ b/scripts/travis-functest.sh
@@ -11,6 +11,16 @@ export KUBE_VERSION=$1
 kube_version() {
     echo "${KUBE_VERSION}" | sed 's/^v//' | cut -d'.' -f"${1}"
 }
+
+# configure global environment variables
+# shellcheck source=build.env
+source "$(dirname "${0}")/../build.env"
+cat << EOF | sudo tee -a /etc/environment
+MINIKUBE_VERSION=${MINIKUBE_VERSION}
+VM_DRIVER=${VM_DRIVER}
+CHANGE_MINIKUBE_NONE_USER=${CHANGE_MINIKUBE_NONE_USER}
+EOF
+
 sudo scripts/minikube.sh up
 sudo scripts/minikube.sh deploy-rook
 sudo scripts/minikube.sh create-block-pool

--- a/scripts/travis-helmtest.sh
+++ b/scripts/travis-helmtest.sh
@@ -10,6 +10,17 @@ export KUBE_VERSION=$1
 kube_version() {
     echo "${KUBE_VERSION}" | sed 's/^v//' | cut -d'.' -f"${1}"
 }
+
+# configure global environment variables
+# shellcheck source=build.env
+source "$(dirname "${0}")/../build.env"
+cat << EOF | sudo tee -a /etc/environment
+HELM_VERSION=${HELM_VERSION}
+EOF
+
+# helm is installed from this shell, not a new one that reads /etc/environment
+export HELM_VERSION=${HELM_VERSION}
+
 sudo scripts/minikube.sh up
 sudo scripts/minikube.sh deploy-rook
 sudo scripts/minikube.sh create-block-pool

--- a/scripts/travis-helmtest.sh
+++ b/scripts/travis-helmtest.sh
@@ -16,6 +16,9 @@ kube_version() {
 source "$(dirname "${0}")/../build.env"
 cat << EOF | sudo tee -a /etc/environment
 HELM_VERSION=${HELM_VERSION}
+MINIKUBE_VERSION=${MINIKUBE_VERSION}
+VM_DRIVER=${VM_DRIVER}
+CHANGE_MINIKUBE_NONE_USER=${CHANGE_MINIKUBE_NONE_USER}
 EOF
 
 # helm is installed from this shell, not a new one that reads /etc/environment


### PR DESCRIPTION
# Describe what this PR does #

The new `build.env` file contains environment variables that are used in several locations. By placing these in a single file, it will be easier to test with newer versions of tools and upgrade everything accordingly.

## Is there anything that requires special attention ##

The following versions/settings have been added to `build.env`:

- [x] Golang version
- [x] Golang CI version
- [x] Gosec version
- [x] Helm version
- [x] minikube variables
- [x] `BASE_IMAGE` for the `FROM` in container images
- [x] `CEPH_VERSION` like "nautilus"
- [x] e2e configuration
- [x] build check for arm64/amd64 container images

## Related issues ##

Fixes: #1180