### PR TITLE
ci: use Kubernetes 1.19.2 for CI jobs

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -3,7 +3,7 @@
     name: mini-e2e
     k8s_version:
       - '1.18'
-      - '1.19'
+      - '1.19.2'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'

--- a/scripts/get_patch_release.py
+++ b/scripts/get_patch_release.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
 '''
 Fetches the Kubernetes releases from GitHub and returns the most recent patch
-release for a major version.
+release for a major version (like 1.19). In case the version that is passed
+contains the patch release already, the latest patch release will not be
+detected, but the passed version will be returned (enables forcing a particular
+version in CI jobs).
 
 Parameters:
  --version=<version>: the major version to find the latest patch release for, i.e. v1.19
@@ -100,6 +103,12 @@ def main():
         version = args.version
         if not version.startswith('v'):
             version = 'v' + version
+
+        # when version already contains the patch release, do not run any
+        # detection
+        if len(version.split('.')) >= 3:
+            print(version)
+            sys.exit(0)
 
         # releases are ordered from newest to oldest, so the 1st match is the
         # most current patch update


### PR DESCRIPTION
The latest Kubernetes patch release (v1.19.3) can not be deployed with
minikube. Selecting version 1.19.2 until the problems with minikube are
addressed.

In case the version that is passed with --version=... contains the patch
release already, the latest patch release will not be detected, but the
passed version will be returned (enables forcing a particular version in
CI jobs).

Updates: #1588
