### PR TITLE
ci: update Travis CI and Mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,6 +42,10 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.17.8"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.18.5"
+      - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
+      - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
       - "status-success=DCO"
       - "status-success=commitlint"
     actions:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_script:
 # Only run the deploy stage on push (not pull_request) events.
 stages:
   - build testing
-  - e2e testing
+  - upgrade testing
   - name: deploy
     if: type = push
 
@@ -96,54 +96,6 @@ jobs:
       name: Build multi-architecture image for amd64 and arm64
       script:
         - ./scripts/build-multi-arch-image.sh || travis_terminate 1;
-
-    - stage: e2e testing
-      name: CephFS with kubernetes v1.17.8
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.17.8 --test-cephfs=true
-          --test-rbd=false || travis_terminate 1;
-
-    - stage: e2e testing
-      name: RBD with kubernetes v1.17.8
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.17.8 --test-cephfs=false
-          --test-rbd=true || travis_terminate 1;
-
-    - stage: e2e testing
-      name: CephFS with kubernetes v1.18.5
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.18.5 --test-cephfs=true
-          --test-rbd=false || travis_terminate 1;
-
-    - stage: e2e testing
-      name: RBD with kubernetes v1.18.5
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-functest.sh v1.18.5 --test-cephfs=false
-          --test-rbd=true || travis_terminate 1;
-
-    - stage: e2e testing
-      name: CephFS helm charts with kubernetes v1.18.5
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-helmtest.sh v1.18.5 --test-cephfs=true
-          --test-rbd=false || travis_terminate 1;
-
-    - stage: e2e testing
-      name: RBD helm charts with kubernetes v1.18.5
-      script:
-        - scripts/skip-doc-change.sh || travis_terminate 0;
-        - make image-cephcsi || travis_terminate 1;
-        - scripts/travis-helmtest.sh v1.18.5 --test-cephfs=false
-          --test-rbd=true || travis_terminate 1;
 
     - stage: upgrade testing
       name: CephFS upgrade tesing with CSI v2.1.2


### PR DESCRIPTION
Removed the E2E testing from the Travis CI configuration and updated the mergify rules to consider the voting of the centos CI E2E testing results for auto merging the PR.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

once we move to upgrade testing to centos CI we can remove its relevant configuration from Travis CI (it's not a blocker as of now)