### PR TITLE
ci: change snapshotter default version to v2.1.1

### DIFF
--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -2,7 +2,7 @@
 
 # This script can be used to install/delete snapshotcontroller and snapshot beta CRD
 
-SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"master"}
+SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v2.1.1"}
 
 SCRIPT_DIR="$(dirname "${0}")"
 


### PR DESCRIPTION
we cannot depend on the master branch of external-snapshotter in cephcsi as the master branch can change anytime. its good to use released tags to our E2E.

fixes: #1416

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

