### PR TITLE
ci: give minikube 8GB RAM on CentOS bare-metal systems

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -64,6 +64,7 @@ function set_env() {
     export GO111MODULE="on"
     export TEST_COVERAGE="stdout"
     export VM_DRIVER="kvm2"
+    export MEMORY="8192"
     export CEPH_CSI_RUN_ALL_TESTS=true
     # downloading rook images is sometimes slow, extend timeout to 15 minutes
     export ROOK_VERSION='v1.3.8'


### PR DESCRIPTION
All bare-metal systems in the CentOS CI have 16GB or more RAM. To
improve performance of the minikube VM, give is 8GB RAM.

See-also: https://wiki.centos.org/QaWiki/PubHardware
