### PR TITLE
ci: store results of podman-login in ~/.docker/config.json

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -102,7 +102,7 @@ node('cico-workspace') {
 			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				ssh "podman login --username=${CREDS_USER} --password='${CREDS_PASSWD}' ${ci_registry}"
+				ssh "podman login --authfile=~/.docker/config.json --username=${CREDS_USER} --password='${CREDS_PASSWD}' ${ci_registry}"
 			}
 
 			// base_image is like ceph/ceph:v15


### PR DESCRIPTION
Once the ssh command finishes, the runtime directory is removed and the
results of "podman login" are lost. By storing the results in the
standard Docker configuration file, subsequent "podman pull" commands
will be able to re-use the authentication details.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
