### PR TITLE
cleanup: address err113 warnings about direct error comparisons

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -269,7 +269,7 @@ func (rv *rbdVolume) open() (*librbd.Image, error) {
 
 	image, err := librbd.OpenImage(rv.ioctx, rv.RbdImageName, librbd.NoSnapshot)
 	if err != nil {
-		if err == librbd.ErrNotFound {
+		if errors.Is(err, librbd.ErrNotFound) {
 			err = ErrImageNotFound{rv.RbdImageName, err}
 		}
 		return nil, err
@@ -851,7 +851,7 @@ func (rv *rbdVolume) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) err
 		return fmt.Errorf("snapshot value is nil for %s", pOpts.RbdSnapName)
 	}
 	err = snap.Remove()
-	if err == librbd.ErrNotFound {
+	if errors.Is(err, librbd.ErrNotFound) {
 		return ErrSnapNotFound{snapName: pOpts.RbdSnapName, err: err}
 	}
 	return err

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -63,7 +63,7 @@ func GetPoolID(monitors string, cr *Credentials, poolName string) (int64, error)
 	defer connPool.Put(conn)
 
 	id, err := conn.GetPoolByName(poolName)
-	if err == rados.ErrNotFound {
+	if errors.Is(err, rados.ErrNotFound) {
 		return InvalidPoolID, ErrPoolNotFound{poolName, fmt.Errorf("pool (%s) not found in Ceph cluster", poolName)}
 	} else if err != nil {
 		return InvalidPoolID, err
@@ -247,7 +247,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	}
 
 	err = ioctx.Create(objectName, rados.CreateExclusive)
-	if err == rados.ErrObjectExists {
+	if errors.Is(err, rados.ErrObjectExists) {
 		return ErrObjectExists{objectName, err}
 	} else if err != nil {
 		klog.Errorf(Log(ctx, "failed creating omap (%s) in pool (%s): (%v)"), objectName, poolName, err)
@@ -282,7 +282,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	}
 
 	err = ioctx.Delete(oMapName)
-	if err == rados.ErrNotFound {
+	if errors.Is(err, rados.ErrNotFound) {
 		return ErrObjectNotFound{oMapName, err}
 	} else if err != nil {
 		klog.Errorf(Log(ctx, "failed removing omap (%s) in pool (%s): (%v)"), oMapName, poolName, err)

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -73,7 +73,7 @@ func (cc *ClusterConnection) GetIoctx(pool string) (*rados.IOContext, error) {
 	ioctx, err := cc.conn.OpenIOContext(pool)
 	if err != nil {
 		// ErrNotFound indicates the Pool was not found
-		if err == rados.ErrNotFound {
+		if errors.Is(err, rados.ErrNotFound) {
 			err = ErrPoolNotFound{pool, err}
 		} else {
 			err = fmt.Errorf("failed to open IOContext for pool %s: %w", pool, err)


### PR DESCRIPTION
Several places in the code compared errors directly with the go-ceph
sentinel errors.  This change uses the errors.Is() function of go
1.13 instead.  The err113 linter reported this issue as:

err113: do not compare errors directly, use errors.Is() instead

Signed-off-by: Sven Anderson <sven@redhat.com>

Updates: #1184