### PR TITLE
ci: copy run-k8s-external-storage-e2e.sh to bare-metal machine

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -92,7 +92,7 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/head"
 			}
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./run-k8s-external-storage-e2e.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('build artifacts') {


### PR DESCRIPTION
The ./run-k8s-external-storage-e2e.sh script that executes the
Kubernetes e2e external-storage tests needs to be placed on the
bare-metal machine. Currently, the k8s-e2e-external-storage job fails
with:

    bash: ./run-k8s-external-storage-e2e.sh: No such file or directory

