### PR TITLE
e2e: fix regression in CephFS Snapshot testing

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -691,6 +691,7 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	defer volOpt.Destroy()
 
 	// safeguard against parallel create or delete requests against the same
 	// name

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -282,6 +282,13 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 	if err != nil {
 		return nil, nil, err
 	}
+	// in case of an error, volOptions is not returned, release any
+	// resources that may have been allocated
+	defer func() {
+		if err != nil {
+			volOptions.Destroy()
+		}
+	}()
 
 	volOptions.FsName, err = volOptions.getFsName(ctx)
 	if err != nil {


### PR DESCRIPTION
1. Connect snapshot to Ceph cluster in newSnapshotOptionsFromID()
    
    Without connection, follow-up operations on the volumeOptions object
    will cause a panic. This should fix a regression in CephFS testing.

1. Cleanup volumeOptions in case of an error in newVolumeOptionsFromVolID()
    
    The allocated, and potentially connected, volumeOptions object in
    newVolumeOptionsFromVolID() is not cleaned-up in case of errors. This
    could cause resource leaks.
