### PR TITLE
util: NewCredentials() dont have any callers

### DIFF
--- a/internal/util/credentials.go
+++ b/internal/util/credentials.go
@@ -110,19 +110,6 @@ func NewAdminCredentials(secrets map[string]string) (*Credentials, error) {
 	return newCredentialsFromSecret(credAdminID, credAdminKey, secrets)
 }
 
-// NewCredentials generates new credentials when id and key are provided.
-func NewCredentials(id, key string) (*Credentials, error) {
-	var c = &Credentials{}
-
-	c.ID = id
-	keyFile, err := storeKey(key)
-	if err == nil {
-		c.KeyFile = keyFile
-	}
-
-	return c, err
-}
-
 // GetMonValFromSecret returns monitors from secret.
 func GetMonValFromSecret(secrets map[string]string) (string, error) {
 	if mons, ok := secrets[credMonitors]; ok {


### PR DESCRIPTION
We have below exported function in credentials.go which is not
called from anywhere in the repo. Removing it for the same reason.

```
 // NewCredentials generates new credentials when id and key
 // are provided.

 func NewCredentials(id, key string) (*Credentials, error) {
...
```

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

