### PR TITLE
ci: fetch full history when cloning for commitlint job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ lint-yaml:
 commitlint: REBASE ?= 0
 commitlint:
 	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
-	@test $(REBASE) -eq 0 || git -c user.name=commitlint -c user.email=commitline@localhost rebase $(GIT_SINCE)
+	@test $(REBASE) -eq 0 || git -c user.name=commitlint -c user.email=commitline@localhost rebase FETCH_HEAD
 	commitlint --from FETCH_HEAD
 
 .PHONY: containerized-test

--- a/commitlint.groovy
+++ b/commitlint.groovy
@@ -34,7 +34,7 @@ node('cico-workspace') {
 				ref = "pull/${ghprbPullId}/head"
 			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh root@${CICO_NODE}:'
-			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref}"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref} --history"
 		}
 
 		stage('run commitlint') {

--- a/prepare.sh
+++ b/prepare.sh
@@ -7,12 +7,14 @@ gitrepo="https://github.com/ceph/ceph-csi"
 workdir="tip/"
 ref="master"
 base="master"
+history="no"
 
 ARGUMENT_LIST=(
     "ref"
     "workdir"
     "gitrepo"
     "base"
+    "history"
 )
 
 opts=$(getopt \
@@ -41,6 +43,7 @@ while true; do
         echo "--workdir                 specify the working directory"
         echo "--gitrepo                 specify the git repository"
         echo "--base                    specify the base branch to checkout"
+        echo "--history                 fetch the history of the base branch"
         echo " "
         echo "Sample Usage:"
         echo "./prepare.sh --gitrepo=https://github.com/example --workdir=/opt/build --ref=pull/123/head"
@@ -63,6 +66,10 @@ while true; do
         shift
         base=${1}
         ;;
+    --history)
+        shift
+        history="yes"
+        ;;
     --)
         shift
         break
@@ -75,7 +82,14 @@ set -x
 
 dnf -y install git podman make
 
-git clone --depth=1 --branch="${base}" "${gitrepo}" "${workdir}"
+# if --history is passed, don't pass --depth=1
+depth='--depth=1'
+if [[ "${history}" == 'yes' ]]
+then
+    depth=''
+fi
+
+git clone "${depth}" --branch="${base}" "${gitrepo}" "${workdir}"
 cd "${workdir}"
 git fetch origin "${ref}:tip/${ref}"
 git checkout "tip/${ref}"


### PR DESCRIPTION
In case the history of the branch is needed (commitlint job), add an
option --history to skip cloning the repository with --depth=1.

See-also: #1395 (was not sufficient)