### PR TITLE
Use a GitHub API token for CI jobs

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -28,6 +28,10 @@ node('cico-workspace') {
 			skip_e2e = 1
 			return
 		}
+
+		// "github-api-token" is a secret text credential configured in Jenkins
+		env.GITHUB_API_TOKEN = credentials("github-api-token")
+
 		skip_e2e = sh(
 			script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
 			returnStatus: true)

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -25,6 +25,10 @@ node('cico-workspace') {
 			skip_e2e = 1
 			return
 		}
+
+		// "github-api-token" is a secret text credential configured in Jenkins
+		env.GITHUB_API_TOKEN = credentials("github-api-token")
+
 		skip_e2e = sh(
 			script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
 			returnStatus: true)

--- a/scripts/get_github_labels.py
+++ b/scripts/get_github_labels.py
@@ -12,11 +12,16 @@ Exit codes:
  0: success
  1: any unexpected failure
  2: --has-label=<label> was passed, <label> is not set on the PR
+
+Environment:
+ GITHUB_API_TOKEN: the GitHub "personal access token" to use
 '''
 
 import argparse
-import sys
+import os
 import requests
+from requests.auth import HTTPBasicAuth
+import sys
 
 LABEL_URL_FMT = 'https://api.github.com/repos/ceph/ceph-csi/issues/%s/labels'
 '''
@@ -32,7 +37,15 @@ def get_json_labels(gh_id):
     '''
     url = LABEL_URL_FMT % gh_id
     headers = {'Accept': 'application/vnd.github.v3+json'}
-    res = requests.get(url, headers=headers)
+
+    auth = None
+    if 'GITHUB_API_TOKEN' in os.environ:
+        github_api_token = os.environ['GITHUB_API_TOKEN']
+        if github_api_token != '':
+            # the username "unused" is not relevant, needs to be non-empty
+            auth = HTTPBasicAuth('unused', github_api_token)
+
+    res = requests.get(url, headers=headers, auth=auth)
 
     # if "res.status_code != requests.codes.ok", raise an exception
     res.raise_for_status()

--- a/scripts/get_patch_release.py
+++ b/scripts/get_patch_release.py
@@ -5,11 +5,16 @@ release for a major version.
 
 Parameters:
  --version=<version>: the major version to find the latest patch release for, i.e. v1.19
+
+Environment:
+ GITHUB_API_TOKEN: the GitHub "personal access token" to use
 '''
 
 import argparse
-import sys
+import os
 import requests
+from requests.auth import HTTPBasicAuth
+import sys
 
 RELEASE_URL = 'https://api.github.com/repos/kubernetes/kubernetes/releases'
 '''
@@ -24,6 +29,14 @@ def get_json_releases():
     obtained.
     '''
     headers = {'Accept': 'application/vnd.github.v3+json'}
+
+    auth = None
+    if 'GITHUB_API_TOKEN' in os.environ:
+        github_api_token = os.environ['GITHUB_API_TOKEN']
+        if github_api_token != '':
+            # the username "unused" is not relevant, needs to be non-empty
+            auth = HTTPBasicAuth('unused', github_api_token)
+
     res = requests.get(RELEASE_URL, headers=headers)
 
     # if "res.status_code != requests.codes.ok", raise an exception

--- a/scripts/get_patch_release.py
+++ b/scripts/get_patch_release.py
@@ -25,6 +25,10 @@ def get_json_releases():
     '''
     headers = {'Accept': 'application/vnd.github.v3+json'}
     res = requests.get(RELEASE_URL, headers=headers)
+
+    # if "res.status_code != requests.codes.ok", raise an exception
+    res.raise_for_status()
+
     return res.json()
 
 
@@ -47,7 +51,12 @@ def main():
     args = parser.parse_args()
 
     # get all the releases
-    json = get_json_releases()
+    try:
+        json = get_json_releases()
+    except Exception as err:
+        print('Error: %s' % err)
+        sys.exit(1)
+
     releases = get_releases(json)
 
     # in case --version is passed, exit with 0 or 1

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -25,6 +25,10 @@ node('cico-workspace') {
 			skip_e2e = 1
 			return
 		}
+
+		// "github-api-token" is a secret text credential configured in Jenkins
+		env.GITHUB_API_TOKEN = credentials("github-api-token")
+
 		skip_e2e = sh(
 			script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
 			returnStatus: true)


### PR DESCRIPTION
Sometimes CI jobs fail with errors like
```
[Pipeline] { (detect k8s-1.18 patch release)
[Pipeline] sh
+ ./scripts/get_patch_release.py --version=1.18
Traceback (most recent call last):
  File "./scripts/get_patch_release.py", line 76, in <module>
    main()
  File "./scripts/get_patch_release.py", line 51, in main
    releases = get_releases(json)
  File "./scripts/get_patch_release.py", line 37, in get_releases
    releases.append(release['name'])
TypeError: string indices must be integers
```
This indicates that the API call to GitHub returned something unexpected.

Because the jobs run in the CentOS CI, there can be many API calls from the environment (not only Ceph-CSI), which trigger a rate limit. When the problem happens, debugging showed
```
403 Client Error: rate limit exceeded
```

The rate limit can be prevented when a CI job logs in to use the API. Our @ceph-csi-bot has a "personal access token" that can be used for this. The token is configured in Jenkins and can be obtained in the groovy scripts (Pipelines).