### PR TITLE
ci: get the GitHub API Token before starting a node

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -16,12 +16,12 @@ def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \"${cmd}\""
 }
 
-node('cico-workspace') {
-	environment {
-		// "github-api-token" is a secret text credential configured in Jenkins
-		GITHUB_API_TOKEN = credentials("github-api-token")
-	}
+environment {
+	// "github-api-token" is a secret text credential configured in Jenkins
+	GITHUB_API_TOKEN = credentials("github-api-token")
+}
 
+node('cico-workspace') {
 	stage('checkout ci repository') {
 		git url: "${ci_git_repo}",
 			branch: "${ci_git_branch}",

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -13,12 +13,12 @@ def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
 }
 
-node('cico-workspace') {
-	environment {
-		// "github-api-token" is a secret text credential configured in Jenkins
-		GITHUB_API_TOKEN = credentials("github-api-token")
-	}
+environment {
+	// "github-api-token" is a secret text credential configured in Jenkins
+	GITHUB_API_TOKEN = credentials("github-api-token")
+}
 
+node('cico-workspace') {
 	stage('checkout ci repository') {
 		git url: "${ci_git_repo}",
 			branch: "${ci_git_branch}",


### PR DESCRIPTION
It still seems that the environment is not set when the GitHub API is
called. Maybe things work better when the environment is set before
starting the cico-workspace node.