### PR TITLE
ci: use "podman login --username" instead of "--user"

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -99,7 +99,7 @@ node('cico-workspace') {
 			def base_image = ssh 'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}'
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				ssh "podman login --user=${CREDS_USER} --password='${CREDS_PASSWD}'"
+				ssh "podman login --username=${CREDS_USER} --password='${CREDS_PASSWD}'"
 			}
 
 			// base_image is like ceph/ceph:v15


### PR DESCRIPTION
It seems the --user option does not exist, but is called --username.

Fixes: #1679 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
