### PR TITLE
build: add ROOK_VERSION to build.env

### DIFF
--- a/build.env
+++ b/build.env
@@ -38,6 +38,9 @@ MINIKUBE_VERSION=v1.14.1
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
+# Rook options
+ROOK_VERSION=v1.3.9
+
 # e2e settings
 # - enable CEPH_CSI_RUN_ALL_TESTS when running tests with if it has root
 #   permissions on the host


### PR DESCRIPTION
The CentOS CI jobs use Rook v1.3.9, this version should be places in
build.env just like other versions that the CI jobs detect.

See-also: #1711 
Updates: #1693

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
