### PR TITLE
ci: remove old jobs when deploying

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -5,4 +5,4 @@ test:
 	cd $(WORKDIR) && jenkins-jobs test -o $(OUTPUT) jobs
 
 deploy:
-	cd $(WORKDIR) && jenkins-jobs update jobs
+	cd $(WORKDIR) && jenkins-jobs update --delete-old jobs


### PR DESCRIPTION
Old jobs stay behind (and active) when jobs get updated with new
versions. This mostly affects the mini-e2e jobs at the moment.

There is no need to keep old job around, so delete them while deploying
updates to jobs.

---

A few old jobs are still listed in the [Jenkins WebUI](https://jenkins-ceph-csi.apps.ocp.ci.centos.org/). These have been manually disabled, so get not triggered anymore. Only admins can disable jobs, and would need to do so each time jobs are abandoned (new version, or the job remove from the git repo).