### PR TITLE
cleanup: fix command in the error msg

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -16,7 +16,7 @@ ARG GOROOT=/usr/local/go
 COPY build.env /
 
 RUN source /build.env && \
-    ( test -n "${GO_ARCH}" && exit 0; echo -e "\n\nMissing GO_ARCH argument for building image, install Golang or run: make image-ceph-csi GOARCH=amd64\n\n"; exit 1 ) && \
+    ( test -n "${GO_ARCH}" && exit 0; echo -e "\n\nMissing GO_ARCH argument for building image, install Golang or run: make image-cephcsi GOARCH=amd64\n\n"; exit 1 ) && \
     mkdir -p ${GOROOT} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

## Describe what this PR does #
This PR fixes typo in err msg: 
`Missing GO_ARCH argument for building image, install Golang or run: make image-cephcsi GOARCH=amd64`
