### PR TITLE
ci: jjb-deploy should have a "deployment" stage

### DIFF
--- a/jobs/jjb-deploy.yaml
+++ b/jobs/jjb-deploy.yaml
@@ -17,7 +17,7 @@
         stage('checkout ci repository') {
           git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
         }
-        stage('validation') {
+        stage('deployment') {
           sh './deploy/jjb.sh deploy'
         }
       }


### PR DESCRIPTION
The stage is called "validate" at the moment, this is a copy/paste
mistake from the jjb-validate job.
