### PR TITLE
ci: add commitlint fallback job

### DIFF
--- a/commitlint.groovy
+++ b/commitlint.groovy
@@ -1,0 +1,53 @@
+def cico_retries = 16
+def cico_retry_interval = 60
+def ci_git_repo = 'https://github.com/ceph/ceph-csi'
+def ci_git_branch = 'ci/centos'
+def ref = "master"
+def git_since = 'origin/master'
+
+node('cico-workspace') {
+	stage('checkout ci repository') {
+		git url: "${ci_git_repo}",
+			branch: "${ci_git_branch}",
+			changelog: false
+	}
+
+	stage('reserve bare-metal machine') {
+		def firstAttempt = true
+		retry(30) {
+			if (!firstAttempt) {
+				sleep(time: 5, unit: "MINUTES")
+			}
+			firstAttempt = false
+			cico = sh(
+				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				returnStdout: true
+			).trim().tokenize(' ')
+			env.CICO_NODE = "${cico[0]}.ci.centos.org"
+			env.CICO_SSID = "${cico[1]}"
+		}
+	}
+
+	try {
+		stage('prepare bare-metal machine') {
+			if (params.ghprbPullId != null) {
+				ref = "pull/${ghprbPullId}/head"
+			}
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh root@${CICO_NODE}:'
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref}"
+		}
+
+		stage('test & build') {
+			if (params.ghprbTargetBranch != null) {
+				git_since = "origin/${ghprbTargetBranch}"
+			}
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test CONTAINER_CMD=podman TARGET=commitlint GIT_SINCE=${git_since}'"
+		}
+	}
+
+	finally {
+		stage('return bare-metal machine') {
+			sh 'cico node done ${CICO_SSID}'
+		}
+	}
+}

--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -1,0 +1,36 @@
+---
+- job:
+    name: commitlint
+    description: Allow re-running commitlint tests, in case the commitlint app
+      does not work correctly.
+    project-type: pipeline
+    sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-csi
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    pipeline-scm:
+      scm:
+        - git:
+            name: origin
+            url: https://github.com/ceph/ceph-csi
+            branches:
+              - ci/centos
+      script-path: containerized-tests.groovy
+      lightweight-checkout: true
+    triggers:
+      - github-pull-request:
+          # the "commitlint" status context is use by the commitlint app
+          status-context: commitlint
+          trigger-phrase: '/(re)?test ((all)|(commitlint))'
+          permit-all: false
+          # TODO: set github-hooks to true when it is configured in GitHub
+          github-hooks: false
+          cron: 'H/5 * * * *'
+          admin-list:
+            - nixpanic
+          org-list:
+            - ceph


### PR DESCRIPTION
Each PR gets tested by the commitlint app (which is deprecated). On
occasion the app does not pickup the change in a PR, and the only way to
start a retest is to re-push the PR. All tests will then get executed
again, even if only commitlint was needed.

The new commitlint CI job introduces '/retest commitlint' and runs in
the CentOS CI like other Jenkins jobs. However, the job does not start
automatically on each (updated) PR, but needs manual starting with the
'/test commitlint' or '/retest commitlint' comments. The normal way of
running commitlint is with the app (at least for now).