### PR TITLE
ci: remove unused parameters section

### DIFF
--- a/deploy/jjb.sh
+++ b/deploy/jjb.sh
@@ -40,6 +40,7 @@ cd "$(dirname "${0}")"
 # unique ID for the session
 SESSION=$(uuidgen)
 
+oc process -f "jjb-${CMD}.yaml" -p=SESSION="${SESSION}" -p=GIT_REF="${GIT_REF}"
 oc process -f "jjb-${CMD}.yaml" -p=SESSION="${SESSION}" -p=GIT_REF="${GIT_REF}" | oc create -f -
 
 # loop until pod is available

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -9,7 +9,6 @@
       - build-discarder:
           days-to-keep: 7
           artifact-days-to-keep: 7
-    parameters:
     dsl: |
       def GIT_REPO = 'https://github.com/ceph/ceph-csi'
       def GIT_BRANCH = 'ci/centos'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -23,14 +23,14 @@
     test_type: '<unset>'
     # generated parameters for the job (used in the groovy script)
     parameters:
-      - name: k8s_version
-        type: string
-        default: '{k8s_version}'
-        description: Kubernetes version to deploy in the test cluster.
-      - name: test_type
-        type: string
-        default: '{test_type}'
-        description: Mentions whether upgrade tests run for rbd/cephfs.
+      - string:
+          name: k8s_version
+          default: '{k8s_version}'
+          description: Kubernetes version to deploy in the test cluster.
+      - string:
+          name: test_type
+          default: '{test_type}'
+          description: Mentions whether upgrade tests run for rbd/cephfs.
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
The incomplete 'parameters:' section causes validation and deploy
issues for jobs.
