### PR TITLE
rebase: update golang version to v.1.15

### DIFF
--- a/build.env
+++ b/build.env
@@ -14,7 +14,7 @@ BASE_IMAGE=ceph/ceph:v15
 CEPH_VERSION=nautilus
 
 # standard Golang options
-GOLANG_VERSION=1.13.9
+GOLANG_VERSION=1.15
 GO111MODULE=on
 
 # static checks and linters


### PR DESCRIPTION
as the  golang v1.15 is released, updated cephcsi golang version to 1.15

kubernetes 1.19 is going to be built with
golang 1.15 see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#api-change

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

