### PR TITLE
cephfs: Add 'pending' state for clone status

### DIFF
--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -155,6 +155,12 @@ func cleanupCloneFromSubvolumeSnapshot(ctx context.Context, volID, cloneID volum
 	return nil
 }
 
+// isCloneRetryError returns true if the clone error is pending,in-progress
+// error.
+func isCloneRetryError(err error) bool {
+	return errors.Is(err, ErrCloneInProgress) || errors.Is(err, ErrClonePending)
+}
+
 func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volumeOptions, vID *volumeIdentifier, sID *snapshotIdentifier, cr *util.Credentials) error {
 	snapID := volumeID(sID.FsSnapshotName)
 	err := cloneSnapshot(ctx, parentVolOpt, cr, volumeID(sID.FsSubvolName), snapID, volumeID(vID.FsSubvolName), volOptions)

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -173,7 +173,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	vID, err := checkVolExists(ctx, volOptions, parentVol, pvID, sID, cr)
 	if err != nil {
-		if errors.Is(err, ErrCloneInProgress) {
+		if isCloneRetryError(err) {
 			return nil, status.Error(codes.Aborted, err.Error())
 		}
 		return nil, status.Error(codes.Internal, err.Error())
@@ -233,7 +233,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	defer func() {
 		if err != nil {
-			if !errors.Is(err, ErrCloneInProgress) {
+			if !isCloneRetryError(err) {
 				errDefer := undoVolReservation(ctx, volOptions, *vID, secret)
 				if errDefer != nil {
 					util.WarningLog(ctx, "failed undoing reservation of volume: %s (%s)",
@@ -246,7 +246,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// Create a volume
 	err = cs.createBackingVolume(ctx, volOptions, parentVol, vID, pvID, sID, cr)
 	if err != nil {
-		if errors.Is(err, ErrCloneInProgress) {
+		if isCloneRetryError(err) {
 			return nil, status.Error(codes.Aborted, err.Error())
 		}
 		return nil, err

--- a/internal/cephfs/errors.go
+++ b/internal/cephfs/errors.go
@@ -39,6 +39,9 @@ var (
 	// ErrCloneInProgress is returned when snapshot clone state is `in progress`
 	ErrCloneInProgress = errors.New("in progress")
 
+	// ErrClonePending is returned when snapshot clone state is `pending`
+	ErrClonePending = errors.New("pending")
+
 	// ErrInvalidVolID is returned when a CSI passed VolumeID is not conformant to any known volume ID
 	// formats.
 	ErrInvalidVolID = errors.New("invalid VolumeID")

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -105,6 +105,9 @@ func checkVolExists(ctx context.Context,
 		if clone.Status.State == cephFSCloneInprogress {
 			return nil, ErrCloneInProgress
 		}
+		if clone.Status.State == cephFSClonePending {
+			return nil, ErrClonePending
+		}
 		if clone.Status.State == cephFSCloneFailed {
 			err = purgeVolume(ctx, volumeID(vid.FsSubvolName), cr, volOptions, true)
 			if err != nil {


### PR DESCRIPTION
In certain cases, clone status can be 'pending'.
In that case, the abort error message should be
returned similar to that during 'in-progress'
state. 
This PR adds support for the 'pending' 
state of a clone.

```
sh-4.2# ceph fs clone status ocs-storagecluster-cephfilesystem csi-vol-d33566ec-1e5d-11eb-b02d-0a580a810216 --group_name csi
{
  "status": {
    "state": "pending",
    "source": {
      "volume": "ocs-storagecluster-cephfilesystem",
      "subvolume": "csi-vol-64b5c569-1e5a-11eb-b02d-0a580a810216",
      "snapshot": "csi-vol-d33566ec-1e5d-11eb-b02d-0a580a810216",
      "group": "csi"
    }
  }
}

```

Signed-off-by: Yug <yuggupta27@gmail.com>