### PR TITLE
ci: use build.env:CSI_IMAGE_VERSION for mini-e2e jobs

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -61,6 +61,7 @@ function set_env() {
     # it and will cause a failure if not annotated with /dev/null.
     # shellcheck source=/dev/null
     source "${GOPATH}"/src/github.com/ceph/ceph-csi/build.env
+    CSI_IMAGE_VERSION=${CSI_IMAGE_VERSION:-"canary"}
     export GO111MODULE="on"
     export TEST_COVERAGE="stdout"
     export VM_DRIVER="kvm2"
@@ -139,7 +140,7 @@ set_env
 install_minikube
 
 install_docker
-podman2minikube quay.io/cephcsi/cephcsi:canary
+podman2minikube "quay.io/cephcsi/cephcsi:${CSI_IMAGE_VERSION}"
 
 deploy_rook
 


### PR DESCRIPTION
By placing CSI_IMAGE_VERSION=v3.1.0 in build.env in the release-v3.1
branch, the CI jobs using single-node-k8s.sh can pickup the version
dynamically.

Other release branches can do the same, and the CI jobs will not need
modifications for each release.
