### PR TITLE
ci: add mini-e2e-helm Jenkins job

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -6,6 +6,7 @@
       - '1.18.5'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
+      - 'mini-e2e-helm_k8s-{k8s_version}'
 
 - job-template:
     name: 'mini-e2e_k8s-{k8s_version}'
@@ -40,6 +41,50 @@
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-{k8s_version})?))'
+          permit-all: true
+          # TODO: set github-hooks to true when it is configured in GitHub
+          github-hooks: false
+          cron: 'H/5 * * * *'
+          black-list-target-branches:
+            - ci/centos
+          admin-list:
+            - nixpanic
+          org-list:
+            - ceph
+
+- job-template:
+    name: 'mini-e2e-helm_k8s-{k8s_version}'
+    project-type: pipeline
+    sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-csi
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    # default variables
+    k8s_version: '<unset>'
+    # generated parameters for the job (used in the groovy script)
+    parameters:
+      - string:
+          name: k8s_version
+          default: '{k8s_version}'
+          description: Kubernetes version to deploy in the test cluster.
+    pipeline-scm:
+      scm:
+        - git:
+            name: origin
+            url: https://github.com/ceph/ceph-csi
+            branches:
+              - ci/centos
+      script-path: mini-e2e-helm.groovy
+      lightweight-checkout: true
+    triggers:
+      - github-pull-request:
+          status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
+          # yamllint disable-line rule:line-length
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e-helm(/k8s-{k8s_version})?))'
           permit-all: true
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -1,0 +1,80 @@
+def cico_retries = 16
+def cico_retry_interval = 60
+def ci_git_repo = 'https://github.com/ceph/ceph-csi'
+def ci_git_branch = 'ci/centos'
+def git_repo = 'https://github.com/ceph/ceph-csi'
+def ref = "master"
+
+def ssh(cmd) {
+	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
+}
+
+node('cico-workspace') {
+	stage('checkout ci repository') {
+		git url: "${ci_git_repo}",
+			branch: "${ci_git_branch}",
+			changelog: false
+	}
+
+	stage('reserve bare-metal machine') {
+		def firstAttempt = true
+		retry(30) {
+			if (!firstAttempt) {
+				sleep(time: 5, unit: "MINUTES")
+			}
+			firstAttempt = false
+			cico = sh(
+				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				returnStdout: true
+			).trim().tokenize(' ')
+			env.CICO_NODE = "${cico[0]}.ci.centos.org"
+			env.CICO_SSID = "${cico[1]}"
+		}
+	}
+
+	try {
+		stage('prepare bare-metal machine') {
+			if (params.ghprbPullId != null) {
+				ref = "pull/${ghprbPullId}/head"
+			}
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
+			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
+		}
+		stage('build artifacts') {
+			// build container image
+			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make image-cephcsi GOARCH=amd64 CONTAINER_CMD=podman'
+			// build e2e.test executable
+			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
+		}
+		stage("deploy k8s v${k8s_version} and rook") {
+			timeout(time: 30, unit: 'MINUTES') {
+				ssh "./single-node-k8s.sh --k8s-version=v${k8s_version}"
+			}
+		}
+		stage('deploy ceph-csi through helm') {
+			timeout(time: 30, unit: 'MINUTES') {
+				env.NAMESPACE = 'cephcsi-e2e-' + UUID.randomUUID().toString().split('-')[-1]
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh up'
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh install-cephcsi ${NAMESPACE}'
+			}
+		}
+		stage('run e2e') {
+			timeout(time: 60, unit: 'MINUTES') {
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE="${NAMESPACE}" E2E_ARGS="--deploy-cephfs=false --deploy-rbd=false'
+			}
+		}
+		stage('cleanup ceph-csi deployment') {
+			timeout(time: 30, unit: 'MINUTES') {
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh cleanup-cephcsi ${NAMESPACE}'
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh clean'
+				ssh 'kubectl delete namespace ${NAMESPACE}'
+			}
+		}
+	}
+
+	finally {
+		stage('return bare-metal machine') {
+			sh 'cico node done ${CICO_SSID}'
+		}
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #

The mini-e2e-helm.groovy script is mostly a copy of mini-e2e.groovy that
does the deployment through the e2e.test executable. The new script
installs Helm and deploys Ceph-CSI through that.

Once the e2e tests have successfully finished, the deployment of
Ceph-CSI is removed again.

## Future concerns ##

If these jobs prove to be stable, the matching jobs can be removed from the `.travis.yaml` in the master branch and status context added to `.mergify.yaml`.