### PR TITLE
ci: do not mark script changes as doc-only

### DIFF
--- a/scripts/skip-doc-change.sh
+++ b/scripts/skip-doc-change.sh
@@ -12,15 +12,12 @@ CHANGED_FILES=$(git diff --name-only "${GIT_SINCE}")
 
 skip=0
 #files to be skipped
-declare -a FILES=(^docs/ .md$ ^scripts/ LICENSE .mergify.yml .github .gitignore .commitlintrc.yml)
+declare -a FILES=(^docs/ .md$ LICENSE .mergify.yml .github .gitignore .commitlintrc.yml)
 
 function check_file_present() {
     local file=$1
     for FILE in "${FILES[@]}"; do
         if [[ $file =~ $FILE ]]; then
-            if [[ $file =~ (minikube.sh|travis-functest.sh) ]]; then
-                continue
-            fi
             return 0
         fi
     done


### PR DESCRIPTION
Changes in scripts will affect the CI jobs as the scripts are used while
deploying minikube, Rook and other components. These changes need
testing, just like anything else.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
