### PR TITLE
Add configuration for the proxy/mirror registry

### DIFF
--- a/container-registry.conf
+++ b/container-registry.conf
@@ -1,0 +1,17 @@
+# /etc/containers/registries.conf
+#
+# This file contains the registry that is hosted in the CentOS CI OpenShift
+# deployment for Ceph-CSI.
+#
+# By overwriting /etc/containers/registries.conf, short-names for
+# container-images can NOT be used anymore.
+#
+# The CI jobs do a "podman login" for the local registry. Only after that, the
+# local mirror is accessible.
+#
+
+[[registry]]
+prefix = "docker.io"
+location = "docker.io"
+[[registry.mirror]]
+location = "registry-ceph-csi.apps.ocp.ci.centos.org"

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -19,6 +19,7 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh 'cp container-registry.conf /etc/containers/registries.conf'
 }
 
 def podman_pull(registry, image) {
@@ -74,7 +75,7 @@ node('cico-workspace') {
 
 	try {
 		stage('prepare bare-metal machine') {
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh container-registry.conf root@${CICO_NODE}:'
 			// TODO: already checked out the PR on the node, scp the contents?
 			ssh "./prepare.sh --workdir=${workdir} --gitrepo=${git_repo} --ref=${ref}"
 		}
@@ -128,7 +129,7 @@ node('cico-workspace') {
 					).trim()
 
 					// base_image is like ceph/ceph:v15
-					podman_pull(ci_registry, "${base_image}")
+					podman_pull("docker.io", "${base_image}")
 				}
 			}
 		}

--- a/deploy/container-registry.yaml
+++ b/deploy/container-registry.yaml
@@ -49,6 +49,8 @@ spec:
           volumeMounts:
             - name: container-images
               mountPath: /var/lib/registry
+            - name: config
+              mountPath: /etc/docker/registry
             - name: htpasswd
               mountPath: /auth
           env:
@@ -62,6 +64,9 @@ spec:
         - name: container-images
           persistentVolumeClaim:
             claimName: ceph-csi-image-registry
+        - name: config
+          secret:
+            secretName: container-registry-config
         - name: htpasswd
           secret:
             secretName: container-registry-auth

--- a/deploy/registry-config.yml.in
+++ b/deploy/registry-config.yml.in
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: container-registry-config
+  labels:
+    app: container-registry
+stringData:
+  # /etc/docker/registry/config.yml
+  config.yml: |-
+    version: 0.1
+    log:
+      fields:
+        service: registry
+    storage:
+      cache:
+        blobdescriptor: inmemory
+      filesystem:
+        rootdirectory: /var/lib/registry
+    http:
+      addr: :5000
+      headers:
+        X-Content-Type-Options: [nosniff]
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    proxy:
+      remoteurl: https://docker.io
+      username: @@USERNAME@@
+      password: @@PASSWD@@

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -144,10 +144,15 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
+			// Tag the images with qualified and unqualified names,
+			// so that moving to qualified names everywhere becomes
+			// possible.
 			podman_pull("docker.io", "vault:latest")
 			ssh "./podman2minikube.sh vault:latest"
+			ssh "./podman2minikube.sh docker.io/vault:latest"
 			podman_pull("docker.io", "nginx:latest")
 			ssh "./podman2minikube.sh nginx:latest"
+			ssh "./podman2minikube.sh docker.io/nginx:latest"
 		}
 		stage('deploy ceph-csi through helm') {
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -19,6 +19,7 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh 'cp container-registry.conf /etc/containers/registries.conf'
 }
 
 def podman_pull(registry, image) {
@@ -103,7 +104,7 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/merge"
 			}
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./podman2minikube.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./podman2minikube.sh container-registry.conf root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('pull base container images') {
@@ -117,7 +118,7 @@ node('cico-workspace') {
 			}
 
 			// base_image is like ceph/ceph:v15
-			podman_pull(ci_registry, "${base_image}")
+			podman_pull("docker.io", "${base_image}")
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, "ceph-csi:devel")
 		}
@@ -135,7 +136,7 @@ node('cico-workspace') {
 
 			if (rook_version != '') {
 				// single-node-k8s.sh pushes the image into minikube
-				podman_pull(ci_registry, "rook/ceph:${rook_version}")
+				podman_pull("docker.io", "rook/ceph:${rook_version}")
 			}
 
 			timeout(time: 30, unit: 'MINUTES') {
@@ -143,9 +144,9 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
-			podman_pull(ci_registry, "vault:latest")
+			podman_pull("docker.io", "vault:latest")
 			ssh "./podman2minikube.sh vault:latest"
-			podman_pull(ci_registry, "nginx:latest")
+			podman_pull("docker.io", "nginx:latest")
 			ssh "./podman2minikube.sh nginx:latest"
 		}
 		stage('deploy ceph-csi through helm') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -16,6 +16,7 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh 'cp container-registry.conf /etc/containers/registries.conf'
 }
 
 def podman_pull(registry, image) {
@@ -100,7 +101,7 @@ node('cico-workspace') {
 			if (params.ghprbPullId != null) {
 				ref = "pull/${ghprbPullId}/merge"
 			}
-			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./podman2minikube.sh root@${CICO_NODE}:'
+			sh 'scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./prepare.sh ./single-node-k8s.sh ./podman2minikube.sh container-registry.conf root@${CICO_NODE}:'
 			ssh "./prepare.sh --workdir=/opt/build/go/src/github.com/ceph/ceph-csi --gitrepo=${git_repo} --ref=${ref}"
 		}
 		stage('pull base container images') {
@@ -114,7 +115,7 @@ node('cico-workspace') {
 			}
 
 			// base_image is like ceph/ceph:v15
-			podman_pull(ci_registry, "${base_image}")
+			podman_pull("docker.io", "${base_image}")
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, "ceph-csi:devel")
 		}
@@ -132,7 +133,7 @@ node('cico-workspace') {
 
 			if (rook_version != '') {
 				// single-node-k8s.sh pushes the image into minikube
-				podman_pull(ci_registry, "rook/ceph:${rook_version}")
+				podman_pull("docker.io", "rook/ceph:${rook_version}")
 			}
 
 			timeout(time: 30, unit: 'MINUTES') {
@@ -140,9 +141,9 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
-			podman_pull(ci_registry, "vault:latest")
+			podman_pull("docker.io", "vault:latest")
 			ssh "./podman2minikube.sh vault:latest"
-			podman_pull(ci_registry, "nginx:latest")
+			podman_pull("docker.io", "nginx:latest")
 			ssh "./podman2minikube.sh nginx:latest"
 		}
 		stage('run e2e') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -141,10 +141,15 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
+			// Tag the images with qualified and unqualified names,
+			// so that moving to qualified names everywhere becomes
+			// possible.
 			podman_pull("docker.io", "vault:latest")
 			ssh "./podman2minikube.sh vault:latest"
+			ssh "./podman2minikube.sh docker.io/vault:latest"
 			podman_pull("docker.io", "nginx:latest")
 			ssh "./podman2minikube.sh nginx:latest"
+			ssh "./podman2minikube.sh docker.io/nginx:latest"
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {

--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -68,7 +68,7 @@ function set_env() {
     export MEMORY="8192"
     export CEPH_CSI_RUN_ALL_TESTS=true
     # downloading rook images is sometimes slow, extend timeout to 15 minutes
-    export ROOK_VERSION='v1.3.9'
+    export ROOK_VERSION=${ROOK_VERSION:-'v1.3.9'}
     export ROOK_DEPLOY_TIMEOUT=900
     # use podman for minikube.sh, Docker is not installed on the host
     export CONTAINER_CMD='podman'

--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -130,7 +130,7 @@ install_minikube
 ./podman2minikube.sh "quay.io/cephcsi/cephcsi:${CSI_IMAGE_VERSION}"
 
 # incase rook/ceph is available on the local system, push it into the VM
-if podman inspect "rook/ceph:${ROOK_VERSION}"
+if podman inspect "rook/ceph:${ROOK_VERSION}" > /dev/null
 then
     ./podman2minikube.sh "rook/ceph:${ROOK_VERSION}"
 fi

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -141,10 +141,15 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
+			// Tag the images with qualified and unqualified names,
+			// so that moving to qualified names everywhere becomes
+			// possible.
 			podman_pull("docker.io", "vault:latest")
 			ssh "./podman2minikube.sh vault:latest"
+			ssh "./podman2minikube.sh docker.io/vault:latest"
 			podman_pull("docker.io", "nginx:latest")
 			ssh "./podman2minikube.sh nginx:latest"
+			ssh "./podman2minikube.sh docker.io/nginx:latest"
 		}
 		stage("run ${test_type} upgrade tests") {
 			timeout(time: 120, unit: 'MINUTES') {


### PR DESCRIPTION
This makes it possible to pull images from Docker Hub through the local
container image registry in the CI OpenShift deployment. The registry in
the CI is configured with the 'cephcsibot' account so that pulling
images is accounted towards the account, and not anonymous consumers
within the whole CentOS CI.

There should be no need to manually sync the images between the local
registry and Docker Hub anymore.

Updates: #1693

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
