### PR TITLE
Prepare for v3.0.0 release of ceph-csi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
 language: go
 branches:
   only:
-    - master
+    - release-v3.0
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CPUS?=$(shell nproc --ignore=1)
 CPUSET?=--cpuset-cpus=0-${CPUS}
 
 CSI_IMAGE_NAME=$(if $(ENV_CSI_IMAGE_NAME),$(ENV_CSI_IMAGE_NAME),quay.io/cephcsi/cephcsi)
-CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),canary)
+CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),v3.0.0)
 CSI_IMAGE=$(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION)
 
 $(info cephcsi image settings: $(CSI_IMAGE_NAME) version $(CSI_IMAGE_VERSION))

--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: canary
+appVersion: v3.0.0
 description: "Container Storage Interface (CSI) driver,
 provisioner, and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
-version: 1.3.0-canary
+version: 3.0.0-canary
 keywords:
   - ceph
   - cephfs

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -75,7 +75,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: canary
+      tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: canary
+appVersion: v3.0.0
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter, and attacher for Ceph RBD"
 name: ceph-csi-rbd
-version: 1.3.0-canary
+version: 3.0.0-canary
 keywords:
   - ceph
   - rbd

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -87,7 +87,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: canary
+      tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -82,8 +82,8 @@ build_push_images() {
 	make push-manifest
 }
 
-if [ "${TRAVIS_BRANCH}" == 'master' ]; then
-	export ENV_CSI_IMAGE_VERSION='canary'
+if [ "${TRAVIS_BRANCH}" == 'release-v3.0' ]; then
+	export ENV_CSI_IMAGE_VERSION='v3.0.0'
 else
 	echo "!!! Branch ${TRAVIS_BRANCH} is not a deployable branch; exiting"
 	exit 0 # Exiting 0 so that this isn't marked as failing

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -83,7 +83,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -119,7 +119,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -54,7 +54,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -104,7 +104,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -99,7 +99,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -139,7 +139,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -55,7 +55,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -107,7 +107,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.0.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -184,7 +184,7 @@ teardown-rook)
     ;;
 cephcsi)
     echo "copying the cephcsi image"
-    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:canary "${CEPHCSI_IMAGE_REPO}"/cephcsi:canary
+    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.0.0 "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.0.0
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"


### PR DESCRIPTION
This PR updates the required  scripts and templates for the v3.0.0 release

closes: #865 