### PR TITLE
 cephfs: replace deleteSnapshot() with a go-ceph implementation

### DIFF
--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -58,7 +58,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 	)
 	defer func() {
 		if protectErr != nil {
-			err = deleteSnapshot(ctx, parentvolOpt, cr, snapshotID, volID)
+			err = parentvolOpt.deleteSnapshot(ctx, cr, snapshotID, volID)
 			if err != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			}
@@ -76,7 +76,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 					util.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapshotID, err)
 				}
 			}
-			if err = deleteSnapshot(ctx, parentvolOpt, cr, snapshotID, volID); err != nil {
+			if err = parentvolOpt.deleteSnapshot(ctx, cr, snapshotID, volID); err != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			}
 		}
@@ -126,7 +126,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 				return err
 			}
 		}
-		if err = deleteSnapshot(ctx, parentvolOpt, cr, snapshotID, volID); err != nil {
+		if err = parentvolOpt.deleteSnapshot(ctx, cr, snapshotID, volID); err != nil {
 			util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			return err
 		}
@@ -153,7 +153,7 @@ func cleanupCloneFromSubvolumeSnapshot(ctx context.Context, volID, cloneID volum
 			return err
 		}
 	}
-	err = deleteSnapshot(ctx, parentVolOpt, cr, snapShotID, volID)
+	err = parentVolOpt.deleteSnapshot(ctx, cr, snapShotID, volID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapShotID, err)
 		return err

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -58,7 +58,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 	)
 	defer func() {
 		if protectErr != nil {
-			err = parentvolOpt.deleteSnapshot(ctx, cr, snapshotID, volID)
+			err = parentvolOpt.deleteSnapshot(ctx, snapshotID, volID)
 			if err != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			}
@@ -76,7 +76,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 					util.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapshotID, err)
 				}
 			}
-			if err = parentvolOpt.deleteSnapshot(ctx, cr, snapshotID, volID); err != nil {
+			if err = parentvolOpt.deleteSnapshot(ctx, snapshotID, volID); err != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			}
 		}
@@ -126,7 +126,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 				return err
 			}
 		}
-		if err = parentvolOpt.deleteSnapshot(ctx, cr, snapshotID, volID); err != nil {
+		if err = parentvolOpt.deleteSnapshot(ctx, snapshotID, volID); err != nil {
 			util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			return err
 		}
@@ -153,7 +153,7 @@ func cleanupCloneFromSubvolumeSnapshot(ctx context.Context, volID, cloneID volum
 			return err
 		}
 	}
-	err = parentVolOpt.deleteSnapshot(ctx, cr, snapShotID, volID)
+	err = parentVolOpt.deleteSnapshot(ctx, snapShotID, volID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapShotID, err)
 		return err

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -594,7 +594,7 @@ func doSnapshot(ctx context.Context, volOpt *volumeOptions, subvolumeName, snaps
 	}
 	defer func() {
 		if err != nil {
-			dErr := deleteSnapshot(ctx, volOpt, cr, snapID, volID)
+			dErr := volOpt.deleteSnapshot(ctx, cr, snapID, volID)
 			if dErr != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapID, err)
 			}
@@ -711,7 +711,7 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
-	err = deleteSnapshot(ctx, volOpt, cr, volumeID(sid.FsSnapshotName), volumeID(sid.FsSubvolName))
+	err = volOpt.deleteSnapshot(ctx, cr, volumeID(sid.FsSnapshotName), volumeID(sid.FsSubvolName))
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -594,7 +594,7 @@ func doSnapshot(ctx context.Context, volOpt *volumeOptions, subvolumeName, snaps
 	}
 	defer func() {
 		if err != nil {
-			dErr := volOpt.deleteSnapshot(ctx, cr, snapID, volID)
+			dErr := volOpt.deleteSnapshot(ctx, snapID, volID)
 			if dErr != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapID, err)
 			}
@@ -711,7 +711,7 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
-	err = volOpt.deleteSnapshot(ctx, cr, volumeID(sid.FsSnapshotName), volumeID(sid.FsSubvolName))
+	err = volOpt.deleteSnapshot(ctx, volumeID(sid.FsSnapshotName), volumeID(sid.FsSubvolName))
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -354,7 +354,7 @@ func checkSnapExists(
 
 	defer func() {
 		if err != nil {
-			err = volOptions.deleteSnapshot(ctx, cr, volumeID(snapID), volumeID(parentSubVolName))
+			err = volOptions.deleteSnapshot(ctx, volumeID(snapID), volumeID(parentSubVolName))
 			if err != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s: %v", snapID, err)
 				return

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -354,7 +354,7 @@ func checkSnapExists(
 
 	defer func() {
 		if err != nil {
-			err = deleteSnapshot(ctx, volOptions, cr, volumeID(snapID), volumeID(parentSubVolName))
+			err = volOptions.deleteSnapshot(ctx, cr, volumeID(snapID), volumeID(parentSubVolName))
 			if err != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s: %v", snapID, err)
 				return

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -61,18 +61,18 @@ func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volum
 	return nil
 }
 
-func deleteSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, snapID, volID volumeID) error {
+func (vo *volumeOptions) deleteSnapshot(ctx context.Context, cr *util.Credentials, snapID, volID volumeID) error {
 	args := []string{
 		"fs",
 		"subvolume",
 		"snapshot",
 		"rm",
-		volOptions.FsName,
+		vo.FsName,
 		string(volID),
 		string(snapID),
 		"--group_name",
-		volOptions.SubvolumeGroup,
-		"-m", volOptions.Monitors,
+		vo.SubvolumeGroup,
+		"-m", vo.Monitors,
 		"-c", util.CephConfigPath,
 		"-n", cephEntityClientPrefix + cr.ID,
 		"--keyfile=" + cr.KeyFile,
@@ -84,7 +84,7 @@ func deleteSnapshot(ctx context.Context, volOptions *volumeOptions, cr *util.Cre
 		"ceph",
 		args[:]...)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, vo.FsName)
 		return err
 	}
 	return nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -70,7 +70,8 @@ func (vo *volumeOptions) deleteSnapshot(ctx context.Context, snapID, volID volum
 
 	err = fsa.ForceRemoveSubVolumeSnapshot(vo.FsName, vo.SubvolumeGroup, string(volID), string(snapID))
 	if err != nil {
-		util.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s(%s) in fs %s", string(snapID), string(volID), err, vo.FsName)
+		util.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s in fs %s: %s",
+			string(snapID), string(volID), vo.FsName, err)
 		return err
 	}
 	return nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -61,7 +61,7 @@ func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volum
 	return nil
 }
 
-func (vo *volumeOptions) deleteSnapshot(ctx context.Context, cr *util.Credentials, snapID, volID volumeID) error {
+func (vo *volumeOptions) deleteSnapshot(ctx context.Context, snapID, volID volumeID) error {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)


### PR DESCRIPTION
Reduce the number of `ceph fs` command executions, and use go-ceph with a cached/shared connection.

~Do-Not-Merge: depends on #1644 and #1663, which need to get merged first~