### PR TITLE
check maximum snapshots on the image during CreateVolume

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -765,24 +765,12 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			},
 		}, nil
 	}
-	var snaps []snapshotInfo
-	// check the number of snapshots on image
-	snaps, err = rbdVol.listSnapshots(ctx, cr)
+
+	err = flattenTemporaryClonedImages(ctx, rbdVol, cr)
 	if err != nil {
-		var einf ErrImageNotFound
-		if errors.As(err, &einf) {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
-	if len(snaps) > int(maxSnapshotsOnImage) {
-		err = flattenClonedRbdImages(ctx, snaps, rbdVol.Pool, rbdVol.Monitors, cr)
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		return nil, status.Errorf(codes.ResourceExhausted, "rbd image %s has %d snapshots", rbdVol, len(snaps))
-	}
 	err = reserveSnap(ctx, rbdSnap, rbdVol, cr)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
create temporary snapshot on the parent image the same as name as the temporary clone rbd image. Naming the snapshot and the temporary cloned image helps to flatten the temporary cloned images when the snapshots on the parent image exceeds the configured maxSnapshotsOnImage.

If the snapshots on the parent image exceed maxSnapshotsOnImage count, we need to flatten all the temporary cloned images to overcome the krbd issue of maximum number of snapshots on an image.