### PR TITLE
e2e: set imagePullPolicy to ifNotPresent

### DIFF
--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -156,6 +156,9 @@ func loadApp(path string) (*v1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
+	for i := range app.Spec.Containers {
+		app.Spec.Containers[i].ImagePullPolicy = v1.PullIfNotPresent
+	}
 	return &app, nil
 }
 


### PR DESCRIPTION
If the imagePullPolicy is not set and the image tag is empty or latest the image is always pulled. This commit sets the policy to pull images if not present. So that in E2E the image is pulled only once.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
