### PR TITLE
ci: do not require commitlint before merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,7 +25,6 @@ pull_request_rules:
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
       - "status-success=DCO"
-      - "status-success=commitlint"
     actions:
       merge:
         method: rebase
@@ -49,7 +48,6 @@ pull_request_rules:
       - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
       - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
       - "status-success=DCO"
-      - "status-success=commitlint"
     actions:
       merge:
         method: rebase
@@ -187,7 +185,6 @@ pull_request_rules:
       - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
       - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
       - "status-success=DCO"
-      - "status-success=commitlint"
     actions:
       merge:
         method: rebase
@@ -213,7 +210,6 @@ pull_request_rules:
       - "status-success=ci/centos/job-validation"
       - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
-      - "status-success=commitlint"
     actions:
       merge:
         method: rebase
@@ -233,7 +229,6 @@ pull_request_rules:
       - "status-success=ci/centos/job-validation"
       - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
-      - "status-success=commitlint"
     actions:
       merge:
         method: rebase


### PR DESCRIPTION
The GitHub commitlint App does not get triggered for new or updated PRs
since the last days. It is possible to manually start a test in the
CentOS CI for this with `/test commitlint`, but Travis CI already
includes a test (as part of "static-checks") too. There is no need to
run the tests 2x, so remove the status check from the Mergify
configuration.