### PR TITLE
ci: Increase timeout for mini-e2e jobs

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -87,7 +87,7 @@ node('cico-workspace') {
 			}
 		}
 		stage('run e2e') {
-			timeout(time: 60, unit: 'MINUTES') {
+			timeout(time: 120, unit: 'MINUTES') {
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='--deploy-cephfs=false --deploy-rbd=false'"
 			}
 		}

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -77,7 +77,7 @@ node('cico-workspace') {
 			}
 		}
 		stage('run e2e') {
-			timeout(time: 60, unit: 'MINUTES') {
+			timeout(time: 120, unit: 'MINUTES') {
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e'
 			}
 		}


### PR DESCRIPTION
Due to a strict timeout, the job tends
to abort sometimes. Increasing the
timeout to allow sufficient time for
tests to execute.

See: https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e_k8s-1.18.5/detail/mini-e2e_k8s-1.18.5/290/pipeline/52