### PR TITLE
cephfs: implement resizeVolume() with go-ceph

### DIFF
--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -100,7 +100,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 		return cloneFailedErr
 	case cephFSCloneComplete:
 		// This is a work around to fix sizing issue for cloned images
-		err = volOpt.resizeVolume(ctx, cr, cloneID, volOpt.Size)
+		err = volOpt.resizeVolume(ctx, cloneID, volOpt.Size)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to expand volume %s: %v", cloneID, err)
 			return err
@@ -179,7 +179,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 		// The clonedvolume currently does not reflect the proper size due to an issue in cephfs
 		// however this is getting addressed in cephfs and the parentvolume size will be reflected
 		// in the new cloned volume too. Till then we are explicitly making the size set
-		err = volOptions.resizeVolume(ctx, cr, volumeID(vID.FsSubvolName), volOptions.Size)
+		err = volOptions.resizeVolume(ctx, volumeID(vID.FsSubvolName), volOptions.Size)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to expand volume %s with error: %v", vID.FsSubvolName, err)
 			return err

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -100,7 +100,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 		return cloneFailedErr
 	case cephFSCloneComplete:
 		// This is a work around to fix sizing issue for cloned images
-		err = resizeVolume(ctx, volOpt, cr, cloneID, volOpt.Size)
+		err = volOpt.resizeVolume(ctx, cr, cloneID, volOpt.Size)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to expand volume %s: %v", cloneID, err)
 			return err
@@ -179,7 +179,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 		// The clonedvolume currently does not reflect the proper size due to an issue in cephfs
 		// however this is getting addressed in cephfs and the parentvolume size will be reflected
 		// in the new cloned volume too. Till then we are explicitly making the size set
-		err = resizeVolume(ctx, volOptions, cr, volumeID(vID.FsSubvolName), volOptions.Size)
+		err = volOptions.resizeVolume(ctx, cr, volumeID(vID.FsSubvolName), volOptions.Size)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to expand volume %s with error: %v", vID.FsSubvolName, err)
 			return err

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -186,7 +186,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			// it will be fixed in cephfs soon with the parentvolume size. Till then by below
 			// resize we are making sure we return or satisfy the requested size by setting the size
 			// explictly
-			err = volOptions.resizeVolume(ctx, cr, volumeID(vID.FsSubvolName), volOptions.Size)
+			err = volOptions.resizeVolume(ctx, volumeID(vID.FsSubvolName), volOptions.Size)
 			if err != nil {
 				purgeErr := purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions, false)
 				if purgeErr != nil {
@@ -426,7 +426,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 
 	RoundOffSize := util.RoundOffBytes(req.GetCapacityRange().GetRequiredBytes())
 
-	if err = volOptions.resizeVolume(ctx, cr, volumeID(volIdentifier.FsSubvolName), RoundOffSize); err != nil {
+	if err = volOptions.resizeVolume(ctx, volumeID(volIdentifier.FsSubvolName), RoundOffSize); err != nil {
 		util.ErrorLog(ctx, "failed to expand volume %s: %v", volumeID(volIdentifier.FsSubvolName), err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -186,7 +186,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			// it will be fixed in cephfs soon with the parentvolume size. Till then by below
 			// resize we are making sure we return or satisfy the requested size by setting the size
 			// explictly
-			err = resizeVolume(ctx, volOptions, cr, volumeID(vID.FsSubvolName), volOptions.Size)
+			err = volOptions.resizeVolume(ctx, cr, volumeID(vID.FsSubvolName), volOptions.Size)
 			if err != nil {
 				purgeErr := purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions, false)
 				if purgeErr != nil {
@@ -426,7 +426,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 
 	RoundOffSize := util.RoundOffBytes(req.GetCapacityRange().GetRequiredBytes())
 
-	if err = resizeVolume(ctx, volOptions, cr, volumeID(volIdentifier.FsSubvolName), RoundOffSize); err != nil {
+	if err = volOptions.resizeVolume(ctx, cr, volumeID(volIdentifier.FsSubvolName), RoundOffSize); err != nil {
 		util.ErrorLog(ctx, "failed to expand volume %s: %v", volumeID(volIdentifier.FsSubvolName), err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -176,7 +176,7 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, volID volumeID
 // resizeVolume will try to use ceph fs subvolume resize command to resize the
 // subvolume. If the command is not available as a fallback it will use
 // CreateVolume to resize the subvolume.
-func (vo *volumeOptions) resizeVolume(ctx context.Context, cr *util.Credentials, volID volumeID, bytesQuota int64) error {
+func (vo *volumeOptions) resizeVolume(ctx context.Context, volID volumeID, bytesQuota int64) error {
 	// keyPresent checks whether corresponding clusterID key is present in clusterAdditionalInfo
 	var keyPresent bool
 	// verify if corresponding ClusterID key is present in the map,


### PR DESCRIPTION
Reduce the number of ceph fs command executions, and use go-ceph with a cached/shared connection.

~Do-Not-Merge: depends on #1612, which needs to get merged first~