### PR TITLE
ci: Add --allowerasing flag to avoid ci failure

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -85,6 +85,7 @@ function install_docker()
 
 function install_minikube()
 {
+    dnf update -y
     dnf -y groupinstall 'Virtualization Host'
     systemctl enable --now libvirtd
     # Warning about "No ACPI IVRS table found", not critical

--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -79,7 +79,7 @@ function set_env() {
 function install_docker()
 {
     curl https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo
-    dnf -y --nobest install docker-ce
+    dnf -y --nobest install docker-ce --allowerasing
     systemctl enable --now docker
 }
 


### PR DESCRIPTION
The ci seems to be failing with package installation
failures. Validating if adding '--allowerasing' flag
resolves the issue.

Signed-off-by: Yug <yuggupta27@gmail.com>