### PR TITLE
ci: mark .commitlintrc.yml as doc-only

### DIFF
--- a/scripts/skip-doc-change.sh
+++ b/scripts/skip-doc-change.sh
@@ -5,7 +5,7 @@ CHANGED_FILES=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
 
 skip=0
 #files to be skipped
-declare -a FILES=(^docs/ .md$ ^scripts/ LICENSE .mergify.yml .github .gitignore)
+declare -a FILES=(^docs/ .md$ ^scripts/ LICENSE .mergify.yml .github .gitignore .commitlintrc.yml)
 
 function check_file_present() {
     local file=$1


### PR DESCRIPTION
There is no need to run e2e tests for changes to the `.commitlintrc.yml` file.