### PR TITLE
cephfs: check ENOTEMPTY when removing subvolume

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -343,7 +343,10 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 
 	if err = purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions, false); err != nil {
 		util.ErrorLog(ctx, "failed to delete volume %s: %v", volID, err)
-		// All errors other than ErrVolumeNotFound should return an error back to the caller
+		if errors.Is(err, ErrVolumeHasSnapshots) {
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		}
+
 		if !errors.Is(err, ErrVolumeNotFound) {
 			return nil, status.Error(codes.Internal, err.Error())
 		}

--- a/internal/cephfs/errors.go
+++ b/internal/cephfs/errors.go
@@ -31,6 +31,8 @@ const (
 	snapNotFound = "Error ENOENT"
 	// snapProtectionExist is returned when the snapshot is already protected
 	snapProtectionExist = "Error EEXIST"
+	// volumeNotEmpty is returned when the volume is not empty.
+	volumeNotEmpty = "Error ENOTEMPTY"
 )
 
 var (
@@ -56,4 +58,7 @@ var (
 
 	// ErrInvalidCommand is returned when a command is not known to the cluster
 	ErrInvalidCommand = errors.New("invalid command")
+
+	// ErrVolumeHasSnapshots is returned when a subvolume has snapshots.
+	ErrVolumeHasSnapshots = errors.New("volume has snapshots")
 )

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -261,6 +261,9 @@ func purgeVolume(ctx context.Context, volID volumeID, cr *util.Credentials, volO
 	err := execCommandErr(ctx, "ceph", arg...)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to purge subvolume %s(%s) in fs %s", string(volID), err, volOptions.FsName)
+		if strings.Contains(err.Error(), volumeNotEmpty) {
+			return util.JoinErrors(ErrVolumeHasSnapshots, err)
+		}
 		if strings.Contains(err.Error(), volumeNotFound) {
 			return util.JoinErrors(ErrVolumeNotFound, err)
 		}


### PR DESCRIPTION
return a proper error message to the user when the subvolume has the snapshots and it cannot be removed until the snapshots on the subvolume have to be deleted.

fixes #1491
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

