### PR TITLE
ci: correct indentation on mini-e2e-helm

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -119,7 +119,8 @@ node('cico-workspace') {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh cleanup-cephcsi '${namespace}'"
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh clean'
-				ssh "kubectl delete namespace '${namespace}'"			}
+				ssh "kubectl delete namespace '${namespace}'"
+			}
 		}
 	}
 


### PR DESCRIPTION
The trailing '}' needs to be one the next line.

Signed-off-by: Yug <yuggupta27@gmail.com>