### PR TITLE
cephfs: Add support for snapshot retention

### DIFF
--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -269,3 +269,16 @@ func purgeVolume(ctx context.Context, volID volumeID, cr *util.Credentials, volO
 
 	return nil
 }
+
+// checkSubvolumeHasFeature verifies if the referred subvolume has
+// the required feature.
+func checkSubvolumeHasFeature(feature string, subVolFeatures []string) bool {
+	// The subvolume "features" are based on the internal version of the subvolume.
+	// Verify if subvolume supports the required feature.
+	for _, subvolFeature := range subVolFeatures {
+		if subvolFeature == feature {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Snapshots can be retained even after subvolume deletion in
Ceph v14.2.12.
Add `--retain-snapshots` flag to purge volume operations
for retaining snapshots.

Updates: https://github.com/ceph/ceph-csi/issues/1338