### PR TITLE
deploy: add vault creation to rbd driver deployment

### DIFF
--- a/examples/rbd/plugin-deploy.sh
+++ b/examples/rbd/plugin-deploy.sh
@@ -1,15 +1,33 @@
 #!/bin/bash
 
 deployment_base="${1}"
+shift
+kms_base="${1}"
 
-if [[ -z $deployment_base ]]; then
+if [[ -z "${deployment_base}" ]]; then
 	deployment_base="../../deploy/rbd/kubernetes"
 fi
 
-cd "$deployment_base" || exit 1
+pushd "${deployment_base}" >/dev/null || exit 1
 
 objects=(csi-provisioner-rbac csi-nodeplugin-rbac csi-config-map csi-rbdplugin-provisioner csi-rbdplugin)
 
 for obj in "${objects[@]}"; do
-	kubectl create -f "./$obj.yaml"
+	kubectl create -f "./${obj}.yaml"
 done
+
+popd >/dev/null || exit 1
+
+if [[ -z "${kms_base}" ]]; then
+	kms_base="../kms/vault"
+fi
+
+pushd "${kms_base}" >/dev/null || exit 1
+
+objects=(vault csi-vaulttokenreview-rbac kms-config)
+
+for obj in "${objects[@]}"; do
+	kubectl create -f "./${obj}.yaml"
+done
+
+popd >/dev/null || exit 1

--- a/examples/rbd/plugin-teardown.sh
+++ b/examples/rbd/plugin-teardown.sh
@@ -1,15 +1,33 @@
 #!/bin/bash
 
 deployment_base="${1}"
+shift
+kms_base="${1}"
 
-if [[ -z $deployment_base ]]; then
+if [[ -z "${deployment_base}" ]]; then
 	deployment_base="../../deploy/rbd/kubernetes"
 fi
 
-cd "$deployment_base" || exit 1
+pushd "${deployment_base}" >/dev/null || exit 1
 
 objects=(csi-rbdplugin-provisioner csi-rbdplugin csi-config-map csi-provisioner-rbac csi-nodeplugin-rbac)
 
 for obj in "${objects[@]}"; do
-	kubectl delete -f "./$obj.yaml"
+	kubectl delete -f "./${obj}.yaml"
 done
+
+popd >/dev/null || exit 1
+
+if [[ -z "${kms_base}" ]]; then
+	kms_base="../kms/vault"
+fi
+
+pushd "${kms_base}" >/dev/null || exit 1
+
+objects=(vault csi-vaulttokenreview-rbac kms-config)
+
+for obj in "${objects[@]}"; do
+	kubectl delete -f "./${obj}.yaml"
+done
+
+popd >/dev/null || exit 1


### PR DESCRIPTION
Currently, the script does not deploy the driver singlehandedly;
As the vault creation needs to be done prior to that.
The script now includes the vault creation so that
one script can be sufficient to deploy the rbd driver.

Fixes: #1288 