### PR TITLE
ci: update k8s version for upgrade tests

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.19'
+    k8s_version: '1.18'
     test_type:
       - 'cephfs'
       - 'rbd'


### PR DESCRIPTION
As the job seems to be unstable for k8s v1.19,
reducing the version to achieve stability for
the same.
See: https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/upgrade-tests-cephfs/detail/upgrade-tests-cephfs/44/pipeline

Signed-off-by: Yug <yuggupta27@gmail.com>

