### PR TITLE
e2e: defend on k8s version for snap-controller install

### DIFF
--- a/build.env
+++ b/build.env
@@ -21,6 +21,10 @@ GO111MODULE=on
 GOLANGCI_VERSION=v1.27.0
 GOSEC_VERSION=v2.3.0
 
+# external snapshotter version
+# Refer: https://github.com/kubernetes-csi/external-snapshotter/releases
+SNAPSHOT_VERSION=v3.0.1
+
 # "go test" configuration
 # set to stdout or html to enable coverage reporting, disabled by default
 #TEST_COVERAGE=html

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -77,6 +77,30 @@ function delete_snapshot_crd() {
     kubectl delete -f "${VOLUME_SNAPSHOT}" --ignore-not-found
 }
 
+# parse the kubernetes version
+# v1.17.2 -> kube_version 1 -> 1  (Major)
+# v1.17.2 -> kube_version 2 -> 17 (Minor)
+function kube_version() {
+    echo "${KUBE_VERSION}" | sed 's/^v//' | cut -d'.' -f"${1}"
+}
+
+if ! get_kube_version=$(kubectl version --short) ||
+   [[ -z "${get_kube_version}" ]]; then
+    echo "could not get Kubernetes server version"
+    echo "hint: check if you have specified the right host or port"
+    exit 1
+fi
+
+KUBE_VERSION=$(echo "${get_kube_version}" | grep "^Server Version" | cut -d' ' -f3)
+KUBE_MAJOR=$(kube_version 1)
+KUBE_MINOR=$(kube_version 2)
+
+# skip snapshot operation if kube version is less than 1.17.0
+if [[ "${KUBE_MAJOR}" -lt 1 ]] || [[ "${KUBE_MAJOR}" -eq 1  &&  "${KUBE_MINOR}" -lt 17 ]]; then
+    echo "skipping: Kubernetes server version is < 1.17.0"
+    exit 1
+fi
+
 case "${1:-}" in
 install)
     install_snapshot_controller "$2"

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -2,7 +2,7 @@
 
 # This script can be used to install/delete snapshotcontroller and snapshot beta CRD
 
-SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v2.1.1"}
+SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v3.0.1"}
 
 SCRIPT_DIR="$(dirname "${0}")"
 
@@ -14,9 +14,9 @@ SNAPSHOT_RBAC="${SNAPSHOTTER_URL}/deploy/kubernetes/snapshot-controller/rbac-sna
 SNAPSHOT_CONTROLLER="${SNAPSHOTTER_URL}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
 
 # snapshot CRD
-SNAPSHOTCLASS="${SNAPSHOTTER_URL}/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
-VOLUME_SNAPSHOT_CONTENT="${SNAPSHOTTER_URL}/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
-VOLUME_SNAPSHOT="${SNAPSHOTTER_URL}/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
+SNAPSHOTCLASS="${SNAPSHOTTER_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
+VOLUME_SNAPSHOT_CONTENT="${SNAPSHOTTER_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
+VOLUME_SNAPSHOT="${SNAPSHOTTER_URL}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
 
 function install_snapshot_controller() {
     local namespace=$1

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -2,9 +2,12 @@
 
 # This script can be used to install/delete snapshotcontroller and snapshot beta CRD
 
-SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v3.0.1"}
-
 SCRIPT_DIR="$(dirname "${0}")"
+
+# shellcheck source=build.env
+source "${SCRIPT_DIR}/../build.env"
+
+SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v3.0.1"}
 
 TEMP_DIR="$(mktemp -d)"
 SNAPSHOTTER_URL="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOT_VERSION}"


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Currently the scripts/install-snapshot.sh script needs to be called
depending on the Kubernetes version. It would be much easier to use the
script if it is intelligent enough to decide itself whether k8s snapshot
controller needs to be installed or not.

Fixes: #1139
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

