### PR TITLE
Utils: remove unused error fields

### DIFF
--- a/internal/cephfs/cephfs_util.go
+++ b/internal/cephfs/cephfs_util.go
@@ -84,7 +84,7 @@ func getMetadataPool(ctx context.Context, monitors string, cr *util.Credentials,
 		}
 	}
 
-	return "", util.ErrPoolNotFound{Pool: fsName, Err: fmt.Errorf("fsName (%s) not found in Ceph cluster", fsName)}
+	return "", util.ErrPoolNotFound{Err: fmt.Errorf("fsName (%s) not found in Ceph cluster", fsName)}
 }
 
 // CephFilesystemDump is a representation of the main json structure returned by 'ceph fs dump'
@@ -114,5 +114,5 @@ func getFsName(ctx context.Context, monitors string, cr *util.Credentials, fscID
 		}
 	}
 
-	return "", util.ErrPoolNotFound{Pool: string(fscID), Err: fmt.Errorf("fscID (%d) not found in Ceph cluster", fscID)}
+	return "", util.ErrPoolNotFound{Err: fmt.Errorf("fscID (%d) not found in Ceph cluster", fscID)}
 }

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -66,7 +66,7 @@ func getOMapValues(
 			klog.Errorf(
 				util.Log(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v"),
 				poolName, namespace, oid, err)
-			return nil, util.NewErrKeyNotFound(oid, err)
+			return nil, util.NewErrKeyNotFound(err)
 		}
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func setOMapKeys(
 
 func omapPoolError(poolName string, err error) error {
 	if errors.Is(err, rados.ErrNotFound) {
-		return util.NewErrPoolNotFound(poolName, err)
+		return util.NewErrPoolNotFound(err)
 	}
 	return err
 }

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -366,7 +366,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 			err = fmt.Errorf("snapname points to different volume, request name (%s)"+
 				" source name (%s) saved source name (%s)",
 				reqName, parentName, savedImageAttributes.SourceName)
-			return nil, util.NewErrSnapNameConflict(reqName, err)
+			return nil, util.NewErrSnapNameConflict(err)
 		}
 	}
 
@@ -657,7 +657,6 @@ func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID
 		imageAttributes.SourceName, found = values[cj.cephSnapSourceKey]
 		if !found {
 			return nil, util.NewErrKeyNotFound(
-				cj.cephSnapSourceKey,
 				fmt.Errorf("no snap source in omap for %q", cj.cephUUIDDirectoryPrefix+objectUUID))
 		}
 	}

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -61,7 +61,7 @@ func GetPoolID(monitors string, cr *Credentials, poolName string) (int64, error)
 
 	id, err := conn.GetPoolByName(poolName)
 	if errors.Is(err, rados.ErrNotFound) {
-		return InvalidPoolID, ErrPoolNotFound{poolName, fmt.Errorf("pool (%s) not found in Ceph cluster", poolName)}
+		return InvalidPoolID, ErrPoolNotFound{fmt.Errorf("pool (%s) not found in Ceph cluster", poolName)}
 	} else if err != nil {
 		return InvalidPoolID, err
 	}
@@ -80,7 +80,7 @@ func GetPoolName(monitors string, cr *Credentials, poolID int64) (string, error)
 
 	name, err := conn.GetPoolByID(poolID)
 	if err != nil {
-		return "", ErrPoolNotFound{string(poolID), fmt.Errorf("pool ID (%d) not found in Ceph cluster", poolID)}
+		return "", ErrPoolNotFound{fmt.Errorf("pool ID (%d) not found in Ceph cluster", poolID)}
 	}
 	return name, nil
 }
@@ -119,7 +119,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if err != nil {
 		var epnf ErrPoolNotFound
 		if errors.As(err, &epnf) {
-			err = ErrObjectNotFound{poolName, err}
+			err = ErrObjectNotFound{err}
 		}
 		return err
 	}
@@ -131,7 +131,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 
 	err = ioctx.Create(objectName, rados.CreateExclusive)
 	if errors.Is(err, rados.ErrObjectExists) {
-		return ErrObjectExists{objectName, err}
+		return ErrObjectExists{err}
 	} else if err != nil {
 		klog.Errorf(Log(ctx, "failed creating omap (%s) in pool (%s): (%v)"), objectName, poolName, err)
 		return err
@@ -154,7 +154,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if err != nil {
 		var epnf ErrPoolNotFound
 		if errors.As(err, &epnf) {
-			err = ErrObjectNotFound{poolName, err}
+			err = ErrObjectNotFound{err}
 		}
 		return err
 	}
@@ -166,7 +166,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 
 	err = ioctx.Delete(oMapName)
 	if errors.Is(err, rados.ErrNotFound) {
-		return ErrObjectNotFound{oMapName, err}
+		return ErrObjectNotFound{err}
 	} else if err != nil {
 		klog.Errorf(Log(ctx, "failed removing omap (%s) in pool (%s): (%v)"), oMapName, poolName, err)
 		return err

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -74,7 +74,7 @@ func (cc *ClusterConnection) GetIoctx(pool string) (*rados.IOContext, error) {
 	if err != nil {
 		// ErrNotFound indicates the Pool was not found
 		if errors.Is(err, rados.ErrNotFound) {
-			err = ErrPoolNotFound{pool, err}
+			err = ErrPoolNotFound{err}
 		} else {
 			err = fmt.Errorf("failed to open IOContext for pool %s: %w", pool, err)
 		}

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -18,13 +18,12 @@ package util
 
 // ErrKeyNotFound is returned when requested key in omap is not found
 type ErrKeyNotFound struct {
-	keyName string
-	err     error
+	err error
 }
 
 // NewErrKeyNotFound returns a new ErrKeyNotFound error.
-func NewErrKeyNotFound(keyName string, err error) ErrKeyNotFound {
-	return ErrKeyNotFound{keyName, err}
+func NewErrKeyNotFound(err error) ErrKeyNotFound {
+	return ErrKeyNotFound{err}
 }
 
 // Error returns the error string for ErrKeyNotFound.
@@ -39,8 +38,7 @@ func (e ErrKeyNotFound) Unwrap() error {
 
 // ErrObjectExists is returned when named omap is already present in rados
 type ErrObjectExists struct {
-	objectName string
-	err        error
+	err error
 }
 
 // Error returns the error string for ErrObjectExists.
@@ -55,8 +53,7 @@ func (e ErrObjectExists) Unwrap() error {
 
 // ErrObjectNotFound is returned when named omap is not found in rados
 type ErrObjectNotFound struct {
-	oMapName string
-	err      error
+	err error
 }
 
 // Error returns the error string for ErrObjectNotFound.
@@ -72,8 +69,7 @@ func (e ErrObjectNotFound) Unwrap() error {
 // ErrSnapNameConflict is generated when a requested CSI snap name already exists on RBD but with
 // different properties, and hence is in conflict with the passed in CSI volume name
 type ErrSnapNameConflict struct {
-	requestName string
-	err         error
+	err error
 }
 
 // Error returns the error string for ErrSnapNameConflict.
@@ -87,14 +83,13 @@ func (e ErrSnapNameConflict) Unwrap() error {
 }
 
 // NewErrSnapNameConflict returns a ErrSnapNameConflict error when CSI snap name already exists.
-func NewErrSnapNameConflict(name string, err error) ErrSnapNameConflict {
-	return ErrSnapNameConflict{name, err}
+func NewErrSnapNameConflict(err error) ErrSnapNameConflict {
+	return ErrSnapNameConflict{err}
 }
 
 // ErrPoolNotFound is returned when pool is not found
 type ErrPoolNotFound struct {
-	Pool string
-	Err  error
+	Err error
 }
 
 // Error returns the error string for ErrPoolNotFound.
@@ -108,6 +103,6 @@ func (e ErrPoolNotFound) Unwrap() error {
 }
 
 // NewErrPoolNotFound returns a new ErrPoolNotFound error.
-func NewErrPoolNotFound(pool string, err error) ErrPoolNotFound {
-	return ErrPoolNotFound{pool, err}
+func NewErrPoolNotFound(err error) ErrPoolNotFound {
+	return ErrPoolNotFound{err}
 }


### PR DESCRIPTION
The additional fields in the errors are used nowhere. This change
removes them and the related code.

Related: #1203

Signed-off-by: Sven Anderson <sven@redhat.com>