### PR TITLE
e2e: validate the error return instead of object for consistency

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -335,7 +335,7 @@ var _ = Describe("cephfs", func() {
 
 			By("create PVC, delete backing subvolume and check pv deletion", func() {
 				pvc, err := loadPVC(pvcPath)
-				if pvc == nil {
+				if err != nil {
 					e2elog.Failf("failed to load PVC with error %v", err)
 				}
 				pvc.Namespace = f.UniqueName

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -65,13 +65,13 @@ func resizePVCAndValidateSize(pvcPath, appPath string, f *framework.Framework) e
 	size := "1Gi"
 	expandSize := "10Gi"
 	pvc, err := loadPVC(pvcPath)
-	if pvc == nil {
+	if err != nil {
 		return err
 	}
 	pvc.Namespace = f.UniqueName
 
 	resizePvc, err := loadPVC(pvcPath)
-	if resizePvc == nil {
+	if err != nil {
 		return err
 	}
 	resizePvc.Namespace = f.UniqueName

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -142,7 +142,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				label := make(map[string]string)
 
 				pvc, err = loadPVC(pvcPath)
-				if pvc == nil {
+				if err != nil {
 					e2elog.Failf("failed to load pvc with error %v", err)
 				}
 				pvc.Namespace = f.UniqueName

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -160,7 +160,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				data := "check data persists"
 
 				pvc, err = loadPVC(pvcPath)
-				if pvc == nil {
+				if err != nil {
 					e2elog.Failf("failed to load pvc with error %v", err)
 				}
 				pvc.Namespace = f.UniqueName

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -188,7 +188,7 @@ func deletePVCAndApp(name string, f *framework.Framework, pvc *v1.PersistentVolu
 
 func createPVCAndAppBinding(pvcPath, appPath string, f *framework.Framework, pvcTimeout int) (*v1.PersistentVolumeClaim, *v1.Pod, error) {
 	pvc, err := loadPVC(pvcPath)
-	if pvc == nil {
+	if err != nil {
 		return nil, nil, err
 	}
 	pvc.Namespace = f.UniqueName
@@ -356,7 +356,7 @@ func writeDataInPod(app *v1.Pod, f *framework.Framework) error {
 func checkDataPersist(pvcPath, appPath string, f *framework.Framework) error {
 	data := "checking data persist"
 	pvc, err := loadPVC(pvcPath)
-	if pvc == nil {
+	if err != nil {
 		return err
 	}
 
@@ -450,7 +450,7 @@ func pvcDeleteWhenPoolNotFound(pvcPath string, cephfs bool, f *framework.Framewo
 
 func checkMountOptions(pvcPath, appPath string, f *framework.Framework, mountFlags []string) error {
 	pvc, err := loadPVC(pvcPath)
-	if pvc == nil {
+	if err != nil {
 		return err
 	}
 

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -98,7 +98,7 @@ func getSecret(path string) (v1.Secret, error) {
 }
 
 // updateSecretForEncryption is an hack to update the secrets created by rook to
-// include the encyption key
+// include the encryption key
 // TODO in cephcsi we need to create own users in ceph cluster and use it for E2E.
 func updateSecretForEncryption(c kubernetes.Interface) error {
 	secrets, err := c.CoreV1().Secrets(rookNamespace).Get(context.TODO(), rbdProvisionerSecretName, metav1.GetOptions{})


### PR DESCRIPTION
If loadPVC() fails, it return error and we expect the PVC object to be nil too. In many places we check on the error and exit. however in few places we are looking at PVC object. This commit make the condition check on `err` instead of `PVC` object for consistency.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>