### PR TITLE
ci: use docker.io/library/ as prefix for nginx and vault images

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -144,15 +144,10 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
-			// Tag the images with qualified and unqualified names,
-			// so that moving to qualified names everywhere becomes
-			// possible.
-			podman_pull("docker.io", "vault:latest")
-			ssh "./podman2minikube.sh vault:latest"
-			ssh "./podman2minikube.sh docker.io/vault:latest"
-			podman_pull("docker.io", "nginx:latest")
-			ssh "./podman2minikube.sh nginx:latest"
-			ssh "./podman2minikube.sh docker.io/nginx:latest"
+			podman_pull("docker.io", "library/vault:latest")
+			ssh "./podman2minikube.sh docker.io/library/vault:latest"
+			podman_pull("docker.io", "library/nginx:latest")
+			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 		}
 		stage('deploy ceph-csi through helm') {
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -141,15 +141,10 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
-			// Tag the images with qualified and unqualified names,
-			// so that moving to qualified names everywhere becomes
-			// possible.
-			podman_pull("docker.io", "vault:latest")
-			ssh "./podman2minikube.sh vault:latest"
-			ssh "./podman2minikube.sh docker.io/vault:latest"
-			podman_pull("docker.io", "nginx:latest")
-			ssh "./podman2minikube.sh nginx:latest"
-			ssh "./podman2minikube.sh docker.io/nginx:latest"
+			podman_pull("docker.io", "library/vault:latest")
+			ssh "./podman2minikube.sh docker.io/library/vault:latest"
+			podman_pull("docker.io", "library/nginx:latest")
+			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -141,15 +141,10 @@ node('cico-workspace') {
 			}
 
 			// vault:latest and nginx:latest are used by the e2e tests
-			// Tag the images with qualified and unqualified names,
-			// so that moving to qualified names everywhere becomes
-			// possible.
-			podman_pull("docker.io", "vault:latest")
-			ssh "./podman2minikube.sh vault:latest"
-			ssh "./podman2minikube.sh docker.io/vault:latest"
-			podman_pull("docker.io", "nginx:latest")
-			ssh "./podman2minikube.sh nginx:latest"
-			ssh "./podman2minikube.sh docker.io/nginx:latest"
+			podman_pull("docker.io", "library/vault:latest")
+			ssh "./podman2minikube.sh docker.io/library/vault:latest"
+			podman_pull("docker.io", "library/nginx:latest")
+			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 		}
 		stage("run ${test_type} upgrade tests") {
 			timeout(time: 120, unit: 'MINUTES') {


### PR DESCRIPTION
docker.io/nginx:latest and docker.io/vault:latest are being redirected
to docker.io/library/. The redirection is not cached, and Docker Hub
might return an error during redirection when the pull rate-limit is
hit.

Updates: #1693

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
