### PR TITLE
rebase: update vendored go-ceph to v0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ceph/ceph-csi
 go 1.13
 
 require (
-	github.com/ceph/go-ceph v0.5.0
+	github.com/ceph/go-ceph v0.6.0
 	github.com/container-storage-interface/spec v1.3.0
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/caddyserver/caddy v1.0.3/go.mod h1:G+ouvOY32gENkJC+jhgl62TyhvqEsFaDiZ4uw0RzP1E=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/ceph/go-ceph v0.5.0 h1:x5VmFq19Op6DjzWuxAUG3wZZoC3L160Rt6pJOOiRfW0=
-github.com/ceph/go-ceph v0.5.0/go.mod h1:wd+keAOqrcsN//20VQnHBGtnBnY0KHl0PA024Ng8HfQ=
+github.com/ceph/go-ceph v0.6.0 h1:/sCL9a6nTIqTCgDAnNeK88Aw+i7rD4bpK+QpxgdDeP4=
+github.com/ceph/go-ceph v0.6.0/go.mod h1:wd+keAOqrcsN//20VQnHBGtnBnY0KHl0PA024Ng8HfQ=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/vendor/github.com/ceph/go-ceph/internal/callbacks/callbacks.go
+++ b/vendor/github.com/ceph/go-ceph/internal/callbacks/callbacks.go
@@ -19,17 +19,17 @@ import (
 // to control and validate what "callbacks" get used.
 type Callbacks struct {
 	mutex sync.RWMutex
-	cmap  map[int]interface{}
+	cmap  map[uintptr]interface{}
 }
 
 // New returns a new callbacks tracker.
 func New() *Callbacks {
-	return &Callbacks{cmap: make(map[int]interface{})}
+	return &Callbacks{cmap: make(map[uintptr]interface{})}
 }
 
 // Add a callback/object to the tracker and return a new index
 // for the object.
-func (cb *Callbacks) Add(v interface{}) int {
+func (cb *Callbacks) Add(v interface{}) uintptr {
 	cb.mutex.Lock()
 	defer cb.mutex.Unlock()
 	// this approach assumes that there are typically very few callbacks
@@ -38,7 +38,7 @@ func (cb *Callbacks) Add(v interface{}) int {
 	// until we find a free key like in the cgo wiki page.
 	// If this code ever becomes a hot path there's surely plenty of room
 	// for optimization in the future :-)
-	index := len(cb.cmap) + 1
+	index := uintptr(len(cb.cmap) + 1)
 	for {
 		if _, found := cb.cmap[index]; !found {
 			break
@@ -50,14 +50,14 @@ func (cb *Callbacks) Add(v interface{}) int {
 }
 
 // Remove a callback/object given it's index.
-func (cb *Callbacks) Remove(index int) {
+func (cb *Callbacks) Remove(index uintptr) {
 	cb.mutex.Lock()
 	defer cb.mutex.Unlock()
 	delete(cb.cmap, index)
 }
 
 // Lookup returns a mapped callback/object given an index.
-func (cb *Callbacks) Lookup(index int) interface{} {
+func (cb *Callbacks) Lookup(index uintptr) interface{} {
 	cb.mutex.RLock()
 	defer cb.mutex.RUnlock()
 	return cb.cmap[index]

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/cutil.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/cutil.go
@@ -1,0 +1,14 @@
+package cutil
+
+import "unsafe"
+
+// VoidPtr casts a uintptr value to an unsafe.Pointer value in order to use it
+// directly as a void* argument in a C function call.
+// CAUTION: NEVER store the result in a variable, or the Go GC could panic.
+func VoidPtr(i uintptr) unsafe.Pointer {
+	var nullPtr unsafe.Pointer
+	// It's not possible to cast uintptr directly to unsafe.Pointer. Therefore we
+	// cast a null pointer to uintptr and apply pointer arithmetic on it, which
+	// allows us to cast it back to unsafe.Pointer.
+	return unsafe.Pointer(uintptr(nullPtr) + i)
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/iovec.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/iovec.go
@@ -1,0 +1,78 @@
+package cutil
+
+/*
+#include <stdlib.h>
+#include <sys/uio.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+var iovecSize uintptr
+
+// StructIovecPtr is an unsafe pointer wrapping C's `*struct iovec`.
+type StructIovecPtr unsafe.Pointer
+
+// Iovec helps manage struct iovec arrays needed by some C functions.
+type Iovec struct {
+	// cvec represents an array of struct iovec C memory
+	cvec unsafe.Pointer
+	// length of the array (in elements)
+	length int
+}
+
+// NewIovec creates an Iovec, and underlying C memory, of the specified size.
+func NewIovec(l int) *Iovec {
+	r := &Iovec{
+		cvec:   C.malloc(C.size_t(l) * C.size_t(iovecSize)),
+		length: l,
+	}
+	return r
+}
+
+// ByteSlicesToIovec takes a slice of byte slices and returns a new iovec that
+// maps the slice data to struct iovec entries.
+func ByteSlicesToIovec(data [][]byte) *Iovec {
+	iov := NewIovec(len(data))
+	for i := range data {
+		iov.Set(i, data[i])
+	}
+	return iov
+}
+
+// Pointer returns a StructIovecPtr that represents the C memory of the
+// underlying array.
+func (v *Iovec) Pointer() StructIovecPtr {
+	return StructIovecPtr(unsafe.Pointer(v.cvec))
+}
+
+// Len returns the number of entries in the Iovec.
+func (v *Iovec) Len() int {
+	return v.length
+}
+
+// Free the C memory in the Iovec.
+func (v *Iovec) Free() {
+	if v.cvec != nil {
+		C.free(v.cvec)
+		v.cvec = nil
+		v.length = 0
+	}
+}
+
+// Set will map the memory of the given byte slice to the iovec at the
+// specified position.
+func (v *Iovec) Set(i int, buf []byte) {
+	offset := uintptr(i) * iovecSize
+	iov := (*C.struct_iovec)(unsafe.Pointer(
+		uintptr(unsafe.Pointer(v.cvec)) + offset))
+	iov.iov_base = unsafe.Pointer(&buf[0])
+	iov.iov_len = C.size_t(len(buf))
+}
+
+func init() {
+	var iovec C.struct_iovec
+	iovecSize = unsafe.Sizeof(iovec)
+}

--- a/vendor/github.com/ceph/go-ceph/rbd/rbd_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/rbd_nautilus.go
@@ -101,3 +101,17 @@ func (image *Image) GetModifyTimestamp() (Timespec, error) {
 
 	return Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&cts))), nil
 }
+
+// Sparsify makes an image sparse by deallocating runs of zeros.
+// The sparseSize value will be used to find runs of zeros and must be
+// a power of two no less than 4096 and no larger than the image size.
+//
+// Implements:
+//  int rbd_sparsify(rbd_image_t image, size_t sparse_size);
+func (image *Image) Sparsify(sparseSize uint) error {
+	if err := image.validate(imageIsOpen); err != nil {
+		return err
+	}
+
+	return getError(C.rbd_sparsify(image.image, C.size_t(sparseSize)))
+}

--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
@@ -1,0 +1,66 @@
+// +build octopus
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <stdlib.h>
+// #include <rbd/librbd.h>
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/retry"
+)
+
+// GetSnapID returns the snapshot ID for the given snapshot name.
+//
+// Implements:
+//  int rbd_snap_get_id(rbd_image_t image, const char *snapname, uint64_t *snap_id)
+func (image *Image) GetSnapID(snapName string) (uint64, error) {
+	var snapID C.uint64_t
+	if err := image.validate(imageIsOpen); err != nil {
+		return uint64(snapID), err
+	}
+	if snapName == "" {
+		return uint64(snapID), ErrSnapshotNoName
+	}
+
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rbd_snap_get_id(image.image, cSnapName, &snapID)
+	return uint64(snapID), getError(ret)
+}
+
+// GetSnapByID returns the snapshot name for the given snapshot ID.
+//
+// Implements:
+//  int rbd_snap_get_name(rbd_image_t image, uint64_t snap_id, char *snapname, size_t *name_len)
+func (image *Image) GetSnapByID(snapID uint64) (string, error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return "", err
+	}
+
+	var (
+		buf []byte
+		err error
+	)
+	// range from 1k to 64KiB
+	retry.WithSizes(1024, 1<<16, func(len int) retry.Hint {
+		cLen := C.size_t(len)
+		buf = make([]byte, cLen)
+		ret := C.rbd_snap_get_name(
+			image.image,
+			(C.uint64_t)(snapID),
+			(*C.char)(unsafe.Pointer(&buf[0])),
+			&cLen)
+		err = getError(ret)
+		return retry.Size(int(cLen)).If(err == errRange)
+	})
+
+	if err != nil {
+		return "", err
+	}
+	return C.GoString((*C.char)(unsafe.Pointer(&buf[0]))), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,7 +2,7 @@
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.0+incompatible
 github.com/blang/semver
-# github.com/ceph/go-ceph v0.5.0
+# github.com/ceph/go-ceph v0.6.0
 github.com/ceph/go-ceph/internal/callbacks
 github.com/ceph/go-ceph/internal/cutil
 github.com/ceph/go-ceph/internal/errutil


### PR DESCRIPTION
go-ceph v0.6 is out and brings the new CephFS Admin package that can be used for provisioning CephFS volumes.

URL: https://github.com/ceph/go-ceph/releases/tag/v0.6.0
Closes: #1547