### PR TITLE
ci: use github/refs/pull/<pr-id>/merge instead of doing a rebase

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -11,7 +11,7 @@ def doc_change = 0
 node('cico-workspace') {
 	stage('checkout ci repository') {
 		if (params.ghprbPullId != null) {
-			ref = "pull/${ghprbPullId}/head"
+			ref = "pull/${ghprbPullId}/merge"
 		}
 		checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
 			userRemoteConfigs: [[url: "${ci_git_repo}", refspec: "${ref}"]]])
@@ -19,7 +19,7 @@ node('cico-workspace') {
 
 	stage('checkout PR') {
 		if (params.ghprbPullId != null) {
-			ref = "pull/${ghprbPullId}/head"
+			ref = "pull/${ghprbPullId}/merge"
 		}
 		if (params.ghprbTargetBranch != null) {
 			git_since = "${ghprbTargetBranch}"
@@ -65,7 +65,7 @@ node('cico-workspace') {
 			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${ci_git_repo} --ref=${ref} ${base}"
 		}
 		stage('test') {
-			sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make REBASE=1"'
+			sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make"'
 		}
 	}
 

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -18,7 +18,7 @@ node('cico-workspace') {
 
 	stage('checkout PR') {
 		if (params.ghprbPullId != null) {
-			ref = "pull/${ghprbPullId}/head"
+			ref = "pull/${ghprbPullId}/merge"
 		}
 		if (params.ghprbTargetBranch != null) {
 			git_since = "${ghprbTargetBranch}"

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -14,7 +14,7 @@
       def GIT_BRANCH = 'ci/centos'
 
       if (params.ghprbPullId != null) {
-          GIT_BRANCH = "pull/${ghprbPullId}/head"
+          GIT_BRANCH = "pull/${ghprbPullId}/merge"
       }
 
       node {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -92,7 +92,7 @@ node('cico-workspace') {
 	try {
 		stage('prepare bare-metal machine') {
 			if (params.ghprbPullId != null) {
-				ref = "pull/${ghprbPullId}/head"
+				ref = "pull/${ghprbPullId}/merge"
 			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -89,7 +89,7 @@ node('cico-workspace') {
 	try {
 		stage('prepare bare-metal machine') {
 			if (params.ghprbPullId != null) {
-				ref = "pull/${ghprbPullId}/head"
+				ref = "pull/${ghprbPullId}/merge"
 			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -89,7 +89,7 @@ node('cico-workspace') {
 	try {
 		stage('prepare bare-metal machine') {
 			if (params.ghprbPullId != null) {
-				ref = "pull/${ghprbPullId}/head"
+				ref = "pull/${ghprbPullId}/merge"
 			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"


### PR DESCRIPTION
When fetching `refs/pull/<pr-id>/merge` from GitHub, there is no need to do
a manual rebase. This makes things easier, as a the scripted rebases
sometimes cause CI jobs to fail.
