### PR TITLE
rbd: make sure csi rbd pv encryption  defaulting to luks2 version

### DIFF
--- a/docs/design/proposals/encrypted-pvc.md
+++ b/docs/design/proposals/encrypted-pvc.md
@@ -3,7 +3,7 @@
 ## Proposal
 
 Subject of this proposal is to add support for encryption of RBD volumes in
-Ceph-CSI.
+Ceph-CSI with type LUKS version 2.
 
 Some but not all the benefits of this approach:
 

--- a/internal/util/cryptsetup.go
+++ b/internal/util/cryptsetup.go
@@ -25,7 +25,7 @@ import (
 
 // LuksFormat sets up volume as an encrypted LUKS partition.
 func LuksFormat(devicePath, passphrase string) (stdout, stderr []byte, err error) {
-	return execCryptsetupCommand(&passphrase, "-q", "luksFormat", "--hash", "sha256", devicePath, "-d", "/dev/stdin")
+	return execCryptsetupCommand(&passphrase, "-q", "luksFormat", "--type", "luks2", "--hash", "sha256", devicePath, "-d", "/dev/stdin")
 }
 
 // LuksOpen opens LUKS encrypted partition and sets up a mapping.


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph-csi/issues/1564

As per release notes this new version is compatible with previous
version of LUKS.
https://www.saout.de/pipermail/dm-crypt/2017-December/005771.html

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


