### PR TITLE
ci: pass BASE_IMAGE to "oc start-build"

### DIFF
--- a/jobs/build-images.yaml
+++ b/jobs/build-images.yaml
@@ -19,14 +19,21 @@
           git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
         }
         stage('build images') {
+          def base_image = sh(script: 'source ${WORKSPACE}/build.env && echo ${BASE_IMAGE}',
+                              returnStdout: true).trim()
           parallel canary: {
-            sh 'source build.env && oc start-build --follow --build-arg=BASE_IMAGE="${BASE_IMAGE}" --build-arg=GO_ARCH=amd64 ceph-csi-canary'
+            sh "oc start-build --follow \
+                  --build-arg=BASE_IMAGE='${base_image}' \
+                  --build-arg=GO_ARCH=amd64 \
+                  ceph-csi-canary"
           },
           test: {
             sh 'oc start-build --follow ceph-csi-test'
           },
           devel: {
-            sh 'source build.env && oc start-build --follow --build-arg=BASE_IMAGE="${BASE_IMAGE}" ceph-csi-devel'
+            sh "oc start-build --follow \
+                  --build-arg=BASE_IMAGE='${base_image}' \
+                  ceph-csi-devel"
           }
         }
       }


### PR DESCRIPTION
Building the :devel and :canary images fails in Jenkins jobs with the following
error:
```
source build.env && oc start-build --follow --build-arg=BASE_IMAGE="${BASE_IMAGE}" --build-arg=GO_ARCH=amd64 ceph-csi-canary
+ source build.env
/var/lib/jenkins/jobs/build-images/workspace@tmp/durable-808caea0/script.sh: line 1: source: build.env: file not found
script returned exit code 1
```

Because the parallel steps, the build.env is not in the local directory
where the command is executed. So fetch the BASE_IMAGE before continuing
with 'oc start-build', and pass the name of the image on the
commandline.

Updates: #1628