### PR TITLE
ci: update mergify rules for e2e tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,10 +43,10 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
-      - "status-success=ci/centos/mini-e2e-helm/k8s-1.17.8"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19.0"
       - "status-success=ci/centos/mini-e2e-helm/k8s-1.18.5"
-      - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
-      - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
+      - "status-success=ci/centos/mini-e2e/k8s-1.19.0"
+      - "status-success=ci/centos/mini-e2e/k8s-1.18.5"
       - "status-success=DCO"
     actions:
       merge:
@@ -180,10 +180,10 @@ pull_request_rules:
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
-      - "status-success=ci/centos/mini-e2e-helm/k8s-1.17.8"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19.0"
       - "status-success=ci/centos/mini-e2e-helm/k8s-1.18.5"
-      - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
-      - "status-success=ci/centos/mini-e2e/k8s-1.17.8"
+      - "status-success=ci/centos/mini-e2e/k8s-1.19.0"
+      - "status-success=ci/centos/mini-e2e/k8s-1.18.5"
       - "status-success=DCO"
     actions:
       merge:


### PR DESCRIPTION
as we have added v1.19.0 in CI for E2E tests and also removed the v1.17.x from CI updating the mergify rules for the same.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

