### PR TITLE
e2e: use registry.centos.org for pulling centos:latest

### DIFF
--- a/examples/rbd/block-pod-clone.yaml
+++ b/examples/rbd/block-pod-clone.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: centos
-      image: centos:latest
+      image: registry.centos.org/centos:latest
       command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data

--- a/examples/rbd/raw-block-pod.yaml
+++ b/examples/rbd/raw-block-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: centos
-      image: centos:latest
+      image: registry.centos.org/centos:latest
       command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data


### PR DESCRIPTION
Reduce the number of images that get pulled from Docker Hub. Use the
official CentOS container registry instead.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
