### PR TITLE
ci: include build.env variables when installing Helm

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -40,7 +40,7 @@ RUN source /build.env \
        | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
     && curl -sfL "https://raw.githubusercontent.com/securego/gosec/master/install.sh" \
        | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}" \
-    && curl -L https://git.io/get_helm.sh | bash \
+    && curl -L https://git.io/get_helm.sh | bash -s -- --version "${HELM_VERSION}" \
     && mkdir /opt/commitlint && pushd /opt/commitlint \
     && npm init -y \
     && npm install @commitlint/cli \

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -4,12 +4,15 @@
 
 TEMP="/tmp/cephcsi-helm-test"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=build.env
+[ ! -e "${SCRIPT_DIR}"/../build.env ] || source "${SCRIPT_DIR}"/../build.env
+
 HELM="helm"
 HELM_VERSION=${HELM_VERSION:-"latest"}
 arch="${ARCH:-}"
 CEPHFS_CHART_NAME="ceph-csi-cephfs"
 RBD_CHART_NAME="ceph-csi-rbd"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 DEPLOY_TIMEOUT=600
 
 # ceph-csi specific variables


### PR DESCRIPTION
By default the install-helm.sh script uses "latest" as version for Helm.
Unfortunately this version does not exist. The HELM_VERSION variable is
already set in build.env, so source the configuration file as one of the
first actions in install-helm.sh.