### PR TITLE
ci: Add pre-commit hook to catch issues locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+---
+repos:
+
+  # Check if the commit message has a valid sign-off.
+  - repo: https://github.com/gklein/check_signoff
+    rev: v1.0.5
+    hooks:
+      - id: check-signoff
+
+  # Catch gofmt issues, if any.
+  - repo: git://github.com/dnephin/pre-commit-golang
+    rev: v0.3.5
+    hooks:
+      - id: go-fmt
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      # Verify syntax of yaml and json files.
+      - id: check-json
+      - id: check-yaml
+        args: [--multi]
+
+      # Makes sure that files end in a new line.
+      - id: end-of-file-fixer
+
+      # Trims trailing whitespace.
+      - id: trailing-whitespace
+
+  # Run commitlint check on the commit message.
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v2.2.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -34,7 +34,20 @@ it is **highly** encouraged to:
 * Fork the [ceph-csi repo](https://github.com/ceph/ceph-csi) on Github.
 * Add your fork as a git remote:
    `$ git remote add fork https://github.com/<your-github-username>/ceph-csi`
+* Set up a pre-commit hook to catch issues locally.
 
+   `$ pip install pre-commit==2.5.1`
+
+   `$ pre-commit install`
+
+   See the [pre-commit installation
+   instructions](https://pre-commit.com/#installation) for more
+   details.
+
+   Pre-commit will be now be triggered next time we commit changes.
+   This will catch some trivial style nitpicks (if any),
+   which will then need resolving. Once the warnings are resolved,
+   the user will be allowed to proceed with the commit.
 > Editors: Our favorite editor is vim with the [vim-go](https://github.com/fatih/vim-go)
 > plugin, but there are many others like [vscode](https://github.com/Microsoft/vscode-go)
 


### PR DESCRIPTION
The Git hooks forces the developers to satisfy
certain rules before committing changes(locally).

Following checks will be run before allowing developers
to commit changes:
1. Check if the commit message has a valid sign-off.
2. Catch gofmt issues, if any.
3. Verify syntax of yaml and json files. (if present)
4. Makes sure that files end in a new line.
5. Trims trailing whitespace.
6. Run commitlint check on the commit message.

The developers will not be allowed to commit changes
without satisfying the above-mentioned rules; This will
inturn help in avoiding failures on CI.