### PR TITLE
ci: store podman-login results in ~/.podman-auth.json

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -102,13 +102,13 @@ node('cico-workspace') {
 			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				ssh "podman login --authfile=~/.docker/config.json --username=${CREDS_USER} --password='${CREDS_PASSWD}' ${ci_registry}"
+				ssh "podman login --authfile=~/.podman-auth.json --username=${CREDS_USER} --password='${CREDS_PASSWD}' ${ci_registry}"
 			}
 
 			// base_image is like ceph/ceph:v15
-			ssh "podman pull ${ci_registry}/${base_image} && podman tag ${ci_registry}/${base_image} ${base_image}"
+			ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/${base_image} && podman tag ${ci_registry}/${base_image} ${base_image}"
 			// cephcsi:devel is used with 'make containerized-build'
-			ssh "podman pull ${ci_registry}/cephcsi:devel"
+			ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/cephcsi:devel"
 		}
 		stage('build artifacts') {
 			// build container image


### PR DESCRIPTION
It seems that "podman pull" does not consume the authentication details
from ~/.docker/config.json, so store the results of "podman login" in
~/.podman-auth.json and use the file for all "podman pull" commands.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
