### PR TITLE
ci: disable centos ci checks from mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,8 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
-      - "status-success=ci/centos/containerized-tests"
+      # Removing/disabling centos check for now as centosci setup is down
+      # -"status-success=ci/centos/containerized-tests"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:
@@ -41,7 +42,8 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
-      - "status-success=ci/centos/containerized-tests"
+      # Removing/disabling centos check for now as centosci setup is down
+      # - "status-success=ci/centos/containerized-tests"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:


### PR DESCRIPTION
CentOS CI outage block PRs to get merged even when it has enough
approvals. Disabling the centos check for now as there is no ETA
on the availability of the setup atm.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

