### PR TITLE
Use pre-build container images for CI jobs

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -9,6 +9,7 @@ def base = ''
 def doc_change = 0
 // private, internal container image repository
 def cached_image = 'registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi'
+def use_pulled_image = 'USE_PULLED_IMAGE=yes'
 
 node('cico-workspace') {
 	stage('checkout ci repository') {
@@ -76,6 +77,7 @@ node('cico-workspace') {
 				returnStatus: true)
 			if (rebuild_container == 10) {
 				// container needs rebuild, don't pull
+				use_pulled_image = 'USE_PULLED_IMAGE=no'
 				return
 			}
 
@@ -84,7 +86,7 @@ node('cico-workspace') {
 			}
 		}
 		stage('test') {
-			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make ENV_CSI_IMAGE_NAME=${cached_image} USE_PULLED_IMAGE=yes'"
+			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make ENV_CSI_IMAGE_NAME=${cached_image} ${use_pulled_image}'"
 		}
 	}
 

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -7,6 +7,10 @@ def ref = "master"
 def git_since = 'master'
 def workdir = '/opt/build/go/src/github.com/ceph/ceph-csi'
 def doc_change = 0
+def rebuild_test_container = 0
+def rebuild_devel_container = 0
+// private, internal container image repository
+def cached_image = 'registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi'
 
 node('cico-workspace') {
 
@@ -61,15 +65,58 @@ node('cico-workspace') {
 			// TODO: already checked out the PR on the node, scp the contents?
 			sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} ./prepare.sh --workdir=${workdir} --gitrepo=${git_repo} --ref=${ref}"
 		}
-		stage('test & build') {
+
+		// run two jobs in parallel, one for the test container, and
+		// one for the devel container
+		//
+		// - check if the PR modifies the container image files
+		// - pull the container image from the repository of no
+		//   modifications are detected
+		stage('pull container images') {
+			rebuild_test_container = sh(
+				script: "cd ~/build/ceph-csi && \${OLDPWD}/scripts/container-needs-rebuild.sh test origin/${git_since}",
+				returnStatus: true)
+
+			rebuild_devel_container = sh(
+				script: "cd ~/build/ceph-csi && \${OLDPWD}/scripts/container-needs-rebuild.sh devel origin/${git_since}",
+				returnStatus: true)
+
 			parallel test: {
-				node ('cico-workspace') {
-					sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test CONTAINER_CMD=podman"'
+				node('cico-workspace') {
+					if (rebuild_test_container == 10) {
+						// container needs rebuild, don't pull
+						return
+					}
+
+					withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
+						sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman pull --creds=${CREDS_USER}:${CREDS_PASSWD} ${cached_image}:test'"
+						sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman inspect -f \'{{.Id}}\' ${cached_image}:test > /opt/build/go/src/github.com/ceph/ceph-csi/.test-container-id'"
+					}
 				}
 			},
 			build: {
 				node('cico-workspace') {
-					sh 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman"'
+					if (rebuild_devel_container == 10) {
+						// container needs rebuild, don't pull
+						return
+					}
+
+					withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
+						sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman pull --creds=${CREDS_USER}:${CREDS_PASSWD} ${cached_image}:devel'"
+						sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'podman inspect -f \'{{.Id}}\' ${cached_image}:devel > /opt/build/go/src/github.com/ceph/ceph-csi/.devel-container-id'"
+					}
+				}
+			}
+		}
+		stage('test & build') {
+			parallel test: {
+				node ('cico-workspace') {
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test CONTAINER_CMD=podman ENV_CSI_IMAGE_NAME=${cached_image}'"
+				}
+			},
+			build: {
+				node('cico-workspace') {
+					sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman ENV_CSI_IMAGE_NAME=${cached_image}'"
 				}
 			}
 		}

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -118,6 +118,11 @@ node('cico-workspace') {
 					ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test CONTAINER_CMD=podman ENV_CSI_IMAGE_NAME=${cached_image} ${use_test_image}"
 				}
 			},
+			verify: {
+				node ('cico-workspace') {
+					ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-test TARGET=mod-check CONTAINER_CMD=podman ENV_CSI_IMAGE_NAME=${cached_image} ${use_test_image}"
+				}
+			},
 			build: {
 				node('cico-workspace') {
 					ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman ENV_CSI_IMAGE_NAME=${cached_image} ${use_build_image}"

--- a/scripts/container-needs-rebuild.sh
+++ b/scripts/container-needs-rebuild.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Check for changes needed by the container image. Two flavours of images are
+# supported, namely 'test' and 'devel'.
+#
+# Usage: scripts/container-needs-rebuild.sh {test|devel} [git-since]
+#
+#   - flavour is either 'test' or 'devel'
+#   - the optional 'git-since' points to a git reference, 'origin/master' if
+#     not set
+#
+# Returns 0 in case changes do not affect the container image.
+# Returns 10 in case the changes need a rebuild of the container image.
+#
+
+FLAVOUR="${1}"
+
+if [ "${FLAVOUR}" != 'test' ] && [ "${FLAVOUR}" != 'devel' ]
+then
+	echo 'ERROR: flavour must be "test" or "devel"'
+	exit 1
+fi
+
+GIT_SINCE="${2}"
+if [ -z "${GIT_SINCE}" ]; then
+	GIT_SINCE='origin/master'
+fi
+
+MODIFIED_FILES=$(git diff --name-only "${GIT_SINCE}")
+
+# files used for container image input
+# :test container
+CONTAINER_FILES="build.env scripts/Dockerfile.${FLAVOUR}"
+
+for MF in ${MODIFIED_FILES}
+do
+	for CF in ${CONTAINER_FILES}
+	do
+		if [ "${MF}" = "${CF}" ]
+		then
+			echo "container needs rebuild, ${CF} was modified"
+			exit 10
+		fi
+	done
+done
+
+exit 0


### PR DESCRIPTION
Pull the container images from the local (internal to CI) registry. This prevents the need to build the images, and speeds up testing. In addition to this, the following cleanups and improvements are added as well:

- use ssh() helper function for containerized-tests
- enable USE_PULLED_IMAGE to prevent image builds (see #1655)
- split "go mod verify" into its own stage

With these changes, the runtime of the **ci/centos/containerized-tests** job has been reduced from 15 minutes, to 8-9 minutes.
Example run with these changes (temporary job, might be removed soon): **[poc/ci/centos/containerized-tests](https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/containerized-tests_ndevos/detail/containerized-tests_ndevos/9/pipeline/)**

Updates: #1628
