### PR TITLE
ci: Correct the stage name

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -46,7 +46,7 @@ node('cico-workspace') {
 			// build e2e.test executable
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
 		}
-		stage("deploy k8s v{k8s_version} and rook") {
+		stage("deploy k8s v${k8s_version} and rook") {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=v${k8s_version}"
 			}


### PR DESCRIPTION
Currently the stage name directly
prints the name of the variable
in place of substituting it.
See [this](https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e_k8s-1.18.5/detail/mini-e2e_k8s-1.18.5/27/pipeline/32)
This PR is a fix for that issue.

Signed-off-by: Yug <yuggupta27@gmail.com>
