### PR TITLE
ci: Add the ability to run JJB from private branch/fork

### DIFF
--- a/deploy/jjb-deploy.yaml
+++ b/deploy/jjb-deploy.yaml
@@ -25,7 +25,7 @@ objects:
               image: image-registry.openshift-image-registry.svc:5000/ceph-csi/jjb:latest
               env:
                 - name: GIT_REPO
-                  value: https://github.com/ceph/ceph-csi
+                  value: "${GIT_REPO}"
                 - name: GIT_REF
                   value: "${GIT_REF}"
                 - name: MAKE_TARGET
@@ -46,4 +46,8 @@ parameters:
   - name: GIT_REF
     description: the git branch or other ref to checkout and deploy
     value: ci/centos
+    required: false
+  - name: GIT_REPO
+    description: the git repo or other fork to checkout and deploy
+    value: https://github.com/ceph/ceph-csi
     required: false

--- a/deploy/jjb-validate.yaml
+++ b/deploy/jjb-validate.yaml
@@ -25,7 +25,7 @@ objects:
               image: image-registry.openshift-image-registry.svc:5000/ceph-csi/jjb:latest
               env:
                 - name: GIT_REPO
-                  value: https://github.com/ceph/ceph-csi
+                  value: "${GIT_REPO}"
                 - name: GIT_REF
                   value: "${GIT_REF}"
           restartPolicy: Never
@@ -36,4 +36,8 @@ parameters:
   - name: GIT_REF
     description: the git branch or other ref to checkout and validate
     value: ci/centos
+    required: false
+  - name: GIT_REPO
+    description: the git repo or other fork to checkout and validate
+    value: https://github.com/ceph/ceph-csi
     required: false

--- a/jobs/jjb-deploy.yaml
+++ b/jobs/jjb-deploy.yaml
@@ -3,6 +3,15 @@
     name: jjb-deploy
     project-type: pipeline
     concurrent: false
+    parameters:
+      - string:
+          name: GIT_REPO
+          default: http://github.com/ceph/ceph-csi
+          description: The git repo url
+      - string:
+          name: GIT_BRANCH
+          default: ci/centos
+          description: The git branch
     properties:
       - github:
           url: https://github.com/ceph/ceph-csi
@@ -10,22 +19,21 @@
           days-to-keep: 7
           artifact-days-to-keep: 7
     dsl: |
-      def GIT_REPO = 'http://github.com/ceph/ceph-csi'
-      def GIT_BRANCH = 'ci/centos'
       node {
         stage('checkout ci repository') {
           git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
         }
         stage('deployment') {
-          sh './deploy/jjb.sh deploy'
+          sh "./deploy/jjb.sh --cmd deploy \
+              --GIT_REF ${GIT_BRANCH} --GIT_REPO ${GIT_REPO}"
         }
       }
     scm:
       - git:
           name: origin
-          url: https://github.com/ceph/ceph-csi
+          url: $GIT_REPO
           branches:
-            - ci/centos
+            - $GIT_BRANCH
     triggers:
       - pollscm:
           cron: "H/5 * * * *"

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -3,6 +3,15 @@
     name: jjb-validate
     project-type: pipeline
     concurrent: false
+    parameters:
+      - string:
+          name: GIT_REPO
+          default: http://github.com/ceph/ceph-csi
+          description: The git repo url
+      - string:
+          name: GIT_BRANCH
+          default: ci/centos
+          description: The git branch
     properties:
       - github:
           url: https://github.com/ceph/ceph-csi
@@ -10,9 +19,6 @@
           days-to-keep: 7
           artifact-days-to-keep: 7
     dsl: |
-      def GIT_REPO = 'https://github.com/ceph/ceph-csi'
-      def GIT_BRANCH = 'ci/centos'
-
       if (params.ghprbPullId != null) {
           GIT_BRANCH = "pull/${ghprbPullId}/merge"
       }
@@ -24,13 +30,14 @@
               refspec: "${GIT_BRANCH}"]]])
         }
         stage('validation') {
-          sh "GIT_REF=${GIT_BRANCH} ./deploy/jjb.sh validate"
+          sh "./deploy/jjb.sh --cmd validate \
+              --GIT_REF ${GIT_BRANCH} --GIT_REPO ${GIT_REPO}"
         }
       }
     triggers:
       - github-pull-request:
           status-context: ci/centos/jjb-validate
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/jjb-validate))'
+          trigger-phrase: "/(re)?test ((all)|(ci/centos/jjb-validate))"
           permit-all: true
           github-hooks: true
           white-list-target-branches:


### PR DESCRIPTION
### Describe this PR:
Add the ability to run JJB from private branch/fork

jjb-deploy.yaml:
- Add GIT_REPO parameter (not required) with default value

jjb.sh:
- Changing PS4 for more indicative debug prompt
- Adding flags to get the repo and branch

jjb-deploy.yaml:
- Calling the jjb.sh with the correct flags
