### PR TITLE
ci: require upgrade tests to pass for merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -47,6 +47,8 @@ pull_request_rules:
       - "status-success=ci/centos/mini-e2e-helm/k8s-1.18"
       - "status-success=ci/centos/mini-e2e/k8s-1.19"
       - "status-success=ci/centos/mini-e2e/k8s-1.18"
+      - "status-success=ci/centos/upgrade-tests-cephfs"
+      - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
       merge:
@@ -184,6 +186,8 @@ pull_request_rules:
       - "status-success=ci/centos/mini-e2e-helm/k8s-1.18"
       - "status-success=ci/centos/mini-e2e/k8s-1.19"
       - "status-success=ci/centos/mini-e2e/k8s-1.18"
+      - "status-success=ci/centos/upgrade-tests-cephfs"
+      - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
       merge:


### PR DESCRIPTION
Add passing of upgrade tests as a necessary condition
for merging PRs.
See: https://github.com/ceph/ceph-csi/pull/1464

Signed-off-by: Yug <yuggupta27@gmail.com>