### PR TITLE
ci: use self-contained kubeconfig for running k8s e2e job

### DIFF
--- a/run-k8s-external-storage-e2e.sh
+++ b/run-k8s-external-storage-e2e.sh
@@ -14,6 +14,11 @@ set -e
 curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/kubernetes-test-linux-amd64.tar.gz"
 tar xzf kubernetes-test-linux-amd64.tar.gz kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 
+# e2e depends on a self-contained KUBECONFIG for some reason
+KUBECONFIG_TMP="$(mktemp -t kubeconfig.XXXXXXXX)"
+kubectl config view --raw --flatten > "${KUBECONFIG_TMP}"
+export KUBECONFIG="${KUBECONFIG_TMP}"
+
 for driver in /opt/build/go/src/github.com/ceph/ceph-csi/scripts/k8s-storage/driver-*.yaml
 do
 	kubernetes/test/bin/ginkgo \


### PR DESCRIPTION
When running on Minikube, the k8s-e2e-external-storage fails with an
error related to the kubeconfig file:

    error creating client: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined

It seems that this is a problem when the kubeconfig is not
self-container, but refers to additional files. This is the case when
Minikube deployed the Kubernetes cluster.

By exporting the kubeconfig into its own self-contained file, the CI job
starts running.
