### PR TITLE
ci: install make in centos ci

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -73,7 +73,7 @@ done
 
 set -x
 
-yum -y install git podman
+yum -y install git podman make
 
 git clone --depth=1 --branch="${base}" "${gitrepo}" "${workdir}"
 cd "${workdir}"


### PR DESCRIPTION
in centos 8 make doesn't come as default we need to install it.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

