### PR TITLE
e2e: use docker.io/library as prefix for official images

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -196,7 +196,7 @@ metadata:
 spec:
   containers:
     - name: my-container
-      image: docker.io/debian:latest
+      image: docker.io/library/debian:latest
       command: ["/bin/bash", "-c"]
       args: [ "tail -f /dev/null" ]
       volumeDevices:
@@ -223,7 +223,7 @@ metadata:
 spec:
   containers:
     - name: my-container
-      image: docker.io/debian:latest
+      image: docker.io/library/debian:latest
       command: ["/bin/bash", "-c"]
       args: [ "tail -f /dev/null" ]
       volumeDevices:

--- a/examples/cephfs/deployment.yaml
+++ b/examples/cephfs/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: web-server
-          image: docker.io/nginx:latest
+          image: docker.io/library/nginx:latest
           volumeMounts:
             - name: mypvc
               mountPath: /var/lib/www/html

--- a/examples/cephfs/pod-clone.yaml
+++ b/examples/cephfs/pod-clone.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: docker.io/nginx:latest
+      image: docker.io/library/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/cephfs/pod-restore.yaml
+++ b/examples/cephfs/pod-restore.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: docker.io/nginx:latest
+      image: docker.io/library/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/cephfs/pod.yaml
+++ b/examples/cephfs/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: docker.io/nginx:latest
+      image: docker.io/library/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: vault
-          image: docker.io/vault:latest
+          image: docker.io/library/vault:latest
           securityContext:
             runAsUser: 100
           env:

--- a/examples/rbd/pod-clone.yaml
+++ b/examples/rbd/pod-clone.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: docker.io/nginx:latest
+      image: docker.io/library/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/pod-restore.yaml
+++ b/examples/rbd/pod-restore.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: docker.io/nginx:latest
+      image: docker.io/library/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/pod.yaml
+++ b/examples/rbd/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: docker.io/nginx:latest
+      image: docker.io/library/nginx:latest
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html


### PR DESCRIPTION
Docker Hub offers a way to pull official images without any project
prefix, like "docker.io/vault:latest". This does a redirect to the
images located under "docker.io/library".

By using the full qualified image name, a redirect gets removed while
pulling the images. This reduces the likelyhood of hittin Docker Hub
pull rate-limits.

Updates: #1693

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
