### PR TITLE
ci: improve rules for commitlint

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -9,8 +9,21 @@ rules:
   header-max-length: [2, always, 72]
   # the subject may not end with a "."
   header-full-stop: [2, never, "."]
+
+  # the subject cannot be empty
+  subject-empty: [2, never]
+
   # we do not use scopes for commit messages
   scope-empty: [1, always]
+
+  # Body shouldn't be empty
+  body-min-length: [2, always, 1]
+  # Wrap the lines to 80 characters.
+  body-max-line-length: [1, always, 80]
+
+  # always sign off the commit
+  signed-off-by: [2, always, "Signed-off-by:"]
+
   # valid types/prefixes, see docs/development-guide.md
   type-enum:
     - 2

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -14,7 +14,7 @@ rules:
   subject-empty: [2, never]
 
   # we do not use scopes for commit messages
-  scope-empty: [1, always]
+  scope-empty: [0, always]
 
   # Body shouldn't be empty
   body-min-length: [2, always, 1]

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,6 +1,6 @@
 ---
 # rules are documented at https://commitlint.js.org/#/reference-rules
-# each rule has a n arry of three values:
+# each rule has an array of three values:
 # - 0, 1, 2 (rule is disabled, warning or error)
 # - always/never
 # - value


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
Add a few more rules, like:
* subject cannot be empty
* body shouldn't be empty
* avoid body line length over 80 characters (warning only)
* always sign-off the commit msg
* disable scopes rule

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
