### PR TITLE
ci: use GitHub Hooks to trigger jobs

### DIFF
--- a/jobs/ci-job-validation.yaml
+++ b/jobs/ci-job-validation.yaml
@@ -24,9 +24,7 @@
           status-context: ci/centos/job-validation
           trigger-phrase: '/(re)?test ((all)|(ci/centos/job-validation))'
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           white-list-target-branches:
             - ci/centos
           org-list:

--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -29,9 +29,7 @@
           # only run on PRs where the trigger-phrase is posted
           only-trigger-phrase: true
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           org-list:
             - ceph
           allow-whitelist-orgs-as-admins: true

--- a/jobs/containerized-tests.yaml
+++ b/jobs/containerized-tests.yaml
@@ -24,9 +24,7 @@
           status-context: ci/centos/containerized-tests
           trigger-phrase: '/(re)?test ((all)|(ci/centos/containerized-tests))'
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           black-list-target-branches:
             - ci/centos
           org-list:

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -38,9 +38,7 @@
           status-context: ci/centos/jjb-validate
           trigger-phrase: '/(re)?test ((all)|(ci/centos/jjb-validate))'
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           white-list-target-branches:
             - ci/centos
           org-list:

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -42,9 +42,7 @@
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-{k8s_version})?))'
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           black-list-target-branches:
             - ci/centos
           org-list:
@@ -84,9 +82,7 @@
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e-helm(/k8s-{k8s_version})?))'
           permit-all: true
-          # TODO: set github-hooks to true when it is configured in GitHub
-          github-hooks: false
-          cron: 'H/5 * * * *'
+          github-hooks: true
           black-list-target-branches:
             - ci/centos
           org-list:


### PR DESCRIPTION
By using GitHub Hooks, jobs get triggers quickers. It also may prevent
the occasional hickup in the Jenkins GitHub-Pull-Request-Builder while
polling events for the cron-jobs.
