### PR TITLE
ci: pass REBASE=1 to have commitlint rebase the branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ deploy/cephcsi/image/cephcsi
 # build container
 .devel-container-id
 
+# detected 'docker' or 'podman'
+.container-cmd
+
 # git merge files
 *.orig
 *.patch

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ e2e.test
 # docker build
 deploy/cephcsi/image/cephcsi
 
-# build container
+# cached container image IDs
 .devel-container-id
+.test-container-id
 
 # detected 'docker' or 'podman'
 .container-cmd

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ check-env:
 commitlint: REBASE ?= 0
 commitlint:
 	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
-	@test $(REBASE) -eq 0 || git -c user.name=commitlint -c user.email=commitline@localhost rebase $(GIT_SINCE)
+	@test $(REBASE) -eq 0 || git -c user.name=commitlint -c user.email=commitline@localhost rebase FETCH_HEAD
 	commitlint --from FETCH_HEAD
 
 .PHONY: cephcsi


### PR DESCRIPTION
When Mergify adds a merge commit to the branch that is being tested with
commitlint, the tool tries to detect the most recent changes based on
the newly merged commit. This is for most PRs the master branch, and
that contains incorrect commit messages in the history. Because of this,
commitlint will fail.

By adding an option (REBASE=1) to the commitlint make target, CI jobs
can request a rebase so that the history of the PR becomes linear again
and commitlint should be able to detect only the new commits.

The 'need-container-cmd' make target is marked as .PHONY which will
cause it to be run every time. That triggers a rebuild of the container
images, even when that is not required.

By removing the 'need-container-cmd' target from .PHONY, and storing the
contents of CONTAINER_CMD in .container-cmd, unneeded rebuilds are
prevented.
