### PR TITLE
rbd: flattern image when it has references to parent

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -238,6 +238,7 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	var err error
 	var readOnly bool
 	var feature bool
+	var depth uint
 
 	var cr *util.Credentials
 	cr, err = util.NewUserCredentials(req.GetSecrets())
@@ -273,7 +274,13 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 			if err != nil {
 				return transaction, err
 			}
-			if feature {
+
+			depth, err = volOptions.getCloneDepth(ctx)
+			if err != nil {
+				return transaction, err
+			}
+
+			if feature && (depth != 0) {
 				err = volOptions.flattenRbdImage(ctx, cr, true, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 				if err != nil {
 					return transaction, err


### PR DESCRIPTION
Currently, as part of node service we add rbd flatten task for new PVC
creates. Ideally, we should add flatten task only for snapshots/cloned
PVCs as required.

Fixes: #1543
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>