### PR TITLE
ci: Fix shellcheck warnings for prepare.sh

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -87,7 +87,7 @@ then
     depth=''
 fi
 
-git clone ${depth} --branch="${base}" "${gitrepo}" "${workdir}"
+git clone "${depth}" --branch="${base}" "${gitrepo}" "${workdir}"
 cd "${workdir}"
 git fetch origin "${ref}:tip/${ref}"
 git checkout "tip/${ref}"


### PR DESCRIPTION
Shellcheck suggests the use of double quotes to prevent
word splitting, hence adding the same.

```
shellcheck --external-sources ./prepare.sh 
In ./prepare.sh line 90:
git clone ${depth} --branch="${base}" "${gitrepo}" "${workdir}"
          ^------^ SC2086: Double quote to prevent globbing and word splitting.
```

Signed-off-by: Yug <yuggupta27@gmail.com>