### PR TITLE
ci: error out for invalid component in commit header

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -13,7 +13,7 @@ rules:
   scope-empty: [1, always]
   # valid types/prefixes, see docs/development-guide.md
   type-enum:
-    - 1
+    - 2
     - always
     - - build
       - cephfs


### PR DESCRIPTION
if the commit header is not present in the list of the component we maintain. the commitlint check should show an error instead of showing the warning.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
