### PR TITLE
ci: the image in the CI registry is called "ceph-csi"

### DIFF
--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -108,13 +108,13 @@ node('cico-workspace') {
 			// base_image is like ceph/ceph:v15
 			ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/${base_image} && podman tag ${ci_registry}/${base_image} ${base_image}"
 			// cephcsi:devel is used with 'make containerized-build'
-			ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/cephcsi:devel"
+			ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/ceph-csi:devel"
 		}
 		stage('build artifacts') {
 			// build container image
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make image-cephcsi GOARCH=amd64 CONTAINER_CMD=podman'
 			// build e2e.test executable
-			ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test ENV_CSI_IMAGE_NAME=${ci_registry}/cephcsi USE_PULLED_IMAGE=yes"
+			ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test ENV_CSI_IMAGE_NAME=${ci_registry}/ceph-csi USE_PULLED_IMAGE=yes"
 		}
 		stage("deploy k8s-${k8s_version} and rook") {
 			timeout(time: 30, unit: 'MINUTES') {


### PR DESCRIPTION
The image is named after the project, so "ceph-csi".

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
