### PR TITLE
ci: use ci/centos/mini-e2e/k8s-1.18 as context for mini-e2e job

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -21,8 +21,8 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-context: ci/centos/mini-e2e
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e))'
+          status-context: ci/centos/mini-e2e/k8s-1.18
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-1.18)?))'
           permit-all: true
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false


### PR DESCRIPTION
# Describe what this PR does #

The current status context for the mini-e2e job in the CentOS CI does not display the Kubernetes version. It is useful for developers to have this attribute in the test results in their PRs.

Restarting the CI job can now be done with the following comments in a
PR:
- /test all
- /retest all
- /test ci/centos/mini-e2e
- /retest ci/centos/mini-e2e
- /test ci/centos/mini-e2e/k8s-1.18
- /retest ci/centos/mini-e2e/k8s-1.18

## Future concerns ##

This is added as preparation for enabling running the mini-e2e job with
different Kubernetes versions.
