### PR TITLE
rbd: add vault token authentication support

### DIFF
--- a/docs/design/proposals/encrypted-pvc.md
+++ b/docs/design/proposals/encrypted-pvc.md
@@ -127,3 +127,10 @@ data:
 metadata:
   name: ceph-csi-encryption-kms-config
 ```
+
+NOTE:
+
+KMS vault can be authenticated using token auth method or kubernetes auth
+method. Ceph CSI driver is capable of authenticating with both methods,
+however kubernetes auth based authentication method is recommended for
+production use.

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -139,6 +139,10 @@ func createRBDSecret(c kubernetes.Interface, f *framework.Framework) error {
 	}
 
 	err = updateSecretForEncryption(c)
+	if err != nil {
+		return err
+	}
+	err = updateVaultTokenForEncryption(c)
 	return err
 }
 

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -9,6 +9,8 @@ data:
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
         "vaultAuthPath": "/v1/auth/kubernetes/login",
         "vaultRole": "csi-kubernetes",
+        "vaultTokenAuth": "true",
+        "vaultTokenFromSecret": "vault-token",
         "vaultPassphraseRoot": "/v1/secret",
         "vaultPassphrasePath": "ceph-csi/",
         "vaultCAVerify": "false"

--- a/examples/rbd/secret.yaml
+++ b/examples/rbd/secret.yaml
@@ -13,3 +13,6 @@ stringData:
 
   # Encryption passphrase
   encryptionPassphrase: test_passphrase
+
+  # Vault token
+  vault-token: sample_root_token_id


### PR DESCRIPTION
Fix: https://github.com/ceph/ceph-csi/issues/1500
    Solution: The vault token auth can use token based auth in a
    setup. If we want to use vault token based authentication in
    a setup, the ceph-csi-encryption-kms-config should have below
    values set:
    
    `
           "vaultTokenAuth": "true",
           "vaultTokenFromSecret": "vault-token",
    `
    
    Here the first param `vaultTokenAuth` say whether token based
    auth is enabled or not. If set, the vault auth token will be fetched
    from node stage/provisioner secret of the key `vault-token`.
    ie the secret key is the value/variable set for `vaultTokenFromSecret`
    parameter in the configmap.

*NOTE for the reviewer:*

The E2E is validated for vault token authentication with this PR. 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


