### PR TITLE
util: Fix tracevol to use --config for oc only

### DIFF
--- a/troubleshooting/tools/tracevol.py
+++ b/troubleshooting/tools/tracevol.py
@@ -502,9 +502,10 @@ def get_pv_data(arg, pvname):
     pvdata = {}
     cmd = [arg.command]
     if arg.kubeconfig != "":
-        cmd += ["--config", arg.kubeconfig]
-    else:
-        cmd += ["--kubeconfig", arg.kubeconfig]
+        if arg.command == "oc":
+            cmd += ["--config", arg.kubeconfig]
+        else:
+            cmd += ["--kubeconfig", arg.kubeconfig]
 
     cmd += ['get', 'pv', pvname, '-o', 'json']
     out = subprocess.Popen(cmd, stdout=subprocess.PIPE,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

When running tracevol.py in a cluster with [rook](https://rook.io/) deployed, it throws an error:

$ python3 ./tracevol.py -c kubectl -k ./config -debug -cm rook-ceph-csi-config -cmn rook-ceph 
failed to get pv %s Expecting value: line 1 column 1 (char 0)

This happens when we invoke the script with command kubeconfig (-c) and a custom kubeconfig path (-k). This PR is supposed to fix that.

## Is there anything that requires special attention ##

IMHO this is a very simple contribution, so no special attention is required

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: none that I know of

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.
