### PR TITLE
rbd: remove unwanted condition check in flattenCloneImage

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -244,10 +244,8 @@ func (rv *rbdVolume) flattenCloneImage(ctx context.Context) error {
 	if err == nil {
 		return tempClone.flattenRbdImage(ctx, tempClone.conn.Creds, false, hardLimit, softLimit)
 	}
-	if err != nil {
-		if !errors.Is(err, ErrImageNotFound) {
-			return err
-		}
+	if !errors.Is(err, ErrImageNotFound) {
+		return err
 	}
 	return rv.flattenRbdImage(ctx, rv.conn.Creds, false, hardLimit, softLimit)
 }


### PR DESCRIPTION
All the previous condition checks exit from the function and
when it reach to this block its obvious that error is non nil,
we dont need an extra check here.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

