### PR TITLE
ci: run commitlint when requested, not containeriized-tests

### DIFF
--- a/commitlint.groovy
+++ b/commitlint.groovy
@@ -37,7 +37,7 @@ node('cico-workspace') {
 			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref}"
 		}
 
-		stage('test & build') {
+		stage('run commitlint') {
 			if (params.ghprbTargetBranch != null) {
 				git_since = "origin/${ghprbTargetBranch}"
 			}

--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -19,13 +19,14 @@
             url: https://github.com/ceph/ceph-csi
             branches:
               - ci/centos
-      script-path: containerized-tests.groovy
+      script-path: commitlint.groovy
       lightweight-checkout: true
     triggers:
       - github-pull-request:
           # the "commitlint" status context is use by the commitlint app
           status-context: commitlint
           trigger-phrase: '/(re)?test ((all)|(commitlint))'
+          # only run on PRs where the trigger-phrase is posted
           permit-all: false
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false

--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -31,7 +31,3 @@
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false
           cron: 'H/5 * * * *'
-          admin-list:
-            - nixpanic
-          org-list:
-            - ceph


### PR DESCRIPTION
The jobs/commitlint.yaml refered to the containerized-test.groovy
script, not the commitlint.groovy script.

Make sure to run the righ job when requested. Add some comments to make
things a little clearer.