### PR TITLE
rbd: check rbd image status only duing DeleteVolume RPC

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -339,21 +339,8 @@ func addRbdManagerTask(ctx context.Context, pOpts *rbdVolume, arg []string) (boo
 // deleteImage deletes a ceph image with provision and volume options.
 func deleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) error {
 	image := pOpts.RbdImageName
-	found, _, err := rbdStatus(ctx, pOpts, cr)
-	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed getting information for image (%s): (%s)"), pOpts, err)
-		if strings.Contains(err.Error(), "rbd: error opening image "+image+
-			": (2) No such file or directory") {
-			return ErrImageNotFound{image, err}
-		}
-		return err
-	}
-	if found {
-		klog.Errorf(util.Log(ctx, "rbd %s is still being used"), image)
-		return fmt.Errorf("rbd %s is still being used", image)
-	}
 	// Support deleting the older rbd images whose imageID is not stored in omap
-	err = pOpts.getImageID()
+	err := pOpts.getImageID()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
currently, various calls to delete image does not need the rbdStatus check. That is only required when calling from DeleteVolume. This PR optimizes the rbd image deletion by removing the status check.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Updates https://github.com/ceph/ceph-csi/issues/1188