### PR TITLE
ci: use major Kubernetes versions again

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -12,7 +12,7 @@
     parameters:
       - string:
           name: k8s_version
-          default: '1.19.2'
+          default: '1.19'
           description: Kubernetes version to deploy in the test cluster.
     pipeline-scm:
       scm:

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,8 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.18.9'
-      - '1.19.2'
+      - '1.18'
+      - '1.19'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.18.9'
+    k8s_version: '1.18'
     test_type:
       - 'cephfs'
       - 'rbd'


### PR DESCRIPTION
With the update to minikube v1.14.1 downloading binaries for the recent
Kubernetes patch releases works again. Enable detection of the latest
patch releases for use in the CI jobs.

Fixes: #1588
