### PR TITLE
ci: disable debug sleep on failure of mini-e2e

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -59,12 +59,6 @@ node('cico-workspace') {
 		}
 	}
 
-	catch(exc) {
-		stage('debug time!') {
-			ssh 'sleep 8h'
-		}
-	}
-
 	finally {
 		stage('return bare-metal machine') {
 			sh 'cico node done ${CICO_SSID}'


### PR DESCRIPTION
While debugging issues with the job itself, a sleep has been very
useful. PRs that have been rebased on the master branch contain all the
deployment fixes that are needed for the job to pass. There is no need
anymore to run into the long sleep when the job fails.
