### PR TITLE
ci: use refs/pull/<id>/merge to prevent need for rebases

### DIFF
--- a/commitlint.groovy
+++ b/commitlint.groovy
@@ -31,7 +31,7 @@ node('cico-workspace') {
 	try {
 		stage('prepare bare-metal machine') {
 			if (params.ghprbPullId != null) {
-				ref = "pull/${ghprbPullId}/head"
+				ref = "pull/${ghprbPullId}/merge"
 			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh root@${CICO_NODE}:'
 			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref} --history"
@@ -41,7 +41,7 @@ node('cico-workspace') {
 			if (params.ghprbTargetBranch != null) {
 				git_since = "origin/${ghprbTargetBranch}"
 			}
-			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test CONTAINER_CMD=podman TARGET=commitlint GIT_SINCE=${git_since} REBASE=1'"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test CONTAINER_CMD=podman TARGET=commitlint GIT_SINCE=${git_since}'"
 		}
 	}
 

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -52,7 +52,7 @@ node('cico-workspace') {
 
 	stage('checkout PR') {
 		if (params.ghprbPullId != null) {
-			ref = "pull/${ghprbPullId}/head"
+			ref = "pull/${ghprbPullId}/merge"
 		}
 		if (params.ghprbTargetBranch != null) {
 			git_since = "${ghprbTargetBranch}"

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -49,7 +49,7 @@ node('cico-workspace') {
 
 	stage('checkout PR') {
 		if (params.ghprbPullId != null) {
-			ref = "pull/${ghprbPullId}/head"
+			ref = "pull/${ghprbPullId}/merge"
 		}
 		if (params.ghprbTargetBranch != null) {
 			git_since = "${ghprbTargetBranch}"

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -49,7 +49,7 @@ node('cico-workspace') {
 
 	stage('checkout PR') {
 		if (params.ghprbPullId != null) {
-			ref = "pull/${ghprbPullId}/head"
+			ref = "pull/${ghprbPullId}/merge"
 		}
 		if (params.ghprbTargetBranch != null) {
 			git_since = "${ghprbTargetBranch}"


### PR DESCRIPTION
`refs/pull/<id>/head` might not contain the most current state of the
branch. In case other PRs got merged, the PR under test needs rebasing.
GitHub offers `refs/pull/<id>/merge` to checkout the rebased PR, use that
in the CI jobs.

In case `refs/pull/<id>/merge` is not available, it means the PR can not
be rebased on its target branch. This will cause the CI job to fail, but
GitHub also will have a message about rebase conflicts.
