### PR TITLE
Use locally mirrored container images for CI jobs

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -92,7 +92,7 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/head"
 			}
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./run-k8s-external-storage-e2e.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh podman2minikube.sh ./run-k8s-external-storage-e2e.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('build artifacts') {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -8,12 +8,21 @@ def git_since = "master"
 def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
+def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
 def namespace = 'cephcsi-e2e-' + UUID.randomUUID().toString().split('-')[-1]
 
 // ssh executes a given command on the reserved bare-metal machine
 // NOTE: do not pass " symbols on the command line, use ' only.
 def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \"${cmd}\""
+}
+
+def podman_login(username, passwd) {
+	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${ci_registry}"
+}
+
+def podman_pull(image) {
+	ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/${image} && podman tag ${ci_registry}/${image} ${image}"
 }
 
 node('cico-workspace') {
@@ -96,6 +105,21 @@ node('cico-workspace') {
 			}
 			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
+		}
+		stage('pull base container images') {
+			def base_image = sh(
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
+				returnStdout: true
+			).trim()
+
+			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
+				podman_login("${CREDS_USER}", "${CREDS_PASSWD}:)
+			}
+
+			// base_image is like ceph/ceph:v15
+			podman_pull("${base_image}")
+			// cephcsi:devel is used with 'make containerized-build'
+			podman_pull("ceph-csi:devel")
 		}
 		stage('build artifacts') {
 			// build container image

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -103,7 +103,7 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/merge"
 			}
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./podman2minikube.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('pull base container images') {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -131,6 +131,12 @@ node('cico-workspace') {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
+
+			// vault:latest and nginx:latest are used by the e2e tests
+			podman_pull("vault:latest")
+			ssh "./podman2minikube.sh vault:latest"
+			podman_pull("nginx:latest")
+			ssh "./podman2minikube.sh nginx:latest"
 		}
 		stage('deploy ceph-csi through helm') {
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -100,7 +100,7 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/merge"
 			}
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./podman2minikube.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('pull base container images') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -128,6 +128,12 @@ node('cico-workspace') {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
+
+			// vault:latest and nginx:latest are used by the e2e tests
+			podman_pull("vault:latest")
+			ssh "./podman2minikube.sh vault:latest"
+			podman_pull("nginx:latest")
+			ssh "./podman2minikube.sh nginx:latest"
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {

--- a/podman2minikube.sh
+++ b/podman2minikube.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# When an image was built with podman, it needs importing into minikube.
+#
+
+# fail when a command returns an error
+set -e -o pipefail
+
+# "minikube ssh" fails to read the image, so use standard ssh instead
+podman image save "${1}" | \
+    ssh \
+        -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+        -l docker -i "$(minikube ssh-key)" \
+        "$(minikube ip)" docker image load
+

--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -121,24 +121,13 @@ function deploy_rook()
     ${GOPATH}/src/github.com/ceph/ceph-csi/scripts/install-snapshot.sh install
 }
 
-# When an image was built with podman, it needs importing into minikube.
-function podman2minikube()
-{
-    # "minikube ssh" fails to read the image, so use standard ssh instead
-    podman image save "${1}" | \
-        ssh \
-            -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-            -l docker -i "$(minikube ssh-key)" \
-            "$(minikube ip)" docker image load
-}
-
 # Set environment variables
 set_env
 
 # prepare minikube environment
 install_minikube
 
-podman2minikube "quay.io/cephcsi/cephcsi:${CSI_IMAGE_VERSION}"
+./podman2minikube.sh "quay.io/cephcsi/cephcsi:${CSI_IMAGE_VERSION}"
 
 deploy_rook
 

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -128,6 +128,12 @@ node('cico-workspace') {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
+
+			// vault:latest and nginx:latest are used by the e2e tests
+			podman_pull("vault:latest")
+			ssh "./podman2minikube.sh vault:latest"
+			podman_pull("nginx:latest")
+			ssh "./podman2minikube.sh nginx:latest"
 		}
 		stage("run ${test_type} upgrade tests") {
 			timeout(time: 120, unit: 'MINUTES') {

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -100,7 +100,7 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/merge"
 			}
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./podman2minikube.sh root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('pull base container images') {


### PR DESCRIPTION
Using the same process as currently is done for the `mini-e2e` jobs, pre-pull the container images for the remaining jobs too.
This PR contains some cleanups as well.

The `vault:latest` and `nginx:latest` images have been manually pushed into the CI registry, this still needs to get automated (an other PR).

Updates: #1693 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
