### PR TITLE
Remove duplicated execCommand() functions and use util.ExecCommand()

### DIFF
--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -31,12 +31,12 @@ import (
 type volumeID string
 
 func execCommandErr(ctx context.Context, program string, args ...string) error {
-	_, _, err := util.ExecCommand(program, args...)
+	_, _, err := util.ExecCommand(ctx, program, args...)
 	return err
 }
 
 func execCommandJSON(ctx context.Context, v interface{}, program string, args ...string) error {
-	stdout, _, err := util.ExecCommand(program, args...)
+	stdout, _, err := util.ExecCommand(ctx, program, args...)
 	if err != nil {
 		return err
 	}

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -41,7 +41,7 @@ func execCommandJSON(ctx context.Context, v interface{}, program string, args ..
 		return err
 	}
 
-	if err = json.Unmarshal(stdout, v); err != nil {
+	if err = json.Unmarshal([]byte(stdout), v); err != nil {
 		return fmt.Errorf("failed to unmarshal JSON for %s %v: %s: %w", program, util.StripSecretInArgs(args), stdout, err)
 	}
 

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -17,11 +17,9 @@ limitations under the License.
 package cephfs
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"github.com/ceph/ceph-csi/internal/util"
 
@@ -32,38 +30,13 @@ import (
 
 type volumeID string
 
-func execCommand(ctx context.Context, program string, args ...string) (stdout, stderr []byte, err error) {
-	var (
-		cmd           = exec.Command(program, args...) // #nosec:G204, not called with user specified parameters.
-		sanitizedArgs = util.StripSecretInArgs(args)
-		stdoutBuf     bytes.Buffer
-		stderrBuf     bytes.Buffer
-	)
-
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-
-	util.DebugLog(ctx, "cephfs: EXEC %s %s", program, sanitizedArgs)
-
-	if err := cmd.Run(); err != nil {
-		if cmd.Process == nil {
-			return nil, nil, fmt.Errorf("cannot get process pid while running %s %v: %w: %s",
-				program, sanitizedArgs, err, stderrBuf.Bytes())
-		}
-		return nil, nil, fmt.Errorf("an error occurred while running (%d) %s %v: %w: %s",
-			cmd.Process.Pid, program, sanitizedArgs, err, stderrBuf.Bytes())
-	}
-
-	return stdoutBuf.Bytes(), stderrBuf.Bytes(), nil
-}
-
 func execCommandErr(ctx context.Context, program string, args ...string) error {
-	_, _, err := execCommand(ctx, program, args...)
+	_, _, err := util.ExecCommand(program, args...)
 	return err
 }
 
 func execCommandJSON(ctx context.Context, v interface{}, program string, args ...string) error {
-	stdout, _, err := execCommand(ctx, program, args...)
+	stdout, _, err := util.ExecCommand(program, args...)
 	if err != nil {
 		return err
 	}

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -67,16 +67,15 @@ func getVolumeRootPathCeph(ctx context.Context, volOptions *volumeOptions, cr *u
 		"--keyfile="+cr.KeyFile)
 
 	if err != nil {
-		stdErrString := string(stderr)
-		klog.Errorf(util.Log(ctx, "failed to get the rootpath for the vol %s(%s) stdError %s"), string(volID), err, stdErrString)
+		klog.Errorf(util.Log(ctx, "failed to get the rootpath for the vol %s(%s) stdError %s"), string(volID), err, stderr)
 
-		if strings.HasPrefix(stdErrString, errNotFoundString) {
+		if strings.HasPrefix(stderr, errNotFoundString) {
 			return "", util.JoinErrors(ErrVolumeNotFound, err)
 		}
 
 		return "", err
 	}
-	return strings.TrimSuffix(string(stdout), "\n"), nil
+	return strings.TrimSuffix(stdout, "\n"), nil
 }
 
 type localClusterState struct {

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -52,6 +52,7 @@ func getVolumeRootPathCephDeprecated(volID volumeID) string {
 
 func getVolumeRootPathCeph(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, volID volumeID) (string, error) {
 	stdout, stderr, err := util.ExecCommand(
+		ctx,
 		"ceph",
 		"fs",
 		"subvolume",

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -176,7 +176,7 @@ func mountFuse(ctx context.Context, mountPoint string, cr *util.Credentials, vol
 	// We need "starting fuse" meaning the mount is ok
 	// and PID of the ceph-fuse daemon for unmount
 
-	match := fusePidRx.FindSubmatch(stderr)
+	match := fusePidRx.FindSubmatch([]byte(stderr))
 	// validMatchLength is set to 2 as match is expected
 	// to have 2 items, starting fuse and PID of the fuse daemon
 	const validMatchLength = 2

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -167,7 +167,7 @@ func mountFuse(ctx context.Context, mountPoint string, cr *util.Credentials, vol
 		args = append(args, "--client_mds_namespace="+volOptions.FsName)
 	}
 
-	_, stderr, err := execCommand(ctx, "ceph-fuse", args[:]...)
+	_, stderr, err := util.ExecCommand("ceph-fuse", args[:]...)
 	if err != nil {
 		return err
 	}

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -167,7 +167,7 @@ func mountFuse(ctx context.Context, mountPoint string, cr *util.Credentials, vol
 		args = append(args, "--client_mds_namespace="+volOptions.FsName)
 	}
 
-	_, stderr, err := util.ExecCommand("ceph-fuse", args[:]...)
+	_, stderr, err := util.ExecCommand(ctx, "ceph-fuse", args[:]...)
 	if err != nil {
 		return err
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1092,7 +1092,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		util.DebugLog(ctx, "rbd volume %s size is %v,resizing to %v", rbdVol, rbdVol.VolSize, volSize)
 		rbdVol.VolSize = volSize
 		nodeExpansion = true
-		err = resizeRBDImage(rbdVol, cr)
+		err = rbdVol.resize(ctx, cr)
 		if err != nil {
 			klog.Errorf(util.Log(ctx, "failed to resize rbd image: %s with error: %v"), rbdVol, err)
 			return nil, status.Error(codes.Internal, err.Error())

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -159,13 +159,13 @@ func checkRbdNbdTools() bool {
 	_, err := os.Stat(fmt.Sprintf("/sys/module/%s", moduleNbd))
 	if os.IsNotExist(err) {
 		// try to load the module
-		_, err = execCommand("modprobe", []string{moduleNbd})
+		_, _, err = util.ExecCommand("modprobe", moduleNbd)
 		if err != nil {
 			util.ExtendedLogMsg("rbd-nbd: nbd modprobe failed with error %v", err)
 			return false
 		}
 	}
-	if _, err := execCommand(rbdTonbd, []string{"--version"}); err != nil {
+	if _, _, err := util.ExecCommand(rbdTonbd, "--version"); err != nil {
 		util.ExtendedLogMsg("rbd-nbd: running rbd-nbd --version failed with error %v", err)
 		return false
 	}
@@ -229,9 +229,9 @@ func createPath(ctx context.Context, volOpt *rbdVolume, cr *util.Credentials) (s
 		mapOptions = append(mapOptions, "--read-only")
 	}
 	// Execute map
-	output, err := execCommand(rbd, mapOptions)
+	stdout, stderr, err := util.ExecCommand(rbd, mapOptions...)
 	if err != nil {
-		klog.Warningf(util.Log(ctx, "rbd: map error %v, rbd output: %s"), err, string(output))
+		klog.Warningf(util.Log(ctx, "rbd: map error %v, rbd output: %s"), err, string(stderr))
 		// unmap rbd image if connection timeout
 		if strings.Contains(err.Error(), rbdMapConnectionTimeout) {
 			detErr := detachRBDImageOrDeviceSpec(ctx, imagePath, true, isNbd, volOpt.Encrypted, volOpt.VolID)
@@ -239,9 +239,9 @@ func createPath(ctx context.Context, volOpt *rbdVolume, cr *util.Credentials) (s
 				klog.Warningf(util.Log(ctx, "rbd: %s unmap error %v"), imagePath, detErr)
 			}
 		}
-		return "", fmt.Errorf("rbd: map failed %v, rbd output: %s", err, string(output))
+		return "", fmt.Errorf("rbd: map failed %v, rbd output: %s", err, string(stderr))
 	}
-	devicePath := strings.TrimSuffix(string(output), "\n")
+	devicePath := strings.TrimSuffix(string(stdout), "\n")
 
 	return devicePath, nil
 }
@@ -280,8 +280,6 @@ func detachRBDDevice(ctx context.Context, devicePath, volumeID string, encrypted
 // detachRBDImageOrDeviceSpec detaches an rbd imageSpec or devicePath, with additional checking
 // when imageSpec is used to decide if image is already unmapped.
 func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, isImageSpec, ndbType, encrypted bool, volumeID string) error {
-	var output []byte
-
 	if encrypted {
 		mapperFile, mapperPath := util.VolumeMapper(volumeID)
 		mappedDevice, mapper, err := util.DeviceEncryptionStatus(ctx, mapperPath)
@@ -308,18 +306,18 @@ func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, i
 	}
 	options := []string{"unmap", "--device-type", accessType, imageOrDeviceSpec}
 
-	output, err := execCommand(rbd, options)
+	_, stderr, err := util.ExecCommand(rbd, options...)
 	if err != nil {
 		// Messages for krbd and nbd differ, hence checking either of them for missing mapping
 		// This is not applicable when a device path is passed in
 		if isImageSpec &&
-			(strings.Contains(string(output), fmt.Sprintf(rbdUnmapCmdkRbdMissingMap, imageOrDeviceSpec)) ||
-				strings.Contains(string(output), fmt.Sprintf(rbdUnmapCmdNbdMissingMap, imageOrDeviceSpec))) {
+			(strings.Contains(string(stderr), fmt.Sprintf(rbdUnmapCmdkRbdMissingMap, imageOrDeviceSpec)) ||
+				strings.Contains(string(stderr), fmt.Sprintf(rbdUnmapCmdNbdMissingMap, imageOrDeviceSpec))) {
 			// Devices found not to be mapped are treated as a successful detach
 			util.TraceLog(ctx, "image or device spec (%s) not mapped", imageOrDeviceSpec)
 			return nil
 		}
-		return fmt.Errorf("rbd: unmap for spec (%s) failed (%v): (%s)", imageOrDeviceSpec, err, string(output))
+		return fmt.Errorf("rbd: unmap for spec (%s) failed (%v): (%s)", imageOrDeviceSpec, err, string(stderr))
 	}
 
 	return nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1042,13 +1042,13 @@ func cleanupRBDImageMetadataStash(path string) error {
 	return nil
 }
 
-// resizeRBDImage resizes the given volume to new size.
-func resizeRBDImage(rbdVol *rbdVolume, cr *util.Credentials) error {
-	mon := rbdVol.Monitors
-	volSzMiB := fmt.Sprintf("%dM", util.RoundOffVolSize(rbdVol.VolSize))
+// resize the given volume to new size.
+func (rv *rbdVolume) resize(ctx context.Context, cr *util.Credentials) error {
+	mon := rv.Monitors
+	volSzMiB := fmt.Sprintf("%dM", util.RoundOffVolSize(rv.VolSize))
 
-	args := []string{"resize", rbdVol.String(), "--size", volSzMiB, "--id", cr.ID, "-m", mon, "--keyfile=" + cr.KeyFile}
-	_, stderr, err := util.ExecCommand(context.TODO(), "rbd", args...)
+	args := []string{"resize", rv.String(), "--size", volSzMiB, "--id", cr.ID, "-m", mon, "--keyfile=" + cr.KeyFile}
+	_, stderr, err := util.ExecCommand(ctx, "rbd", args...)
 
 	if err != nil {
 		return fmt.Errorf("failed to resize rbd image (%w), command output: %s", err, stderr)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -307,11 +307,11 @@ func addRbdManagerTask(ctx context.Context, pOpts *rbdVolume, arg []string) (boo
 
 	if err != nil {
 		switch {
-		case strings.Contains(string(stderr), rbdTaskRemoveCmdInvalidString1) &&
-			strings.Contains(string(stderr), rbdTaskRemoveCmdInvalidString2):
+		case strings.Contains(stderr, rbdTaskRemoveCmdInvalidString1) &&
+			strings.Contains(stderr, rbdTaskRemoveCmdInvalidString2):
 			klog.Warningf(util.Log(ctx, "cluster with cluster ID (%s) does not support Ceph manager based rbd commands (minimum ceph version required is v14.2.3)"), pOpts.ClusterID)
 			supported = false
-		case strings.HasPrefix(string(stderr), rbdTaskRemoveCmdAccessDeniedMessage):
+		case strings.HasPrefix(stderr, rbdTaskRemoveCmdAccessDeniedMessage):
 			klog.Warningf(util.Log(ctx, "access denied to Ceph MGR-based rbd commands on cluster ID (%s)"), pOpts.ClusterID)
 			supported = false
 		default:
@@ -883,17 +883,17 @@ func (rv *rbdVolume) updateVolWithImageInfo(cr *util.Credentials) error {
 		"info", rv.String())
 	if err != nil {
 		klog.Errorf("failed getting information for image (%s): (%s)", rv, err)
-		if strings.Contains(string(stderr), "rbd: error opening image "+rv.RbdImageName+
+		if strings.Contains(stderr, "rbd: error opening image "+rv.RbdImageName+
 			": (2) No such file or directory") {
 			return util.JoinErrors(ErrImageNotFound, err)
 		}
 		return err
 	}
 
-	err = json.Unmarshal(stdout, &imgInfo)
+	err = json.Unmarshal([]byte(stdout), &imgInfo)
 	if err != nil {
 		klog.Errorf("failed to parse JSON output of image info (%s): (%s)", rv, err)
-		return fmt.Errorf("unmarshal failed: %+v.  raw buffer response: %s", err, string(stdout))
+		return fmt.Errorf("unmarshal failed: %+v.  raw buffer response: %s", err, stdout)
 	}
 
 	rv.VolSize = imgInfo.Size
@@ -1051,7 +1051,7 @@ func resizeRBDImage(rbdVol *rbdVolume, cr *util.Credentials) error {
 	_, stderr, err := util.ExecCommand(context.TODO(), "rbd", args...)
 
 	if err != nil {
-		return fmt.Errorf("failed to resize rbd image (%w), command output: %s", err, string(stderr))
+		return fmt.Errorf("failed to resize rbd image (%w), command output: %s", err, stderr)
 	}
 
 	return nil
@@ -1129,17 +1129,17 @@ func (rv *rbdVolume) listSnapshots(ctx context.Context, cr *util.Credentials) ([
 		"--all", rv.String())
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed getting information for image (%s): (%s)"), rv, err)
-		if strings.Contains(string(stderr), "rbd: error opening image "+rv.RbdImageName+
+		if strings.Contains(stderr, "rbd: error opening image "+rv.RbdImageName+
 			": (2) No such file or directory") {
 			return snapInfo, util.JoinErrors(ErrImageNotFound, err)
 		}
 		return snapInfo, err
 	}
 
-	err = json.Unmarshal(stdout, &snapInfo)
+	err = json.Unmarshal([]byte(stdout), &snapInfo)
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed to parse JSON output of snapshot info (%s)"), err)
-		return snapInfo, fmt.Errorf("unmarshal failed: %w. raw buffer response: %s", err, string(stdout))
+		return snapInfo, fmt.Errorf("unmarshal failed: %w. raw buffer response: %s", err, stdout)
 	}
 	return snapInfo, nil
 }

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -303,7 +303,7 @@ func addRbdManagerTask(ctx context.Context, pOpts *rbdVolume, arg []string) (boo
 	args = append(args, arg...)
 	util.DebugLog(ctx, "executing %v for image (%s) using mon %s, pool %s", args, pOpts.RbdImageName, pOpts.Monitors, pOpts.Pool)
 	supported := true
-	_, stderr, err := util.ExecCommand("ceph", args...)
+	_, stderr, err := util.ExecCommand(ctx, "ceph", args...)
 
 	if err != nil {
 		switch {
@@ -872,7 +872,9 @@ func (rv *rbdVolume) updateVolWithImageInfo(cr *util.Credentials) error {
 	// rbd --format=json info [image-spec | snap-spec]
 	var imgInfo imageInfo
 
-	stdout, stderr, err := util.ExecCommand("rbd",
+	stdout, stderr, err := util.ExecCommand(
+		context.TODO(),
+		"rbd",
 		"-m", rv.Monitors,
 		"--id", cr.ID,
 		"--keyfile="+cr.KeyFile,
@@ -1046,7 +1048,7 @@ func resizeRBDImage(rbdVol *rbdVolume, cr *util.Credentials) error {
 	volSzMiB := fmt.Sprintf("%dM", util.RoundOffVolSize(rbdVol.VolSize))
 
 	args := []string{"resize", rbdVol.String(), "--size", volSzMiB, "--id", cr.ID, "-m", mon, "--keyfile=" + cr.KeyFile}
-	_, stderr, err := util.ExecCommand("rbd", args...)
+	_, stderr, err := util.ExecCommand(context.TODO(), "rbd", args...)
 
 	if err != nil {
 		return fmt.Errorf("failed to resize rbd image (%w), command output: %s", err, string(stderr))
@@ -1114,7 +1116,9 @@ type snapshotInfo struct {
 func (rv *rbdVolume) listSnapshots(ctx context.Context, cr *util.Credentials) ([]snapshotInfo, error) {
 	// rbd snap ls <image> --pool=<pool-name> --all --format=json
 	var snapInfo []snapshotInfo
-	stdout, stderr, err := util.ExecCommand("rbd",
+	stdout, stderr, err := util.ExecCommand(
+		ctx,
+		"rbd",
 		"-m", rv.Monitors,
 		"--id", cr.ID,
 		"--keyfile="+cr.KeyFile,


### PR DESCRIPTION
# Describe what this PR does #

Both cephFS and RBD components have their own `execCommand()` with slightly different semantics. There is also a `util.ExecCommand()` that is used a few times too.

In order to clean things up, remove the `cephfs.execCommand()` and `rbd.execCommand()` functions, and replace the calls with `util.ExecCommand()`.
