### PR TITLE
cleanup: [WIP] Reduce code nesting

### DIFF
--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -275,26 +275,24 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 	volOptions.RequestName = imageAttributes.RequestName
 	vid.FsSubvolName = imageAttributes.ImageName
 
-	if volOpt != nil {
-		if err = extractOptionalOption(&volOptions.Pool, "pool", volOpt); err != nil {
-			return nil, nil, err
-		}
+	if err = extractOptionalOption(&volOptions.Pool, "pool", volOpt); err != nil && volOpt != nil {
+		return nil, nil, err
+	}
 
-		if err = extractOptionalOption(&volOptions.KernelMountOptions, "kernelMountOptions", volOpt); err != nil {
-			return nil, nil, err
-		}
+	if err = extractOptionalOption(&volOptions.KernelMountOptions, "kernelMountOptions", volOpt); err != nil && volOpt != nil {
+		return nil, nil, err
+	}
 
-		if err = extractOptionalOption(&volOptions.FuseMountOptions, "fuseMountOptions", volOpt); err != nil {
-			return nil, nil, err
-		}
+	if err = extractOptionalOption(&volOptions.FuseMountOptions, "fuseMountOptions", volOpt); err != nil && volOpt != nil {
+		return nil, nil, err
+	}
 
-		if err = extractOptionalOption(&volOptions.SubvolumeGroup, "subvolumeGroup", volOpt); err != nil {
-			return nil, nil, err
-		}
+	if err = extractOptionalOption(&volOptions.SubvolumeGroup, "subvolumeGroup", volOpt); err != nil && volOpt != nil {
+		return nil, nil, err
+	}
 
-		if err = extractMounter(&volOptions.Mounter, volOpt); err != nil {
-			return nil, nil, err
-		}
+	if err = extractMounter(&volOptions.Mounter, volOpt); err != nil && volOpt != nil {
+		return nil, nil, err
 	}
 
 	volOptions.ProvisionVolume = true

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -315,11 +315,11 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 		savedImagePoolID = int64(binary.BigEndian.Uint64(buf64))
 
 		savedImagePool, err = util.GetPoolName(conn.monitors, conn.cr, savedImagePoolID)
+		var epnf util.ErrPoolNotFound
+		if errors.As(err, &epnf) {
+			err = conn.UndoReservation(ctx, journalPool, "", "", reqName)
+		}
 		if err != nil {
-			var epnf util.ErrPoolNotFound
-			if errors.As(err, &epnf) {
-				err = conn.UndoReservation(ctx, journalPool, "", "", reqName)
-			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
nestif warns about deeply nested codeblocks
which can be addressed by reducing
"arrowed code".

Issue Reported:
internal/journal/voljournal.go:302:2: `if len(objUUIDAndPool) == uuidEncodedLength` is deeply nested (complexity: 5) (nestif)
internal/cephfs/volumeoptions.go:278:2: `if volOpt != nil` is deeply nested (complexity: 5) (nestif)

Updates: #1157

Signed-off-by: Yug <yuggupta27@gmail.com>
