### PR TITLE
ci: push ceph/ceph container image into minikube

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -135,6 +135,12 @@ then
     ./podman2minikube.sh "rook/ceph:${ROOK_VERSION}"
 fi
 
+# Rook also uses ceph/ceph:v15 (build.env:BASE_IMAGE), so push it into the VM
+if [ -n "${BASE_IMAGE}" ] && podman inspect "${BASE_IMAGE}" > /dev/null
+then
+    ./podman2minikube.sh "${BASE_IMAGE}"
+fi
+
 deploy_rook
 
 # running e2e.test requires librados and librbd


### PR DESCRIPTION
Deploying Ceph with Rook fails as the ceph/ceph:v15 base image can not
be pulled from within the minikube VM. By pushing the image into the VM,
but before deploying Rook, there should be no need to pull the image
from Docker Hub anymore.

Updates: #1693

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
