### PR TITLE
liveness: add health status liveness probe sidecar

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -37,6 +37,7 @@ rules:
       - e2e
       - helm
       - journal
+      - liveness
       - rbd
       - rebase
       - revert

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -66,7 +66,7 @@ func init() {
 	flag.BoolVar(&conf.ForceKernelCephFS, "forcecephkernelclient", false, "enable Ceph Kernel clients on kernel < 4.17 which support quotas")
 
 	// liveness/grpc metrics related flags
-	flag.IntVar(&conf.MetricsPort, "metricsport", 8080, "TCP port for liveness/grpc metrics requests")
+	flag.StringVar(&conf.MetricsPort, "metricsport", "8080", "TCP port for liveness/grpc metrics requests")
 	flag.StringVar(&conf.MetricsPath, "metricspath", "/metrics", "path of prometheus endpoint where metrics will be available")
 	flag.DurationVar(&conf.PollTime, "polltime", time.Second*pollTime, "time interval in seconds between each poll")
 	flag.DurationVar(&conf.ProbeTimeout, "timeout", time.Second*probeTimeout, "probe timeout in seconds")

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -70,6 +70,8 @@ func init() {
 	flag.StringVar(&conf.MetricsPath, "metricspath", "/metrics", "path of prometheus endpoint where metrics will be available")
 	flag.DurationVar(&conf.PollTime, "polltime", time.Second*pollTime, "time interval in seconds between each poll")
 	flag.DurationVar(&conf.ProbeTimeout, "timeout", time.Second*probeTimeout, "probe timeout in seconds")
+	flag.StringVar(&conf.HealthzPort, "healthzport", "9808", "TCP ports for listening healthz requests")
+	flag.StringVar(&conf.HealthzPath, "healthzpath", "/healthz", "path of liveness endpoint where health status will be available")
 
 	flag.BoolVar(&conf.EnableGRPCMetrics, "enablegrpcmetrics", false, "[DEPRECATED] enable grpc metrics")
 	flag.StringVar(&conf.HistogramOption, "histogramoption", "0.5,2,6",

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -69,7 +69,7 @@ func init() {
 	flag.IntVar(&conf.MetricsPort, "metricsport", 8080, "TCP port for liveness/grpc metrics requests")
 	flag.StringVar(&conf.MetricsPath, "metricspath", "/metrics", "path of prometheus endpoint where metrics will be available")
 	flag.DurationVar(&conf.PollTime, "polltime", time.Second*pollTime, "time interval in seconds between each poll")
-	flag.DurationVar(&conf.PoolTimeout, "timeout", time.Second*probeTimeout, "probe timeout in seconds")
+	flag.DurationVar(&conf.ProbeTimeout, "timeout", time.Second*probeTimeout, "probe timeout in seconds")
 
 	flag.BoolVar(&conf.EnableGRPCMetrics, "enablegrpcmetrics", false, "[DEPRECATED] enable grpc metrics")
 	flag.StringVar(&conf.HistogramOption, "histogramoption", "0.5,2,6",

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -148,6 +148,7 @@ spec:
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"
+            - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8681"
             - "--metricspath=/metrics"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -154,7 +154,7 @@ spec:
             - "--metricspath=/metrics"
             - "--healthzport=9681"
             - "--healthzpath=/healthz"
-            - "--polltime=60s"
+            - "--polltime=15s"
             - "--timeout=3s"
           env:
             - name: CSI_ENDPOINT

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -152,6 +152,8 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8681"
             - "--metricspath=/metrics"
+            - "--healthzport=9681"
+            - "--healthzpath=/healthz"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -105,7 +105,7 @@ spec:
             - "--metricspath=/metrics"
             - "--healthzport=9681"
             - "--healthzpath=/healthz"
-            - "--polltime=60s"
+            - "--polltime=15s"
             - "--timeout=3s"
           env:
             - name: CSI_ENDPOINT

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -103,6 +103,8 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8681"
             - "--metricspath=/metrics"
+            - "--healthzport=9681"
+            - "--healthzpath=/healthz"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -99,6 +99,7 @@ spec:
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"
+            - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8681"
             - "--metricspath=/metrics"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -152,6 +152,7 @@ spec:
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"
+            - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8680"
             - "--metricspath=/metrics"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -156,6 +156,8 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8680"
             - "--metricspath=/metrics"
+            - "--healthzport=9680"
+            - "--healthzpath=/healthz"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -158,7 +158,7 @@ spec:
             - "--metricspath=/metrics"
             - "--healthzport=9680"
             - "--healthzpath=/healthz"
-            - "--polltime=60s"
+            - "--polltime=15s"
             - "--timeout=3s"
           env:
             - name: CSI_ENDPOINT

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -108,7 +108,7 @@ spec:
             - "--metricspath=/metrics"
             - "--healthzport=9680"
             - "--healthzpath=/healthz"
-            - "--polltime=60s"
+            - "--polltime=15s"
             - "--timeout=3s"
           env:
             - name: CSI_ENDPOINT

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -102,6 +102,7 @@ spec:
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"
+            - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8680"
             - "--metricspath=/metrics"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -106,6 +106,8 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--metricsport=8680"
             - "--metricspath=/metrics"
+            - "--healthzport=9680"
+            - "--healthzpath=/healthz"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -146,6 +146,7 @@ The `component` in the subject of the commit message can be one of the following
 
 * `cephfs`: bugs or enhancements related to CephFS
 * `rbd`: bugs or enhancements related to RBD
+* `liveness`: bugs or enhancements related to Liveness
 * `doc`: documentation updates
 * `util`: utilities shared between components use `cephfs` or `rbd` if the
    change is only relevant for one of the type of storage

--- a/internal/liveness/liveness.go
+++ b/internal/liveness/liveness.go
@@ -86,7 +86,7 @@ func Run(conf *util.Config) {
 	util.ExtendedLogMsg("Liveness Running")
 
 	// start liveness collection
-	go recordLiveness(conf.Endpoint, conf.DriverName, conf.PollTime, conf.PoolTimeout)
+	go recordLiveness(conf.Endpoint, conf.DriverName, conf.PollTime, conf.ProbeTimeout)
 
 	// start up prometheus endpoint
 	util.StartMetricsServer(conf)

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -17,7 +16,7 @@ func ValidateURL(c *Config) error {
 
 // StartMetricsServer starts http server.
 func StartMetricsServer(c *Config) {
-	addr := net.JoinHostPort(c.MetricsIP, strconv.Itoa(c.MetricsPort))
+	addr := net.JoinHostPort(c.MetricsIP, c.MetricsPort)
 	http.Handle(c.MetricsPath, promhttp.Handler())
 	err := http.ListenAndServe(addr, nil)
 	if err != nil {

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -19,8 +19,12 @@ func StartMetricsServer(c *Config) {
 	addr := net.JoinHostPort(c.MetricsIP, c.MetricsPort)
 	http.Handle(c.MetricsPath, promhttp.Handler())
 	ExtendedLogMsg("Serving Metrics requests on: http://%s%s", addr, c.MetricsPath)
-	err := http.ListenAndServe(addr, nil)
-	if err != nil {
-		FatalLogMsg("failed to listen on address %v: %s", addr, err)
-	}
+
+	// Spawn a new go routine to listen on specified endpoint
+	go func() {
+		err := http.ListenAndServe(addr, nil)
+		if err != nil {
+			FatalLogMsg("failed to listen on address %v: %s", addr, err)
+		}
+	}()
 }

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -18,6 +18,7 @@ func ValidateURL(c *Config) error {
 func StartMetricsServer(c *Config) {
 	addr := net.JoinHostPort(c.MetricsIP, c.MetricsPort)
 	http.Handle(c.MetricsPath, promhttp.Handler())
+	ExtendedLogMsg("Serving Metrics requests on: http://%s%s", addr, c.MetricsPath)
 	err := http.ListenAndServe(addr, nil)
 	if err != nil {
 		FatalLogMsg("failed to listen on address %v: %s", addr, err)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -81,7 +81,7 @@ type Config struct {
 	HistogramOption   string        // Histogram option for grpc metrics, should be comma separated value, ex:= "0.5,2,6" where start=0.5 factor=2, count=6
 	MetricsIP         string        // TCP port for liveness/ metrics requests
 	PidLimit          int           // PID limit to configure through cgroups")
-	MetricsPort       int           // TCP port for liveness/grpc metrics requests
+	MetricsPort       string        // TCP port for liveness/grpc metrics requests
 	PollTime          time.Duration // time interval in seconds between each poll
 	ProbeTimeout      time.Duration // probe timeout in seconds
 	EnableGRPCMetrics bool          // option to enable grpc metrics

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -82,6 +82,8 @@ type Config struct {
 	MetricsIP         string        // TCP port for liveness/ metrics requests
 	PidLimit          int           // PID limit to configure through cgroups")
 	MetricsPort       string        // TCP port for liveness/grpc metrics requests
+	HealthzPort       string        // TCP port for liveness/health requests
+	HealthzPath       string        // path for liveness/health requests
 	PollTime          time.Duration // time interval in seconds between each poll
 	ProbeTimeout      time.Duration // probe timeout in seconds
 	EnableGRPCMetrics bool          // option to enable grpc metrics

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -83,7 +83,7 @@ type Config struct {
 	PidLimit          int           // PID limit to configure through cgroups")
 	MetricsPort       int           // TCP port for liveness/grpc metrics requests
 	PollTime          time.Duration // time interval in seconds between each poll
-	PoolTimeout       time.Duration // probe timeout in seconds
+	ProbeTimeout      time.Duration // probe timeout in seconds
 	EnableGRPCMetrics bool          // option to enable grpc metrics
 
 	IsControllerServer bool // if set to true start provisoner server


### PR DESCRIPTION
# Describe what this PR does

The health status liveness probe shares and runs within the liveness-prometheus container. The health status liveness probe listen and serve requests at a dedicated port and path. By default they listen at '/healthz' path and '9680' port, which can be easily configurable.

Useful logs:
```
[0] pkalever 😎 ceph-csi✨ kubectl logs csi-rbdplugin-5dzrn liveness-prometheus                                   
I1104 20:16:06.923915  212212 cephcsi.go:125] Driver version: canary and Git version: 59aff136b51f38bdbca65bb0782215b7b786f89b
I1104 20:16:06.924212  212212 cephcsi.go:171] Starting driver type: liveness with name: liveness.csi.ceph.com     
I1104 20:16:06.924263  212212 liveness.go:122] Liveness Running                  
I1104 20:16:06.924458  212212 httpserver.go:21] Serving Metrics requests on: http://192.168.39.188:8680/metrics   
I1104 20:16:06.924555  212212 liveness.go:133] Serving Health requests on: http://192.168.39.188:9680/healthz
I1104 20:16:06.924739  212212 connection.go:153] Connecting to unix:///csi/csi.sock                               
I1104 20:16:06.927573  212212 liveness.go:110] CSI driver: "rbd.csi.ceph.com", Endpoint: unix:///csi/csi.sock
I1104 20:16:21.928003  212212 liveness.go:73] Metrics req: Sending probe request to CSI driver: "rbd.csi.ceph.com"
I1104 20:16:21.930418  212212 liveness.go:87] Metrics req: Health check succeeded
[...]
I1104 20:17:21.931447  212212 liveness.go:87] Metrics req: Health check succeeded
I1104 20:17:36.928015  212212 liveness.go:73] Metrics req: Sending probe request to CSI driver: "rbd.csi.ceph.com"
I1104 20:17:36.930653  212212 liveness.go:87] Metrics req: Health check succeeded
I1104 20:17:48.331070  212212 liveness.go:48] Healthz req: Sending probe request to CSI driver "rbd.csi.ceph.com" 
I1104 20:17:48.332878  212212 liveness.go:66] Healthz req: Health check succeeded

```

useful commands:
```
# kubectl exec -it  csi-rbdplugin-5dzrn -c csi-rbdplugin -- curl -X GET http://192.168.39.188:8680/metrics
# kubectl exec -it  csi-rbdplugin-5dzrn -c csi-rbdplugin -- curl -X GET http://192.168.39.188:9680/healthz

Also,
# minikube ssh
# docker ps | grep csi-rbdplugin-
# docker stop <contaner-ID> 

```



Fixes: #1096

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>



