### PR TITLE
ci: prepare.sh should accept --history without argument

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -14,11 +14,10 @@ ARGUMENT_LIST=(
     "workdir"
     "gitrepo"
     "base"
-    "history"
 )
 
 opts=$(getopt \
-    --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")help" \
+    --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")history,help" \
     --name "$(basename "${0}")" \
     --options "" \
     -- "$@"


### PR DESCRIPTION
The --history does not take an argument, similar to --help. Move it out
of ARGUMENT_LIST so 'getopt' does not complain about it.

Currently the commitlint CI job fails with:
```
prepare.sh: option '--history' requires an argument
```