### PR TITLE
ci: Add an escape character before UPGRADE_VERSION

### DIFF
--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -106,7 +106,7 @@ node('cico-workspace') {
 				if ("${test_type}" == "cephfs"){
 					upgrade_args = "--test-cephfs=true --test-rbd=false --upgrade-testing=true"
 				}
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && source build.env && scripts/travis-functest.sh ${k8s_release} --upgrade-version=${UPGRADE_VERSION} ${upgrade_args}"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && source build.env && scripts/travis-functest.sh ${k8s_release} --upgrade-version=\${UPGRADE_VERSION} ${upgrade_args}"
 			}
 		}
 	}


### PR DESCRIPTION
Since UPGRADE_VERSION is not a groovy variable, adding an
escape character is required for the proper execution of
upgrade-testing job.

See: https://github.com/ceph/ceph-csi/pull/1464

Signed-off-by: Yug <yuggupta27@gmail.com>
