### PR TITLE
doc: add common bot commands to GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,3 +33,18 @@ Fixes: #issue_number
 
 List items that are not part of the PR and do not impact it's
 functionality, but are work items that can be taken up subsequently.
+
+---
+
+<details>
+<summary>Show available bot commands</summary>
+
+These commands are normally not required, but in case of issues, leave any of
+the following bot commands in an otherwise empty comment in this PR:
+
+- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
+  failure (please report the failure too!)
+- `/retest all`: run this in case the CentOS CI failed to start/report any test
+  progress or results
+
+</details>

--- a/scripts/mdl-style.rb
+++ b/scripts/mdl-style.rb
@@ -5,5 +5,6 @@ all
 
 rule 'MD013', :code_blocks => false, :tables => false
 
+exclude_rule 'MD033' # In-line HTML: GitHub style markdown adds HTML tags
 exclude_rule 'MD040' # Fenced code blocks should have a language specified
 exclude_rule 'MD041' # First line in file should be a top level header


### PR DESCRIPTION
By placing the common bot commands and their description in the PR
template, developers are reminded on their usage. The idea comes from
the Ceph project where this is done too.
