### PR TITLE
ci: make members of the GitHub "ceph" organization admins

### DIFF
--- a/jobs/ci-job-validation.yaml
+++ b/jobs/ci-job-validation.yaml
@@ -29,7 +29,6 @@
           cron: 'H/5 * * * *'
           white-list-target-branches:
             - ci/centos
-          admin-list:
-            - nixpanic
           org-list:
             - ceph
+          allow-whitelist-orgs-as-admins: true

--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -27,7 +27,11 @@
           status-context: commitlint
           trigger-phrase: '/(re)?test ((all)|(commitlint))'
           # only run on PRs where the trigger-phrase is posted
+          only-trigger-phrase: true
           permit-all: false
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false
           cron: 'H/5 * * * *'
+          org-list:
+            - ceph
+          allow-whitelist-orgs-as-admins: true

--- a/jobs/containerized-tests.yaml
+++ b/jobs/containerized-tests.yaml
@@ -29,7 +29,6 @@
           cron: 'H/5 * * * *'
           black-list-target-branches:
             - ci/centos
-          admin-list:
-            - nixpanic
           org-list:
             - ceph
+          allow-whitelist-orgs-as-admins: true

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -43,7 +43,6 @@
           cron: 'H/5 * * * *'
           white-list-target-branches:
             - ci/centos
-          admin-list:
-            - nixpanic
           org-list:
             - ceph
+          allow-whitelist-orgs-as-admins: true

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -47,8 +47,6 @@
           cron: 'H/5 * * * *'
           black-list-target-branches:
             - ci/centos
-          admin-list:
-            - nixpanic
           org-list:
             - ceph
 
@@ -91,7 +89,6 @@
           cron: 'H/5 * * * *'
           black-list-target-branches:
             - ci/centos
-          admin-list:
-            - nixpanic
           org-list:
             - ceph
+          allow-whitelist-orgs-as-admins: true


### PR DESCRIPTION
Not everyone can restart CI jobs, only members of the Ceph organization
in GitHub. All jibs (except "commitlint") are started automatically, so
there is no functional change.