### PR TITLE
cephfs: Fix issues in cephfs clone

### DIFF
--- a/internal/cephfs/cephfs_util.go
+++ b/internal/cephfs/cephfs_util.go
@@ -38,7 +38,7 @@ func getFscID(ctx context.Context, monitors string, cr *util.Credentials, fsName
 	// ceph fs get myfs --format=json
 	// {"mdsmap":{...},"id":2}
 	var fsDetails CephFilesystemDetails
-	err := execCommandJSON(ctx, &fsDetails,
+	stdErr, err := execCommandJSON(ctx, &fsDetails,
 		"ceph",
 		"-m", monitors,
 		"--id", cr.ID,
@@ -47,6 +47,7 @@ func getFscID(ctx context.Context, monitors string, cr *util.Credentials, fsName
 		"fs", "get", fsName, "--format=json",
 	)
 	if err != nil {
+		util.ErrorLog(ctx, "failed to get filesystem details %s with Error: %v. stdError: %s", fsName, err, stdErr)
 		return 0, err
 	}
 
@@ -66,7 +67,7 @@ func getMetadataPool(ctx context.Context, monitors string, cr *util.Credentials,
 	// ./tbox ceph fs ls --format=json
 	// [{"name":"myfs","metadata_pool":"myfs-metadata","metadata_pool_id":4,...},...]
 	var filesystems []CephFilesystem
-	err := execCommandJSON(ctx, &filesystems,
+	stdErr, err := execCommandJSON(ctx, &filesystems,
 		"ceph",
 		"-m", monitors,
 		"--id", cr.ID,
@@ -75,6 +76,7 @@ func getMetadataPool(ctx context.Context, monitors string, cr *util.Credentials,
 		"fs", "ls", "--format=json",
 	)
 	if err != nil {
+		util.ErrorLog(ctx, "failed to list filesystem with Error: %v. stdError: %s", err, stdErr)
 		return "", err
 	}
 
@@ -96,7 +98,7 @@ func getFsName(ctx context.Context, monitors string, cr *util.Credentials, fscID
 	// ./tbox ceph fs dump --format=json
 	// JSON: {...,"filesystems":[{"mdsmap":{},"id":<n>},...],...}
 	var fsDump CephFilesystemDump
-	err := execCommandJSON(ctx, &fsDump,
+	stdErr, err := execCommandJSON(ctx, &fsDump,
 		"ceph",
 		"-m", monitors,
 		"--id", cr.ID,
@@ -105,6 +107,7 @@ func getFsName(ctx context.Context, monitors string, cr *util.Credentials, fscID
 		"fs", "dump", "--format=json",
 	)
 	if err != nil {
+		util.ErrorLog(ctx, "failed to dump filesystem details with Error: %v. stdError: %s", err, stdErr)
 		return "", err
 	}
 

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -27,6 +27,8 @@ import (
 const (
 	// cephFSCloneFailed indicates that clone is in failed state.
 	cephFSCloneFailed = "failed"
+	// cephFSClonePending indicates that clone is in pending state.
+	cephFSClonePending = "pending"
 	// cephFSCloneCompleted indicates that clone is in in-progress state.
 	cephFSCloneInprogress = "in-progress"
 	// cephFSCloneComplete indicates that clone is in complete state.
@@ -94,6 +96,9 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 	case cephFSCloneInprogress:
 		util.ErrorLog(ctx, "clone is in progress for %v", cloneID)
 		return ErrCloneInProgress
+	case cephFSClonePending:
+		util.ErrorLog(ctx, "clone is pending for %v", cloneID)
+		return ErrClonePending
 	case cephFSCloneFailed:
 		util.ErrorLog(ctx, "clone failed for %v", cloneID)
 		cloneFailedErr := fmt.Errorf("clone %s is in %s state", cloneID, clone.Status.State)
@@ -150,6 +155,12 @@ func cleanupCloneFromSubvolumeSnapshot(ctx context.Context, volID, cloneID volum
 	return nil
 }
 
+// isCloneRetryError returns true if the clone error is pending,in-progress
+// error.
+func isCloneRetryError(err error) bool {
+	return errors.Is(err, ErrCloneInProgress) || errors.Is(err, ErrClonePending)
+}
+
 func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volumeOptions, vID *volumeIdentifier, sID *snapshotIdentifier, cr *util.Credentials) error {
 	snapID := volumeID(sID.FsSnapshotName)
 	err := cloneSnapshot(ctx, parentVolOpt, cr, volumeID(sID.FsSubvolName), snapID, volumeID(vID.FsSubvolName), volOptions)
@@ -158,7 +169,7 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 	}
 	defer func() {
 		if err != nil {
-			if !errors.Is(err, ErrCloneInProgress) {
+			if !isCloneRetryError(err) {
 				if dErr := purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions, true); dErr != nil {
 					util.ErrorLog(ctx, "failed to delete volume %s: %v", vID.FsSubvolName, dErr)
 				}
@@ -173,6 +184,8 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 	switch clone.Status.State {
 	case cephFSCloneInprogress:
 		return ErrCloneInProgress
+	case cephFSClonePending:
+		return ErrClonePending
 	case cephFSCloneFailed:
 		return fmt.Errorf("clone %s is in %s state", vID.FsSubvolName, clone.Status.State)
 	case cephFSCloneComplete:

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -211,13 +211,13 @@ func getCloneInfo(ctx context.Context, volOptions *volumeOptions, cr *util.Crede
 		"--keyfile=" + cr.KeyFile,
 		"--format=json",
 	}
-	err := execCommandJSON(
+	stdErr, err := execCommandJSON(
 		ctx,
 		&clone,
 		"ceph",
 		args[:]...)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get subvolume clone info %s(%s) in fs %s", string(volID), err, volOptions.FsName)
+		util.ErrorLog(ctx, "failed to get subvolume clone info %s in fs %s with Error: %v. stdError: %s", string(volID), volOptions.FsName, err, stdErr)
 		return clone, err
 	}
 	return clone, nil

--- a/internal/cephfs/errors.go
+++ b/internal/cephfs/errors.go
@@ -38,7 +38,8 @@ const (
 var (
 	// ErrCloneInProgress is returned when snapshot clone state is `in progress`
 	ErrCloneInProgress = errors.New("in progress")
-
+	// ErrClonePending is returned when snapshot clone state is `pending`
+	ErrClonePending = errors.New("pending")
 	// ErrInvalidVolID is returned when a CSI passed VolumeID is not conformant to any known volume ID
 	// formats.
 	ErrInvalidVolID = errors.New("invalid VolumeID")

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -105,6 +105,9 @@ func checkVolExists(ctx context.Context,
 		if clone.Status.State == cephFSCloneInprogress {
 			return nil, ErrCloneInProgress
 		}
+		if clone.Status.State == cephFSClonePending {
+			return nil, ErrClonePending
+		}
 		if clone.Status.State == cephFSCloneFailed {
 			err = purgeVolume(ctx, volumeID(vid.FsSubvolName), cr, volOptions, true)
 			if err != nil {

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -39,17 +39,23 @@ func execCommandErr(ctx context.Context, program string, args ...string) error {
 }
 
 // nolint:unparam //  todo:program values has to be revisited later
-func execCommandJSON(ctx context.Context, v interface{}, program string, args ...string) error {
-	stdout, _, err := util.ExecCommand(ctx, program, args...)
+func execCommandWithStdErr(ctx context.Context, program string, args ...string) (string, error) {
+	_, stdErr, err := util.ExecCommand(ctx, program, args...)
+	return stdErr, err
+}
+
+// nolint:unparam //  todo:program values has to be revisited later
+func execCommandJSON(ctx context.Context, v interface{}, program string, args ...string) (string, error) {
+	stdout, stderr, err := util.ExecCommand(ctx, program, args...)
 	if err != nil {
-		return err
+		return stderr, err
 	}
 
 	if err = json.Unmarshal([]byte(stdout), v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON for %s %v: %s: %w", program, util.StripSecretInArgs(args), stdout, err)
+		return "", fmt.Errorf("failed to unmarshal JSON for %s %v: %s: %w", program, util.StripSecretInArgs(args), stdout, err)
 	}
 
-	return nil
+	return "", nil
 }
 
 // Controller service request validation.

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -48,7 +48,7 @@ func ExecCommand(ctx context.Context, program string, args ...string) (string, s
 	stderr := stderrBuf.String()
 
 	if err != nil {
-		err = fmt.Errorf("an error (%w) occurred while running %s args: %v", err, program, sanitizedArgs)
+		err = fmt.Errorf("an error (%w) and stdError (%s) occurred while running %s args: %v", err, stderr, program, sanitizedArgs)
 		if ctx != context.TODO() {
 			UsefulLog(ctx, "%s", err)
 		}


### PR DESCRIPTION
This PR fixes the below issues for cephfs

* check clone pending state   
sometimes, cephfs returns pending as clone status if we request for the subvolume clone.  cephcsi needs to consider the pending state when checking the clone status and it should return an abort error message if the clone is in a pending state or in-progress state.
* check stderror for CLI commands
currently, in some places, we are checking the stderr for CLI errors, and in some places, we are checking for just error. This commit fixes the issue by checking the stderror for actual CLI errors.
* log stderror in ExecCommand
all the CLI commands we execute logs the actual error in stdError. logging stderror is using for debugging.

Co-authored-by: Yug <yuggupta27@gmail.com>
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Note:**

This PR is to fix issues in the release branch. @Yuggupta27 will fix it in the master branch (PR https://github.com/ceph/ceph-csi/pull/1660)  later. not all changes are required in the master branch as we dont use `ceph fs` CLI anymore in the master branch