### PR TITLE
ci: set GITHUB_API_TOKEN in the environment for all stages

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -17,6 +17,11 @@ def ssh(cmd) {
 }
 
 node('cico-workspace') {
+	environment {
+		// "github-api-token" is a secret text credential configured in Jenkins
+		GITHUB_API_TOKEN = credentials("github-api-token")
+	}
+
 	stage('checkout ci repository') {
 		git url: "${ci_git_repo}",
 			branch: "${ci_git_branch}",
@@ -24,11 +29,6 @@ node('cico-workspace') {
 	}
 
 	stage('skip ci/skip/e2e label') {
-		environment {
-			// "github-api-token" is a secret text credential configured in Jenkins
-			GITHUB_API_TOKEN = credentials("github-api-token")
-		}
-
 		if (params.ghprbPullId == null) {
 			skip_e2e = 1
 			return

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -14,6 +14,11 @@ def ssh(cmd) {
 }
 
 node('cico-workspace') {
+	environment {
+		// "github-api-token" is a secret text credential configured in Jenkins
+		GITHUB_API_TOKEN = credentials("github-api-token")
+	}
+
 	stage('checkout ci repository') {
 		git url: "${ci_git_repo}",
 			branch: "${ci_git_branch}",
@@ -21,11 +26,6 @@ node('cico-workspace') {
 	}
 
 	stage('skip ci/skip/e2e label') {
-		environment {
-			// "github-api-token" is a secret text credential configured in Jenkins
-			GITHUB_API_TOKEN = credentials("github-api-token")
-		}
-
 		if (params.ghprbPullId == null) {
 			skip_e2e = 1
 			return

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -14,6 +14,11 @@ def ssh(cmd) {
 }
 
 node('cico-workspace') {
+	environment {
+		// "github-api-token" is a secret text credential configured in Jenkins
+		GITHUB_API_TOKEN = credentials("github-api-token")
+	}
+
 	stage('checkout ci repository') {
 		git url: "${ci_git_repo}",
 			branch: "${ci_git_branch}",
@@ -21,11 +26,6 @@ node('cico-workspace') {
 	}
 
 	stage('skip ci/skip/e2e label') {
-		environment {
-			// "github-api-token" is a secret text credential configured in Jenkins
-			GITHUB_API_TOKEN = credentials("github-api-token")
-		}
-
 		if (params.ghprbPullId == null) {
 			skip_e2e = 1
 			return


### PR DESCRIPTION
The GITHUB_API_TOKEN is currently set in the 1st stage that needs it. Unfortunately the `environment { .. }` block does not behave similar to setting `env.GITHUB_API_TOKEN` and gets wiped for the next stage(s).

Setting the GITHUB_API_TOKEN for all stages, allow any of the scripts to use the environment variable and access the GitHub API with a much higher rate limit.