### PR TITLE
ci: fix Blue Ocean status-url for JJB templates

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -37,7 +37,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-url: ${RUN_DISPLAY_URL}
+          status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-{k8s_version})?))'
@@ -77,7 +77,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-url: ${RUN_DISPLAY_URL}
+          status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e-helm(/k8s-{k8s_version})?))'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -48,7 +48,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-url: ${RUN_DISPLAY_URL}
+          status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/upgrade-tests-{test_type}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/upgrade-tests(-{test_type})?))'


### PR DESCRIPTION
As ${RUN_DISPLAY_URL} also matches the format for template
substitutions, it can not be used like this for all Jenkins Jobs Builder
files. Instead, $RUN_DISPLAY_URL can be used, as it does not have the
{curly_braces} format and the template engine skips it.

Fixes: 87870369 (ci: link to the job in the Blue Ocean webui)
See-also: [errors while deploying jobs](https://jenkins-ceph-csi.apps.ocp.ci.centos.org/job/jjb-deploy/27/console)
