### PR TITLE
ci: strip localhost/ prefix after importing images in minikube

### DIFF
--- a/podman2minikube.sh
+++ b/podman2minikube.sh
@@ -2,14 +2,34 @@
 #
 # When an image was built with podman, it needs importing into minikube.
 #
+# Some versions of minikube/docker add a "localhost/" prefix to imported
+# images. In that case, the image needs to get tagged without the prefix as
+# well.
+#
 
 # fail when a command returns an error
 set -e -o pipefail
 
 # "minikube ssh" fails to read the image, so use standard ssh instead
-podman image save "${1}" | \
+function minikube_ssh() {
     ssh \
         -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
         -l docker -i "$(minikube ssh-key)" \
-        "$(minikube ip)" docker image load
+        "$(minikube ip)" "${*}"
+}
 
+IMAGE="${1}"
+# if IMAGE is empty, fail the script
+[ -n "${IMAGE}" ]
+
+# import the image, save response in STDOUT
+STDOUT=$(podman image save "${IMAGE}" | minikube_ssh docker image load)
+
+# check the name of the image that was imported in docker
+DOCKER_IMAGE=$(awk '/Loaded image/ {print $NF}' <<< "${STDOUT}")
+
+# strip "localhost/" from the image name
+if [[ "${DOCKER_IMAGE}" =~ ^localhost/* ]]
+then
+    minikube_ssh docker tag "${DOCKER_IMAGE}" "${IMAGE}"
+fi


### PR DESCRIPTION
Some versions of minikube/docker add a "localhost/" prefix to imported
images. In that case, the image needs to get tagged without the prefix
as well.

When running podman2minikube.sh, the docker process inside the minikube
VM sometimes responds with:

    # ./podman2minikube.sh rook/ceph:v1.3.9
    Loaded image: localhost/rook/ceph:v1.3.9

When the "localhost/" prefix is added to the image name, deploying Rook
will try to pull the rook/ceph:v1.3.9 image again. This can fail when
the Docker Hub pull rate-limit is hit.

Without the "localhost/" prefix, there should be no further attempt to
pull the image, as it should be detected that the image is available.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
