### PR TITLE
rbd: use different variable instead of builtin `cap` attribute

### DIFF
--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -62,7 +62,7 @@ func (cs *DefaultControllerServer) ControllerGetCapabilities(ctx context.Context
 	util.TraceLog(ctx, "Using default ControllerGetCapabilities")
 
 	return &csi.ControllerGetCapabilitiesResponse{
-		Capabilities: cs.Driver.cap,
+		Capabilities: cs.Driver.capabilities,
 	}, nil
 }
 

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -33,9 +33,9 @@ type CSIDriver struct {
 	nodeID  string
 	version string
 	// topology constraints that this nodeserver will advertise
-	topology map[string]string
-	cap      []*csi.ControllerServiceCapability
-	vc       []*csi.VolumeCapability_AccessMode
+	topology     map[string]string
+	capabilities []*csi.ControllerServiceCapability
+	vc           []*csi.VolumeCapability_AccessMode
 }
 
 // NewCSIDriver Creates a NewCSIDriver object. Assumes vendor
@@ -73,7 +73,7 @@ func (d *CSIDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapa
 		return nil
 	}
 
-	for _, capability := range d.cap {
+	for _, capability := range d.capabilities {
 		if c == capability.GetRpc().GetType() {
 			return nil
 		}
@@ -91,7 +91,7 @@ func (d *CSIDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceC
 		csc = append(csc, NewControllerServiceCapability(c))
 	}
 
-	d.cap = csc
+	d.capabilities = csc
 }
 
 // AddVolumeCapabilityAccessModes stores volume access modes.

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -95,12 +95,12 @@ func (cs *ControllerServer) parseVolCreateRequest(ctx context.Context, req *csi.
 
 	isMultiNode := false
 	isBlock := false
-	for _, cap := range req.VolumeCapabilities {
+	for _, capability := range req.VolumeCapabilities {
 		// RO modes need to be handled independently (ie right now even if access mode is RO, they'll be RW upon attach)
-		if cap.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
+		if capability.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
 			isMultiNode = true
 		}
-		if cap.GetBlock() != nil {
+		if capability.GetBlock() != nil {
 			isBlock = true
 		}
 	}
@@ -689,8 +689,8 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		return nil, status.Error(codes.InvalidArgument, "empty volume capabilities in request")
 	}
 
-	for _, cap := range req.VolumeCapabilities {
-		if cap.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+	for _, capability := range req.VolumeCapabilities {
+		if capability.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
 			return &csi.ValidateVolumeCapabilitiesResponse{Message: ""}, nil
 		}
 	}

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -82,8 +82,8 @@ func ValidateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) err
 // CheckReadOnlyManyIsSupported checks the request is to create ReadOnlyMany
 // volume is from source as empty ReadOnlyMany is not supported.
 func CheckReadOnlyManyIsSupported(req *csi.CreateVolumeRequest) error {
-	for _, cap := range req.GetVolumeCapabilities() {
-		if m := cap.GetAccessMode().Mode; m == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY || m == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
+	for _, capability := range req.GetVolumeCapabilities() {
+		if m := capability.GetAccessMode().Mode; m == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY || m == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
 			if req.GetVolumeContentSource() == nil {
 				return status.Error(codes.InvalidArgument, "readOnly accessMode is supported only with content source")
 			}


### PR DESCRIPTION
    `cap` builtin function returns the capacity of a type. Its not
    good practice to use this builtin function for other variable
    names, removing it here
    
    Ref# https://golang.org/pkg/builtin/#cap

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

