### PR TITLE
ci: drop Kubernetes patch version from conditions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,10 +43,10 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
-      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19.0"
-      - "status-success=ci/centos/mini-e2e-helm/k8s-1.18.5"
-      - "status-success=ci/centos/mini-e2e/k8s-1.19.0"
-      - "status-success=ci/centos/mini-e2e/k8s-1.18.5"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.18"
+      - "status-success=ci/centos/mini-e2e/k8s-1.19"
+      - "status-success=ci/centos/mini-e2e/k8s-1.18"
       - "status-success=DCO"
     actions:
       merge:
@@ -180,10 +180,10 @@ pull_request_rules:
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
-      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19.0"
-      - "status-success=ci/centos/mini-e2e-helm/k8s-1.18.5"
-      - "status-success=ci/centos/mini-e2e/k8s-1.19.0"
-      - "status-success=ci/centos/mini-e2e/k8s-1.18.5"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.18"
+      - "status-success=ci/centos/mini-e2e/k8s-1.19"
+      - "status-success=ci/centos/mini-e2e/k8s-1.18"
       - "status-success=DCO"
     actions:
       merge:


### PR DESCRIPTION
With the improvements from #1480 there is no need to specify the full
Kubernetes versions anymore, the major version is sufficient now.

See-also: #1480 (needs to be merged before this PR)