### PR TITLE
cephfs: trim spaces around fuseMountOptions

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -234,6 +234,43 @@ var _ = Describe("cephfs", func() {
 				}
 			})
 
+			By("create a storageclass with ceph-fuse and a PVC then bind it to an app", func() {
+				params := map[string]string{
+					"mounter": "fuse",
+				}
+				err := createCephfsStorageClass(f.ClientSet, f, true, params)
+				if err != nil {
+					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
+				}
+				err = validatePVCAndAppBinding(pvcPath, appPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+				}
+				err = deleteResource(cephfsExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+				}
+			})
+
+			By("create a storageclass with ceph-fuse, mount-options and a PVC then bind it to an app", func() {
+				params := map[string]string{
+					"mounter":          "fuse",
+					"fuseMountOptions": "debug",
+				}
+				err := createCephfsStorageClass(f.ClientSet, f, true, params)
+				if err != nil {
+					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
+				}
+				err = validatePVCAndAppBinding(pvcPath, appPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+				}
+				err = deleteResource(cephfsExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+				}
+			})
+
 			By("create a PVC and bind it to an app", func() {
 				err := createCephfsStorageClass(f.ClientSet, f, false, nil)
 				if err != nil {

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -220,7 +220,7 @@ var _ = Describe("cephfs", func() {
 			})
 
 			By("create a storageclass with pool and a PVC then bind it to an app", func() {
-				err := createCephfsStorageClass(f.ClientSet, f, true, "")
+				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
 				if err != nil {
 					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
 				}
@@ -235,7 +235,7 @@ var _ = Describe("cephfs", func() {
 			})
 
 			By("create a PVC and bind it to an app", func() {
-				err := createCephfsStorageClass(f.ClientSet, f, false, "")
+				err := createCephfsStorageClass(f.ClientSet, f, false, nil)
 				if err != nil {
 					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
 				}
@@ -332,7 +332,10 @@ var _ = Describe("cephfs", func() {
 				if err != nil {
 					e2elog.Failf("failed to create configmap with error %v", err)
 				}
-				err = createCephfsStorageClass(f.ClientSet, f, false, "clusterID-1")
+				params := map[string]string{
+					"clusterID": "clusterID-1",
+				}
+				err = createCephfsStorageClass(f.ClientSet, f, false, params)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -352,7 +355,8 @@ var _ = Describe("cephfs", func() {
 
 				// create resources and verify subvolume group creation
 				// for the second cluster.
-				err = createCephfsStorageClass(f.ClientSet, f, false, "clusterID-2")
+				params["clusterID"] = "clusterID-2"
+				err = createCephfsStorageClass(f.ClientSet, f, false, params)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -376,7 +380,7 @@ var _ = Describe("cephfs", func() {
 				if err != nil {
 					e2elog.Failf("failed to create configmap with error %v", err)
 				}
-				err = createCephfsStorageClass(f.ClientSet, f, false, "")
+				err = createCephfsStorageClass(f.ClientSet, f, false, nil)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -55,7 +55,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to create secret with error %v", err)
 		}
-		err = createCephfsStorageClass(f.ClientSet, f, true, "")
+		err = createCephfsStorageClass(f.ClientSet, f, true, nil)
 		if err != nil {
 			e2elog.Failf("failed to create storageclass with error %v", err)
 		}

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -154,12 +154,13 @@ func mountFuse(ctx context.Context, mountPoint string, cr *util.Credentials, vol
 		"-c", util.CephConfigPath,
 		"-n", cephEntityClientPrefix + cr.ID, "--keyfile=" + cr.KeyFile,
 		"-r", volOptions.RootPath,
-		"-o", "nonempty",
 	}
 
+	fmo := "nonempty"
 	if volOptions.FuseMountOptions != "" {
-		args = append(args, ","+volOptions.FuseMountOptions)
+		fmo += "," + strings.TrimSpace(volOptions.FuseMountOptions)
 	}
+	args = append(args, "-o", fmo)
 
 	if volOptions.FsName != "" {
 		args = append(args, "--client_mds_namespace="+volOptions.FsName)


### PR DESCRIPTION
When passing

    fuseMountOptions: debug

in the StorageClass, the mount options passed on the ceph-fuse
commandline result in "-o nonempty ,debug". The additional space before
the ",debug" causes the mount command to fail.

Fixes: #1485