### PR TITLE
ci: pass registry to podman helper functions

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -17,12 +17,12 @@ def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \"${cmd}\""
 }
 
-def podman_login(username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${ci_registry}"
+def podman_login(registry, username, passwd) {
+	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
 }
 
-def podman_pull(image) {
-	ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/${image} && podman tag ${ci_registry}/${image} ${image}"
+def podman_pull(registry, image) {
+	ssh "podman pull --authfile=~/.podman-auth.json ${registry}/${image} && podman tag ${registry}/${image} ${image}"
 }
 
 node('cico-workspace') {
@@ -113,13 +113,13 @@ node('cico-workspace') {
 			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login("${CREDS_USER}", "${CREDS_PASSWD}")
+				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
 			// base_image is like ceph/ceph:v15
-			podman_pull("${base_image}")
+			podman_pull(ci_registry, "${base_image}")
 			// cephcsi:devel is used with 'make containerized-build'
-			podman_pull("ceph-csi:devel")
+			podman_pull(ci_registry, "ceph-csi:devel")
 		}
 		stage('build artifacts') {
 			// build container image
@@ -133,9 +133,9 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
-			podman_pull("vault:latest")
+			podman_pull(ci_registry, "vault:latest")
 			ssh "./podman2minikube.sh vault:latest"
-			podman_pull("nginx:latest")
+			podman_pull(ci_registry, "nginx:latest")
 			ssh "./podman2minikube.sh nginx:latest"
 		}
 		stage('deploy ceph-csi through helm') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -14,12 +14,12 @@ def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
 }
 
-def podman_login(username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${ci_registry}"
+def podman_login(registry, username, passwd) {
+	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
 }
 
-def podman_pull(image) {
-	ssh "podman pull --authfile=~/.podman-auth.json ${ci_registry}/${image} && podman tag ${ci_registry}/${image} ${image}"
+def podman_pull(registry, image) {
+	ssh "podman pull --authfile=~/.podman-auth.json ${registry}/${image} && podman tag ${registry}/${image} ${image}"
 }
 
 node('cico-workspace') {
@@ -110,13 +110,13 @@ node('cico-workspace') {
 			).trim()
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login("${CREDS_USER}", "${CREDS_PASSWD}")
+				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
 			// base_image is like ceph/ceph:v15
-			podman_pull("${base_image}")
+			podman_pull(ci_registry, "${base_image}")
 			// cephcsi:devel is used with 'make containerized-build'
-			podman_pull("ceph-csi:devel")
+			podman_pull(ci_registry, "ceph-csi:devel")
 		}
 		stage('build artifacts') {
 			// build container image
@@ -130,9 +130,9 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
-			podman_pull("vault:latest")
+			podman_pull(ci_registry, "vault:latest")
 			ssh "./podman2minikube.sh vault:latest"
-			podman_pull("nginx:latest")
+			podman_pull(ci_registry, "nginx:latest")
 			ssh "./podman2minikube.sh nginx:latest"
 		}
 		stage('run e2e') {


### PR DESCRIPTION
Functions with Groovy can not use `def ci_registry` as the variable is
not in the scope. Pass the registry to the podman_login() and
podman_pull() functions instead.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
