### PR TITLE
cephfs: replace getCloneInfo() with a go-ceph implementation

### DIFF
--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -93,7 +93,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 		return cloneErr
 	}
 
-	cloneState, cloneErr := volOpt.getCloneState(ctx, cr, cloneID)
+	cloneState, cloneErr := volOpt.getCloneState(ctx, cloneID)
 	if cloneErr != nil {
 		return cloneErr
 	}
@@ -183,7 +183,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 		}
 	}()
 
-	cloneState, err := volOptions.getCloneState(ctx, cr, volumeID(vID.FsSubvolName))
+	cloneState, err := volOptions.getCloneState(ctx, volumeID(vID.FsSubvolName))
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 	return nil
 }
 
-func (vo *volumeOptions) getCloneState(ctx context.Context, cr *util.Credentials, volID volumeID) (cephFSCloneState, error) {
+func (vo *volumeOptions) getCloneState(ctx context.Context, volID volumeID) (cephFSCloneState, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin, can get clone status for volume %s with ID %s: %v", vo.FsName, string(volID), err)

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -83,7 +83,7 @@ func checkVolExists(ctx context.Context,
 	vid.FsSubvolName = imageData.ImageAttributes.ImageName
 
 	if sID != nil || pvID != nil {
-		cloneState, cloneStateErr := volOptions.getCloneState(ctx, cr, volumeID(vid.FsSubvolName))
+		cloneState, cloneStateErr := volOptions.getCloneState(ctx, volumeID(vid.FsSubvolName))
 		if cloneStateErr != nil {
 			if errors.Is(cloneStateErr, ErrVolumeNotFound) {
 				if pvID != nil {

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -83,9 +83,9 @@ func checkVolExists(ctx context.Context,
 	vid.FsSubvolName = imageData.ImageAttributes.ImageName
 
 	if sID != nil || pvID != nil {
-		cloneState, cloneInfoErr := getCloneState(ctx, volOptions, cr, volumeID(vid.FsSubvolName))
-		if cloneInfoErr != nil {
-			if errors.Is(cloneInfoErr, ErrVolumeNotFound) {
+		cloneState, cloneStateErr := volOptions.getCloneState(ctx, cr, volumeID(vid.FsSubvolName))
+		if cloneStateErr != nil {
+			if errors.Is(cloneStateErr, ErrVolumeNotFound) {
 				if pvID != nil {
 					err = cleanupCloneFromSubvolumeSnapshot(
 						ctx, volumeID(pvID.FsSubvolName),


### PR DESCRIPTION
getCloneInfo() does not need to return a full CloneStatus struct that
only has one member. Instead, it can just return the value of the single
member, so the JSON type/struct does not need to be exposed.

This makes the API for getCloneInfo() a little simpler, so it can be
replaced by a go-ceph implementation later on.

As there is little information returned about the clone status, the
function has been renamed to getCloneState() as well.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
