### PR TITLE
Add liveness probe sidecar container

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -161,6 +161,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--health-port=9809"
+            - "--metrics-address=:8081"
+            - "--metrics-path=/metrics"
             - "--v=5"
           env:
             - name: ADDRESS

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -144,6 +144,31 @@ spec:
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+          ports:
+            - name: liveness-port
+              containerPort: 9809
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: liveness-port
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:canary
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--health-port=9809"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi-provisioner.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: liveness-prometheus
           image: quay.io/cephcsi/cephcsi:canary
           args:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -93,6 +93,31 @@ spec:
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+          ports:
+            - name: liveness-port
+              containerPort: 9809
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: liveness-port
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:canary
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--health-port=9809"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: liveness-prometheus
           securityContext:
             privileged: true

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -110,6 +110,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--health-port=9809"
+            - "--metrics-address=:8081"
+            - "--metrics-path=/metrics"
             - "--v=5"
           env:
             - name: ADDRESS

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -165,6 +165,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--health-port=9808"
+            - "--metrics-address=:8080"
+            - "--metrics-path=/metrics"
             - "--v=5"
           env:
             - name: ADDRESS

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -148,6 +148,31 @@ spec:
               mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+          ports:
+            - name: liveness-port
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: liveness-port
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:canary
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--health-port=9808"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi-provisioner.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: liveness-prometheus
           image: quay.io/cephcsi/cephcsi:canary
           args:

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -113,6 +113,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--health-port=9808"
+            - "--metrics-address=:8080"
+            - "--metrics-path=/metrics"
             - "--v=5"
           env:
             - name: ADDRESS

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -96,6 +96,31 @@ spec:
               mountPropagation: "Bidirectional"
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+          ports:
+            - name: liveness-port
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: liveness-port
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:canary
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--health-port=9808"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: liveness-prometheus
           securityContext:
             privileged: true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
The CSI livenessprobe is a sidecar container that monitors the health of the CSI driver and reports it to Kubernetes via the Liveness Probe mechanism. This enables Kubernetes to automatically detect issues with the driver and restart the pod to try and fix the issue.

Fixes: #1096

