### PR TITLE
deploy: Missing quotes

### DIFF
--- a/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
@@ -24,7 +24,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", watch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]


### PR DESCRIPTION
Missing quotes in deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
