### PR TITLE
ci: flatten images for internal consumption

### DIFF
--- a/deploy/ceph-csi-buildconfig.yaml
+++ b/deploy/ceph-csi-buildconfig.yaml
@@ -17,6 +17,7 @@ spec:
   strategy:
     dockerStrategy:
       dockerfilePath: deploy/cephcsi/image/Dockerfile
+      imageOptimizationPolicy: SkipLayers
   output:
     to:
       kind: DockerImage
@@ -42,6 +43,7 @@ spec:
   strategy:
     dockerStrategy:
       dockerfilePath: scripts/Dockerfile.test
+      imageOptimizationPolicy: SkipLayers
   output:
     to:
       kind: DockerImage
@@ -67,6 +69,7 @@ spec:
   strategy:
     dockerStrategy:
       dockerfilePath: scripts/Dockerfile.devel
+      imageOptimizationPolicy: SkipLayers
   output:
     to:
       kind: DockerImage


### PR DESCRIPTION
There is no need to re-use different layers with the images that are
built. The separation of the layers causes more time to be used while
pulling the images, so flattening makes speeds up the CI jobs a little
(about 30 seconds from 2+ minutes).

This change is already active in the current CI deployment.

Updates: #1628
