### PR TITLE
ci: correctly indent parameters for mini-e2e job

### DIFF
--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -10,11 +10,16 @@
       - build-discarder:
           days-to-keep: 7
           artifact-days-to-keep: 7
+    parameters:
+      - string:
+          name: ghprbPullId
+          description: GitHub Pull-Request ID for testing
+          default: 0
     dsl: |
       def GIT_REPO = 'https://github.com/ceph/ceph-csi'
       def GIT_BRANCH = 'ci/centos'
 
-      if (params.ghprbPullId != null) {
+      if (params.ghprbPullId != null && "${ghprbPullId}" != "0") {
           GIT_BRANCH = "pull/${ghprbPullId}/head"
       }
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -23,9 +23,9 @@
     # generated parameters for the job (used in the groovy script)
     parameters:
       - string:
-        name: k8s_version
-        default: '{k8s_version}'
-        description: Kubernetes version to deploy in the test cluster.
+          name: k8s_version
+          default: '{k8s_version}'
+          description: Kubernetes version to deploy in the test cluster.
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
#1307 had incorrect indentions for the parameters in the job-template. For some reason the validation of the job (using the same tools as deploying) did not catch the issue. Deployment failed however :disappointed: 

This change fixes the indention to how the example in the documentation does it.

See-also: https://jenkins-job-builder.readthedocs.io/en/latest/parameters.html