### PR TITLE
ci: fix calling podman_login()

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -95,7 +95,7 @@ node('cico-workspace') {
 				returnStatus: true)
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login("${CREDS_USER}", "${CREDS_PASSWD}:)
+				podman_login("${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
 			parallel test: {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -113,7 +113,7 @@ node('cico-workspace') {
 			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login("${CREDS_USER}", "${CREDS_PASSWD}:)
+				podman_login("${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
 			// base_image is like ceph/ceph:v15

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -110,7 +110,7 @@ node('cico-workspace') {
 			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login("${CREDS_USER}", "${CREDS_PASSWD}:)
+				podman_login("${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
 			// base_image is like ceph/ceph:v15

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -110,7 +110,7 @@ node('cico-workspace') {
 			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login("${CREDS_USER}", "${CREDS_PASSWD}:)
+				podman_login("${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
 			// base_image is like ceph/ceph:v15


### PR DESCRIPTION
A typo when calling podman_log() causes CI jobs to fail.

Fixes: 1eec379 "ci: pre-pull Ceph base-image and cephcsi:devel for mini-e2e-helm jobs"

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
