### PR TITLE
Do not Go panic on missing or wrong arguments to the executable

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -191,11 +191,11 @@ func main() {
 func validateCloneDepthFlag(conf *util.Config) {
 	// keeping hardlimit to 14 as max to avoid max image depth
 	if conf.RbdHardMaxCloneDepth == 0 || conf.RbdHardMaxCloneDepth > 14 {
-		klog.Fatalln("rbdhardmaxclonedepth flag value should be between 1 and 14")
+		logAndExit("rbdhardmaxclonedepth flag value should be between 1 and 14")
 	}
 
 	if conf.RbdSoftMaxCloneDepth > conf.RbdHardMaxCloneDepth {
-		klog.Fatalln("rbdsoftmaxclonedepth flag value should not be greater than rbdhardmaxclonedepth")
+		logAndExit("rbdsoftmaxclonedepth flag value should not be greater than rbdhardmaxclonedepth")
 	}
 }
 

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -123,7 +123,7 @@ func main() {
 	util.DefaultLog("Driver version: %s and Git version: %s", util.DriverVersion, util.GitCommit)
 
 	if conf.Vtype == "" {
-		klog.Fatalln("driver type not specified")
+		logAndExit("driver type not specified")
 	}
 
 	dname := getDriverName()

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -162,7 +162,7 @@ func main() {
 		}
 		err = util.ValidateURL(&conf)
 		if err != nil {
-			klog.Fatalln(err)
+			logAndExit(err.Error())
 		}
 	}
 

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -205,7 +205,7 @@ func validateMaxSnaphostFlag(conf *util.Config) {
 	// [1] https://github.com/torvalds/linux/blob/master/drivers/block/rbd.c#L98
 	// [2] https://github.com/torvalds/linux/blob/master/drivers/block/rbd.c#L92
 	if conf.MaxSnapshotsOnImage == 0 || conf.MaxSnapshotsOnImage > 500 {
-		klog.Fatalln("maxsnapshotsonimage flag value should be between 1 and 500")
+		logAndExit("maxsnapshotsonimage flag value should be between 1 and 500")
 	}
 }
 

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -180,9 +180,6 @@ func main() {
 
 	case livenessType:
 		liveness.Run(&conf)
-
-	default:
-		klog.Fatalln("invalid volume type", conf.Vtype) // calls exit
 	}
 
 	os.Exit(0)

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -208,3 +208,8 @@ func validateMaxSnaphostFlag(conf *util.Config) {
 		klog.Fatalln("maxsnapshotsonimage flag value should be between 1 and 500")
 	}
 }
+
+func logAndExit(msg string) {
+	klog.Errorln(msg)
+	os.Exit(1)
+}

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -129,7 +129,7 @@ func main() {
 	dname := getDriverName()
 	err := util.ValidateDriverName(dname)
 	if err != nil {
-		klog.Fatalln(err) // calls exit
+		logAndExit(err.Error())
 	}
 
 	// the driver may need a higher PID limit for handling all concurrent requests


### PR DESCRIPTION
When running the 'cephcsi' executable without, or with wrong arguments, a Go panic is
reported:

    $ ./_output/cephcsi
    F1026 13:59:04.302740 3409054 cephcsi.go:126] driver type not specified
    goroutine 1 [running]:
    k8s.io/klog/v2.stacks(0xc000010001, 0xc0000520a0, 0x48, 0x9a)
    	/go/src/github.com/ceph/ceph-csi/vendor/k8s.io/klog/v2/klog.go:996 +0xb9
    k8s.io/klog/v2.(*loggingT).output(0x2370360, 0xc000000003, 0x0, 0x0, 0xc000194770, 0x20cb265, 0xa, 0x7e, 0x413500)
    	/go/src/github.com/ceph/ceph-csi/vendor/k8s.io/klog/v2/klog.go:945 +0x191
    k8s.io/klog/v2.(*loggingT).println(0x2370360, 0x3, 0x0, 0x0, 0xc000163e08, 0x1, 0x1)
    	/go/src/github.com/ceph/ceph-csi/vendor/k8s.io/klog/v2/klog.go:699 +0x11a
    k8s.io/klog/v2.Fatalln(...)
    	/go/src/github.com/ceph/ceph-csi/vendor/k8s.io/klog/v2/klog.go:1456
    main.main()
    	/go/src/github.com/ceph/ceph-csi/cmd/cephcsi.go:126 +0xafa

Just logging the error and exiting should be sufficient. This stack-trace from the Go panic does not add any useful information.

This PR addresses several of these `klog.Fatalln()` calls during the startup of the executable.