### PR TITLE
ci: use environment{} to fetch the GitHub API token

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -24,13 +24,15 @@ node('cico-workspace') {
 	}
 
 	stage('skip ci/skip/e2e label') {
+		environment {
+			// "github-api-token" is a secret text credential configured in Jenkins
+			GITHUB_API_TOKEN = credentials("github-api-token")
+		}
+
 		if (params.ghprbPullId == null) {
 			skip_e2e = 1
 			return
 		}
-
-		// "github-api-token" is a secret text credential configured in Jenkins
-		env.GITHUB_API_TOKEN = credentials("github-api-token")
 
 		skip_e2e = sh(
 			script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -21,13 +21,15 @@ node('cico-workspace') {
 	}
 
 	stage('skip ci/skip/e2e label') {
+		environment {
+			// "github-api-token" is a secret text credential configured in Jenkins
+			GITHUB_API_TOKEN = credentials("github-api-token")
+		}
+
 		if (params.ghprbPullId == null) {
 			skip_e2e = 1
 			return
 		}
-
-		// "github-api-token" is a secret text credential configured in Jenkins
-		env.GITHUB_API_TOKEN = credentials("github-api-token")
 
 		skip_e2e = sh(
 			script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -21,13 +21,15 @@ node('cico-workspace') {
 	}
 
 	stage('skip ci/skip/e2e label') {
+		environment {
+			// "github-api-token" is a secret text credential configured in Jenkins
+			GITHUB_API_TOKEN = credentials("github-api-token")
+		}
+
 		if (params.ghprbPullId == null) {
 			skip_e2e = 1
 			return
 		}
-
-		// "github-api-token" is a secret text credential configured in Jenkins
-		env.GITHUB_API_TOKEN = credentials("github-api-token")
 
 		skip_e2e = sh(
 			script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",


### PR DESCRIPTION
The `credentials()` function might only work in the `environment` block
in the Pipelines. At the moment, running the 'skip ci/skip/e2e label'
stage always reports 'Error: 401 Client Error: Unauthorized'.

Fixes: e0d49908 (ci: fetch GITHUB_API_TOKEN from Jenkins credential store)