### PR TITLE
deploy: remove preStop hook from daemonset templates

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -44,18 +44,6 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/{{ .Values.pluginSocketFile }}"
             - "--kubelet-registration-path={{ .Values.socketDir }}/{{ .Values.pluginSocketFile }}"
-          lifecycle:
-            preStop:
-              exec:
-                {{- /*
-                NOTE(wilmardo): The replace functions ensures there are no spaces in the string.
-                To avoid `rm -rf /registration/driver name`
-                */}}
-                command: [
-                  "/bin/sh", "-c",
-                  "rm -rf /registration/{{ .Values.driverName | replace " " "" }} \
-                  /registration/{{ .Values.driverName | replace " " "" }}-reg.sock"
-                ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -45,18 +45,6 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/{{ .Values.pluginSocketFile }}"
             - "--kubelet-registration-path={{ .Values.socketDir }}/{{ .Values.pluginSocketFile }}"
-          lifecycle:
-            preStop:
-              exec:
-                {{- /*
-                NOTE(wilmardo): The replace functions ensures there are no spaces in the string.
-                To avoid `rm -rf /registration/driver name`
-                */}}
-                command: [
-                  "/bin/sh", "-c",
-                  "rm -rf /registration/{{ .Values.driverName | replace " " "" }} \
-                  /registration/{{ .Values.driverName | replace " " "" }}-reg.sock"
-                ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -29,14 +29,6 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/cephfs.csi.ceph.com/csi.sock"
-          lifecycle:
-            preStop:
-              exec:
-                command: [
-                  "/bin/sh", "-c",
-                  "rm -rf /registration/cephfs.csi.ceph.com \
-                  /registration/cephfs.csi.ceph.com-reg.sock"
-                ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -30,14 +30,6 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/rbd.csi.ceph.com/csi.sock"
-          lifecycle:
-            preStop:
-              exec:
-                command: [
-                  "/bin/sh", "-c",
-                  "rm -rf /registration/rbd.csi.ceph.com \
-                  /registration/rbd.csi.ceph.com-reg.sock"
-                ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:


### PR DESCRIPTION
The lifecycle preStop hook fails on container stop/exit because /bin/sh is not present in the driver registrar container
image. the driver-registrar (v2.0.0)  will remove the socket file before stopping. we don't need to have any preStop hook to remove the socket as it was not working as expected

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

