### PR TITLE
deploy: update the default configmap value of helm chart

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -203,7 +203,7 @@ pluginDir: /var/lib/kubelet/plugins
 # Name of the csi-driver
 driverName: cephfs.csi.ceph.com
 # Name of the configmap used for state
-configMapName: ceph-csi-config-cephfs
+configMapName: ceph-csi-config
 # Key to use in the Configmap if not config.json
 # configMapKey:
 # Use an externally provided configmap

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -222,7 +222,7 @@ pluginDir: /var/lib/kubelet/plugins
 # Name of the csi-driver
 driverName: rbd.csi.ceph.com
 # Name of the configmap used for state
-configMapName: ceph-csi-config-rbd
+configMapName: ceph-csi-config
 # Key to use in the Configmap if not config.json
 # configMapKey:
 # Use an externally provided configmap


### PR DESCRIPTION
update the configmap from ceph-csi-config-cephfs and ceph-csi-config-rbd to ceph-csi-config

## Related issues ##
#1296 

Fixes: #1296 

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.
