### PR TITLE
ci: prevent Mergify from doing merge commits

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,8 +35,9 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label
@@ -58,8 +59,9 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release v1.2.0 branch
@@ -83,8 +85,9 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v2.0 branch
@@ -108,8 +111,9 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v2.1 branch
@@ -133,8 +137,9 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v3.0 branch
@@ -158,8 +163,9 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v3.1 branch
@@ -191,6 +197,7 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
+        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -216,8 +223,9 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label on ci/centos
@@ -235,7 +243,8 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: smart
         bot_account: ceph-csi-bot
+        strict: smart
+        strict_method: rebase
       dismiss_reviews: {}
       delete_head_branch: {}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,10 +1,5 @@
 ---
 pull_request_rules:
-  - name: rebase on request
-    conditions: []
-    actions:
-      rebase:
-        bot_account: ceph-csi-bot
   - name: remove outdated approvals
     conditions:
       - base=master


### PR DESCRIPTION
Merge commits cause the CentOS CI commitlint job to fail. By configuring
Mergify to not do merge commits, but rebases before final testing, we
can use the CentOS CI commitlint job when the GitHub commitlint App does
not work.