### PR TITLE
rbd: remove false error condition check in genVolFromVolID

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -306,10 +306,6 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 			return false, err
 		}
 	}
-	if err != nil {
-		util.ErrorLog(ctx, "failed to get stored image id: %v", err)
-		return false, err
-	}
 
 	// size checks
 	if rv.VolSize < requestSize {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -206,10 +206,6 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		}
 	}
 
-	if err != nil {
-		return false, err
-	}
-
 	util.DebugLog(ctx, "found existing image (%s) with name (%s) for request (%s)",
 		rbdSnap.SnapID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
 	return true, nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -738,11 +738,6 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 			return rbdVol, err
 		}
 	}
-	if err != nil {
-		util.ErrorLog(ctx, "failed to get stored image id: %v", err)
-		return rbdVol, err
-	}
-
 	err = rbdVol.getImageInfo()
 	return rbdVol, err
 }


### PR DESCRIPTION
The error check condition in genVolFromID() is always false as far as
code reading/workflow goes. Removing it for the same reason.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

