### PR TITLE
build: install git as when building from Dockerfile

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -23,7 +23,12 @@ RUN source /build.env && \
 # test if the downloaded version of Golang works (different arch?)
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 
-RUN dnf install libcephfs-devel librados-devel librbd-devel /usr/bin/cc make -y
+RUN dnf -y install \
+	libcephfs-devel librados-devel librbd-devel \
+	/usr/bin/cc \
+	make \
+	git \
+    && true
 
 ENV GOROOT=${GOROOT} \
     GOPATH=/go \


### PR DESCRIPTION
When running a simple build with only the required arguments, the
following warning are reported:

    $ buildah bud --build-arg=BASE_IMAGE=ceph/ceph:v15 --build-arg=GO_ARCH=amd64 -f ./deploy/cephcsi/image/Dockerfile .
    ...
    STEP 15: COPY . ${SRC_DIR}
    STEP 16: RUN make cephcsi
    cephcsi image settings: quay.io/cephcsi/cephcsi version canary
    make: git: Command not found
    make: git: Command not found
    if [ ! -d ./vendor ]; then (go mod tidy && go mod vendor); fi
    make: git: Command not found
    ...
    STEP 23: COMMIT
    Getting image source signatures
    ...
    Writing manifest to image destination
    Storing signatures
    --> 239b19c4049

git is used to detect the current commit, and store it in the binary
that is built. Without the commit, the "Git Commit:" in the output is
empty, making it impossible to get the exact version:

    $ podman run --rm 239b19c4049 --version
    Cephcsi Version: canary
    Git Commit:
    Go Version: go1.15
    Compiler: gc
    Platform: linux/amd64
    Kernel: 5.8.4-200.fc32.x86_64
