### PR TITLE
 cephfs: implement getFsName() with go-ceph

### DIFF
--- a/internal/cephfs/cephfs_util.go
+++ b/internal/cephfs/cephfs_util.go
@@ -96,13 +96,13 @@ type CephFilesystemDump struct {
 	Filesystems []CephFilesystemDetails `json:"filesystems"`
 }
 
-func getFsName(ctx context.Context, monitors string, cr *util.Credentials, fscID int64) (string, error) {
+func (vo *volumeOptions) getFsName(ctx context.Context, cr *util.Credentials) (string, error) {
 	// ./tbox ceph fs dump --format=json
 	// JSON: {...,"filesystems":[{"mdsmap":{},"id":<n>},...],...}
 	var fsDump CephFilesystemDump
 	err := execCommandJSON(ctx, &fsDump,
 		"ceph",
-		"-m", monitors,
+		"-m", vo.Monitors,
 		"--id", cr.ID,
 		"--keyfile="+cr.KeyFile,
 		"-c", util.CephConfigPath,
@@ -113,10 +113,10 @@ func getFsName(ctx context.Context, monitors string, cr *util.Credentials, fscID
 	}
 
 	for _, fs := range fsDump.Filesystems {
-		if fs.ID == fscID {
+		if fs.ID == vo.FscID {
 			return fs.MDSMap.FilesystemName, nil
 		}
 	}
 
-	return "", fmt.Errorf("%w: fscID (%d) not found in Ceph cluster", util.ErrPoolNotFound, fscID)
+	return "", fmt.Errorf("%w: fscID (%d) not found in Ceph cluster", util.ErrPoolNotFound, vo.FscID)
 }

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -283,7 +283,7 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 		return nil, nil, err
 	}
 
-	volOptions.FsName, err = volOptions.getFsName(ctx, cr)
+	volOptions.FsName, err = volOptions.getFsName(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -478,7 +478,7 @@ func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Crede
 		return &volOptions, nil, &sid, fmt.Errorf("failed to fetch subvolumegroup list using clusterID (%s): %w", vi.ClusterID, err)
 	}
 
-	volOptions.FsName, err = volOptions.getFsName(ctx, cr)
+	volOptions.FsName, err = volOptions.getFsName(ctx)
 	if err != nil {
 		return &volOptions, nil, &sid, err
 	}

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -283,7 +283,7 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 		return nil, nil, err
 	}
 
-	volOptions.FsName, err = getFsName(ctx, volOptions.Monitors, cr, volOptions.FscID)
+	volOptions.FsName, err = volOptions.getFsName(ctx, cr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -478,7 +478,7 @@ func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Crede
 		return &volOptions, nil, &sid, fmt.Errorf("failed to fetch subvolumegroup list using clusterID (%s): %w", vi.ClusterID, err)
 	}
 
-	volOptions.FsName, err = getFsName(ctx, volOptions.Monitors, cr, volOptions.FscID)
+	volOptions.FsName, err = volOptions.getFsName(ctx, cr)
 	if err != nil {
 		return &volOptions, nil, &sid, err
 	}


### PR DESCRIPTION
Reduce the numbed of `ceph fs` command executions, and use go-ceph with a cached/shared connection.

Fixes: #1549
~Do-Not-Merge: depends on #1545 and #1577, which needs to get merged first~