### PR TITLE
rebase: run tests with Rook v1.5.1

### DIFF
--- a/build.env
+++ b/build.env
@@ -39,7 +39,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.3.9
+ROOK_VERSION=v1.5.1
 
 # e2e settings
 # - enable CEPH_CSI_RUN_ALL_TESTS when running tests with if it has root


### PR DESCRIPTION
Rook v1.5.1 has been released, so lets use it for testing.

This PR is used to verify the CI jobs, and to check if deploying needs adaption for the new Rook version.

See-also: https://github.com/rook/rook/releases/tag/v1.5.1

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
