### PR TITLE
Migrate ci/centos branch to new OCP4 Jenkins deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ in a `jjb` container. To build the container, and provide the configuration for
 Jenkins Job Builder, see the [documentation in the `deploy/`
 directory](deploy/README.md).
 
-[ceph_csi_ci]: https://jenkins-ceph-csi.apps.ci.centos.org
-[app_ci_centos_org]: https://console.apps.ci.centos.org:8443/console/project/ceph-csi
+[ceph_csi_ci]: https://jenkins-ceph-csi.apps.ocp.ci.centos.org
+[app_ci_centos_org]: https://console-openshift-console.apps.ocp.ci.centos.org/k8s/cluster/projects/ceph-csi
 [jjb]: https://jenkins-job-builder.readthedocs.io/en/latest/index.html
 [pipeline]: https://docs.openstack.org/infra/jenkins-job-builder/project_pipeline.html
 [centos_ci_hw]: https://wiki.centos.org/QaWiki/PubHardware

--- a/deploy/jjb-deploy.yaml
+++ b/deploy/jjb-deploy.yaml
@@ -22,7 +22,7 @@ objects:
         spec:
           containers:
             - name: jjb
-              image: 172.30.254.79:5000/ceph-csi/jjb:latest
+              image: image-registry.openshift-image-registry.svc:5000/ceph-csi/jjb:latest
               env:
                 - name: GIT_REPO
                   value: https://github.com/ceph/ceph-csi

--- a/deploy/jjb-validate.yaml
+++ b/deploy/jjb-validate.yaml
@@ -22,7 +22,7 @@ objects:
         spec:
           containers:
             - name: jjb-validate
-              image: 172.30.254.79:5000/ceph-csi/jjb:latest
+              image: image-registry.openshift-image-registry.svc:5000/ceph-csi/jjb:latest
               env:
                 - name: GIT_REPO
                   value: https://github.com/ceph/ceph-csi

--- a/deploy/jjb.sh
+++ b/deploy/jjb.sh
@@ -63,7 +63,8 @@ oc logs "${jjb_pod}"
 
 # delete the job, so a next run can create it again
 oc process -f "jjb-${CMD}.yaml" -p=SESSION="${SESSION}" | oc delete --wait -f -
-oc delete pod "${jjb_pod}"
+# depending on the OpenShift version, the pod gets deleted automatically
+oc delete --ignore-not-found pod "${jjb_pod}"
 
 # return the exit status of the pod
 [ "${status}" = 'Succeeded' ]


### PR DESCRIPTION
The CentOS team requested all the projects that use their CI to move to the new OCP4 cluster. At the moment, Ceph-CSI has a Jenkins deployment hosted on the old CentOS OCP-3.6 cluster.

This PR updates the links to Jenkins and the OCP console for administration of the Ceph-CSI namespace.

The new Jenkins deployment is not 100% ready yet, the changes in this PR will make it easier to start using it.