### PR TITLE
cephfs:  change the volumetype to RWX instead of RWO

### DIFF
--- a/examples/cephfs/pvc-clone.yaml
+++ b/examples/cephfs/pvc-clone.yaml
@@ -9,7 +9,7 @@ spec:
     name: csi-cephfs-pvc
     kind: PersistentVolumeClaim
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi

--- a/examples/cephfs/pvc-restore.yaml
+++ b/examples/cephfs/pvc-restore.yaml
@@ -10,7 +10,7 @@ spec:
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
The intention here is to keep the example YAMLs with recommended Access Mode of CephFS which is RWX.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


