### PR TITLE
ci: add pylint as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,12 @@ jobs:
         # yamllint disable rule:line-length
         - mkdir -p /opt/commitlint && pushd /opt/commitlint
           && npm init -y && npm install --save-dev @commitlint/travis-cli && popd
-        # yamllint enable rule:line-length
         - export PATH=/opt/commitlint/node_modules/.bin:$PATH
+        # install pylint and prettytable.
+        # target python script requires python3 dependencies.
+        - sudo apt install python3-pip python3-prettytable python3-setuptools python3-wheel -y
+        - pip3 install pylint
+        # yamllint enable rule:line-length
       script:
         - commitlint-travis
         - make go-lint

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,9 @@ lint-yaml:
 lint-helm:
 	./scripts/lint-extras.sh lint-helm
 
+lint-py:
+	./scripts/lint-extras.sh lint-py
+
 gosec:
 	./scripts/gosec.sh
 

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -31,6 +31,8 @@ RUN source /build.env \
 	ShellCheck \
 	yamllint \
 	npm \
+      python3-prettytable \
+      pylint \
     && dnf -y update \
     && dnf -y clean all \
     && gem install mdl \

--- a/scripts/lint-extras.sh
+++ b/scripts/lint-extras.sh
@@ -59,6 +59,11 @@ function lint_helm() {
     run_check '' helm lint --namespace=test charts/*
 }
 
+function lint_py() {
+    # Install via: sudo apt-get install python3-pylint
+    run_check '.*\.py' pylint --score n --output-format=colorized
+}
+
 function lint_all() {
     # runs all checks
     all_required=1
@@ -66,6 +71,7 @@ function lint_all() {
     lint_yaml
     lint_markdown
     lint_helm
+    lint_py
 }
 case "${1:-}" in
 lint-shell)
@@ -80,6 +86,9 @@ lint-markdown)
 lint-helm)
     lint_helm
     ;;
+lint-py)
+    lint_py
+    ;;
 lint-all)
     lint_all
     ;;
@@ -90,6 +99,7 @@ Available Commands:
   lint-yaml              Lint yaml files
   lint-markdown          Lint markdown files
   lint-helm              Lint helm charts
+  lint-py                Lint python files
   lint-all               Run lint on all non-go files
 " >&2
     ;;


### PR DESCRIPTION
add pylint to catch static issues of python
files in the repo.

User can now run `make lint-py` for pylint
check on python files.

Fixes: #1132 

Signed-off-by: Yug Gupta <ygupta@redhat.com>
