### PR TITLE
cleanup: use common logging functions in the util package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ check-env:
 	@./scripts/check-env.sh
 
 commitlint:
+	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
 	commitlint --from $(GIT_SINCE)
 
 .PHONY: cephcsi

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 
 	"github.com/ceph/go-ceph/rados"
-	klog "k8s.io/klog/v2"
 )
 
 // InvalidPoolID used to denote an invalid pool.
@@ -147,7 +146,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrObjectExists) {
 		return JoinErrors(ErrObjectExists, err)
 	} else if err != nil {
-		klog.Errorf(Log(ctx, "failed creating omap (%s) in pool (%s): (%v)"), objectName, poolName, err)
+		ErrorLog(Log(ctx, "failed creating omap (%s) in pool (%s): (%v)"), objectName, poolName, err)
 		return err
 	}
 
@@ -181,7 +180,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrNotFound) {
 		return JoinErrors(ErrObjectNotFound, err)
 	} else if err != nil {
-		klog.Errorf(Log(ctx, "failed removing omap (%s) in pool (%s): (%v)"), oMapName, poolName, err)
+		ErrorLog(Log(ctx, "failed removing omap (%s) in pool (%s): (%v)"), oMapName, poolName, err)
 		return err
 	}
 

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 
 	"crypto/rand"
-
-	klog "k8s.io/klog/v2"
 )
 
 const (
@@ -160,7 +158,7 @@ func GetCryptoPassphrase(ctx context.Context, volumeID string, kms EncryptionKMS
 		}
 		return passphrase, nil
 	}
-	klog.Errorf(Log(ctx, "failed to get encryption passphrase for %s: %s"), volumeID, err)
+	ErrorLog(Log(ctx, "failed to get encryption passphrase for %s: %s"), volumeID, err)
 	return "", err
 }
 

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	klog "k8s.io/klog/v2"
 )
 
 // ValidateURL validates the url.
@@ -22,6 +21,6 @@ func StartMetricsServer(c *Config) {
 	http.Handle(c.MetricsPath, promhttp.Handler())
 	err := http.ListenAndServe(addr, nil)
 	if err != nil {
-		klog.Fatalln(err)
+		FatalLog("failed to listen on address %v: %s", addr, err)
 	}
 }

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	klog "k8s.io/klog/v2"
 )
 
 const (
@@ -254,6 +253,6 @@ func (ol *OperationLock) release(op operation, volumeID string) {
 			}
 		}
 	default:
-		klog.Errorf("%v operation not supported", op)
+		ErrorLog("%v operation not supported", op)
 	}
 }

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -22,7 +22,6 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	klog "k8s.io/klog/v2"
 )
 
 // NewK8sClient create kubernetes client.
@@ -33,20 +32,17 @@ func NewK8sClient() *k8s.Clientset {
 	if cPath != "" {
 		cfg, err = clientcmd.BuildConfigFromFlags("", cPath)
 		if err != nil {
-			klog.Errorf("Failed to get cluster config with error: %v\n", err)
-			os.Exit(1)
+			FatalLog("Failed to get cluster config with error: %v\n", err)
 		}
 	} else {
 		cfg, err = rest.InClusterConfig()
 		if err != nil {
-			klog.Errorf("Failed to get cluster config with error: %v\n", err)
-			os.Exit(1)
+			FatalLog("Failed to get cluster config with error: %v\n", err)
 		}
 	}
 	client, err := k8s.NewForConfig(cfg)
 	if err != nil {
-		klog.Errorf("Failed to create client with error: %v\n", err)
-		os.Exit(1)
+		FatalLog("Failed to create client with error: %v\n", err)
 	}
 	return client
 }

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -16,6 +16,17 @@ package util
 import (
 	"context"
 	"fmt"
+
+	klog "k8s.io/klog/v2"
+)
+
+// enum defining logging levels.
+const (
+	Default klog.Level = iota + 1
+	Useful
+	Extended
+	Debug
+	Trace
 )
 
 type contextKey string
@@ -39,4 +50,76 @@ func Log(ctx context.Context, format string) string {
 	}
 	a += fmt.Sprintf("Req-ID: %v ", reqID)
 	return a + format
+}
+
+// DefaultLog helps in logging with klog.level 1.
+func DefaultLog(message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(message, args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Default).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
+}
+
+// UsefulLog helps in logging with klog.level 2.
+func UsefulLog(ctx context.Context, message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(Log(ctx, message), args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Useful).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
+}
+
+// ExtendedLogMsg helps in logging a message with klog.level 3.
+func ExtendedLogMsg(message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(message, args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Extended).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
+}
+
+// ExtendedLog helps in logging with klog.level 3.
+func ExtendedLog(ctx context.Context, message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(Log(ctx, message), args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Extended).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
+}
+
+// DebugLogMsg helps in logging a message with klog.level 4.
+func DebugLogMsg(message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(message, args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Debug).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
+}
+
+// DebugLog helps in logging with klog.level 4.
+func DebugLog(ctx context.Context, message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(Log(ctx, message), args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Debug).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
+}
+
+// TraceLogMsg helps in logging a message with klog.level 5.
+func TraceLogMsg(message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(message, args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Trace).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
+}
+
+// TraceLog helps in logging with klog.level 5.
+func TraceLog(ctx context.Context, message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(Log(ctx, message), args...)
+	// If logging is disabled, don't evaluate the arguments
+	if klog.V(Trace).Enabled() {
+		klog.InfoDepth(1, logMessage)
+	}
 }

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -52,6 +52,24 @@ func Log(ctx context.Context, format string) string {
 	return a + format
 }
 
+// FatalLog helps in logging fatal errors.
+func FatalLog(message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(message, args...)
+	klog.FatalDepth(1, logMessage)
+}
+
+// ErrorLog helps in logging errors.
+func ErrorLog(message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(message, args...)
+	klog.ErrorDepth(1, logMessage)
+}
+
+// WarningLog helps in logging warnings.
+func WarningLog(message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(message, args...)
+	klog.WarningDepth(1, logMessage)
+}
+
 // DefaultLog helps in logging with klog.level 1.
 func DefaultLog(message string, args ...interface{}) {
 	logMessage := fmt.Sprintf(message, args...)

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	klog "k8s.io/klog/v2"
 )
 
 const (
@@ -60,7 +59,7 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 
 	// Convert passed in labels to a map, and check for uniqueness
 	labelsToRead := strings.SplitN(domainLabels, labelSeparator, -1)
-	klog.Infof("passed in node labels for processing : %+v", labelsToRead)
+	DefaultLog("passed in node labels for processing : %+v", labelsToRead)
 
 	labelsIn := make(map[string]bool)
 	labelCount := 0
@@ -106,7 +105,7 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 		return nil, fmt.Errorf("missing domain labels %v on node (%s)", missingLabels, nodeName)
 	}
 
-	klog.Infof("list of domains processed : %+v", domainMap)
+	DefaultLog("list of domains processed : %+v", domainMap)
 
 	topology := make(map[string]string)
 	for domain, value := range domainMap {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -35,15 +35,6 @@ import (
 	"k8s.io/utils/mount"
 )
 
-// enum defining logging levels.
-const (
-	Default klog.Level = iota + 1
-	Useful
-	Extended
-	Debug
-	Trace
-)
-
 // RoundOffVolSize rounds up given quantity upto chunks of MiB/GiB.
 func RoundOffVolSize(size int64) int64 {
 	size = RoundOffBytes(size)
@@ -322,76 +313,4 @@ func contains(s []string, key string) bool {
 	}
 
 	return false
-}
-
-// DefaultLog helps in logging with klog.level 1.
-func DefaultLog(message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(message, args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Default).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
-}
-
-// UsefulLog helps in logging with klog.level 2.
-func UsefulLog(ctx context.Context, message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(Log(ctx, message), args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Useful).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
-}
-
-// ExtendedLogMsg helps in logging a message with klog.level 3.
-func ExtendedLogMsg(message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(message, args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Extended).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
-}
-
-// ExtendedLog helps in logging with klog.level 3.
-func ExtendedLog(ctx context.Context, message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(Log(ctx, message), args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Extended).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
-}
-
-// DebugLogMsg helps in logging a message with klog.level 4.
-func DebugLogMsg(message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(message, args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Debug).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
-}
-
-// DebugLog helps in logging with klog.level 4.
-func DebugLog(ctx context.Context, message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(Log(ctx, message), args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Debug).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
-}
-
-// TraceLogMsg helps in logging a message with klog.level 5.
-func TraceLogMsg(message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(message, args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Trace).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
-}
-
-// TraceLog helps in logging with klog.level 5.
-func TraceLog(ctx context.Context, message string, args ...interface{}) {
-	logMessage := fmt.Sprintf(Log(ctx, message), args...)
-	// If logging is disabled, don't evaluate the arguments
-	if klog.V(Trace).Enabled() {
-		klog.InfoDepth(1, logMessage)
-	}
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cloud-provider/volume/helpers"
-	klog "k8s.io/klog/v2"
 	"k8s.io/utils/mount"
 )
 
@@ -174,12 +173,12 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 	vers := strings.Split(strings.SplitN(release, "-", 2)[0], ".")
 	version, err := strconv.Atoi(vers[0])
 	if err != nil {
-		klog.Errorf("failed to parse version from %s: %v", release, err)
+		ErrorLog("failed to parse version from %s: %v", release, err)
 		return false
 	}
 	patchlevel, err := strconv.Atoi(vers[1])
 	if err != nil {
-		klog.Errorf("failed to parse patchlevel from %s: %v", release, err)
+		ErrorLog("failed to parse patchlevel from %s: %v", release, err)
 		return false
 	}
 	sublevel := 0
@@ -187,7 +186,7 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 	if len(vers) >= minLenForSublvl {
 		sublevel, err = strconv.Atoi(vers[2])
 		if err != nil {
-			klog.Errorf("failed to parse sublevel from %s: %v", release, err)
+			ErrorLog("failed to parse sublevel from %s: %v", release, err)
 			return false
 		}
 	}
@@ -224,7 +223,7 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 			}
 		}
 	}
-	klog.Errorf("kernel %s does not support required features", release)
+	ErrorLog("kernel %s does not support required features", release)
 	return false
 }
 


### PR DESCRIPTION
# Describe what this PR does #

Introduce additional log functions in the util package, so that `klog.Errorf()`, `klog.Fatalf()` and `klog.Warningf()` can be replaced by our own common logging functions. In the end, this makes us less dependent on the klog package, so upgrading becomes easier.

## Future concerns ##

Other parts of the code need replacing the klog package too. This can be done is multiple follow-up PRs.

See-also: #1330 (got incorrectly closed)