### PR TITLE
Cleanup messages related to Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 # need for docker build
+os: linux
 dist: bionic
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 # need for docker build
-sudo: true
 dist: bionic
 
 addons:


### PR DESCRIPTION
When browsing to the Travis CI build, each build has a "view config" tab. This tab lists several messages that can be addressed. Instead of the warning orange dot next to the tab, things should now become green.