### PR TITLE
cephfs: implement getMetadataPool() with go-ceph

### DIFF
--- a/internal/cephfs/cephfs_util.go
+++ b/internal/cephfs/cephfs_util.go
@@ -55,13 +55,13 @@ type CephFilesystem struct {
 	DataPoolIDs    []int    `json:"data_pool_ids"`
 }
 
-func getMetadataPool(ctx context.Context, monitors string, cr *util.Credentials, fsName string) (string, error) {
+func (vo *volumeOptions) getMetadataPool(ctx context.Context, cr *util.Credentials) (string, error) {
 	// ./tbox ceph fs ls --format=json
 	// [{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":4,...},...]
 	var filesystems []CephFilesystem
 	err := execCommandJSON(ctx, &filesystems,
 		"ceph",
-		"-m", monitors,
+		"-m", vo.Monitors,
 		"--id", cr.ID,
 		"--keyfile="+cr.KeyFile,
 		"-c", util.CephConfigPath,
@@ -72,12 +72,12 @@ func getMetadataPool(ctx context.Context, monitors string, cr *util.Credentials,
 	}
 
 	for _, fs := range filesystems {
-		if fs.Name == fsName {
+		if fs.Name == vo.FsName {
 			return fs.MetadataPool, nil
 		}
 	}
 
-	return "", fmt.Errorf("%w: fsName (%s) not found in Ceph cluster", util.ErrPoolNotFound, fsName)
+	return "", fmt.Errorf("%w: fsName (%s) not found in Ceph cluster", util.ErrPoolNotFound, vo.FsName)
 }
 
 func (vo *volumeOptions) getFsName(ctx context.Context) (string, error) {

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -38,7 +38,6 @@ func execCommandErr(ctx context.Context, program string, args ...string) error {
 	return err
 }
 
-// nolint:unparam //  todo:program values has to be revisited later
 func execCommandJSON(ctx context.Context, v interface{}, program string, args ...string) error {
 	stdout, _, err := util.ExecCommand(ctx, program, args...)
 	if err != nil {

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -220,7 +220,7 @@ func newVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVo
 		return nil, err
 	}
 
-	opts.MetadataPool, err = opts.getMetadataPool(ctx, cr)
+	opts.MetadataPool, err = opts.getMetadataPool(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 		return nil, nil, err
 	}
 
-	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx, cr)
+	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -503,7 +503,7 @@ func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Crede
 		return &volOptions, nil, &sid, err
 	}
 
-	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx, cr)
+	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx)
 	if err != nil {
 		return &volOptions, nil, &sid, err
 	}

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -220,7 +220,7 @@ func newVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVo
 		return nil, err
 	}
 
-	opts.MetadataPool, err = getMetadataPool(ctx, opts.Monitors, cr, opts.FsName)
+	opts.MetadataPool, err = opts.getMetadataPool(ctx, cr)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 		return nil, nil, err
 	}
 
-	volOptions.MetadataPool, err = getMetadataPool(ctx, volOptions.Monitors, cr, volOptions.FsName)
+	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx, cr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -503,7 +503,7 @@ func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Crede
 		return &volOptions, nil, &sid, err
 	}
 
-	volOptions.MetadataPool, err = getMetadataPool(ctx, volOptions.Monitors, cr, volOptions.FsName)
+	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx, cr)
 	if err != nil {
 		return &volOptions, nil, &sid, err
 	}


### PR DESCRIPTION
Reduce the number of `ceph fs` command executions, and use go-ceph with a cached/shared connection.

Fixes: #1554
~Do-Not-Merge: depends on #1545, #1581 and #1577, which need to get merged first~