### PR TITLE
rebase: use Rook v1.3.9 for mini-e2e jobs

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -68,7 +68,7 @@ function set_env() {
     export MEMORY="8192"
     export CEPH_CSI_RUN_ALL_TESTS=true
     # downloading rook images is sometimes slow, extend timeout to 15 minutes
-    export ROOK_VERSION='v1.3.8'
+    export ROOK_VERSION='v1.3.9'
     export ROOK_DEPLOY_TIMEOUT=900
 
     # script/minikube.sh installs under /usr/local/bin


### PR DESCRIPTION
Rook v1.3.9 was released yesterday, so we can consume it for our CI jobs
now.
