### PR TITLE
ci: correctly fetch BASE_IMAGE from build.env

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -96,7 +96,10 @@ node('cico-workspace') {
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('pull base container images') {
-			def base_image = ssh 'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}'
+			def base_image = sh(
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}"',
+				returnStdout: true
+			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				ssh "podman login --username=${CREDS_USER} --password='${CREDS_PASSWD}' ${ci_registry}"


### PR DESCRIPTION
The BASE_IMAGE variable was not stored in the variable so that the CI
job can consume it. By using sh(), this should be the case now.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
