### PR TITLE
rebase: use gosec-2.3.0

### DIFF
--- a/build.env
+++ b/build.env
@@ -19,7 +19,7 @@ GO111MODULE=on
 
 # static checks and linters
 GOLANGCI_VERSION=v1.21.0
-GOSEC_VERSION=2.0.0
+GOSEC_VERSION=v2.3.0
 
 # "go test" configuration
 # set to stdout or html to enable coverage reporting, disabled by default

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -142,7 +142,12 @@ func GetOMapValue(ctx context.Context, monitors string, cr *Credentials, poolNam
 		klog.Errorf(Log(ctx, "failed creating a temporary file for key contents"))
 		return "", err
 	}
-	defer tmpFile.Close()
+	defer func() {
+		ce := tmpFile.Close()
+		if ce != nil {
+			klog.Warningf(Log(ctx, "failed closing temporary file: %s"), ce)
+		}
+	}()
 	defer os.Remove(tmpFile.Name())
 
 	args := []string{

--- a/internal/util/cephconf.go
+++ b/internal/util/cephconf.go
@@ -49,7 +49,7 @@ func WriteCephConfig() error {
 		return err
 	}
 
-	err := ioutil.WriteFile(CephConfigPath, cephConfig, 0640)
+	err := ioutil.WriteFile(CephConfigPath, cephConfig, 0600)
 	if err != nil {
 		return err
 	}

--- a/internal/util/pidlimit.go
+++ b/internal/util/pidlimit.go
@@ -41,7 +41,7 @@ func getCgroupPidsFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer cgroup.Close()
+	defer cgroup.Close() // #nosec: error on close is not critical here
 
 	scanner := bufio.NewScanner(cgroup)
 	var slice string
@@ -75,7 +75,7 @@ func GetPIDLimit() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer f.Close() // #nosec: error on close is not critical here
 
 	maxPidsStr, err := bufio.NewReader(f).ReadString('\n')
 	if err != nil && err != io.EOF {
@@ -110,12 +110,12 @@ func SetPIDLimit(limit int) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	_, err = f.WriteString(limitStr)
 	if err != nil {
+		f.Close() // #nosec: a write error will be more useful to return
 		return err
 	}
 
-	return nil
+	return f.Close()
 }


### PR DESCRIPTION
gosec 2.3.0 has been released a while ago and adds more checks. With a few modifications ceph-csi passes the new additions. With the newer version of gosec, the code will be checked for more security issues than with the previous 2.0.0 version.

See-also: https://github.com/securego/gosec/releases/tag/v2.3.0