### PR TITLE
ci: skip CI jobs when a PR contains a doc-only change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint-yaml:
 
 commitlint:
 	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
-	commitlint --from $(GIT_SINCE)
+	commitlint --from FETCH_HEAD
 
 .PHONY: containerized-test
 containerized-test: .test-container-id

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -4,6 +4,8 @@ def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
 def ref = "master"
+def git_since = 'master'
+def doc_change = 0
 
 def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
@@ -14,6 +16,29 @@ node('cico-workspace') {
 		git url: "${ci_git_repo}",
 			branch: "${ci_git_branch}",
 			changelog: false
+	}
+
+	stage('checkout PR') {
+		if (params.ghprbPullId != null) {
+			ref = "pull/${ghprbPullId}/head"
+		}
+		if (params.ghprbTargetBranch != null) {
+			git_since = "${ghprbTargetBranch}"
+		}
+
+		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
+		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+	}
+
+	stage('check doc-only change') {
+		doc_change = sh(
+			script: "cd ~/build/ceph-csi && \${OLDPWD}/scripts/skip-doc-change.sh origin/${git_since}",
+			returnStatus: true)
+	}
+	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
+	if (doc_change == 1) {
+		currentBuild.result = 'SUCCESS'
+		return
 	}
 
 	stage('reserve bare-metal machine') {

--- a/scripts/skip-doc-change.sh
+++ b/scripts/skip-doc-change.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+#
+
+GIT_SINCE="${1}"
+if [ -z "${GIT_SINCE}" ]; then
+	GIT_SINCE='origin/master'
+fi
+
+CHANGED_FILES=$(git diff --name-only "${GIT_SINCE}")
+
+[[ -z $CHANGED_FILES ]] && exit 1
+
+skip=0
+#files to be skipped
+declare -a FILES=(^docs/ .md$ ^scripts/ LICENSE .mergify.yml .github .gitignore)
+
+function check_file_present() {
+    local file=$1
+    for FILE in "${FILES[@]}"; do
+        if [[ $file =~ $FILE ]]; then
+            if [[ $file =~ (minikube.sh|travis-functest.sh) ]]; then
+                continue
+            fi
+            return 0
+        fi
+    done
+    return 1
+}
+
+for CHANGED_FILE in $CHANGED_FILES; do
+    if ! check_file_present "$CHANGED_FILE"; then
+        skip=1
+    fi
+done
+if [ $skip -eq 0 ]; then
+    echo "doc change only"
+    exit 1
+fi


### PR DESCRIPTION
Adapt the Jenkins Pipelines to check for a doc-only change. If that is the case, there is no need to reserve a bare-metal system and run the tests.

The CI jobs will run, but get aborted (with `SUCCESS`) in an early stage. That means the PR status context will get a green :heavy_check_mark: for the jobs.

Closes: #1357