### PR TITLE
Skip E2E tests if the PR has the 'ci/skip/e2e' label

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -5,6 +5,7 @@ def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
 def ref = "master"
 def git_since = "master"
+def skip_e2e = 0
 def doc_change = 0
 def namespace = 'cephcsi-e2e-' + UUID.randomUUID().toString().split('-')[-1]
 
@@ -19,6 +20,21 @@ node('cico-workspace') {
 		git url: "${ci_git_repo}",
 			branch: "${ci_git_branch}",
 			changelog: false
+	}
+
+	stage('skip ci/skip/e2e label') {
+		if (params.ghprbPullId == null) {
+			skip_e2e = 1
+			return
+		}
+		skip_e2e = sh(
+			script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
+			returnStatus: true)
+	}
+	// if skip_e2e returned 0, do not run full tests
+	if (skip_e2e == 0) {
+		currentBuild.result = 'SUCCESS'
+		return
 	}
 
 	stage('checkout PR') {


### PR DESCRIPTION
# Describe what this PR does #

Add script to fetch labels for GitHub PR: `scripts/get_github_labels.py`
The script runs in a minimal Jenkins Slave container, but Python is available there.

By passing `--id=<id>` the labels of the given Pull-Request or Issue get
printed. When adding `--has-label=<label>`, the script verifies if the
label is set and returns 0 on succes, or 1 on failure.

The label will skip the following jobs:

* mini-e2e-helm
* mini-e2e

## Is there anything that requires special attention ##

The jobs will run, but exit early in case the label is set on the PR. This sets the status-context in the PR as if the job has passed. Mergify will be happy with this.

Note that the jobs will get started in case a PR gets created without the label. Once the label is added, and the CI jobs for the PR are already running, the jobs will need to run to completion. Rebases should not trigger a full run of of the jobss anymore.

## Related issues ##

Fixes: #1427

## Future concerns ##

The `[ci/skip/e2e]` label has been added. Following that approach, it is easy to add more labels that require additional testing, and or skipping of other CI jobs.