### PR TITLE
cephfs: implement getFscID() with go-ceph

### DIFF
--- a/internal/cephfs/cephfs_util.go
+++ b/internal/cephfs/cephfs_util.go
@@ -34,17 +34,17 @@ type CephFilesystemDetails struct {
 	MDSMap MDSMap `json:"mdsmap"`
 }
 
-func getFscID(ctx context.Context, monitors string, cr *util.Credentials, fsName string) (int64, error) {
+func (vo *volumeOptions) getFscID(ctx context.Context, cr *util.Credentials) (int64, error) {
 	// ceph fs get myfs --format=json
 	// {"mdsmap":{...},"id":2}
 	var fsDetails CephFilesystemDetails
 	err := execCommandJSON(ctx, &fsDetails,
 		"ceph",
-		"-m", monitors,
+		"-m", vo.Monitors,
 		"--id", cr.ID,
 		"--keyfile="+cr.KeyFile,
 		"-c", util.CephConfigPath,
-		"fs", "get", fsName, "--format=json",
+		"fs", "get", vo.FsName, "--format=json",
 	)
 	if err != nil {
 		return 0, err

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -215,7 +215,7 @@ func newVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVo
 		return nil, err
 	}
 
-	opts.FscID, err = opts.getFscID(ctx, cr)
+	opts.FscID, err = opts.getFscID(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -215,7 +215,7 @@ func newVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVo
 		return nil, err
 	}
 
-	opts.FscID, err = getFscID(ctx, opts.Monitors, cr, opts.FsName)
+	opts.FscID, err = opts.getFscID(ctx, cr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reduce the numbed of `ceph fs` command executions, and use go-ceph with a cached/shared connection.

Fixes: #1550
~Do-Not-Merge: depends on #1545, which needs to get merged first~