### PR TITLE
Add CI job for running Kubernetes external-storage e2e tests

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: k8s-e2e-external-storage
+    project-type: pipeline
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-csi
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    parameters:
+      - string:
+          name: k8s_version
+          default: '1.19.2'
+          description: Kubernetes version to deploy in the test cluster.
+    pipeline-scm:
+      scm:
+        - git:
+            name: origin
+            url: https://github.com/ceph/ceph-csi
+            branches:
+              - ci/centos
+      script-path: k8s-e2e-external-storage.groovy
+      lightweight-checkout: true
+    triggers:
+      - github-pull-request:
+          status-context: ci/centos/k8s-e2e-external-storage
+          # yamllint disable-line rule:line-length
+          trigger-phrase: '/(re)?test ci/centos/k8s-e2e-external-storage'
+          only-trigger-phrase: true
+          permit-all: true
+          github-hooks: true
+          black-list-target-branches:
+            - ci/centos
+          org-list:
+            - ceph
+          allow-whitelist-orgs-as-admins: true

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -1,0 +1,132 @@
+def cico_retries = 16
+def cico_retry_interval = 60
+def ci_git_repo = 'https://github.com/ceph/ceph-csi'
+def ci_git_branch = 'ci/centos'
+def git_repo = 'https://github.com/ceph/ceph-csi'
+def ref = "master"
+def git_since = 'master'
+def skip_e2e = 0
+def doc_change = 0
+def k8s_release = 'latest'
+def namespace = 'k8s-e2e-storage-' + UUID.randomUUID().toString().split('-')[-1]
+
+def ssh(cmd) {
+	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
+}
+
+node('cico-workspace') {
+	stage('checkout ci repository') {
+		git url: "${ci_git_repo}",
+			branch: "${ci_git_branch}",
+			changelog: false
+	}
+
+	// "github-api-token" is a secret text credential configured in Jenkins
+	withCredentials([string(credentialsId: 'github-api-token', variable: 'GITHUB_API_TOKEN')]) {
+		stage('skip ci/skip/e2e label') {
+			if (params.ghprbPullId == null) {
+				skip_e2e = 1
+				return
+			}
+
+			skip_e2e = sh(
+				script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
+				returnStatus: true)
+		}
+
+		stage("detect k8s-${k8s_version} patch release") {
+			k8s_release = sh(
+				script: "./scripts/get_patch_release.py --version=${k8s_version}",
+				returnStdout: true).trim()
+			echo "detected Kubernetes patch release: ${k8s_release}"
+		}
+	}
+
+	// if skip_e2e returned 0, do not run full tests
+	if (skip_e2e == 0) {
+		currentBuild.result = 'SUCCESS'
+		return
+	}
+
+	stage('checkout PR') {
+		if (params.ghprbPullId != null) {
+			ref = "pull/${ghprbPullId}/head"
+		}
+		if (params.ghprbTargetBranch != null) {
+			git_since = "${ghprbTargetBranch}"
+		}
+
+		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
+		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+	}
+
+	stage('check doc-only change') {
+		doc_change = sh(
+			script: "cd ~/build/ceph-csi && \${OLDPWD}/scripts/skip-doc-change.sh origin/${git_since}",
+			returnStatus: true)
+	}
+	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
+	if (doc_change == 1) {
+		currentBuild.result = 'SUCCESS'
+		return
+	}
+
+	stage('reserve bare-metal machine') {
+		def firstAttempt = true
+		retry(30) {
+			if (!firstAttempt) {
+				sleep(time: 5, unit: "MINUTES")
+			}
+			firstAttempt = false
+			cico = sh(
+				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				returnStdout: true
+			).trim().tokenize(' ')
+			env.CICO_NODE = "${cico[0]}.ci.centos.org"
+			env.CICO_SSID = "${cico[1]}"
+		}
+	}
+
+	try {
+		stage('prepare bare-metal machine') {
+			if (params.ghprbPullId != null) {
+				ref = "pull/${ghprbPullId}/head"
+			}
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
+			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
+		}
+		stage('build artifacts') {
+			// build container image
+			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make image-cephcsi GOARCH=amd64 CONTAINER_CMD=podman'
+		}
+		stage("deploy k8s-${k8s_version} and rook") {
+			timeout(time: 30, unit: 'MINUTES') {
+				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
+			}
+		}
+		stage('deploy ceph-csi through helm') {
+			timeout(time: 30, unit: 'MINUTES') {
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh up'
+				ssh "kubectl create namespace '${namespace}'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh install-cephcsi '${namespace}'"
+			}
+		}
+		stage("create ConfigMap & StorageClasses") {
+			timeout(time: 5, unit: 'MINUTES') {
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi/scripts/k8s-storage/ && ./create-configmap.sh '${namespace}'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi/scripts/k8s-storage/ && ./create-storageclasses.sh '${namespace}'"
+			}
+		}
+		stage('run e2e') {
+			timeout(time: 120, unit: 'MINUTES') {
+				ssh "KUBE_VERSION=${k8s_release} ./run-k8s-external-storage-e2e.sh"
+			}
+		}
+	}
+
+	finally {
+		stage('return bare-metal machine') {
+			sh 'cico node done ${CICO_SSID}'
+		}
+	}
+}

--- a/run-k8s-external-storage-e2e.sh
+++ b/run-k8s-external-storage-e2e.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Download the Kubernetes test suite, extract it and run the external-storage suite.
+#
+# Requirements:
+# - KUBE_VERSION needs to be set in the environment (format: "v1.18.5")
+
+# exit on failure
+set -e
+
+[ -n "${KUBE_VERSION}" ] || { echo "KUBE_VERSION not set" ; exit 1 ; }
+
+# download and extract the tests
+curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-test-linux-amd64.tar.gz"
+tar xzf kubernetes-test-linux-amd64.tar.gz kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
+
+for driver in /opt/build/go/src/github.com/ceph/ceph-csi/scripts/k8s-storage/driver-*.yaml
+do
+	kubernetes/test/bin/ginkgo \
+		-focus="External.Storage.*.csi.ceph.com" \
+		-skip='\[Feature:|\[Disruptive\]' \
+		kubernetes/test/bin/e2e.test \
+		-- \
+		-storage.testdriver="${driver}"
+done


### PR DESCRIPTION
This adds a CI job for running the Kubernetes external-storage e2e tests against a PR. The job can be triggered with `/test ci/centos/k8s-e2e-external-storage`. There will be an attempt to test RBD and CephFS, of which RBD is expected to succeed, whereas CephFS seems to have some failure (probably in the driver configuration, _**TO BE TESTED**_).

This PR alone is not sufficient to run the tests, see #1526 for the additions in the master branch.

Merging this PR should not affect any other testing, the job is not started for all PRs, only when requested with a comment.