### PR TITLE
ci: do not assume Docker is availble on the minikube host

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -26,7 +26,13 @@ function copy_image_to_cluster() {
         ${CONTAINER_CMD} tag "${build_image}" "${final_image}"
         return
     fi
-    ${CONTAINER_CMD} save "${build_image}" | (eval "$(${minikube} docker-env --shell bash)" && docker load && docker tag "${build_image}" "${final_image}")
+
+    # "minikube ssh" fails to read the image, so use standard ssh instead
+    ${CONTAINER_CMD} save "${build_image}" | \
+        ssh \
+            -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+            -i "$(${minikube} ssh-key)" -l docker \
+            "$(${minikube} ip)" docker image load
 }
 
 # parse the minikube version, return the digit passed as argument


### PR DESCRIPTION
Instead of using the Docker command to push the image to to minikube VM,
read the image from stdin over ssh and load it with the Docker command
that is available inside the VM.

See-also: #1515
