### PR TITLE
ci: require jjb-validate job to succeed for ci/centos branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -137,6 +137,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=ci/centos/job-validation"
+      - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:
@@ -154,6 +155,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "status-success=ci/centos/job-validation"
+      - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:


### PR DESCRIPTION
The jjb-validate job can not be run in parallel, so it may fail when
multiple PRs for the ci/centos branch are sent. However, the ci/centos
branch is not very active, so problems should be minimal.

In case of problems, leave the following comment in the PR and the job
should restart:

    /retest ci/centos/jjb-validate

See-also: #1273
