### PR TITLE
ci: use Kubernetes 1.18.9 for CI jobs

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,7 +2,7 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.18'
+      - '1.18.9'
       - '1.19.2'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.18'
+    k8s_version: '1.18.9'
     test_type:
       - 'cephfs'
       - 'rbd'


### PR DESCRIPTION
The latest Kubernetes patch release (v1.18.10) can not be deployed with
minikube. Selecting version 1.18.9 until the problems with minikube are
addressed.

Updates: #1588 
Note: v1.19.3 has the same problem, kubernetes/minikube#9470 lists 1.18.10 too
