### PR TITLE
ci: pass Kubernetes version as parameter to mini-e2e job

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -1,6 +1,14 @@
 ---
-- job:
+- project:
     name: mini-e2e
+    k8s_version:
+      - '1.17.8'
+      - '1.18.5'
+    jobs:
+      - 'mini-e2e/k8s-{k8s_version}'
+
+- job-template:
+    name: 'mini-e2e/k8s-{k8s_version}'
     project-type: pipeline
     sandbox: true
     concurrent: true
@@ -10,6 +18,14 @@
       - build-discarder:
           days-to-keep: 7
           artifact-days-to-keep: 7
+    # default variables
+    k8s_version: '<unset>'
+    # generated parameters for the job (used in the groovy script)
+    parameters:
+      - string:
+        name: k8s_version
+        default: '{k8s_version}'
+        description: Kubernetes version to deploy in the test cluster.
     pipeline-scm:
       scm:
         - git:
@@ -21,8 +37,9 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-context: ci/centos/mini-e2e/k8s-1.18
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-1.18)?))'
+          status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
+          # yamllint disable-line rule:line-length
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-{k8s_version})?))'
           permit-all: true
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -46,9 +46,9 @@ node('cico-workspace') {
 			// build e2e.test executable
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
 		}
-		stage('deploy k8s v1.18.3 and rook') {
+		stage('deploy k8s v{k8s_version} and rook') {
 			timeout(time: 30, unit: 'MINUTES') {
-				ssh './single-node-k8s.sh --k8s-version=v1.18.3'
+				ssh './single-node-k8s.sh --k8s-version=v${k8s_version}'
 			}
 		}
 		stage('run e2e') {


### PR DESCRIPTION
# Describe what this PR does #

Move the mini-e2e job into a template-job and generate two jobs out of
it: mini-e2e/k8s-1.17.8 and mini-e2e/k8s-1.18.5

By passing the k8s_version as variable to the job-template, and placing
it in the parameters for the mini-e2e.groovy script, all hard-coded
occurences of the Kubernetes version can be replaced by the
{k8s_version} placeholder.

See-also: https://jenkins-job-builder.readthedocs.io/en/latest/definition.html#job-template

## Is there anything that requires special attention ##

When this PR gets merged, the mini-e2e job in the Jenkins deployment needs to be disabled and removed. This is a manual operation that only admins can do.

## Future concerns ##

Current  Kubernetes versions come from the `travis.yaml` in the master branch. Only two versions are included in this PR for testing. More versions can be added easily.
