### PR TITLE
ci: run only one jjb-validate at the time

### DIFF
--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -2,7 +2,7 @@
 - job:
     name: jjb-validate
     project-type: pipeline
-    concurrent: true
+    concurrent: false
     properties:
       - github:
           url: https://github.com/ceph/ceph-csi


### PR DESCRIPTION
The jjb-validate job creates a Batch Job in OCP. This job has a fixed
name, and fails to get created when one with the same name already
exists. There is no need to run jjb-validate concurrently, the number of
changes for CI jobs are not blocked by this serialization.