### PR TITLE
 cephfs: replace createSnapshot() with a go-ceph implementation

### DIFF
--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -45,7 +45,7 @@ const (
 
 func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volOpt, parentvolOpt *volumeOptions, cr *util.Credentials) error {
 	snapshotID := cloneID
-	err := parentvolOpt.createSnapshot(ctx, cr, snapshotID, volID)
+	err := parentvolOpt.createSnapshot(ctx, snapshotID, volID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to create snapshot %s %v", snapshotID, err)
 		return err

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -45,7 +45,7 @@ const (
 
 func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volOpt, parentvolOpt *volumeOptions, cr *util.Credentials) error {
 	snapshotID := cloneID
-	err := createSnapshot(ctx, parentvolOpt, cr, snapshotID, volID)
+	err := parentvolOpt.createSnapshot(ctx, cr, snapshotID, volID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to create snapshot %s %v", snapshotID, err)
 		return err

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -587,7 +587,7 @@ func doSnapshot(ctx context.Context, volOpt *volumeOptions, subvolumeName, snaps
 	volID := volumeID(subvolumeName)
 	snapID := volumeID(snapshotName)
 	snap := snapshotInfo{}
-	err := createSnapshot(ctx, volOpt, cr, snapID, volID)
+	err := volOpt.createSnapshot(ctx, cr, snapID, volID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to create snapshot %s %v", snapID, err)
 		return snap, err

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -587,7 +587,7 @@ func doSnapshot(ctx context.Context, volOpt *volumeOptions, subvolumeName, snaps
 	volID := volumeID(subvolumeName)
 	snapID := volumeID(snapshotName)
 	snap := snapshotInfo{}
-	err := volOpt.createSnapshot(ctx, cr, snapID, volID)
+	err := volOpt.createSnapshot(ctx, snapID, volID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to create snapshot %s %v", snapID, err)
 		return snap, err

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -45,7 +45,7 @@ type cephfsSnapshot struct {
 	ReservedID string
 }
 
-func (vo *volumeOptions) createSnapshot(ctx context.Context, cr *util.Credentials, snapID, volID volumeID) error {
+func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volumeID) error {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -54,7 +54,8 @@ func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volum
 
 	err = fsa.CreateSubVolumeSnapshot(vo.FsName, vo.SubvolumeGroup, string(volID), string(snapID))
 	if err != nil {
-		util.ErrorLog(ctx, "failed to create subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, vo.FsName)
+		util.ErrorLog(ctx, "failed to create subvolume snapshot %s %s in fs %s: %s",
+			string(snapID), string(volID), vo.FsName, err)
 		return err
 	}
 	return nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -45,18 +45,18 @@ type cephfsSnapshot struct {
 	ReservedID string
 }
 
-func createSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, snapID, volID volumeID) error {
+func (vo *volumeOptions) createSnapshot(ctx context.Context, cr *util.Credentials, snapID, volID volumeID) error {
 	args := []string{
 		"fs",
 		"subvolume",
 		"snapshot",
 		"create",
-		volOptions.FsName,
+		vo.FsName,
 		string(volID),
 		string(snapID),
 		"--group_name",
-		volOptions.SubvolumeGroup,
-		"-m", volOptions.Monitors,
+		vo.SubvolumeGroup,
+		"-m", vo.Monitors,
 		"-c", util.CephConfigPath,
 		"-n", cephEntityClientPrefix + cr.ID,
 		"--keyfile=" + cr.KeyFile,
@@ -67,7 +67,7 @@ func createSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Cre
 		"ceph",
 		args[:]...)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to create subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to create subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, vo.FsName)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Reduce the number of `ceph fs` command executions, and use go-ceph with a cached/shared connection.

~Do-Not-Merge: depends on #1644, which needs to get merged first~