### PR TITLE
ci: move skip-e2e-check after GitHub API usage

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -35,11 +35,6 @@ node('cico-workspace') {
 				script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
 				returnStatus: true)
 		}
-		// if skip_e2e returned 0, do not run full tests
-		if (skip_e2e == 0) {
-			currentBuild.result = 'SUCCESS'
-			return
-		}
 
 		stage("detect k8s-${k8s_version} patch release") {
 			k8s_release = sh(
@@ -47,6 +42,12 @@ node('cico-workspace') {
 				returnStdout: true).trim()
 			echo "detected Kubernetes patch release: ${k8s_release}"
 		}
+	}
+
+	// if skip_e2e returned 0, do not run full tests
+	if (skip_e2e == 0) {
+		currentBuild.result = 'SUCCESS'
+		return
 	}
 
 	stage('checkout PR') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -32,11 +32,6 @@ node('cico-workspace') {
 				script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
 				returnStatus: true)
 		}
-		// if skip_e2e returned 0, do not run full tests
-		if (skip_e2e == 0) {
-			currentBuild.result = 'SUCCESS'
-			return
-		}
 
 		stage("detect k8s-${k8s_version} patch release") {
 			k8s_release = sh(
@@ -44,6 +39,12 @@ node('cico-workspace') {
 				returnStdout: true).trim()
 			echo "detected Kubernetes patch release: ${k8s_release}"
 		}
+	}
+
+	// if skip_e2e returned 0, do not run full tests
+	if (skip_e2e == 0) {
+		currentBuild.result = 'SUCCESS'
+		return
 	}
 
 	stage('checkout PR') {

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -32,11 +32,6 @@ node('cico-workspace') {
 				script: "./scripts/get_github_labels.py --id=${ghprbPullId} --has-label=ci/skip/e2e",
 				returnStatus: true)
 		}
-		// if skip_e2e returned 0, do not run full tests
-		if (skip_e2e == 0) {
-			currentBuild.result = 'SUCCESS'
-			return
-		}
 
 		stage("detect k8s-${k8s_version} patch release") {
 			k8s_release = sh(
@@ -44,6 +39,12 @@ node('cico-workspace') {
 				returnStdout: true).trim()
 			echo "detected Kubernetes patch release: ${k8s_release}"
 		}
+	}
+
+	// if skip_e2e returned 0, do not run full tests
+	if (skip_e2e == 0) {
+		currentBuild.result = 'SUCCESS'
+		return
 	}
 
 	stage('checkout PR') {


### PR DESCRIPTION
When the [ci/skip/e2e] label is set on PRs, the withCredentials()
statement is aborted, but the other stages still continue. This causes
the tests to run, which is not what we want when the label is added.

Affected PR: #1606