### PR TITLE
ci: the ci-job-validation script uses an undefined variable

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -2,6 +2,7 @@ def cico_retries = 16
 def cico_retry_interval = 60
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
+def git_repo = 'https://github.com/ceph/ceph-csi'
 def ref = 'ci/centos'
 def git_since = 'ci/centos'
 def base = ''


### PR DESCRIPTION
It seems ci-job-validation.groovy got merged with a mistake. The
git_repo variable is used, but was not defined.