### PR TITLE
build: change default to use podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@
 
 .PHONY: all cephcsi check-env
 
-CONTAINER_CMD?=$(shell docker version >/dev/null 2>&1 && echo docker)
+CONTAINER_CMD?=$(shell podman version >/dev/null 2>&1 && echo podman)
 ifeq ($(CONTAINER_CMD),)
-    CONTAINER_CMD=$(shell podman version >/dev/null 2>&1 && echo podman)
+    CONTAINER_CMD=$(shell docker version >/dev/null 2>&1 && echo docker)
 endif
 CPUS?=$(shell nproc --ignore=1)
 CPUSET?=--cpuset-cpus=0-${CPUS}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

With '# make image-cephcsi GOARCH=amd64'
On Fedora observed errors like:
```
[...]
 ---> Running in 3e2dbf48ebc6
OCI runtime create failed: this version of runc doesn't work on cgroups
v2: unknown
make: *** [Makefile:175: image-cephcsi] Error 1
```

hence it is recommended to switch to podman if available.


