### PR TITLE
Revert "build:  update templates for v3.1.1 release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CPUS?=$(shell nproc --ignore=1)
 CPUSET?=--cpuset-cpus=0-${CPUS}
 
 CSI_IMAGE_NAME=$(if $(ENV_CSI_IMAGE_NAME),$(ENV_CSI_IMAGE_NAME),quay.io/cephcsi/cephcsi)
-CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),v3.1.1)
+CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),v3.1-canary)
 CSI_IMAGE=$(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION)
 
 $(info cephcsi image settings: $(CSI_IMAGE_NAME) version $(CSI_IMAGE_VERSION))

--- a/build.env
+++ b/build.env
@@ -43,4 +43,4 @@ DEPLOY_TIMEOUT=10
 UPGRADE_VERSION=v3.0.0
 
 # This var will be used by CentOS CI to build the image
-CSI_IMAGE_VERSION=v3.1.1
+CSI_IMAGE_VERSION=v3.1-canary

--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.1.1
+appVersion: v3.1-canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
-version: 3.1.1-canary
+version: 3.1-canary
 keywords:
   - ceph
   - cephfs

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -75,7 +75,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.1.1
+      tag: v3.1-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.1.1
+appVersion: v3.1-canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter, and attacher for Ceph RBD"
 name: ceph-csi-rbd
-version: 3.1.1-canary
+version: 3.1-canary
 keywords:
   - ceph
   - rbd

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -87,7 +87,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.1.1
+      tag: v3.1-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -83,7 +83,7 @@ build_push_images() {
 }
 
 if [ "${TRAVIS_BRANCH}" == 'release-v3.1' ]; then
-	export ENV_CSI_IMAGE_VERSION='v3.1.1'
+	export ENV_CSI_IMAGE_VERSION='v3.1-canary'
 else
 	echo "!!! Branch ${TRAVIS_BRANCH} is not a deployable branch; exiting"
 	exit 0 # Exiting 0 so that this isn't marked as failing

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -99,7 +99,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -135,7 +135,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -54,7 +54,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -104,7 +104,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -99,7 +99,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -139,7 +139,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -55,7 +55,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -107,7 +107,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.1.1
+          image: quay.io/cephcsi/cephcsi:v3.1-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -239,7 +239,7 @@ teardown-rook)
     ;;
 cephcsi)
     echo "copying the cephcsi image"
-    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.1.1 "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.1.1
+    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.1-canary "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.1-canary
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"


### PR DESCRIPTION
This reverts commit 22b631e991c5309e117f1b99f49d1163aa5c8744.

Reverting back  the template changes and build version change information as the release PR is https://github.com/ceph/ceph-csi/pull/1528  merged