### PR TITLE
ci: do not run commitlint on "/retest all"

### DIFF
--- a/jobs/commitlint.yaml
+++ b/jobs/commitlint.yaml
@@ -25,7 +25,7 @@
           status-url: ${RUN_DISPLAY_URL}
           # the "commitlint" status context is use by the commitlint app
           status-context: commitlint
-          trigger-phrase: '/(re)?test ((all)|(commitlint))'
+          trigger-phrase: '/(re)?test commitlint'
           # only run on PRs where the trigger-phrase is posted
           only-trigger-phrase: true
           permit-all: true


### PR DESCRIPTION
The commitlint job is not used normally, so there is no need to run it
when all CI jobs need retesting.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
