### PR TITLE
ci: Trigger upgrade test jobs automatically

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -53,7 +53,6 @@
           trigger-phrase: '/(re)?test ((all)|(ci/centos/upgrade-tests(-{test_type})?))'
           permit-all: true
           github-hooks: true
-          only-trigger-phrase: true
           black-list-target-branches:
             - ci/centos
           org-list:


### PR DESCRIPTION
Since upgrade tests will become a necessity to
merge PRs, it is better to trigger them
automatically now.

See: https://github.com/ceph/ceph-csi/pull/1529 https://github.com/ceph/ceph-csi/pull/1464

Signed-off-by: Yug <yuggupta27@gmail.com>

