### PR TITLE
rbd: volJournal.Connect() error return wrongly pushed  to caller

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -186,10 +186,10 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 
-		j, err2 := volJournal.Connect(volOptions.Monitors, volOptions.RadosNamespace, cr)
-		if err2 != nil {
-			util.ErrorLog(ctx, "failed to establish cluster connection: %v", err2)
-			return nil, status.Error(codes.Internal, err.Error())
+		j, connErr := volJournal.Connect(volOptions.Monitors, volOptions.RadosNamespace, cr)
+		if connErr != nil {
+			util.ErrorLog(ctx, "failed to establish cluster connection: %v", connErr)
+			return nil, status.Error(codes.Internal, connErr.Error())
 		}
 		defer j.Destroy()
 


### PR DESCRIPTION
volJournal.Connect() got the error on `err2` variable, however
the return was on variable `err` which hold the error return of
DecomposeCSIID() which is wrong. This cause the error return wrongly
parsed and pushed from the caller.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
