### PR TITLE
ci: use ceph-csi:ci/centos for fetching job scripts

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -1,8 +1,7 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-// temporary git repository for testing purpose
-def ci_git_repo = 'https://github.com/nixpanic/ceph-csi'
-def ci_git_branch = 'mini-e2e'
+def ci_git_repo = 'https://github.com/ceph/ceph-csi'
+def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
 def ref = "master"
 


### PR DESCRIPTION
Commit f5cba3aaa830f added the mini-e2e job, but still referred to the
temporary location that was used for testing the job. As everything is
available in the ceph-csi:ci/centos repository:branch, there is no need
to refer to the temporary location.
