### PR TITLE
deploy: add missing " for nodes watch verb

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
@@ -52,7 +52,7 @@ rules:
 {{- if .Values.topology.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", watch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
add missing " for nodes watch verb in clusterrole binding

fixes #1433

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

