### PR TITLE
ci: add a way to supply CONTAINER_CMD of choice

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -97,13 +97,14 @@ function install_kubectl() {
 }
 
 function validate_container_cmd() {
-    if [[ "${CONTAINER_CMD}" == "docker" ]] || [[ "${CONTAINER_CMD}" == "podman" ]]; then
-        if ! command -v "${CONTAINER_CMD}" &> /dev/null; then
-            echo "'${CONTAINER_CMD}' not found"
+    local cmd="${CONTAINER_CMD##* }"
+    if [[ "${cmd}" == "docker" ]] || [[ "${cmd}" == "podman" ]]; then
+        if ! command -v "${cmd}" &> /dev/null; then
+            echo "'${cmd}' not found"
             exit 1
         fi
     else
-        echo "'CONTAINER_CMD' should be either docker or podman and not '${CONTAINER_CMD}'"
+        echo "'CONTAINER_CMD' should be either docker or podman and not '${cmd}'"
         exit 1
     fi
 }

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -18,14 +18,15 @@ function wait_for_ssh() {
 function copy_image_to_cluster() {
     local build_image=$1
     local final_image=$2
-    if [ -z "$(docker images -q "${build_image}")" ]; then
-        docker pull "${build_image}"
+    validate_container_cmd
+    if [ -z "$(${CONTAINER_CMD} images -q "${build_image}")" ]; then
+        ${CONTAINER_CMD} pull "${build_image}"
     fi
     if [[ "${VM_DRIVER}" == "none" ]]; then
-        docker tag "${build_image}" "${final_image}"
+        ${CONTAINER_CMD} tag "${build_image}" "${final_image}"
         return
     fi
-    docker save "${build_image}" | (eval "$(${minikube} docker-env --shell bash)" && docker load && docker tag "${build_image}" "${final_image}")
+    ${CONTAINER_CMD} save "${build_image}" | (eval "$(${minikube} docker-env --shell bash)" && docker load && docker tag "${build_image}" "${final_image}")
 }
 
 # parse the minikube version, return the digit passed as argument
@@ -95,6 +96,18 @@ function install_kubectl() {
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBE_VERSION}"/bin/linux/"${MINIKUBE_ARCH}"/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
 }
 
+function validate_container_cmd() {
+    if [[ "${CONTAINER_CMD}" == "docker" ]] || [[ "${CONTAINER_CMD}" == "podman" ]]; then
+        if ! command -v "${CONTAINER_CMD}" &> /dev/null; then
+            echo "'${CONTAINER_CMD}' not found"
+            exit 1
+        fi
+    else
+        echo "'CONTAINER_CMD' should be either docker or podman and not '${CONTAINER_CMD}'"
+        exit 1
+    fi
+}
+
 function enable_psp() {
     echo "prepare minikube to support pod security policies"
     mkdir -p "$HOME"/.minikube/files/etc/kubernetes/addons
@@ -138,6 +151,7 @@ function minikube_supports_psp() {
 MINIKUBE_ARCH=${MINIKUBE_ARCH:-"amd64"}
 MINIKUBE_VERSION=${MINIKUBE_VERSION:-"latest"}
 KUBE_VERSION=${KUBE_VERSION:-"latest"}
+CONTAINER_CMD=${CONTAINER_CMD:-"docker"}
 MEMORY=${MEMORY:-"4096"}
 CPUS=${CPUS:-"$(nproc)"}
 VM_DRIVER=${VM_DRIVER:-"virtualbox"}


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
Add a way to supply local CONTAINER_CMD option of choice via
env variable to minikube.sh

## Is there anything that requires special attention ##

Note: we still use docker daemon env at minikube box, in the future
we can switch to podman service env '# minikube podman-env' if needed

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>




