### PR TITLE
ci: enable containerized test job in mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,8 +23,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
-      # Removing/disabling centos check for now as centosci setup is down
-      # -"status-success=ci/centos/containerized-tests"
+      - "status-success=ci/centos/containerized-tests"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:
@@ -42,8 +41,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
-      # Removing/disabling centos check for now as centosci setup is down
-      # - "status-success=ci/centos/containerized-tests"
+      - "status-success=ci/centos/containerized-tests"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:


### PR DESCRIPTION
Since containerized-tests job is functioning
again, we can re-enable the job as a required
condition to merge PRs.
https://jenkins-ceph-csi.apps.ci.centos.org/blue/organizations/jenkins/containerized-tests/activity/

Signed-off-by: Yug <yuggupta27@gmail.com>