### PR TITLE
ci: use last "git fetch" output to test commitlint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ check-env:
 
 commitlint:
 	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
-	commitlint --from $(GIT_SINCE)
+	commitlint --from FETCH_HEAD
 
 .PHONY: cephcsi
 cephcsi: check-env


### PR DESCRIPTION
When running in the CI the git repository is not completely cloned. This
causes the 'commitlint' job to be unable to resolve the history of the
commits.

By using FETCH_HEAD, the last 'git fetch' output will be used.