### PR TITLE
ci: pass strings with quotes over ssh in mini-e2e-helm

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -6,8 +6,10 @@ def git_repo = 'https://github.com/ceph/ceph-csi'
 def ref = "master"
 def namespace = 'cephcsi-e2e-' + UUID.randomUUID().toString().split('-')[-1]
 
+// ssh executes a given command on the reserved bare-metal machine
+// NOTE: do not pass " symbols on the command line, use ' only.
 def ssh(cmd) {
-	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
+	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \"${cmd}\""
 }
 
 node('cico-workspace') {


### PR DESCRIPTION
When running some commands over ssh on the bare metal machine, unexpected errors are reported.

This is likely caused by passing quoted strings over sh into ssh on the commandline. This PR is an attempt to fix this problem.

```
+ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@n15.crusty.ci.centos.org 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE=cephcsi-e2e-b9ddfc80a5e5 E2E_ARGS=--deploy-cephfs=false' --deploy-rbd=false
Warning: Permanently added 'n15.crusty.ci.centos.org,172.19.2.15' (ECDSA) to the list of known hosts.
make: unrecognized option '--deploy-rbd=false'
Usage: make [options] [target] ...
Options:
  -b, -m                      Ignored for compatibility.
  -B, --always-make           Unconditionally make all targets.
  -C DIRECTORY, --directory=DIRECTORY
                              Change to DIRECTORY before doing anything.
  -d                          Print lots of debugging information.
  --debug[=FLAGS]             Print various types of debugging information.
  -e, --environment-overrides
                              Environment variables override makefiles.
  --eval=STRING               Evaluate STRING as a makefile statement.
  -f FILE, --file=FILE, --makefile=FILE
                              Read FILE as a makefile.
  -h, --help                  Print this message and exit.
  -i, --ignore-errors         Ignore errors from recipes.
  -I DIRECTORY, --include-dir=DIRECTORY
                              Search DIRECTORY for included makefiles.
  -j [N], --jobs[=N]          Allow N jobs at once; infinite jobs with no arg.
  -k, --keep-going            Keep going when some targets can't be made.
  -l [N], --load-average[=N], --max-load[=N]
                              Don't start multiple jobs unless load is below N.
  -L, --check-symlink-times   Use the latest mtime between symlinks and target.
  -n, --just-print, --dry-run, --recon
                              Don't actually run any recipe; just print them.
  -o FILE, --old-file=FILE, --assume-old=FILE
                              Consider FILE to be very old and don't remake it.
  -O[TYPE], --output-sync[=TYPE]
                              Synchronize output of parallel jobs by TYPE.
  -p, --print-data-base       Print make's internal database.
  -q, --question              Run no recipe; exit status says if up to date.
  -r, --no-builtin-rules      Disable the built-in implicit rules.
  -R, --no-builtin-variables  Disable the built-in variable settings.
  -s, --silent, --quiet       Don't echo recipes.
  -S, --no-keep-going, --stop
                              Turns off -k.
  -t, --touch                 Touch targets instead of remaking them.
  --trace                     Print tracing information.
  -v, --version               Print the version number of make and exit.
  -w, --print-directory       Print the current directory.
  --no-print-directory        Turn off -w, even if it was turned on implicitly.
  -W FILE, --what-if=FILE, --new-file=FILE, --assume-new=FILE
                              Consider FILE to be infinitely new.
  --warn-undefined-variables  Warn when an undefined variable is referenced.

This program built for x86_64-redhat-linux-gnu
Report bugs to <bug-make@gnu.org>
```