### PR TITLE
ci: add missing " in mini-e2e-helm script

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -60,7 +60,7 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 60, unit: 'MINUTES') {
-				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE="${NAMESPACE}" E2E_ARGS="--deploy-cephfs=false --deploy-rbd=false'
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE="${NAMESPACE}" E2E_ARGS="--deploy-cephfs=false --deploy-rbd=false"'
 			}
 		}
 		stage('cleanup ceph-csi deployment') {


### PR DESCRIPTION
Due to a missing `"` in the groovy script, the following error occurs:

```
+ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@n36.crusty.ci.centos.org 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE="${NAMESPACE}" E2E_ARGS="--deploy-cephfs=false --deploy-rbd=false'
Warning: Permanently added 'n36.crusty.ci.centos.org,172.19.2.36' (ECDSA) to the list of known hosts.
bash: -c: line 0: unexpected EOF while looking for matching `"'
bash: -c: line 1: syntax error: unexpected end of file
```