### PR TITLE
ci: fix the minikube version check failure

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -47,7 +47,6 @@ function detect_minikube() {
     # default if minikube is not available
     echo '/usr/local/bin/minikube'
 }
-minikube="$(detect_minikube)"
 
 # install minikube
 function install_minikube() {
@@ -99,6 +98,19 @@ function minikube_losetup() {
     ${minikube} ssh 'sudo sh -c "rm -f /sbin/losetup && cp ~docker/losetup /sbin"'
 }
 
+function minikube_supports_psp() {
+    local MINIKUBE_MAJOR
+    local MINIKUBE_MINOR
+    local MINIKUBE_PATCH
+    MINIKUBE_MAJOR=$(minikube_version 1)
+    MINIKUBE_MINOR=$(minikube_version 2)
+    MINIKUBE_PATCH=$(minikube_version 3)
+    if [[ "${MINIKUBE_MAJOR}" -ge 1 ]] && [[ "${MINIKUBE_MINOR}" -ge 11 ]] && [[ "${MINIKUBE_PATCH}" -ge 1 ]] || [[ "${MINIKUBE_MAJOR}" -ge 1 ]] && [[ "${MINIKUBE_MINOR}" -ge 12 ]]; then
+        return 1
+    fi
+    return 0
+}
+
 # configure minikube
 MINIKUBE_ARCH=${MINIKUBE_ARCH:-"amd64"}
 MINIKUBE_VERSION=${MINIKUBE_VERSION:-"latest"}
@@ -136,18 +148,7 @@ EXTRA_CONFIG="${EXTRA_CONFIG} --extra-config=kubelet.resolv-conf=${RESOLV_CONF}"
 #extra Rook configuration
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}
 
-function minikube_supports_psp() {
-    local MINIKUBE_MAJOR
-    local MINIKUBE_MINOR
-    local MINIKUBE_PATCH
-    MINIKUBE_MAJOR=$(minikube_version 1)
-    MINIKUBE_MINOR=$(minikube_version 2)
-    MINIKUBE_PATCH=$(minikube_version 3)
-    if [[ "${MINIKUBE_MAJOR}" -ge 1 ]] && [[ "${MINIKUBE_MINOR}" -ge 11 ]] && [[ "${MINIKUBE_PATCH}" -ge 1 ]] || [[ "${MINIKUBE_MAJOR}" -ge 1 ]] && [[ "${MINIKUBE_MINOR}" -ge 12 ]]; then
-        return 1
-    fi
-    return 0
-}
+minikube="$(detect_minikube)"
 
 case "${1:-}" in
 up)

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -76,7 +76,7 @@ function enable_psp() {
     echo "prepare minikube to support pod security policies"
     mkdir -p "$HOME"/.minikube/files/etc/kubernetes/addons
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-	  cp "$DIR"/psp.yaml "$HOME"/.minikube/files/etc/kubernetes/addons/psp.yaml
+    cp "$DIR"/psp.yaml "$HOME"/.minikube/files/etc/kubernetes/addons/psp.yaml
 }
 
 # Storage providers and the default storage class is not needed for Ceph-CSI

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -54,10 +54,6 @@ function install_minikube() {
         local mk_version version
         read -ra mk_version <<<"$(${minikube} version)"
         version=${mk_version[2]}
-        if [[ "${version}" != "${MINIKUBE_VERSION}" ]]; then
-            echo "installed minikube version ${version} is not matching requested version ${MINIKUBE_VERSION}"
-            exit 1
-        fi
         echo "minikube already installed with ${version}"
         return
     fi

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -50,16 +50,26 @@ function detect_minikube() {
 
 # install minikube
 function install_minikube() {
+    local mku_version latest_version
+    mku_version=$(${minikube} update-check 2> /dev/null | grep "LatestVersion" || true)
+    latest_version=$(echo "${mku_version}" | cut -d' ' -f2)
+    if [[ -z "${latest_version}" ]]; then
+        # skip: update-check failed for some reason, lets continue with what we have
+        latest_version=${MINIKUBE_VERSION}
+    fi
     if type "${minikube}" >/dev/null 2>&1; then
         local mk_version version
         read -ra mk_version <<<"$(${minikube} version)"
         version=${mk_version[2]}
         echo "minikube already installed with ${version}"
-        return
+        if [[ "${version}" == "${latest_version}" ]]; then
+            echo "minikube is already the latest version"
+            return
+        fi
     fi
 
-    echo "Installing minikube. Version: ${MINIKUBE_VERSION}"
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-"${MINIKUBE_ARCH}" && chmod +x minikube && mv minikube /usr/local/bin/
+    echo "Installing minikube. Version: ${latest_version}"
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${latest_version}"/minikube-linux-"${MINIKUBE_ARCH}" && chmod +x minikube && mv minikube /usr/local/bin/
 }
 
 function install_kubectl() {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

## Describe what this PR does ##

 Problem:                                                                        
 ------------                                                                         
Fix the minikube version check failure
                                                                                 
 $ minikube version                                                              
 minikube version: v1.12.2                                                       
 commit: be7c19d391302656d27f1f213657d925c4e1cfc2-dirty                          
                                                                                 
 $ ./scripts/minikube.sh up                                                      
 installed minikube version v1.12.2 is not matching requested version latest     
                                                                                 
 Here v1.12.2 is the latest version of minikube, but the script simply bails out.
