### PR TITLE
ci: pre-pull rook/ceph image from local registry

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -128,6 +128,16 @@ node('cico-workspace') {
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
 		}
 		stage("deploy k8s-${k8s_version} and rook") {
+			def rook_version = sh(
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_VERSION}\'',
+				returnStdout: true
+			).trim()
+
+			if (rook_version != '') {
+				// single-node-k8s.sh pushes the image into minikube
+				podman_pull(ci_registry, "rook/ceph:${rook_version}")
+			}
+
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}

--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -129,6 +129,12 @@ install_minikube
 
 ./podman2minikube.sh "quay.io/cephcsi/cephcsi:${CSI_IMAGE_VERSION}"
 
+# incase rook/ceph is available on the local system, push it into the VM
+if podman inspect "rook/ceph:${ROOK_VERSION}"
+then
+    ./podman2minikube.sh "rook/ceph:${ROOK_VERSION}"
+fi
+
 deploy_rook
 
 # running e2e.test requires librados and librbd

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -125,6 +125,16 @@ node('cico-workspace') {
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
 		}
 		stage("deploy k8s-${k8s_version} and rook") {
+			def rook_version = sh(
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_VERSION}\'',
+				returnStdout: true
+			).trim()
+
+			if (rook_version != '') {
+				// single-node-k8s.sh pushes the image into minikube
+				podman_pull(ci_registry, "rook/ceph:${rook_version}")
+			}
+
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}


### PR DESCRIPTION
Use the local CI registry to pull the rook/ceph:v1.3.9 image. The image has been pushed manually to the registry for now.

Updates: #1679 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
