### PR TITLE
ci: use double quotes for variables

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -46,9 +46,9 @@ node('cico-workspace') {
 			// build e2e.test executable
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
 		}
-		stage('deploy k8s v{k8s_version} and rook') {
+		stage("deploy k8s v{k8s_version} and rook") {
 			timeout(time: 30, unit: 'MINUTES') {
-				ssh './single-node-k8s.sh --k8s-version=v${k8s_version}'
+				ssh "./single-node-k8s.sh --k8s-version=v${k8s_version}"
 			}
 		}
 		stage('run e2e') {


### PR DESCRIPTION
Using double quotes as variables are
expanded inside them.
The script fails currently [here](https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e_k8s-1.18.5/detail/mini-e2e_k8s-1.18.5/23/pipeline) as it is
unable to expand the variables.

Signed-off-by: Yug <yuggupta27@gmail.com>
