### PR TITLE
ci: separate the cephfs and rbd tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,25 +95,52 @@ jobs:
         - ./scripts/build-multi-arch-image.sh || travis_terminate 1;
 
     - stage: e2e testing
-      name: cephcsi with kube 1.16.9
+      name: CephFS with kubernetes v1.16.9
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.16.9 || travis_terminate 1;
+        - scripts/travis-functest.sh v1.16.9 --test-cephfs=true
+          --test-rbd=false || travis_terminate 1;
 
     - stage: e2e testing
-      name: cephcsi with kube 1.17.5
+      name: RBD with kubernetes v1.16.9
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.17.5 || travis_terminate 1;
+        - scripts/travis-functest.sh v1.16.9 --test-cephfs=false
+          --test-rbd=true || travis_terminate 1;
 
     - stage: e2e testing
-      name: cephcsi helm charts with kube 1.17.5
+      name: CephFS with kubernetes v1.17.5
       script:
         - scripts/skip-doc-change.sh || travis_terminate 0;
         - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-helmtest.sh v1.17.5 || travis_terminate 1;
+        - scripts/travis-functest.sh v1.17.5 --test-cephfs=true
+          --test-rbd=false|| travis_terminate 1;
+
+    - stage: e2e testing
+      name: RBD with kubernetes v1.17.5
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-functest.sh v1.17.5 --test-cephfs=false
+          --test-rbd=true || travis_terminate 1;
+
+    - stage: e2e testing
+      name: CephFS helm charts with kubernetes v1.17.5
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-helmtest.sh v1.17.5 --test-cephfs=true
+          --test-rbd=false || travis_terminate 1;
+
+    - stage: e2e testing
+      name: RBD helm charts with kubernetes v1.17.5
+      script:
+        - scripts/skip-doc-change.sh || travis_terminate 0;
+        - make image-cephcsi || travis_terminate 1;
+        - scripts/travis-helmtest.sh v1.17.5 --test-cephfs=false
+          --test-rbd=true || travis_terminate 1;
 
     - stage: deploy
       name: push artifacts to repositories

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -78,6 +78,8 @@ are available while running tests:
 | deploy-timeout    | Timeout to wait for created kubernetes resources (default: 10 minutes)        |
 | deploy-cephfs     | Deploy cephfs csi driver as part of E2E (default: true)                       |
 | deploy-rbd        | Deploy rbd csi driver as part of E2E (default: true)                          |
+| test-cephfs       | Test cephfs csi driver as part of E2E (default: true)                         |
+| test-rbd          | Test rbd csi driver as part of E2E (default: true)                            |
 | cephcsi-namespace | The namespace in which cephcsi driver will be created (default: "default")    |
 | rook-namespace    | The namespace in which rook operator is installed (default: "rook-ceph")      |
 | kubeconfig        | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config) |

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -115,6 +115,9 @@ var _ = Describe("cephfs", func() {
 	var c clientset.Interface
 	// deploy cephfs CSI
 	BeforeEach(func() {
+		if !testCephFS {
+			Skip("Skipping CephFS E2E")
+		}
 		c = f.ClientSet
 		if deployCephFS {
 			if cephCSINamespace != defaultNs {
@@ -130,6 +133,9 @@ var _ = Describe("cephfs", func() {
 	})
 
 	AfterEach(func() {
+		if !testRBD {
+			Skip("Skipping CephFS E2E")
+		}
 		if CurrentGinkgoTestDescription().Failed {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-cephfs", c)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -20,6 +20,8 @@ func init() {
 	flag.IntVar(&deployTimeout, "deploy-timeout", 10, "timeout to wait for created kubernetes resources")
 	flag.BoolVar(&deployCephFS, "deploy-cephfs", true, "deploy cephfs csi driver")
 	flag.BoolVar(&deployRBD, "deploy-rbd", true, "deploy rbd csi driver")
+	flag.BoolVar(&testCephFS, "test-cephfs", true, "test cephfs csi driver")
+	flag.BoolVar(&testRBD, "test-rbd", true, "test rbd csi driver")
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
 	setDefaultKubeconfig()

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -128,6 +128,9 @@ var _ = Describe("RBD", func() {
 	var c clientset.Interface
 	// deploy RBD CSI
 	BeforeEach(func() {
+		if !testRBD {
+			Skip("Skipping RBD E2E")
+		}
 		c = f.ClientSet
 		if deployRBD {
 			createNodeLabel(f, nodeRegionLabel, regionValue)
@@ -147,6 +150,9 @@ var _ = Describe("RBD", func() {
 	})
 
 	AfterEach(func() {
+		if !testRBD {
+			Skip("Skipping RBD E2E")
+		}
 		if CurrentGinkgoTestDescription().Failed {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-rbd", c)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -52,6 +52,8 @@ var (
 	deployTimeout    int
 	deployCephFS     bool
 	deployRBD        bool
+	testCephFS       bool
+	testRBD          bool
 	cephCSINamespace string
 	rookNamespace    string
 	ns               string

--- a/scripts/travis-functest.sh
+++ b/scripts/travis-functest.sh
@@ -4,7 +4,7 @@ set -e
 # This script will be used by travis to run functional test
 # against different kuberentes version
 export KUBE_VERSION=$1
-
+shift
 # parse the kubernetes version, return the digit passed as argument
 # v1.17.0 -> kube_version 1 -> 1
 # v1.17.0 -> kube_version 2 -> 17
@@ -39,7 +39,7 @@ if [[ "${KUBE_MAJOR}" -ge 1 ]] && [[ "${KUBE_MINOR}" -ge 17 ]]; then
 fi
 
 # functional tests
-go test "${GO_TAGS}" github.com/ceph/ceph-csi/e2e --deploy-timeout="${DEPLOY_TIMEOUT}" -timeout="${E2E_TIMEOUT}" --cephcsi-namespace=cephcsi-e2e-$RANDOM -v -mod=vendor
+go test "${GO_TAGS}" github.com/ceph/ceph-csi/e2e --deploy-timeout="${DEPLOY_TIMEOUT}" -timeout="${E2E_TIMEOUT}" --cephcsi-namespace=cephcsi-e2e-$RANDOM -v -mod=vendor "${@}"
 
 if [[ "${KUBE_MAJOR}" -ge 1 ]] && [[ "${KUBE_MINOR}" -ge 17 ]]; then
     # delete snapshot CRD

--- a/scripts/travis-helmtest.sh
+++ b/scripts/travis-helmtest.sh
@@ -4,6 +4,7 @@ set -e
 # This script will be used by travis to run functional test
 # against different kuberentes version
 export KUBE_VERSION=$1
+shift
 # parse the kubernetes version, return the digit passed as argument
 # v1.17.0 -> kube_version 1 -> 1
 # v1.17.0 -> kube_version 2 -> 17
@@ -49,7 +50,7 @@ scripts/install-helm.sh up
 # install cephcsi helm charts
 scripts/install-helm.sh install-cephcsi ${NAMESPACE}
 # functional tests
-go test "${GO_TAGS}" github.com/ceph/ceph-csi/e2e -mod=vendor --deploy-timeout="${DEPLOY_TIMEOUT}" -timeout="${E2E_TIMEOUT}" --cephcsi-namespace=${NAMESPACE} --deploy-cephfs=false --deploy-rbd=false -v
+go test "${GO_TAGS}" github.com/ceph/ceph-csi/e2e -mod=vendor --deploy-timeout="${DEPLOY_TIMEOUT}" -timeout="${E2E_TIMEOUT}" --cephcsi-namespace=${NAMESPACE} --deploy-cephfs=false --deploy-rbd=false -v "${@}"
 
 #cleanup
 # skip snapshot operation if kube version is less than 1.17.0


### PR DESCRIPTION
As the maximum time allocated for the Travis CI is 50 minutes and the cephfs and rbd E2E takes around 45 Minutes to run completely. This is blocking us from adding more tests in E2E. splitting out the E2E will help us to run more tests for each driver as we will get 50 minutes for each Travis CI instance.

Added two new parameters for the e2e test to skip rbd and cephfs tests. This will help us to run more tests in Travis CI.
    

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>