### PR TITLE
cleanup: use errors.As() for error type checks

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -155,7 +155,8 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		if errors.As(err, &einf) {
 			err = parentVol.deleteSnapshot(ctx, rbdSnap)
 			if err != nil {
-				if _, ok := err.(ErrSnapNotFound); !ok {
+				var esnf ErrSnapNotFound
+				if !errors.As(err, &esnf) {
 					klog.Errorf(util.Log(ctx, "failed to delete snapshot %s: %v"), rbdSnap, err)
 					return false, err
 				}
@@ -181,7 +182,8 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 
 	// check snapshot exists if not create it
 	_, err = vol.getSnapInfo(rbdSnap)
-	if _, ok := err.(ErrSnapNotFound); ok {
+	var esnf ErrSnapNotFound
+	if errors.As(err, &esnf) {
 		// create snapshot
 		sErr := vol.createSnapshot(ctx, rbdSnap)
 		if sErr != nil {

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -17,10 +17,11 @@ package rbd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/util"
 
-	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
 
@@ -36,7 +37,7 @@ func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap
 	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap)
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed to clone rbd image %s from snapshot %s: %v"), cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
-		err = errors.Errorf("failed to clone rbd image %s from snapshot %s: %v", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
+		err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
 	}
 	errSnap := parentVol.deleteSnapshot(ctx, snap)
 	if errSnap != nil {
@@ -64,14 +65,16 @@ func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap
 func cleanUpSnapshot(ctx context.Context, parentVol *rbdVolume, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, cr *util.Credentials) error {
 	err := parentVol.deleteSnapshot(ctx, rbdSnap)
 	if err != nil {
-		if _, ok := err.(ErrSnapNotFound); !ok {
+		var esnf ErrSnapNotFound
+		if !errors.As(err, &esnf) {
 			klog.Errorf(util.Log(ctx, "failed to delete snapshot: %v"), err)
 			return err
 		}
 	}
 	err = deleteImage(ctx, rbdVol, cr)
 	if err != nil {
-		if _, ok := err.(ErrImageNotFound); !ok {
+		var einf ErrImageNotFound
+		if !errors.As(err, &einf) {
 			klog.Errorf(util.Log(ctx, "failed to delete rbd image: %s/%s with error: %v"), rbdVol.Pool, rbdVol.VolName, err)
 			return err
 		}


### PR DESCRIPTION
Replaces some remaining old-style error type checks with errors.As()

Signed-off-by: Sven Anderson <sven@redhat.com>

Related: #1189
