### PR TITLE
cephfs: use util Log package for logging

### DIFF
--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -162,7 +162,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 		if err != nil {
 			if !errors.Is(err, ErrCloneInProgress) {
 				if dErr := purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions, true); dErr != nil {
-					klog.Errorf(util.Log(ctx, "failed to delete volume %s: %v"), vID.FsSubvolName, dErr)
+					util.ErrorLog(ctx, "failed to delete volume %s: %v", vID.FsSubvolName, dErr)
 				}
 			}
 		}
@@ -183,7 +183,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 		// in the new cloned volume too. Till then we are explicitly making the size set
 		err = resizeVolume(ctx, volOptions, cr, volumeID(vID.FsSubvolName), volOptions.Size)
 		if err != nil {
-			klog.Errorf(util.Log(ctx, "failed to expand volume %s with error: %v"), vID.FsSubvolName, err)
+			util.ErrorLog(ctx, "failed to expand volume %s with error: %v", vID.FsSubvolName, err)
 			return err
 		}
 	}

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -190,6 +190,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 	return nil
 }
 
+// CloneStatus represents the subvolume clone status.
 type CloneStatus struct {
 	Status struct {
 		State string `json:"state"`

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -140,13 +140,13 @@ func cleanupCloneFromSubvolumeSnapshot(ctx context.Context, volID, cloneID volum
 	if snapInfo.Protected == snapshotIsProtected {
 		err = unprotectSnapshot(ctx, parentVolOpt, cr, snapShotID, volID)
 		if err != nil {
-			klog.Errorf(util.Log(ctx, "failed to unprotect snapshot %s %v"), snapShotID, err)
+			util.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapShotID, err)
 			return err
 		}
 	}
 	err = deleteSnapshot(ctx, parentVolOpt, cr, snapShotID, volID)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to delete snapshot %s %v"), snapShotID, err)
+		util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapShotID, err)
 		return err
 	}
 	return nil

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/util"
-
-	klog "k8s.io/klog/v2"
 )
 
 const (
@@ -219,7 +217,7 @@ func getCloneInfo(ctx context.Context, volOptions *volumeOptions, cr *util.Crede
 		"ceph",
 		args[:]...)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to get subvolume clone info %s(%s) in fs %s"), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to get subvolume clone info %s(%s) in fs %s", string(volID), err, volOptions.FsName)
 		return clone, err
 	}
 	return clone, nil

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -147,7 +147,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	// Existence and conflict checks
 	if acquired := cs.VolumeLocks.TryAcquire(requestName); !acquired {
-		klog.Errorf(util.Log(ctx, util.VolumeOperationAlreadyExistsFmt), requestName)
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, requestName)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, requestName)
 	}
 	defer cs.VolumeLocks.Release(requestName)
@@ -193,7 +193,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 				}
 				errUndo := undoVolReservation(ctx, volOptions, *vID, secret)
 				if errUndo != nil {
-					klog.Warningf(util.Log(ctx, "failed undoing reservation of volume: %s (%s)"),
+					util.WarningLog(ctx, "failed undoing reservation of volume: %s (%s)",
 						requestName, errUndo)
 				}
 				util.ErrorLog(ctx, "failed to expand volume %s: %v", volumeID(vID.FsSubvolName), err)
@@ -230,7 +230,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			if !errors.Is(err, ErrCloneInProgress) {
 				errDefer := undoVolReservation(ctx, volOptions, *vID, secret)
 				if errDefer != nil {
-					klog.Warningf(util.Log(ctx, "failed undoing reservation of volume: %s (%s)"),
+					util.WarningLog(ctx, "failed undoing reservation of volume: %s (%s)",
 						requestName, errDefer)
 				}
 			}

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -61,34 +61,34 @@ func (cs *ControllerServer) createBackingVolume(
 	var err error
 	if sID != nil {
 		if err = cs.OperationLocks.GetRestoreLock(sID.SnapshotID); err != nil {
-			util.ErrorLog(util.Log(ctx, err.Error()))
+			util.ErrorLog(ctx, err.Error())
 			return status.Error(codes.Aborted, err.Error())
 		}
 		defer cs.OperationLocks.ReleaseRestoreLock(sID.SnapshotID)
 
 		err = createCloneFromSnapshot(ctx, parentVolOpt, volOptions, vID, sID, cr)
 		if err != nil {
-			klog.Errorf(util.Log(ctx, "failed to create clone from snapshot %s: %v"), sID.FsSnapshotName, err)
+			util.ErrorLog(ctx, "failed to create clone from snapshot %s: %v", sID.FsSnapshotName, err)
 			return err
 		}
 		return err
 	}
 	if parentVolOpt != nil {
 		if err = cs.OperationLocks.GetCloneLock(pvID.VolumeID); err != nil {
-			klog.Error(util.Log(ctx, err.Error()))
+			util.ErrorLog(ctx, err.Error())
 			return status.Error(codes.Aborted, err.Error())
 		}
 		defer cs.OperationLocks.ReleaseCloneLock(pvID.VolumeID)
 		err = createCloneFromSubvolume(ctx, volumeID(pvID.FsSubvolName), volumeID(vID.FsSubvolName), volOptions, parentVolOpt, cr)
 		if err != nil {
-			klog.Errorf(util.Log(ctx, "failed to create clone from subvolume %s: %v"), volumeID(pvID.FsSubvolName), err)
+			util.ErrorLog(ctx, "failed to create clone from subvolume %s: %v", volumeID(pvID.FsSubvolName), err)
 			return err
 		}
 		return nil
 	}
 
 	if err = createVolume(ctx, volOptions, cr, volumeID(vID.FsSubvolName), volOptions.Size); err != nil {
-		klog.Errorf(util.Log(ctx, "failed to create volume %s: %v"), volOptions.RequestName, err)
+		util.ErrorLog(ctx, "failed to create volume %s: %v", volOptions.RequestName, err)
 		return status.Error(codes.Internal, err.Error())
 	}
 	return nil

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -296,7 +296,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		// if error is ErrPoolNotFound, the pool is already deleted we dont
 		// need to worry about deleting subvolume or omap data, return success
 		if errors.Is(err, util.ErrPoolNotFound) {
-			klog.Warningf(util.Log(ctx, "failed to get backend volume for %s: %v"), string(volID), err)
+			util.WarningLog(ctx, "failed to get backend volume for %s: %v", string(volID), err)
 			return &csi.DeleteVolumeResponse{}, nil
 		}
 		// if error is ErrKeyNotFound, then a previous attempt at deletion was complete

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -610,7 +610,7 @@ func doSnapshot(ctx context.Context, volOpt *volumeOptions, subvolumeName, snaps
 
 func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.CreateSnapshotRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
-		klog.Errorf(util.Log(ctx, "invalid create snapshot req: %v"), protosanitizer.StripSecrets(req))
+		util.ErrorLog(ctx, "invalid create snapshot req: %v", protosanitizer.StripSecrets(req))
 		return err
 	}
 

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
 )
 
 // ControllerServer struct of CEPH CSI driver with supported methods of CSI
@@ -465,7 +464,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	parentVolOptions, vid, err := newVolumeOptionsFromVolID(ctx, sourceVolID, nil, req.GetSecrets())
 	if err != nil {
 		if errors.Is(err, util.ErrPoolNotFound) {
-			klog.Warningf(util.Log(ctx, "failed to get backend volume for %s: %v"), sourceVolID, err)
+			util.WarningLog(ctx, "failed to get backend volume for %s: %v", sourceVolID, err)
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
 
@@ -513,7 +512,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		if sid != nil {
 			errDefer := undoSnapReservation(ctx, parentVolOptions, *sid, snapName, cr)
 			if errDefer != nil {
-				klog.Warningf(util.Log(ctx, "failed undoing reservation of snapshot: %s (%s)"),
+				util.WarningLog(ctx, "failed undoing reservation of snapshot: %s (%s)",
 					requestName, errDefer)
 			}
 		}
@@ -527,7 +526,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			err = protectSnapshot(ctx, parentVolOptions, cr, volumeID(sid.FsSnapshotName), volumeID(vid.FsSubvolName))
 			if err != nil {
 				protected = false
-				klog.Warningf(util.Log(ctx, "failed to protect snapshot of snapshot: %s (%s)"),
+				util.WarningLog(ctx, "failed to protect snapshot of snapshot: %s (%s)",
 					sid.FsSnapshotName, err)
 			}
 		}
@@ -552,7 +551,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		if err != nil {
 			errDefer := undoSnapReservation(ctx, parentVolOptions, *sID, snapName, cr)
 			if errDefer != nil {
-				klog.Warningf(util.Log(ctx, "failed undoing reservation of snapshot: %s (%s)"),
+				util.WarningLog(ctx, "failed undoing reservation of snapshot: %s (%s)",
 					requestName, errDefer)
 			}
 		}
@@ -661,7 +660,7 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 		// if error is ErrPoolNotFound, the pool is already deleted we dont
 		// need to worry about deleting snapshot or omap data, return success
 		if errors.Is(err, util.ErrPoolNotFound) {
-			klog.Warningf(util.Log(ctx, "failed to get backend snapshot for %s: %v"), snapshotID, err)
+			util.WarningLog(ctx, "failed to get backend snapshot for %s: %v", snapshotID, err)
 			return &csi.DeleteSnapshotResponse{}, nil
 		}
 

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -579,20 +579,20 @@ func doSnapshot(ctx context.Context, volOpt *volumeOptions, subvolumeName, snaps
 	snap := snapshotInfo{}
 	err := createSnapshot(ctx, volOpt, cr, snapID, volID)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to create snapshot %s %v"), snapID, err)
+		util.ErrorLog(ctx, "failed to create snapshot %s %v", snapID, err)
 		return snap, err
 	}
 	defer func() {
 		if err != nil {
 			dErr := deleteSnapshot(ctx, volOpt, cr, snapID, volID)
 			if dErr != nil {
-				klog.Errorf(util.Log(ctx, "failed to delete snapshot %s %v"), snapID, err)
+				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapID, err)
 			}
 		}
 	}()
 	snap, err = getSnapshotInfo(ctx, volOpt, cr, snapID, volID)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to get snapshot info %s %v"), snapID, err)
+		util.ErrorLog(ctx, "failed to get snapshot info %s %v", snapID, err)
 		return snap, fmt.Errorf("failed to get snapshot info for snapshot:%s", snapID)
 	}
 	var t *timestamp.Timestamp
@@ -603,7 +603,7 @@ func doSnapshot(ctx context.Context, volOpt *volumeOptions, subvolumeName, snaps
 	snap.CreationTime = t
 	err = protectSnapshot(ctx, volOpt, cr, snapID, volID)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to protect snapshot %s %v"), snapID, err)
+		util.ErrorLog(ctx, "failed to protect snapshot %s %v", snapID, err)
 	}
 	return snap, err
 }

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -61,7 +61,7 @@ func (cs *ControllerServer) createBackingVolume(
 	var err error
 	if sID != nil {
 		if err = cs.OperationLocks.GetRestoreLock(sID.SnapshotID); err != nil {
-			klog.Error(util.Log(ctx, err.Error()))
+			util.ErrorLog(util.Log(ctx, err.Error()))
 			return status.Error(codes.Aborted, err.Error())
 		}
 		defer cs.OperationLocks.ReleaseRestoreLock(sID.SnapshotID)

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -449,13 +449,13 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	sourceVolID := req.GetSourceVolumeId()
 	// Existence and conflict checks
 	if acquired := cs.SnapshotLocks.TryAcquire(requestName); !acquired {
-		klog.Errorf(util.Log(ctx, util.SnapshotOperationAlreadyExistsFmt), requestName)
+		util.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, requestName)
 		return nil, status.Errorf(codes.Aborted, util.SnapshotOperationAlreadyExistsFmt, requestName)
 	}
 	defer cs.SnapshotLocks.Release(requestName)
 
 	if err = cs.OperationLocks.GetSnapshotCreateLock(sourceVolID); err != nil {
-		klog.Error(util.Log(ctx, err.Error()))
+		util.ErrorLog(ctx, err.Error())
 		return nil, status.Error(codes.Aborted, err.Error())
 	}
 
@@ -486,7 +486,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 
 	// lock out parallel snapshot create operations
 	if acquired := cs.VolumeLocks.TryAcquire(sourceVolID); !acquired {
-		klog.Errorf(util.Log(ctx, util.VolumeOperationAlreadyExistsFmt), sourceVolID)
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, sourceVolID)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, sourceVolID)
 	}
 	defer cs.VolumeLocks.Release(sourceVolID)

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -95,11 +95,11 @@ func (fs *Driver) Run(conf *util.Config) {
 
 	// Configuration
 	if err = loadAvailableMounters(conf); err != nil {
-		klog.Fatalf("cephfs: failed to load ceph mounters: %v", err)
+		util.FatalLogMsg("cephfs: failed to load ceph mounters: %v", err)
 	}
 
 	if err = util.WriteCephConfig(); err != nil {
-		klog.Fatalf("failed to write ceph configuration file: %v", err)
+		util.FatalLogMsg("failed to write ceph configuration file: %v", err)
 	}
 
 	// Use passed in instance ID, if provided for omap suffix naming
@@ -114,7 +114,7 @@ func (fs *Driver) Run(conf *util.Config) {
 
 	fs.cd = csicommon.NewCSIDriver(conf.DriverName, util.DriverVersion, conf.NodeID)
 	if fs.cd == nil {
-		klog.Fatalln("failed to initialize CSI driver")
+		util.FatalLogMsg("failed to initialize CSI driver")
 	}
 
 	if conf.IsControllerServer || !conf.IsNodeServer {
@@ -136,7 +136,7 @@ func (fs *Driver) Run(conf *util.Config) {
 	if conf.IsNodeServer {
 		topology, err = util.GetTopologyFromDomainLabels(conf.DomainLabels, conf.NodeID, conf.DriverName)
 		if err != nil {
-			klog.Fatalln(err)
+			util.FatalLogMsg(err.Error())
 		}
 		fs.ns = NewNodeServer(fs.cd, conf.Vtype, topology)
 	}
@@ -147,7 +147,7 @@ func (fs *Driver) Run(conf *util.Config) {
 	if !conf.IsControllerServer && !conf.IsNodeServer {
 		topology, err = util.GetTopologyFromDomainLabels(conf.DomainLabels, conf.NodeID, conf.DriverName)
 		if err != nil {
-			klog.Fatalln(err)
+			util.FatalLogMsg(err.Error())
 		}
 		fs.ns = NewNodeServer(fs.cd, conf.Vtype, topology)
 		fs.cs = NewControllerServer(fs.cd)

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cephfs
 
 import (
-	klog "k8s.io/klog/v2"
-
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -156,7 +154,7 @@ func (fs *Driver) Run(conf *util.Config) {
 	server := csicommon.NewNonBlockingGRPCServer()
 	server.Start(conf.Endpoint, conf.HistogramOption, fs.is, fs.cs, fs.ns, conf.EnableGRPCMetrics)
 	if conf.EnableGRPCMetrics {
-		klog.Warning("EnableGRPCMetrics is deprecated")
+		util.WarningLogMsg("EnableGRPCMetrics is deprecated")
 		go util.StartMetricsServer(conf)
 	}
 	server.Wait()

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -109,7 +109,7 @@ func checkVolExists(ctx context.Context,
 		if clone.Status.State == cephFSCloneFailed {
 			err = purgeVolume(ctx, volumeID(vid.FsSubvolName), cr, volOptions, true)
 			if err != nil {
-				klog.Errorf(util.Log(ctx, "failed to delete volume %s: %v"), vid.FsSubvolName, err)
+				util.ErrorLog(ctx, "failed to delete volume %s: %v", vid.FsSubvolName, err)
 				return nil, err
 			}
 			if pvID != nil {

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
-	klog "k8s.io/klog/v2"
 )
 
 // volumeIdentifier structure contains an association between the CSI VolumeID to its subvolume
@@ -354,13 +353,13 @@ func checkSnapExists(
 		if err != nil {
 			err = deleteSnapshot(ctx, volOptions, cr, volumeID(snapID), volumeID(parentSubVolName))
 			if err != nil {
-				klog.Errorf(util.Log(ctx, "failed to delete snapshot %s: %v"), snapID, err)
+				util.ErrorLog(ctx, "failed to delete snapshot %s: %v", snapID, err)
 				return
 			}
 			err = j.UndoReservation(ctx, volOptions.MetadataPool,
 				volOptions.MetadataPool, snapID, snap.RequestName)
 			if err != nil {
-				klog.Errorf(util.Log(ctx, "removing reservation failed for snapshot %s: %v"), snapID, err)
+				util.ErrorLog(ctx, "removing reservation failed for snapshot %s: %v", snapID, err)
 			}
 		}
 	}()

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -259,7 +259,7 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	targetPath := req.GetTargetPath()
 
 	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
-		klog.Errorf(util.Log(ctx, util.VolumeOperationAlreadyExistsFmt), volID)
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
 	}
 	defer ns.VolumeLocks.Release(volID)

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -139,14 +139,14 @@ func (*NodeServer) mount(ctx context.Context, volOptions *volumeOptions, req *cs
 
 	cr, err := getCredentialsForVolume(volOptions, req)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to get ceph credentials for volume %s: %v"), volID, err)
+		util.ErrorLog(ctx, "failed to get ceph credentials for volume %s: %v", volID, err)
 		return status.Error(codes.Internal, err.Error())
 	}
 	defer cr.DeleteCredentials()
 
 	m, err := newMounter(volOptions)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to create mounter for volume %s: %v"), volID, err)
+		util.ErrorLog(ctx, "failed to create mounter for volume %s: %v", volID, err)
 		return status.Error(codes.Internal, err.Error())
 	}
 
@@ -173,8 +173,8 @@ func (*NodeServer) mount(ctx context.Context, volOptions *volumeOptions, req *cs
 	}
 
 	if err = m.mount(ctx, stagingTargetPath, cr, volOptions); err != nil {
-		klog.Errorf(util.Log(ctx,
-			"failed to mount volume %s: %v Check dmesg logs if required."),
+		util.ErrorLog(ctx,
+			"failed to mount volume %s: %v Check dmesg logs if required.",
 			volID,
 			err)
 		return status.Error(codes.Internal, err.Error())
@@ -183,10 +183,10 @@ func (*NodeServer) mount(ctx context.Context, volOptions *volumeOptions, req *cs
 		// #nosec - allow anyone to write inside the stagingtarget path
 		err = os.Chmod(stagingTargetPath, 0777)
 		if err != nil {
-			klog.Errorf(util.Log(ctx, "failed to change stagingtarget path %s permission for volume %s: %v"), stagingTargetPath, volID, err)
+			util.ErrorLog(ctx, "failed to change stagingtarget path %s permission for volume %s: %v", stagingTargetPath, volID, err)
 			uErr := unmountVolume(ctx, stagingTargetPath)
 			if uErr != nil {
-				klog.Errorf(util.Log(ctx, "failed to umount stagingtarget path %s for volume %s: %v"), stagingTargetPath, volID, uErr)
+				util.ErrorLog(ctx, "failed to umount stagingtarget path %s for volume %s: %v", stagingTargetPath, volID, uErr)
 			}
 			return status.Error(codes.Internal, err.Error())
 		}

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -206,13 +206,13 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	volID := req.GetVolumeId()
 
 	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
-		klog.Errorf(util.Log(ctx, util.VolumeOperationAlreadyExistsFmt), volID)
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
 	}
 	defer ns.VolumeLocks.Release(volID)
 
 	if err := util.CreateMountPoint(targetPath); err != nil {
-		klog.Errorf(util.Log(ctx, "failed to create mount point at %s: %v"), targetPath, err)
+		util.ErrorLog(ctx, "failed to create mount point at %s: %v", targetPath, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -227,7 +227,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	isMnt, err := util.IsMountPoint(targetPath)
 
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "stat failed: %v"), err)
+		util.ErrorLog(ctx, "stat failed: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -239,7 +239,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// It's not, mount now
 
 	if err = bindMount(ctx, req.GetStagingTargetPath(), req.GetTargetPath(), req.GetReadonly(), mountOptions); err != nil {
-		klog.Errorf(util.Log(ctx, "failed to bind-mount volume %s: %v"), volID, err)
+		util.ErrorLog(ctx, "failed to bind-mount volume %s: %v", volID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -29,7 +29,6 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
 )
 
 // NodeServer struct of ceph CSI driver with supported methods of CSI
@@ -288,7 +287,7 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 	volID := req.GetVolumeId()
 	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
-		klog.Errorf(util.Log(ctx, util.VolumeOperationAlreadyExistsFmt), volID)
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
 	}
 	defer ns.VolumeLocks.Release(volID)

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -82,7 +82,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	volID := volumeID(req.GetVolumeId())
 
 	if acquired := ns.VolumeLocks.TryAcquire(req.GetVolumeId()); !acquired {
-		klog.Errorf(util.Log(ctx, util.VolumeOperationAlreadyExistsFmt), volID)
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, req.GetVolumeId())
 	}
 	defer ns.VolumeLocks.Release(req.GetVolumeId())
@@ -114,7 +114,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	isMnt, err := util.IsMountPoint(stagingTargetPath)
 
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "stat failed: %v"), err)
+		util.ErrorLog(ctx, "stat failed: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
-	klog "k8s.io/klog/v2"
 )
 
 // cephfsSnapshot represents a CSI snapshot and its cluster information.
@@ -230,7 +229,7 @@ func cloneSnapshot(ctx context.Context, parentVolOptions *volumeOptions, cr *uti
 		args[:]...)
 
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to clone subvolume snapshot %s %s(%s) in fs %s"), string(cloneID), string(volID), err, parentVolOptions.FsName)
+		util.ErrorLog(ctx, "failed to clone subvolume snapshot %s %s(%s) in fs %s", string(cloneID), string(volID), err, parentVolOptions.FsName)
 		if strings.HasPrefix(err.Error(), ErrVolumeNotFound.Error()) {
 			return ErrVolumeNotFound
 		}

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -89,7 +89,7 @@ func deleteSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Cre
 		"ceph",
 		args[:]...)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to delete subvolume snapshot %s %s(%s) in fs %s"), string(snapID), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, volOptions.FsName)
 		return err
 	}
 	return nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -195,7 +195,7 @@ func unprotectSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.
 		if strings.Contains(err.Error(), ErrSnapProtectionExist.Error()) {
 			return nil
 		}
-		klog.Errorf(util.Log(ctx, "failed to unprotect subvolume snapshot %s %s(%s) in fs %s"), string(snapID), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to unprotect subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, volOptions.FsName)
 		return err
 	}
 	return nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -131,7 +131,7 @@ func getSnapshotInfo(ctx context.Context, volOptions *volumeOptions, cr *util.Cr
 		if strings.Contains(err.Error(), ErrSnapNotFound.Error()) {
 			return snapshotInfo{}, err
 		}
-		klog.Errorf(util.Log(ctx, "failed to get subvolume snapshot info %s %s(%s) in fs %s"), string(snapID), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to get subvolume snapshot info %s %s(%s) in fs %s", string(snapID), string(volID), err, volOptions.FsName)
 		return snapshotInfo{}, err
 	}
 	return snap, nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -162,7 +162,7 @@ func protectSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Cr
 		if strings.Contains(err.Error(), ErrSnapProtectionExist.Error()) {
 			return nil
 		}
-		klog.Errorf(util.Log(ctx, "failed to protect subvolume snapshot %s %s(%s) in fs %s"), string(snapID), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to protect subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, volOptions.FsName)
 		return err
 	}
 	return nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -60,7 +60,7 @@ func createSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Cre
 		"ceph",
 		args[:]...)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to create subvolume snapshot %s %s(%s) in fs %s"), string(snapID), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to create subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, volOptions.FsName)
 		return err
 	}
 	return nil

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -29,7 +29,6 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
 )
 
 type volumeID string
@@ -136,7 +135,7 @@ func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (sn
 
 	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed getting mons (%s)"), err)
+		util.ErrorLog(ctx, "failed getting mons (%s)", err)
 		return nil, err
 	}
 	if namePrefix, ok := snapOptions["snapshotNamePrefix"]; ok {

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -152,12 +152,12 @@ func parseTime(ctx context.Context, createTime string) (*timestamp.Timestamp, er
 	var t time.Time
 	t, err := time.Parse(layout, createTime)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to parse time %s %v"), createTime, err)
+		util.ErrorLog(ctx, "failed to parse time %s %v", createTime, err)
 		return tm, err
 	}
 	tm, err = ptypes.TimestampProto(t)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to convert time %s %v"), createTime, err)
+		util.ErrorLog(ctx, "failed to convert time %s %v", createTime, err)
 		return tm, err
 	}
 	return tm, nil

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -146,7 +146,7 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, cr *util.Crede
 			"-n", cephEntityClientPrefix+cr.ID,
 			"--keyfile="+cr.KeyFile)
 		if err != nil {
-			klog.Errorf(util.Log(ctx, "failed to create subvolume group %s, for the vol %s(%s)"), volOptions.SubvolumeGroup, string(volID), err)
+			util.ErrorLog(ctx, "failed to create subvolume group %s, for the vol %s(%s)", volOptions.SubvolumeGroup, string(volID), err)
 			return err
 		}
 		util.DebugLog(ctx, "cephfs: created subvolume group %s", volOptions.SubvolumeGroup)
@@ -178,7 +178,7 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, cr *util.Crede
 		"ceph",
 		args[:]...)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to create subvolume %s(%s) in fs %s"), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to create subvolume %s(%s) in fs %s", string(volID), err, volOptions.FsName)
 		return err
 	}
 

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -102,7 +102,7 @@ func getSubVolumeInfo(ctx context.Context, volOptions *volumeOptions, cr *util.C
 		"-n", cephEntityClientPrefix+cr.ID,
 		"--keyfile="+cr.KeyFile)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to get subvolume info for the vol %s(%s)"), string(volID), err)
+		util.ErrorLog(ctx, "failed to get subvolume info for the vol %s(%s)", string(volID), err)
 		if strings.HasPrefix(err.Error(), ErrVolumeNotFound.Error()) {
 			return info, ErrVolumeNotFound
 		}

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -225,7 +225,7 @@ func resizeVolume(ctx context.Context, volOptions *volumeOptions, cr *util.Crede
 		}
 		// Incase the error is other than invalid command return error to the caller.
 		if !strings.Contains(err.Error(), ErrInvalidCommand.Error()) {
-			klog.Errorf(util.Log(ctx, "failed to resize subvolume %s(%s) in fs %s"), string(volID), err, volOptions.FsName)
+			util.ErrorLog(ctx, "failed to resize subvolume %s(%s) in fs %s", string(volID), err, volOptions.FsName)
 			return err
 		}
 	}

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/ceph/ceph-csi/internal/util"
-
-	klog "k8s.io/klog/v2"
 )
 
 var (
@@ -253,7 +251,7 @@ func purgeVolume(ctx context.Context, volID volumeID, cr *util.Credentials, volO
 
 	err := execCommandErr(ctx, "ceph", arg...)
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to purge subvolume %s(%s) in fs %s"), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to purge subvolume %s(%s) in fs %s", string(volID), err, volOptions.FsName)
 		if strings.HasPrefix(err.Error(), ErrVolumeNotFound.Error()) {
 			return util.JoinErrors(ErrVolumeNotFound, err)
 		}

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -74,7 +74,7 @@ func getVolumeRootPathCeph(ctx context.Context, volOptions *volumeOptions, cr *u
 		"--keyfile="+cr.KeyFile)
 
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to get the rootpath for the vol %s(%s) stdError %s"), string(volID), err, stderr)
+		util.ErrorLog(ctx, "failed to get the rootpath for the vol %s(%s) stdError %s", string(volID), err, stderr)
 		if strings.Contains(stderr, ErrVolumeNotFound.Error()) {
 			return "", util.JoinErrors(ErrVolumeNotFound, err)
 		}

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -77,7 +77,7 @@ func loadAvailableMounters(conf *util.Config) error {
 
 	err := kernelMounterProbe.Run()
 	if err != nil {
-		klog.Errorf("failed to run mount.ceph %v", err)
+		util.ErrorLogMsg("failed to run mount.ceph %v", err)
 	} else {
 		// fetch the current running kernel info
 		release, kvErr := util.GetKernelVersion()
@@ -95,7 +95,7 @@ func loadAvailableMounters(conf *util.Config) error {
 
 	err = fuseMounterProbe.Run()
 	if err != nil {
-		klog.Errorf("failed to run ceph-fuse %v", err)
+		util.ErrorLogMsg("failed to run ceph-fuse %v", err)
 	} else {
 		util.DefaultLog("loaded mounter: %s", volumeMounterFuse)
 		availableMounters = append(availableMounters, volumeMounterFuse)

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 
 	"github.com/ceph/ceph-csi/internal/util"
-
-	klog "k8s.io/klog/v2"
 )
 
 const (
@@ -276,10 +274,10 @@ func unmountVolume(ctx context.Context, mountPoint string) error {
 	if ok {
 		p, err := os.FindProcess(pid)
 		if err != nil {
-			klog.Warningf(util.Log(ctx, "failed to find process %d: %v"), pid, err)
+			util.WarningLog(ctx, "failed to find process %d: %v", pid, err)
 		} else {
 			if _, err = p.Wait(); err != nil {
-				klog.Warningf(util.Log(ctx, "%d is not a child process: %v"), pid, err)
+				util.WarningLog(ctx, "%d is not a child process: %v", pid, err)
 			}
 		}
 	}

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -146,7 +146,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrObjectExists) {
 		return JoinErrors(ErrObjectExists, err)
 	} else if err != nil {
-		ErrorLogMsg(Log(ctx, "failed creating omap (%s) in pool (%s): (%v)"), objectName, poolName, err)
+		ErrorLog(ctx, "failed creating omap (%s) in pool (%s): (%v)", objectName, poolName, err)
 		return err
 	}
 
@@ -180,7 +180,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrNotFound) {
 		return JoinErrors(ErrObjectNotFound, err)
 	} else if err != nil {
-		ErrorLogMsg(Log(ctx, "failed removing omap (%s) in pool (%s): (%v)"), oMapName, poolName, err)
+		ErrorLog(ctx, "failed removing omap (%s) in pool (%s): (%v)", oMapName, poolName, err)
 		return err
 	}
 

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -146,7 +146,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrObjectExists) {
 		return JoinErrors(ErrObjectExists, err)
 	} else if err != nil {
-		ErrorLog(Log(ctx, "failed creating omap (%s) in pool (%s): (%v)"), objectName, poolName, err)
+		ErrorLogMsg(Log(ctx, "failed creating omap (%s) in pool (%s): (%v)"), objectName, poolName, err)
 		return err
 	}
 
@@ -180,7 +180,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrNotFound) {
 		return JoinErrors(ErrObjectNotFound, err)
 	} else if err != nil {
-		ErrorLog(Log(ctx, "failed removing omap (%s) in pool (%s): (%v)"), oMapName, poolName, err)
+		ErrorLogMsg(Log(ctx, "failed removing omap (%s) in pool (%s): (%v)"), oMapName, poolName, err)
 		return err
 	}
 

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -158,7 +158,7 @@ func GetCryptoPassphrase(ctx context.Context, volumeID string, kms EncryptionKMS
 		}
 		return passphrase, nil
 	}
-	ErrorLogMsg(Log(ctx, "failed to get encryption passphrase for %s: %s"), volumeID, err)
+	ErrorLog(ctx, "failed to get encryption passphrase for %s: %s", volumeID, err)
 	return "", err
 }
 

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -158,7 +158,7 @@ func GetCryptoPassphrase(ctx context.Context, volumeID string, kms EncryptionKMS
 		}
 		return passphrase, nil
 	}
-	ErrorLog(Log(ctx, "failed to get encryption passphrase for %s: %s"), volumeID, err)
+	ErrorLogMsg(Log(ctx, "failed to get encryption passphrase for %s: %s"), volumeID, err)
 	return "", err
 }
 

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -21,6 +21,6 @@ func StartMetricsServer(c *Config) {
 	http.Handle(c.MetricsPath, promhttp.Handler())
 	err := http.ListenAndServe(addr, nil)
 	if err != nil {
-		FatalLog("failed to listen on address %v: %s", addr, err)
+		FatalLogMsg("failed to listen on address %v: %s", addr, err)
 	}
 }

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -253,6 +253,6 @@ func (ol *OperationLock) release(op operation, volumeID string) {
 			}
 		}
 	default:
-		ErrorLog("%v operation not supported", op)
+		ErrorLogMsg("%v operation not supported", op)
 	}
 }

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -32,17 +32,17 @@ func NewK8sClient() *k8s.Clientset {
 	if cPath != "" {
 		cfg, err = clientcmd.BuildConfigFromFlags("", cPath)
 		if err != nil {
-			FatalLog("Failed to get cluster config with error: %v\n", err)
+			FatalLogMsg("Failed to get cluster config with error: %v\n", err)
 		}
 	} else {
 		cfg, err = rest.InClusterConfig()
 		if err != nil {
-			FatalLog("Failed to get cluster config with error: %v\n", err)
+			FatalLogMsg("Failed to get cluster config with error: %v\n", err)
 		}
 	}
 	client, err := k8s.NewForConfig(cfg)
 	if err != nil {
-		FatalLog("Failed to create client with error: %v\n", err)
+		FatalLogMsg("Failed to create client with error: %v\n", err)
 	}
 	return client
 }

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -70,8 +70,8 @@ func ErrorLog(ctx context.Context, message string, args ...interface{}) {
 	klog.ErrorDepth(1, logMessage)
 }
 
-// WarningLog helps in logging warnings.
-func WarningLog(message string, args ...interface{}) {
+// WarningLogMsg helps in logging warnings with message.
+func WarningLogMsg(message string, args ...interface{}) {
 	logMessage := fmt.Sprintf(message, args...)
 	klog.WarningDepth(1, logMessage)
 }

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -76,6 +76,12 @@ func WarningLogMsg(message string, args ...interface{}) {
 	klog.WarningDepth(1, logMessage)
 }
 
+// WarningLog helps in logging warnings with context.
+func WarningLog(ctx context.Context, message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(Log(ctx, message), args...)
+	klog.WarningDepth(1, logMessage)
+}
+
 // DefaultLog helps in logging with klog.level 1.
 func DefaultLog(message string, args ...interface{}) {
 	logMessage := fmt.Sprintf(message, args...)

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -58,8 +58,8 @@ func FatalLog(message string, args ...interface{}) {
 	klog.FatalDepth(1, logMessage)
 }
 
-// ErrorLog helps in logging errors.
-func ErrorLog(message string, args ...interface{}) {
+// ErrorLogMsg helps in logging errors with message.
+func ErrorLogMsg(message string, args ...interface{}) {
 	logMessage := fmt.Sprintf(message, args...)
 	klog.ErrorDepth(1, logMessage)
 }

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -64,6 +64,12 @@ func ErrorLogMsg(message string, args ...interface{}) {
 	klog.ErrorDepth(1, logMessage)
 }
 
+// ErrorLog helps in logging errors with context.
+func ErrorLog(ctx context.Context, message string, args ...interface{}) {
+	logMessage := fmt.Sprintf(Log(ctx, message), args...)
+	klog.ErrorDepth(1, logMessage)
+}
+
 // WarningLog helps in logging warnings.
 func WarningLog(message string, args ...interface{}) {
 	logMessage := fmt.Sprintf(message, args...)

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -53,7 +53,7 @@ func Log(ctx context.Context, format string) string {
 }
 
 // FatalLog helps in logging fatal errors.
-func FatalLog(message string, args ...interface{}) {
+func FatalLogMsg(message string, args ...interface{}) {
 	logMessage := fmt.Sprintf(message, args...)
 	klog.FatalDepth(1, logMessage)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -173,12 +173,12 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 	vers := strings.Split(strings.SplitN(release, "-", 2)[0], ".")
 	version, err := strconv.Atoi(vers[0])
 	if err != nil {
-		ErrorLog("failed to parse version from %s: %v", release, err)
+		ErrorLogMsg("failed to parse version from %s: %v", release, err)
 		return false
 	}
 	patchlevel, err := strconv.Atoi(vers[1])
 	if err != nil {
-		ErrorLog("failed to parse patchlevel from %s: %v", release, err)
+		ErrorLogMsg("failed to parse patchlevel from %s: %v", release, err)
 		return false
 	}
 	sublevel := 0
@@ -186,7 +186,7 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 	if len(vers) >= minLenForSublvl {
 		sublevel, err = strconv.Atoi(vers[2])
 		if err != nil {
-			ErrorLog("failed to parse sublevel from %s: %v", release, err)
+			ErrorLogMsg("failed to parse sublevel from %s: %v", release, err)
 			return false
 		}
 	}
@@ -223,7 +223,7 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 			}
 		}
 	}
-	ErrorLog("kernel %s does not support required features", release)
+	ErrorLogMsg("kernel %s does not support required features", release)
 	return false
 }
 


### PR DESCRIPTION
Updated cephfs packages to use util package for logging instead of using klog directly.