### PR TITLE
ci: increase deploy-timeout for upgrade-tests-cephfs job

### DIFF
--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -109,7 +109,7 @@ node('cico-workspace') {
 			timeout(time: 120, unit: 'MINUTES') {
 				upgrade_args = "--test-cephfs=false --test-rbd=true --upgrade-testing=true"
 				if ("${test_type}" == "cephfs"){
-					upgrade_args = "--test-cephfs=true --test-rbd=false --upgrade-testing=true"
+					upgrade_args = "--deploy-timeout=300 --test-cephfs=true --test-rbd=false --upgrade-testing=true"
 				}
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS=\"--upgrade-version=${csi_upgrade_version} ${upgrade_args}\""
 			}


### PR DESCRIPTION
The upgrade-tests-cephfs fails relative regularly with the following
error during intial deployment:

    timeout waiting for deployment csi-cephfsplugin-provisioner with error error waiting for deployment "csi-cephfsplugin-provisioner" status to match expectation: etcdserver: request timed out

Increasing the timeout to 300 seconds (default 10) might make the job
more reliable.
