### PR TITLE
ci: trigger upgrade tests job only on phrase

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -53,6 +53,7 @@
           trigger-phrase: '/(re)?test ((all)|(ci/centos/upgrade-tests(-{test_type})?))'
           permit-all: true
           github-hooks: true
+          only-trigger-phrase: true
           black-list-target-branches:
             - ci/centos
           org-list:


### PR DESCRIPTION
To avoid runs of upgrade tests on all PRs till
the job is stable, trigger it only through
phrase.

Signed-off-by: Yug <yuggupta27@gmail.com>
