### PR TITLE
cephfs: add support for "snapshot-autoprotect" feature

### DIFF
--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -25,6 +25,10 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 )
 
+// autoProtect points to the snapshot auto-protect feature of
+// the subvolume.
+const autoProtect = "snapshot-autoprotect"
+
 // cephfsSnapshot represents a CSI snapshot and its cluster information.
 type cephfsSnapshot struct {
 	NamePrefix string
@@ -137,6 +141,11 @@ func getSnapshotInfo(ctx context.Context, volOptions *volumeOptions, cr *util.Cr
 }
 
 func protectSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, snapID, volID volumeID) error {
+	// If "snapshot-autoprotect" feature is present, The ProtectSnapshot
+	// call should be treated as a no-op.
+	if checkSubvolumeHasFeature(autoProtect, volOptions.Features) {
+		return nil
+	}
 	args := []string{
 		"fs",
 		"subvolume",

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -27,7 +27,9 @@ import (
 
 // autoProtect points to the snapshot auto-protect feature of
 // the subvolume.
-const autoProtect = "snapshot-autoprotect"
+const (
+	autoProtect = "snapshot-autoprotect"
+)
 
 // cephfsSnapshot represents a CSI snapshot and its cluster information.
 type cephfsSnapshot struct {
@@ -177,6 +179,11 @@ func protectSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Cr
 }
 
 func unprotectSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, snapID, volID volumeID) error {
+	// If "snapshot-autoprotect" feature is present, The UnprotectSnapshot
+	// call should be treated as a no-op.
+	if checkSubvolumeHasFeature(autoProtect, volOptions.Features) {
+		return nil
+	}
 	args := []string{
 		"fs",
 		"subvolume",

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -475,6 +475,12 @@ func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Crede
 	sid.FsSnapshotName = imageAttributes.ImageName
 	sid.FsSubvolName = imageAttributes.SourceName
 
+	subvolInfo, err := getSubVolumeInfo(ctx, &volOptions, cr, volumeID(sid.FsSubvolName))
+	if err != nil {
+		return &volOptions, nil, &sid, err
+	}
+	volOptions.Features = subvolInfo.Features
+
 	info, err := getSnapshotInfo(ctx, &volOptions, cr, volumeID(sid.FsSnapshotName), volumeID(sid.FsSubvolName))
 	if err != nil {
 		return &volOptions, nil, &sid, err


### PR DESCRIPTION
Subvolume snapshots required to be protected, prior to
cloning the same. Ceph v14.2.12 brought in the feature
of "snapshot-autoprotect".
Adding support for the same in ceph-csi.

Signed-off-by: Yug Gupta <yuggupta27@gmail.com>

Fixes: #1338 