### PR TITLE
cephfs: fix regression in subvolumegroups

### DIFF
--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -299,6 +299,14 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 
 	volOptions.ProvisionVolume = true
 
+	// TODO remove this check once we stop supporting volumes provisioned by
+	// less than ceph-csi v3.0.0
+	if _, ok := volOpt[subvolumeGroupName]; !ok {
+		// if the subvolumeGroupName is not present on the volumecontext assume
+		// it as PVC created by older cephcsi driver (ie <3.0.0)
+		volOptions.SubvolumeGroup = util.DefaultCsiSubvolumeGroup
+	}
+
 	volOptions.RootPath, err = getVolumeRootPathCeph(ctx, &volOptions, cr, volumeID(vid.FsSubvolName))
 	if err != nil {
 		return &volOptions, &vid, err

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	// defaultCsiSubvolumeGroup defines the default name for the CephFS CSI subvolumegroup.
+	// DefaultCsiSubvolumeGroup defines the default name for the CephFS CSI subvolumegroup.
 	// This was hardcoded once and defaults to the old value to keep backward compatibility.
-	defaultCsiSubvolumeGroup = "csi"
+	DefaultCsiSubvolumeGroup = "csi"
 )
 
 // ClusterInfo strongly typed JSON spec for the below JSON structure.
@@ -104,7 +104,7 @@ func CephFSSubvolumeGroup(pathToConfig, clusterID string) (string, error) {
 	}
 
 	if cluster.CephFS.SubvolumeGroup == "" {
-		return defaultCsiSubvolumeGroup, nil
+		return DefaultCsiSubvolumeGroup, nil
 	}
 	return cluster.CephFS.SubvolumeGroup, nil
 }


### PR DESCRIPTION
If the PVC is created by ceph-csi <v3.0.0 (master as of now) the subvolume will be default ie "csi" if the user updates the cephcsi
to v3.0.0 and have the subvolume group in configmap, remounting of older PVC will start failing as the ceph-csi will read the subvolumegroup from configmap and use it for mounting the PVC created cephcsi <3.0.0.

This commit fixes it by adding subvolume group name in the volume context and use it to get the root path of the subvolume.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

closes https://github.com/ceph/ceph-csi/issues/1261