### PR TITLE
Update mergify rules to auto merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,12 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19.2"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.18.9"
+      - "status-success=ci/centos/mini-e2e/k8s-1.19.2"
+      - "status-success=ci/centos/mini-e2e/k8s-1.18.9"
+      - "status-success=ci/centos/upgrade-tests-cephfs"
+      - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -180,7 +180,6 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "#approved-reviews-by>=1"
       - "status-success=continuous-integration/travis-ci/pr"
-      - "status-success=continuous-integration/travis-ci/pr"
       - "status-success=ci/centos/containerized-tests"
       - "status-success=ci/centos/mini-e2e-helm/k8s-1.19.2"
       - "status-success=ci/centos/mini-e2e-helm/k8s-1.18.9"


### PR DESCRIPTION
Updated Mergify rules to wait for centos CI to go green before merging the PR, even if the PR has two approvals