### PR TITLE
cephfs: Add SINGLE_NODE_WRITER capability to CephFS

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -123,7 +123,7 @@ func (fs *Driver) Run(conf *util.Config) {
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 		})
 
-		fs.cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
+		fs.cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 			csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 		})
 	}


### PR DESCRIPTION
This mode specify a volume can only be published once as read/write
on a single node, at any given time.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

