### PR TITLE
ci: link to the job in the Blue Ocean webui

### DIFF
--- a/jobs/ci-job-validation.yaml
+++ b/jobs/ci-job-validation.yaml
@@ -20,6 +20,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           status-context: ci/centos/job-validation
           trigger-phrase: '/(re)?test ((all)|(ci/centos/job-validation))'
           permit-all: true

--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -22,6 +22,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           # the "commitlint" status context is use by the commitlint app
           status-context: commitlint
           trigger-phrase: '/(re)?test ((all)|(commitlint))'

--- a/jobs/containerized-tests.yaml
+++ b/jobs/containerized-tests.yaml
@@ -20,6 +20,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           status-context: ci/centos/containerized-tests
           trigger-phrase: '/(re)?test ((all)|(ci/centos/containerized-tests))'
           permit-all: true

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -36,6 +36,7 @@
       }
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           status-context: ci/centos/jjb-validate
           trigger-phrase: "/(re)?test ((all)|(ci/centos/jjb-validate))"
           permit-all: true

--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -25,6 +25,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           status-context: ci/centos/k8s-e2e-external-storage
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ci/centos/k8s-e2e-external-storage'

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -37,6 +37,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-{k8s_version})?))'
@@ -76,6 +77,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e-helm(/k8s-{k8s_version})?))'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -48,6 +48,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
+          status-url: ${RUN_DISPLAY_URL}
           status-context: 'ci/centos/upgrade-tests-{test_type}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/upgrade-tests(-{test_type})?))'


### PR DESCRIPTION
The new Blue Ocean webui is much easier to navigate than the traditional
Jenkins webui. Developers that want to check failures of CI jobs will be
able to find the logs much quicker as each stage/step has a clear
success or failed status.

Example or manually adapted job: **[ci/centos/job-validation](https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/ci-job-validation/detail/ci-job-validation/53/pipeline)**