### PR TITLE
deploy: use docker.io for unqualified image names

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -196,7 +196,7 @@ metadata:
 spec:
   containers:
     - name: my-container
-      image: debian
+      image: docker.io/debian:latest
       command: ["/bin/bash", "-c"]
       args: [ "tail -f /dev/null" ]
       volumeDevices:
@@ -223,7 +223,7 @@ metadata:
 spec:
   containers:
     - name: my-container
-      image: debian
+      image: docker.io/debian:latest
       command: ["/bin/bash", "-c"]
       args: [ "tail -f /dev/null" ]
       volumeDevices:

--- a/examples/cephfs/deployment.yaml
+++ b/examples/cephfs/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: web-server
-          image: nginx
+          image: docker.io/nginx:latest
           volumeMounts:
             - name: mypvc
               mountPath: /var/lib/www/html

--- a/examples/cephfs/pod-clone.yaml
+++ b/examples/cephfs/pod-clone.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: nginx
+      image: docker.io/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/cephfs/pod-restore.yaml
+++ b/examples/cephfs/pod-restore.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: nginx
+      image: docker.io/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/cephfs/pod.yaml
+++ b/examples/cephfs/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: nginx
+      image: docker.io/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: vault
-          image: vault
+          image: docker.io/vault:latest
           securityContext:
             runAsUser: 100
           env:

--- a/examples/rbd/pod-clone.yaml
+++ b/examples/rbd/pod-clone.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: nginx
+      image: docker.io/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/pod-restore.yaml
+++ b/examples/rbd/pod-restore.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: nginx
+      image: docker.io/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/pod.yaml
+++ b/examples/rbd/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: nginx
+      image: docker.io/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html


### PR DESCRIPTION
Images that have an unqualified name (no explicit registry) come from
Docker Hub. This can be made explicit by adding docker.io as prefix. In
addition, the default :latest tag has been added too.

By using the docker.io registry explicitly, it is possible to configure a
mirror for the registry, and point it to the local registry in the CI.

Updates: #1693

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
