### PR TITLE
ci: add more logging during Rook deployment

### DIFF
--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -59,6 +59,12 @@ kubectl_retry() {
             ret=1
             break
         fi
+
+	# log stderr and empty the tmpfile
+	cat "${stderr}" > /dev/stderr
+	true > "${stderr}"
+	echo "kubectl_retry ${*} failed, will retry in ${KUBECTL_RETRY_DELAY} seconds"
+
         sleep ${KUBECTL_RETRY_DELAY}
     done
 
@@ -160,7 +166,7 @@ function check_ceph_cluster_health() {
 
 	if [ "$retry" -gt "$ROOK_DEPLOY_TIMEOUT" ]; then
 		echo "[Timeout] CEPH cluster not in a healthy state (timeout)"
-		exit 1
+		return 1
 	fi
 	echo ""
 }
@@ -186,7 +192,7 @@ function check_mds_stat() {
 
 	if [ "$retry" -gt "$ROOK_DEPLOY_TIMEOUT" ]; then
 		echo "[Timeout] Failed to get ceph filesystem pods"
-		exit 1
+		return 1
 	fi
 	echo ""
 }
@@ -213,7 +219,7 @@ function check_rbd_stat() {
 
 	if [ "$retry" -gt "$ROOK_DEPLOY_TIMEOUT" ]; then
 		echo "[Timeout] Failed to get RBD pool stats"
-		exit 1
+		return 1
 	fi
 	echo ""
 }


### PR DESCRIPTION
It seems that the new log_errors() function does not get triggered when
the script hits `exit 1` conditions in functions. The functions should
return a non-0 value, not cause an exit of the script.

Updates: #1636

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
