### PR TITLE
Build ceph-csi:test and ceph-csi:latest container images in CentOS CI OpenShift

### DIFF
--- a/deploy/ceph-csi-buildconfig.yaml
+++ b/deploy/ceph-csi-buildconfig.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: ceph-csi-canary
+  labels:
+    app: ceph-csi
+spec:
+  runPolicy: Serial
+  successfulBuildsHistoryLimit: 1
+  failedBuildsHistoryLimit: 1
+  source:
+    git:
+      uri: https://github.com/ceph/ceph-csi
+      ref: master
+    contextDir: .
+  strategy:
+    dockerStrategy:
+      dockerfilePath: deploy/cephcsi/image/Dockerfile
+  output:
+    to:
+      kind: DockerImage
+      name: registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi:canary
+    pushSecret:
+      name: container-registry-auth
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: ceph-csi-test
+  labels:
+    app: ceph-csi
+spec:
+  runPolicy: Serial
+  successfulBuildsHistoryLimit: 1
+  failedBuildsHistoryLimit: 1
+  source:
+    git:
+      uri: https://github.com/ceph/ceph-csi
+      ref: master
+    contextDir: .
+  strategy:
+    dockerStrategy:
+      dockerfilePath: scripts/Dockerfile.test
+  output:
+    to:
+      kind: DockerImage
+      name: registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi:test
+    pushSecret:
+      name: container-registry-auth
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: ceph-csi-devel
+  labels:
+    app: ceph-csi
+spec:
+  runPolicy: Serial
+  successfulBuildsHistoryLimit: 1
+  failedBuildsHistoryLimit: 1
+  source:
+    git:
+      uri: https://github.com/ceph/ceph-csi
+      ref: master
+    contextDir: .
+  strategy:
+    dockerStrategy:
+      dockerfilePath: scripts/Dockerfile.devel
+  output:
+    to:
+      kind: DockerImage
+      name: registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi:devel
+    pushSecret:
+      name: container-registry-auth

--- a/deploy/container-registry.yaml
+++ b/deploy/container-registry.yaml
@@ -1,0 +1,100 @@
+#
+#
+# Also requires linking the pushSecret to the builder Service Account:
+#   $ oc secrets link builder container-registry-auth
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: container-registry-auth
+  labels:
+    app: container-registry
+stringData:
+  username: "@@USERNAME@@"
+  password: "@@RANDOM_STRING@@"
+  # contents created with:
+  #   $ htpasswd -Bbn $USER $PASSWD
+  htpasswd: |-
+    "@@REPLACE_WITH_OUTPUT_OF_HTPASSWD_CMD@@"
+  # contents created with:
+  #   $ podman login -u $USER -p $PASSWD --authfile=config.json $URL
+  config.json: |-
+    {
+      "auths": {
+        "registry-ceph-csi.apps.ocp.ci.centos.org": {
+          "auth": "@@SOME_B64ENCODED_STRING@@"
+        }
+      }
+    }
+---
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: container-registry
+  labels:
+    app: container-registry
+spec:
+  triggers:
+    - type: ConfigChange
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: container-registry
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: docker-registry
+          image: docker.io/library/registry:2
+          volumeMounts:
+            - name: container-images
+              mountPath: /var/lib/registry
+            - name: htpasswd
+              mountPath: /auth
+          env:
+            - name: REGISTRY_AUTH
+              value: htpasswd
+            - name: REGISTRY_AUTH_HTPASSWD_REALM
+              value: Ceph-CSI CI Container Registry
+            - name: REGISTRY_AUTH_HTPASSWD_PATH
+              value: /auth/htpasswd
+      volumes:
+        - name: container-images
+          persistentVolumeClaim:
+            claimName: ceph-csi-image-registry
+        - name: htpasswd
+          secret:
+            secretName: container-registry-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: container-registry
+  labels:
+    app: container-registry
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    name: container-registry
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: registry
+  labels:
+    app: container-registry
+spec:
+  port:
+    targetPort: 5000
+  tls:
+    insecureEdgeTerminationPolicy: Allow
+    termination: edge
+  to:
+    kind: Service
+    name: container-registry
+    weight: 100
+  wildcardPolicy: None

--- a/jobs/build-images.yaml
+++ b/jobs/build-images.yaml
@@ -1,0 +1,42 @@
+---
+- job:
+    name: build-images
+    description: Build container images from the master branch.
+    project-type: pipeline
+    concurrent: false
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-csi
+      - build-discarder:
+          days-to-keep: 7
+          artifact-days-to-keep: 7
+    # yamllint disable rule:line-length
+    dsl: |
+      def GIT_REPO = 'http://github.com/ceph/ceph-csi'
+      def GIT_BRANCH = 'master'
+      node {
+        stage('checkout repository') {
+          git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
+        }
+        stage('build images') {
+          parallel canary: {
+            sh 'source build.env && oc start-build --follow --build-arg=BASE_IMAGE="${BASE_IMAGE}" --build-arg=GO_ARCH=amd64 ceph-csi-canary'
+          },
+          test: {
+            sh 'oc start-build --follow ceph-csi-test'
+          },
+          devel: {
+            sh 'source build.env && oc start-build --follow --build-arg=BASE_IMAGE="${BASE_IMAGE}" ceph-csi-devel'
+          }
+        }
+      }
+    # yamllint enable rule:line-length
+    scm:
+      - git:
+          name: origin
+          url: https://github.com/ceph/ceph-csi
+          branches:
+            - master
+    triggers:
+      - pollscm:
+          cron: "H/5 * * * *"


### PR DESCRIPTION
This a first part to improve performance of some of the CI jobs that build and
run the ceph-csi:test container image. By building the image in the OpenShift
environment where the CI jobs run, the jobs do not need to rebuild the images
every time, and can save time by just pulling the image. The change for the
job(s) to use the image from the local OpenShift image registry will be
submitted later.

The new 'build-images' job rebuilds ceph-csi:latest and ceph-csi:test
images after a PR has been merged in the master branch. These images can
then be used by other CI jobs, to improve the speed by reducing unneeded
rebuilds of the images.

The ImageStream and BuildConfig can be imported in the OpenShift
environment so that Ceph-CSI images can be built automatically. These
images will be cached in the local OpenShift image registry, which can
speed up CI jobs that currently rebuild the images every time.

Updates: #1628