### PR TITLE
ci: use testCephFS flag to skip cephfs tests

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -133,7 +133,7 @@ var _ = Describe("cephfs", func() {
 	})
 
 	AfterEach(func() {
-		if !testRBD {
+		if !testCephFS {
 			Skip("Skipping CephFS E2E")
 		}
 		if CurrentGinkgoTestDescription().Failed {


### PR DESCRIPTION
This commit fixes the flag check to skip cephfs E2E tests.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
