### PR TITLE
ci: use the Fedora container registry for cephcsi:test

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -8,7 +8,7 @@
 # little different.
 #
 
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 
 ARG GOPATH=/go
 


### PR DESCRIPTION
This reduces the dependency on Docker, where image pull rate limits are
seen in the CI.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
