### PR TITLE
ci: update minikube only when latest is asked

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -50,26 +50,26 @@ function detect_minikube() {
 
 # install minikube
 function install_minikube() {
-    local mku_version latest_version
-    mku_version=$(${minikube} update-check 2> /dev/null | grep "LatestVersion" || true)
-    latest_version=$(echo "${mku_version}" | cut -d' ' -f2)
-    if [[ -z "${latest_version}" ]]; then
-        # skip: update-check failed for some reason, lets continue with what we have
-        latest_version=${MINIKUBE_VERSION}
+    if [[ "${MINIKUBE_VERSION}" == "latest" ]]; then
+        local mku_version
+        mku_version=$(${minikube} update-check 2> /dev/null | grep "LatestVersion" || true)
+        if [[ -n "${mku_version}" ]]; then
+            MINIKUBE_VERSION=$(echo "${mku_version}" | cut -d' ' -f2)
+        fi
     fi
+
     if type "${minikube}" >/dev/null 2>&1; then
         local mk_version version
         read -ra mk_version <<<"$(${minikube} version)"
         version=${mk_version[2]}
-        echo "minikube already installed with ${version}"
-        if [[ "${version}" == "${latest_version}" ]]; then
-            echo "minikube is already the latest version"
+        if [[ "${version}" == "${MINIKUBE_VERSION}" ]]; then
+            echo "minikube already installed with ${version}"
             return
         fi
     fi
 
-    echo "Installing minikube. Version: ${latest_version}"
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${latest_version}"/minikube-linux-"${MINIKUBE_ARCH}" && chmod +x minikube && mv minikube /usr/local/bin/
+    echo "Installing minikube. Version: ${MINIKUBE_VERSION}"
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-"${MINIKUBE_ARCH}" && chmod +x minikube && mv minikube /usr/local/bin/
 }
 
 function detect_kubectl() {


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
Currently minikube is updated as and when a latest version is found, changing this to update minikube only when latest is asked

## Related issues ##
Fixes: #1431

## Is there anything that requires special attention ##
Please note that currently the default MINIKUBE_VERSION in the minikube script is set to 'latest'.
You can simply `export MINIKUBE_VERSION=<current_minikube_version>` if you choose to not update it.

