### PR TITLE
ci: use CentOS-8 bare-metal systems for testing

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -22,7 +22,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --retry-count ${cico_retries} --retry-interval ${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -20,7 +20,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --retry-count ${cico_retries} --retry-interval ${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"


### PR DESCRIPTION
Currently CentOS-7 machines were requested. CentOS-8 has been out for a
while now, and is stable for running manual jobs. There is nothing
preventing us from using CentOS-8 bare-metal machines for testing.
