### PR TITLE
ci: escape command to be executed over ssh to fetch BASE_IMAGE

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -97,7 +97,7 @@ node('cico-workspace') {
 		}
 		stage('pull base container images') {
 			def base_image = sh(
-				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} "source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}"',
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
 


### PR DESCRIPTION
The ${BASE_IMAGE} variable gets expanded by running the ssh command.
This becomes an empty variable, so the "echo" part of the command does
not output anything.

By escaping the command, there is no variable substitution, and the
BASE_IMAGE variable should get stored in the variable.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
