### PR TITLE
cleanup: rename newVolumeOptionsFromVersion1Context for more clarity

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -94,7 +94,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 
-		// check for pre-provisioned volumes (plugin versions > 1.0.0)
+		// gets mon IPs from the supplied cluster info
 		volOptions, _, err = newVolumeOptionsFromStaticVolume(string(volID), req.GetVolumeContext())
 		if err != nil {
 			var ensv ErrNonStaticVolume
@@ -102,8 +102,8 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 				return nil, status.Error(codes.Internal, err.Error())
 			}
 
-			// check for volumes from plugin versions <= 1.0.0
-			volOptions, _, err = newVolumeOptionsFromVersion1Context(string(volID), req.GetVolumeContext(),
+			// get mon IPs from the volume context
+			volOptions, _, err = newVolumeOptionsFromMonitorList(string(volID), req.GetVolumeContext(),
 				req.GetSecrets())
 			if err != nil {
 				return nil, status.Error(codes.Internal, err.Error())

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -307,10 +307,9 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 	return &volOptions, &vid, nil
 }
 
-// newVolumeOptionsFromVersion1Context generates a new instance of volumeOptions and
-// volumeIdentifier from the provided CSI volume context, if the provided context was
-// for a volume created by version 1.0.0 (or prior) of the CSI plugin
-func newVolumeOptionsFromVersion1Context(volID string, options, secrets map[string]string) (*volumeOptions, *volumeIdentifier, error) {
+// newVolumeOptionsFromMonitorList generates a new instance of volumeOptions and
+// volumeIdentifier from the provided CSI volume context
+func newVolumeOptionsFromMonitorList(volID string, options, secrets map[string]string) (*volumeOptions, *volumeIdentifier, error) {
 	var (
 		opts                volumeOptions
 		vid                 volumeIdentifier
@@ -318,7 +317,7 @@ func newVolumeOptionsFromVersion1Context(volID string, options, secrets map[stri
 		err                 error
 	)
 
-	// Check if monitors is part of the options, that is an indicator this is an 1.0.0 volume
+	// Check if monitors is part of the options
 	if err = extractOption(&opts.Monitors, "monitors", options); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
rename newVolumeOptionsFromVersion1Context to newVolumeOptionsFromMonitorList to provide more clarity to the function readers and also fixed comments.

closes #1228 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

