### PR TITLE
util: move getMonsAndClusterID to util

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -30,9 +30,6 @@ const (
 	// volIDVersion is the version number of volume ID encoding scheme
 	volIDVersion uint16 = 1
 
-	// csiConfigFile is the location of the CSI config file
-	csiConfigFile = "/etc/ceph-csi-config/config.json"
-
 	// RADOS namespace to store CSI specific objects and keys
 	radosNamespace = "csi"
 )

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -153,7 +153,7 @@ func getMonsAndClusterID(ctx context.Context, options map[string]string) (monito
 		return
 	}
 
-	if monitors, err = util.Mons(csiConfigFile, clusterID); err != nil {
+	if monitors, err = util.Mons(util.CsiConfigFile, clusterID); err != nil {
 		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
 		err = fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", clusterID, err)
 		return

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -122,13 +122,13 @@ func getClusterInformation(options map[string]string) (*util.ClusterInfo, error)
 		return nil, err
 	}
 
-	monitors, err := util.Mons(csiConfigFile, clusterID)
+	monitors, err := util.Mons(util.CsiConfigFile, clusterID)
 	if err != nil {
 		err = fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", clusterID, err)
 		return nil, err
 	}
 
-	subvolumeGroup, err := util.CephFSSubvolumeGroup(csiConfigFile, clusterID)
+	subvolumeGroup, err := util.CephFSSubvolumeGroup(util.CsiConfigFile, clusterID)
 	if err != nil {
 		err = fmt.Errorf("failed to fetch subvolumegroup using clusterID (%s): %w", clusterID, err)
 		return nil, err
@@ -237,11 +237,11 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 	vid.VolumeID = volID
 	volOptions.FscID = vi.LocationID
 
-	if volOptions.Monitors, err = util.Mons(csiConfigFile, vi.ClusterID); err != nil {
+	if volOptions.Monitors, err = util.Mons(util.CsiConfigFile, vi.ClusterID); err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", vi.ClusterID, err)
 	}
 
-	if volOptions.SubvolumeGroup, err = util.CephFSSubvolumeGroup(csiConfigFile, vi.ClusterID); err != nil {
+	if volOptions.SubvolumeGroup, err = util.CephFSSubvolumeGroup(util.CsiConfigFile, vi.ClusterID); err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch subvolumegroup list using clusterID (%s): %w", vi.ClusterID, err)
 	}
 
@@ -430,11 +430,11 @@ func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Crede
 	sid.SnapshotID = snapID
 	volOptions.FscID = vi.LocationID
 
-	if volOptions.Monitors, err = util.Mons(csiConfigFile, vi.ClusterID); err != nil {
+	if volOptions.Monitors, err = util.Mons(util.CsiConfigFile, vi.ClusterID); err != nil {
 		return &volOptions, nil, &sid, fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", vi.ClusterID, err)
 	}
 
-	if volOptions.SubvolumeGroup, err = util.CephFSSubvolumeGroup(csiConfigFile, vi.ClusterID); err != nil {
+	if volOptions.SubvolumeGroup, err = util.CephFSSubvolumeGroup(util.CsiConfigFile, vi.ClusterID); err != nil {
 		return &volOptions, nil, &sid, fmt.Errorf("failed to fetch subvolumegroup list using clusterID (%s): %w", vi.ClusterID, err)
 	}
 

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -29,9 +29,6 @@ import (
 const (
 	// volIDVersion is the version number of volume ID encoding scheme
 	volIDVersion uint16 = 1
-
-	// csiConfigFile is the location of the CSI config file
-	csiConfigFile = "/etc/ceph-csi-config/config.json"
 )
 
 // Driver contains the default identity,node and controller struct.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -671,7 +671,7 @@ func getMonsAndClusterID(ctx context.Context, options map[string]string) (monito
 		return
 	}
 
-	if monitors, err = util.Mons(csiConfigFile, clusterID); err != nil {
+	if monitors, err = util.Mons(util.CsiConfigFile, clusterID); err != nil {
 		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
 		err = fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", clusterID, err)
 		return

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -531,8 +531,9 @@ func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID str
 	rbdSnap.ClusterID = vi.ClusterID
 	options["clusterID"] = rbdSnap.ClusterID
 
-	rbdSnap.Monitors, _, err = getMonsAndClusterID(ctx, options)
+	rbdSnap.Monitors, _, err = util.GetMonsAndClusterID(options)
 	if err != nil {
+		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
 		return err
 	}
 
@@ -593,8 +594,9 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 	rbdVol.ClusterID = vi.ClusterID
 	options["clusterID"] = rbdVol.ClusterID
 
-	rbdVol.Monitors, _, err = getMonsAndClusterID(ctx, options)
+	rbdVol.Monitors, _, err = util.GetMonsAndClusterID(options)
 	if err != nil {
+		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
 		return rbdVol, err
 	}
 
@@ -663,23 +665,6 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 	return rbdVol, err
 }
 
-func getMonsAndClusterID(ctx context.Context, options map[string]string) (monitors, clusterID string, err error) {
-	var ok bool
-
-	if clusterID, ok = options["clusterID"]; !ok {
-		err = errors.New("clusterID must be set")
-		return
-	}
-
-	if monitors, err = util.Mons(util.CsiConfigFile, clusterID); err != nil {
-		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
-		err = fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", clusterID, err)
-		return
-	}
-
-	return
-}
-
 func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[string]string, disableInUseChecks bool) (*rbdVolume, error) {
 	var (
 		ok         bool
@@ -699,8 +684,9 @@ func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[st
 		rbdVol.NamePrefix = namePrefix
 	}
 
-	rbdVol.Monitors, rbdVol.ClusterID, err = getMonsAndClusterID(ctx, volOptions)
+	rbdVol.Monitors, rbdVol.ClusterID, err = util.GetMonsAndClusterID(volOptions)
 	if err != nil {
+		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
 		return nil, err
 	}
 
@@ -757,8 +743,9 @@ func genSnapFromOptions(ctx context.Context, rbdVol *rbdVolume, snapOptions map[
 	rbdSnap.Pool = rbdVol.Pool
 	rbdSnap.JournalPool = rbdVol.JournalPool
 
-	rbdSnap.Monitors, rbdSnap.ClusterID, err = getMonsAndClusterID(ctx, snapOptions)
+	rbdSnap.Monitors, rbdSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
 	if err != nil {
+		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
 		return nil, err
 	}
 

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -110,4 +111,20 @@ func CephFSSubvolumeGroup(pathToConfig, clusterID string) (string, error) {
 		return defaultCsiSubvolumeGroup, nil
 	}
 	return cluster.CephFS.SubvolumeGroup, nil
+}
+
+// GetMonsAndClusterID returns monitors and clusterID information read from
+// configfile.
+func GetMonsAndClusterID(options map[string]string) (string, string, error) {
+	clusterID, ok := options["clusterID"]
+	if !ok {
+		return "", "", errors.New("clusterID must be set")
+	}
+
+	monitors, err := Mons(CsiConfigFile, clusterID)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", clusterID, err)
+	}
+
+	return monitors, clusterID, nil
 }

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -27,6 +27,9 @@ const (
 	// defaultCsiSubvolumeGroup defines the default name for the CephFS CSI subvolumegroup.
 	// This was hardcoded once and defaults to the old value to keep backward compatibility.
 	defaultCsiSubvolumeGroup = "csi"
+
+	// CsiConfigFile is the location of the CSI config file
+	CsiConfigFile = "/etc/ceph-csi-config/config.json"
 )
 
 // ClusterInfo strongly typed JSON spec for the below JSON structure.


### PR DESCRIPTION
as we had duplicate functions in both cephfs and rbd this commit moves the function to util and also as we have csiconfigfile in both cephfs and rbd moving the configfile path to util

updates #1242 