### PR TITLE
Pass major k8s version to jobs, detect patch release

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,8 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.18.5'
-      - '1.19.0'
+      - '1.18'
+      - '1.19'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -7,6 +7,7 @@ def ref = "master"
 def git_since = 'master'
 def skip_e2e = 0
 def doc_change = 0
+def k8s_release = 'latest'
 
 def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
@@ -32,6 +33,13 @@ node('cico-workspace') {
 	if (skip_e2e == 0) {
 		currentBuild.result = 'SUCCESS'
 		return
+	}
+
+	stage("detect k8s-${k8s_version} patch release") {
+		k8s_release = sh(
+			script: "./scripts/get_patch_release.py --version=${k8s_version}",
+			returnStdout: true).trim()
+		echo "detected Kubernetes patch release: ${k8s_release}"
 	}
 
 	stage('checkout PR') {
@@ -87,9 +95,9 @@ node('cico-workspace') {
 			// build e2e.test executable
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
 		}
-		stage("deploy k8s v${k8s_version} and rook") {
+		stage("deploy k8s-${k8s_version} and rook") {
 			timeout(time: 30, unit: 'MINUTES') {
-				ssh "./single-node-k8s.sh --k8s-version=v${k8s_version}"
+				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
 		}
 		stage('run e2e') {

--- a/scripts/get_patch_release.py
+++ b/scripts/get_patch_release.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+'''
+Fetches the Kubernetes releases from GitHub and returns the most recent patch
+release for a major version.
+
+Parameters:
+ --version=<version>: the major version to find the latest patch release for, i.e. v1.19
+'''
+
+import argparse
+import sys
+import requests
+
+RELEASE_URL = 'https://api.github.com/repos/kubernetes/kubernetes/releases'
+'''
+URL for fetching the releases. Add '?per_num=50' to increase the number of
+returned releases from default 30 to 50 (max 100).
+'''
+
+
+def get_json_releases():
+    '''
+    Fetch the releases from GitHub, return the full JSON structures that were
+    obtained.
+    '''
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    res = requests.get(RELEASE_URL, headers=headers)
+    return res.json()
+
+
+def get_releases(gh_releases):
+    '''
+    Take the JSON formatted releases, and return a list of the name for each label.
+    '''
+    releases = list()
+    for release in gh_releases:
+        releases.append(release['name'])
+    return releases
+
+
+def main():
+    '''
+    main() function to parse arguments and run the actions.
+    '''
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', help='major version to find patch release for')
+    args = parser.parse_args()
+
+    # get all the releases
+    json = get_json_releases()
+    releases = get_releases(json)
+
+    # in case --version is passed, exit with 0 or 1
+    if args.version:
+        version = args.version
+        if not version.startswith('v'):
+            version = 'v' + version
+
+        # releases are ordered from newest to oldest, so the 1st match is the
+        # most current patch update
+        for release in releases:
+            if release.startswith(version + '.'):
+                print(release)
+                sys.exit(0)
+
+        # no match, exit with an error
+        sys.exit(1)
+    # --version was not passed, list all releases
+    else:
+        for release in releases:
+            print(release)
+
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adding a script to detect latest Kubernetes patch release, so jobs can
now pass the wanted Kubernetes major version (like '1.19') to the
Jenkins Pipelines. The Pipelines detect the most recent patch release
for the major version with the new get_patch_release.py script.

This causes the CI Job status context to not have the patch number (last
digit of the release) included anymore. Restarting a test will only need
the major version number, as does updating the Mergify configuration.
