### PR TITLE
ci: update upgrade tests job

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -5,6 +5,7 @@
     test_type:
       - 'cephfs'
       - 'rbd'
+    csi_upgrade_version: 'v3.1.0'
     jobs:
       - 'upgrade-tests-{test_type}'
 
@@ -21,6 +22,7 @@
     # default variables
     k8s_version: '<unset>'
     test_type: '<unset>'
+    csi_upgrade_version: '<unset>'
     # generated parameters for the job (used in the groovy script)
     parameters:
       - string:
@@ -31,6 +33,10 @@
           name: test_type
           default: '{test_type}'
           description: Mentions whether upgrade tests run for rbd/cephfs.
+      - string:
+          name: csi_upgrade_version
+          default: '{csi_upgrade_version}'
+          description: Ceph CSI base version to be used before upgrade.
     pipeline-scm:
       scm:
         - git:

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -106,7 +106,7 @@ node('cico-workspace') {
 				if ("${test_type}" == "cephfs"){
 					upgrade_args = "--test-cephfs=true --test-rbd=false --upgrade-testing=true"
 				}
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && source build.env && scripts/travis-functest.sh ${k8s_release} --upgrade-version=\${UPGRADE_VERSION} ${upgrade_args}"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS=\"--upgrade-version=${csi_upgrade_version} ${upgrade_args}\""
 			}
 		}
 	}


### PR DESCRIPTION
Instead of accessing the upgrade version from the environment
variable, set the variable directly in the configuration file.
Also, use 'make run-e2e' to run the functional tests.

Signed-off-by: Yug <yuggupta27@gmail.com>