### PR TITLE
deploy: update sidecar image repository from `quay.io/k8scsi` to `k8s.gcr.io/sig-storage`

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -67,7 +67,7 @@ nodeplugin:
 
   registrar:
     image:
-      repository: quay.io/k8scsi/csi-node-driver-registrar
+      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
       tag: v1.3.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -133,7 +133,7 @@ provisioner:
 
   provisioner:
     image:
-      repository: quay.io/k8scsi/csi-provisioner
+      repository: k8s.gcr.io/sig-storage/csi-provisioner
       tag: v1.6.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -142,8 +142,8 @@ provisioner:
     name: attacher
     enabled: true
     image:
-      repository: quay.io/k8scsi/csi-attacher
-      tag: v2.1.1
+      repository: k8s.gcr.io/sig-storage/csi-attacher
+      tag: v2.2.0
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -151,14 +151,14 @@ provisioner:
     name: resizer
     enabled: true
     image:
-      repository: quay.io/k8scsi/csi-resizer
+      repository: k8s.gcr.io/sig-storage/csi-resizer
       tag: v0.5.0
       pullPolicy: IfNotPresent
     resources: {}
 
   snapshotter:
     image:
-      repository: quay.io/k8scsi/csi-snapshotter
+      repository: k8s.gcr.io/sig-storage/csi-snapshotter
       tag: v2.1.1
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -79,7 +79,7 @@ nodeplugin:
 
   registrar:
     image:
-      repository: quay.io/k8scsi/csi-node-driver-registrar
+      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
       tag: v1.3.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -152,7 +152,7 @@ provisioner:
 
   provisioner:
     image:
-      repository: quay.io/k8scsi/csi-provisioner
+      repository: k8s.gcr.io/sig-storage/csi-provisioner
       tag: v1.6.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -161,8 +161,8 @@ provisioner:
     name: attacher
     enabled: true
     image:
-      repository: quay.io/k8scsi/csi-attacher
-      tag: v2.1.1
+      repository: k8s.gcr.io/sig-storage/csi-attacher
+      tag: v2.2.0
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -170,14 +170,14 @@ provisioner:
     name: resizer
     enabled: true
     image:
-      repository: quay.io/k8scsi/csi-resizer
+      repository: k8s.gcr.io/sig-storage/csi-resizer
       tag: v0.5.0
       pullPolicy: IfNotPresent
     resources: {}
 
   snapshotter:
     image:
-      repository: quay.io/k8scsi/csi-snapshotter
+      repository: k8s.gcr.io/sig-storage/csi-snapshotter
       tag: v2.1.0
       pullPolicy: IfNotPresent
     resources: {}

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -90,7 +90,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccount: cephfs-csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -59,7 +59,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -74,7 +74,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -90,7 +90,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-attacher:v2.1.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -24,7 +24,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccount: rbd-csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -59,7 +59,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -75,7 +75,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-attacher:v2.1.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -89,7 +89,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -75,7 +75,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -25,7 +25,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -53,7 +53,7 @@ following environment variables can be exported to customize kubernetes deployme
 | MEMORY               | Amount of RAM allocated to the minikube VM in MB | 4096                                                               |
 | VM_DRIVER            | VM driver to create virtual machine              | virtualbox                                                         |
 | CEPHCSI_IMAGE_REPO   | Repo URL to pull cephcsi images                  | quay.io/cephcsi                                                    |
-| K8S_IMAGE_REPO       | Repo URL to pull kubernetes sidecar images       | quay.io/k8scsi                                                     |
+| K8S_IMAGE_REPO       | Repo URL to pull kubernetes sidecar images       | k8s.gcr.io/sig-storage                                             |
 | K8S_FEATURE_GATES    | Feature gates to enable on kubernetes cluster    | BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true |
 | ROOK_BLOCK_POOL_NAME | Block pool name to create in the rook instance   | newrbdpool                                                         |
 

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -275,7 +275,7 @@ cephcsi)
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1 "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v1.2.2
+    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v2.1.1 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v2.1.1
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.3.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.3.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-resizer:v0.5.0 "${K8S_IMAGE_REPO}"/csi-resizer:v0.5.0

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -274,7 +274,7 @@ cephcsi)
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"
-    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1 "${K8S_IMAGE_REPO}"/csi-attacher:v2.1.1
+    copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-attacher:v2.2.0 "${K8S_IMAGE_REPO}"/csi-attacher:v2.2.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-snapshotter:v2.1.1 $"${K8S_IMAGE_REPO}"/csi-snapshotter:v2.1.1
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0 "${K8S_IMAGE_REPO}"/csi-provisioner:v1.4.0
     copy_image_to_cluster "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.3.0 "${K8S_IMAGE_REPO}"/csi-node-driver-registrar:v1.3.0

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -164,7 +164,7 @@ CPUS=${CPUS:-"$(nproc)"}
 VM_DRIVER=${VM_DRIVER:-"virtualbox"}
 #configure image repo
 CEPHCSI_IMAGE_REPO=${CEPHCSI_IMAGE_REPO:-"quay.io/cephcsi"}
-K8S_IMAGE_REPO=${K8S_IMAGE_REPO:-"quay.io/k8scsi"}
+K8S_IMAGE_REPO=${K8S_IMAGE_REPO:-"k8s.gcr.io/sig-storage"}
 DISK="sda1"
 if [[ "${VM_DRIVER}" == "kvm2" ]]; then
     # use vda1 instead of sda1 when running with the libvirt driver


### PR DESCRIPTION
Update sidecar image repository and tag
   
The image repository has been migrated to k8s.gcr.io/sig-storage from
quay.io/k8scsi.
 
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
