### PR TITLE
rbd: Bail out from nodeexpansion if its block mode pvc

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -715,21 +715,6 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	}
 	defer ns.VolumeLocks.Release(volumeID)
 
-	// volumePath is targetPath for block PVC and stagingPath for filesystem.
-	// check the path is mountpoint or not, if it is
-	// mountpoint treat this as block PVC or else it is filesystem PVC
-	// TODO remove this once ceph-csi supports CSI v1.2.0 spec
-	notMnt, err := mount.IsNotMountPoint(ns.mounter, volumePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if !notMnt {
-		return &csi.NodeExpandVolumeResponse{}, nil
-	}
-
 	devicePath, err := getDevicePath(ctx, volumePath)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
At CSI spec < 1.2.0, there was no volumecapability in the
expand request. However its available from v1.2+ which allows
us to declare the node operations based on the volume mode.

Fixes: https://github.com/ceph/ceph-csi/issues/1379
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

