### PR TITLE
ci: run minikube.sh with podman

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -70,6 +70,8 @@ function set_env() {
     # downloading rook images is sometimes slow, extend timeout to 15 minutes
     export ROOK_VERSION='v1.3.9'
     export ROOK_DEPLOY_TIMEOUT=900
+    # use podman for minikube.sh, Docker is not installed on the host
+    export CONTAINER_CMD='podman'
 
     # script/minikube.sh installs under /usr/local/bin
     export PATH=$PATH:/usr/local/bin


### PR DESCRIPTION
The mini-e2e jobs fail to run `minikube.sh` because if defaults to use Docker. However, on recent CentOS-8 deployments Docker and Podman can not be installed at the same time. Everything should use podman on the host, but the minikube VM can still use Docker.