### PR TITLE
ci: generate golangci.yml with correct CEPH_VERSION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ deploy/cephcsi/image/cephcsi
 *.orig
 *.patch
 *.rej
+
+# generated golangci-lint configuration
+scripts/golangci.yml

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,10 @@ mod-check: check-env
 	@echo 'running: go mod verify'
 	@go mod verify && [ "$(shell sha512sum go.mod)" = "`sha512sum go.mod`" ] || ( echo "ERROR: go.mod was modified by 'go mod verify'" && false )
 
-go-lint:
+scripts/golangci.yml: scripts/golangci.yml.in
+	sed "s/@@CEPH_VERSION@@/$(CEPH_VERSION)/g" < scripts/golangci.yml.in > scripts/golangci.yml
+
+go-lint: scripts/golangci.yml
 	./scripts/lint-go.sh
 
 lint-extras:
@@ -163,6 +166,7 @@ clean:
 	go clean -mod=vendor -r -x
 	rm -f deploy/cephcsi/image/cephcsi
 	rm -f _output/cephcsi
+	$(RM) scripts/golangci.yml
 	$(RM) e2e.test
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
 	$(RM) .devel-container-id

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -465,6 +465,8 @@ func (cs *ControllerServer) DeleteLegacyVolume(ctx context.Context, req *csi.Del
 
 // DeleteVolume deletes the volume in backend and removes the volume metadata
 // from store
+// TODO: make this function less complex
+// nolint:gocyclo // golangci-lint did not catch this earlier, needs to get fixed later
 func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		klog.Errorf(util.Log(ctx, "invalid delete volume req: %v"), protosanitizer.StripSecrets(req))

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -5,6 +5,9 @@
 
 # options for analysis running
 run:
+  build-tags:
+    - @@CEPH_VERSION@@
+
   # default concurrency is a available CPU number
   concurrency: 4
 


### PR DESCRIPTION
# Describe what this PR does #

When building against go-ceph, the most recent version of Ceph is
assumed to be available (currently Octopus). In case an older version of
the development packages is installed, building go-ceph will fail.

Golangci-lint does not accept the `-tags nautilus` parameter like other
Golang tools. Instead, the build-constraints need to be configured in a
confguration file.

This change takes care of the following:
- move the current scripts/golangci.yml to a template
- add the @@CEPH_VERSION@@ substitute
- generate the configuration file when needed

