### PR TITLE
ci: update kubernetes version in e2e job

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,8 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.17.8'
       - '1.18.5'
+      - '1.19.0'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
removed 1.17 as we are testing only two versions in centos CI. as v1.19 is released, we will be testing v1.18 and v1.19 in CI.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

