### PR TITLE
cephfs: check error output contains Error: ENOENT

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -331,7 +331,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	if acquired := cs.VolumeLocks.TryAcquire(volOptions.RequestName); !acquired {
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volOptions.RequestName)
 	}
-	defer cs.VolumeLocks.Release(string(volID))
+	defer cs.VolumeLocks.Release(volOptions.RequestName)
 
 	// Deleting a volume requires admin credentials
 	cr, err := util.NewAdminCredentials(secrets)

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -252,7 +252,7 @@ func purgeVolume(ctx context.Context, volID volumeID, cr *util.Credentials, volO
 	err := execCommandErr(ctx, "ceph", arg...)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to purge subvolume %s(%s) in fs %s", string(volID), err, volOptions.FsName)
-		if strings.HasPrefix(err.Error(), ErrVolumeNotFound.Error()) {
+		if strings.Contains(err.Error(), ErrVolumeNotFound.Error()) {
 			return util.JoinErrors(ErrVolumeNotFound, err)
 		}
 		return err


### PR DESCRIPTION
execCommandErr returns both error and stderr message. checking strings.HasPrefix is not helpful
as the stderr will be the first string. its good to do string contains check and find out that error is volume not found an error.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

