### PR TITLE
rbd: check image not found error

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -151,8 +151,8 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 	// Fetch on-disk image attributes
 	err = vol.getImageInfo()
 	if err != nil {
-		var esnf ErrSnapNotFound
-		if errors.As(err, &esnf) {
+		var einf ErrImageNotFound
+		if errors.As(err, &einf) {
 			err = parentVol.deleteSnapshot(ctx, rbdSnap)
 			if err != nil {
 				if _, ok := err.(ErrSnapNotFound); !ok {


### PR DESCRIPTION
during the checkSnapCloneExists we are checking the image, if the image not found we are deleting the snapshot on the parent image, This PR corrects the comparison. instead of snapshotNotFound, we need to check ImageNotFound error.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
