### PR TITLE
e2e: use centos as container image

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -276,7 +276,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 			Containers: []v1.Container{
 				{
 					Name:    "write-pod",
-					Image:   "alpine",
+					Image:   "registry.centos.org/centos:latest",
 					Command: []string{"/bin/sleep", "999999"},
 					SecurityContext: &v1.SecurityContext{
 						RunAsUser: &user,

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -147,4 +147,5 @@ spec:
           command:
             - /bin/sh
             - /init-scripts/init-vault.sh
+          imagePullPolicy: "IfNotPresent"
       restartPolicy: Never

--- a/examples/rbd/block-pod-clone.yaml
+++ b/examples/rbd/block-pod-clone.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: centos
-      image: centos:latest
+      image: registry.centos.org/centos:latest
       command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data

--- a/examples/rbd/raw-block-pod.yaml
+++ b/examples/rbd/raw-block-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: centos
-      image: centos:latest
+      image: registry.centos.org/centos:latest
       command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data


### PR DESCRIPTION
updated E2E to use centos as container image and also set the vault imagepullpolicy  to pull if the image is not present

Closes: #1682 (duplicate, both PRs fail because they are incomplete, merged into this one)