### PR TITLE
ci: allow everyone to run the "commitlint" job

### DIFF
--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -28,7 +28,7 @@
           trigger-phrase: '/(re)?test ((all)|(commitlint))'
           # only run on PRs where the trigger-phrase is posted
           only-trigger-phrase: true
-          permit-all: false
+          permit-all: true
           # TODO: set github-hooks to true when it is configured in GitHub
           github-hooks: false
           cron: 'H/5 * * * *'


### PR DESCRIPTION
Without this option, nobody seems to have the permissions to run `/retest commitlint`.