### PR TITLE
ci: always fetch GIT_SINCE for commitlint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ lint-yaml:
 	./scripts/lint-extras.sh lint-yaml
 
 commitlint:
+	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
 	commitlint --from $(GIT_SINCE)
 
 .PHONY: containerized-test


### PR DESCRIPTION
When running the commitlint CI job, the branch that the PR is based on
may not be available. That makes it impossible for commitlint to detect
the changes between the HEAD of the branch, and the commits in the PR.

By fetching GIT_SINCE unconditionally, commitlint should be able to
detect the changes and only run the tests against the commits that were
added through the PR.