### PR TITLE
ci: disable 'testpackage' linter in golangci

### DIFF
--- a/scripts/golangci.yml
+++ b/scripts/golangci.yml
@@ -161,3 +161,4 @@ linters:
     - godox
     - wsl
     - funlen
+    - testpackage


### PR DESCRIPTION
# Describe what this PR does #

The 'testpackage' linter recommends "black box" testing, which prevents
testing internal/non-exported functions from being tested. We have tests
that *do* test non-exported functions and types.

Disabling the linter allows us to test non-exported types and functions.

## Related issues ##

Updates: #1184
