### PR TITLE
fix: Stale bot configuration changes

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -23,7 +23,7 @@ limitPerRun: 5
 
 # Specify configuration settings that are specific to issues
 issues:
-  daysUntilStale: 60
+  daysUntilStale: 90
   daysUntilClose: 7
   markComment: >
     This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION


# Describe what this PR does #

As I mention on slack channel. I check configuration of stale probot and add global stale and close period because it seems that actual version of probot needs to have this addressed in stale.yml file. And also rename it from stale.yaml to stale.yml.


