### PR TITLE
e2e: cleanup Kubernetes version checks

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -425,13 +425,8 @@ var _ = Describe("cephfs", func() {
 			})
 
 			By("Resize PVC and check application directory size", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error with error %v", err)
-				}
-
 				// Resize 0.3.0 is only supported from v1.15+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "15") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 15) {
 					err := resizePVCAndValidateSize(pvcPath, appPath, f)
 					if err != nil {
 						e2elog.Failf("failed to resize PVC with error %v", err)
@@ -483,19 +478,15 @@ var _ = Describe("cephfs", func() {
 			})
 
 			By("create a PVC clone and bind it to an app", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error with error %v", err)
-				}
 				// snapshot beta is only supported from v1.17+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "17") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
 					var wg sync.WaitGroup
 					totalCount := 3
 					// totalSubvolumes represents the subvolumes in backend
 					// always totalCount+parentPVC
 					totalSubvolumes := totalCount + 1
 					wg.Add(totalCount)
-					err = createCephFSSnapshotClass(f)
+					err := createCephFSSnapshotClass(f)
 					if err != nil {
 						e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
 					}
@@ -643,12 +634,8 @@ var _ = Describe("cephfs", func() {
 			})
 
 			By("create a PVC-PVC clone and bind it to an app", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error with error %v", err)
-				}
 				// pvc clone is only supported from v1.16+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					var wg sync.WaitGroup
 					totalCount := 3
 					// totalSubvolumes represents the subvolumes in backend

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -357,16 +357,12 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("create a PVC clone and bind it to an app", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error with error %v", err)
-				}
 				// snapshot beta is only supported from v1.17+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "17") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
 					var wg sync.WaitGroup
 					totalCount := 10
 					wg.Add(totalCount)
-					err = createRBDSnapshotClass(f)
+					err := createRBDSnapshotClass(f)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}
@@ -511,12 +507,8 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("create a PVC-PVC clone and bind it to an app", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error %v", err)
-				}
 				// pvc clone is only supported from v1.16+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					validatePVCClone(pvcPath, pvcSmartClonePath, appSmartClonePath, f)
 				}
 
@@ -586,13 +578,8 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("Resize Filesystem PVC and check application directory size", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error with error %v", err)
-				}
-
 				// Resize 0.3.0 is only supported from v1.15+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "15") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 15) {
 					err := resizePVCAndValidateSize(pvcPath, appPath, f)
 					if err != nil {
 						e2elog.Failf("failed to resize filesystem PVC %v", err)
@@ -617,13 +604,8 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("Resize Block PVC and check Device size", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error with error %v", err)
-				}
-
 				// Block PVC resize is supported in kubernetes 1.16+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					err := resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
 					if err != nil {
 						e2elog.Failf("failed to resize block PVC with error %v", err)
@@ -920,12 +902,8 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("create ROX PVC clone and mount it to multiple pods", func() {
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error %v", err)
-				}
 				// snapshot beta is only supported from v1.17+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "17") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
 					// create PVC and bind it to an app
 					pvc, err := loadPVC(pvcPath)
 					if err != nil {
@@ -1084,14 +1062,9 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error with error %v", err)
-				}
-
 				// Resize Block PVC and check Device size within the namespace
 				// Block PVC resize is supported in kubernetes 1.16+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					err = resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
 					if err != nil {
 						e2elog.Failf("failed to resize block PVC with error %v", err)
@@ -1100,7 +1073,7 @@ var _ = Describe("RBD", func() {
 
 				// Create a PVC clone and bind it to an app within the namespace
 				// snapshot beta is only supported from v1.17+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "17") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
 					pvc, err := loadPVC(pvcPath)
 					if err != nil {
 						e2elog.Failf("failed to load PVC with error %v", err)

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -158,10 +158,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				var err error
 				label := make(map[string]string)
 				data := "check data persists"
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error %v", err)
-				}
+
 				pvc, err = loadPVC(pvcPath)
 				if pvc == nil {
 					e2elog.Failf("failed to load pvc with error %v", err)
@@ -209,7 +206,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				}
 
 				// pvc clone is only supported from v1.16+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					// Create snapshot of the pvc
 					snapshotPath := rbdExamplePath + "snapshot.yaml"
 					snap := getSnapshot(snapshotPath)
@@ -246,12 +243,9 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				pvcClonePath := rbdExamplePath + "pvc-restore.yaml"
 				appClonePath := rbdExamplePath + "pod-restore.yaml"
 				label := make(map[string]string)
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error %v", err)
-				}
+
 				// pvc clone is only supported from v1.16+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					pvcClone, err := loadPVC(pvcClonePath)
 					if err != nil {
 						e2elog.Failf("failed to load pvc with error %v", err)
@@ -298,12 +292,9 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				pvcSmartClonePath := rbdExamplePath + "pvc-clone.yaml"
 				appSmartClonePath := rbdExamplePath + "pod-clone.yaml"
 				label := make(map[string]string)
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error %v", err)
-				}
+
 				// pvc clone is only supported from v1.16+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					pvcClone, err := loadPVC(pvcSmartClonePath)
 					if err != nil {
 						e2elog.Failf("failed to load pvc with error %v", err)
@@ -349,16 +340,14 @@ var _ = Describe("RBD Upgrade Testing", func() {
 			By("Resize pvc and verify expansion", func() {
 				pvcExpandSize := "5Gi"
 				label := make(map[string]string)
-				v, err := f.ClientSet.Discovery().ServerVersion()
-				if err != nil {
-					e2elog.Failf("failed to get server version with error %v", err)
-				}
+
 				// Resize 0.3.0 is only supported from v1.15+
-				if v.Major > "1" || (v.Major == "1" && v.Minor >= "15") {
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 15) {
 					label[appKey] = appLabel
 					opt := metav1.ListOptions{
 						LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
 					}
+					var err error
 					pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 					if err != nil {
 						e2elog.Failf("failed to get pvc with error %v", err)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -568,3 +568,27 @@ func validatePVCClone(sourcePvcPath, clonePvcPath, clonePvcAppPath string, f *fr
 	wg.Wait()
 	validateRBDImageCount(f, 0)
 }
+
+// k8sVersionGreaterEquals checks the ServerVersion of the Kubernetes cluster
+// and compares it to the major.minor version passed. In case the version of
+// the cluster is equal or higher to major.minor, `true` is returned, `false`
+// otherwise.
+//
+// If fetching the ServerVersion of the Kubernetes cluster fails, the calling
+// test case is marked as `FAILED` and gets aborted.
+//
+// nolint:unparam // currently major is always 1, this can change in the future
+func k8sVersionGreaterEquals(c kubernetes.Interface, major, minor int) bool {
+	v, err := c.Discovery().ServerVersion()
+	if err != nil {
+		e2elog.Failf("failed to get server version with error %v", err)
+		// Failf() marks the case as failure, and returns from the
+		// Go-routine that runs the case. This function will not have a
+		// return value.
+	}
+
+	maj := fmt.Sprintf("%d", major)
+	min := fmt.Sprintf("%d", minor)
+
+	return (v.Major > maj) || (v.Major == maj && v.Minor >= min)
+}


### PR DESCRIPTION
Reduce redundant code, add a helper to check the Kubernetes version so that tests can run depending on the version that is used.