### PR TITLE
helm: make kubelet path configurable

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           args:
             - "--v={{ .Values.logLevel }}"
             - "--csi-address=/csi/{{ .Values.pluginSocketFile }}"
-            - "--kubelet-registration-path={{ .Values.socketDir }}/{{ .Values.pluginSocketFile }}"
+            - "--kubelet-registration-path={{ .Values.kubeletDir }}/{{ .Values.driverName }}/{{ .Values.pluginSocketFile }}"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -95,10 +95,10 @@ spec:
             - name: socket-dir
               mountPath: /csi
             - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ .Values.kubeletDir }}/pods
               mountPropagation: Bidirectional
             - name: plugin-dir
-              mountPath: /var/lib/kubelet/plugins
+              mountPath: {{ .Values.kubeletDir }}/plugins
               mountPropagation: "Bidirectional"
             - mountPath: /dev
               name: host-dev
@@ -144,19 +144,19 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: {{ .Values.socketDir }}
+            path: "{{ .Values.kubeletDir }}/{{ .Values.driverName }}"
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: {{ .Values.registrationDir }}
+            path: {{ .Values.kubeletDir }}/plugins_registry
             type: Directory
         - name: mountpoint-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.kubeletDir }}/pods
             type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins
+            path: {{ .Values.kubeletDir }}/plugins
             type: Directory
         - name: host-sys
           hostPath:

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
@@ -40,12 +40,6 @@ spec:
       readOnly: false
     - pathPrefix: '/lib/modules'
       readOnly: true
-    - pathPrefix: '/var/lib/kubelet/pods'
-      readOnly: false
-    - pathPrefix: '{{ .Values.socketDir }}'
-      readOnly: false
-    - pathPrefix: '{{ .Values.registrationDir }}'
-      readOnly: false
-    - pathPrefix: '{{ .Values.pluginDir }}'
+    - pathPrefix: '{{ .Values.kubeletDir }}'
       readOnly: false
 {{- end }}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -195,16 +195,12 @@ topology:
 # Variables for 'internal' use please use with caution! #
 #########################################################
 
-# The directory where the provisioner and pluginSocketFile will be mounted
-socketDir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
 # The filename of the provisioner socket
 provisionerSocketFile: csi-provisioner.sock
 # The filename of the plugin socket
 pluginSocketFile: csi.sock
-# The directory where nodeplugin socket is created
-registrationDir: /var/lib/kubelet/plugins_registry
-# The nodeplugin plugins directory
-pluginDir: /var/lib/kubelet/plugins
+# kubelet working directory,can be set using `--root-dir` when starting kubelet.
+kubeletDir: /var/lib/kubelet
 # Name of the csi-driver
 driverName: cephfs.csi.ceph.com
 # Name of the configmap used for state

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           args:
             - "--v={{ .Values.logLevel }}"
             - "--csi-address=/csi/{{ .Values.pluginSocketFile }}"
-            - "--kubelet-registration-path={{ .Values.socketDir }}/{{ .Values.pluginSocketFile }}"
+            - "--kubelet-registration-path={{ .Values.kubeletDir }}/{{ .Values.driverName }}/{{ .Values.pluginSocketFile }}"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -106,10 +106,10 @@ spec:
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: plugin-dir
-              mountPath: /var/lib/kubelet/plugins
+              mountPath: {{ .Values.kubeletDir }}/plugins
               mountPropagation: "Bidirectional"
             - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ .Values.kubeletDir }}/pods
               mountPropagation: "Bidirectional"
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
@@ -144,19 +144,19 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: {{ .Values.socketDir }}
+            path: "{{ .Values.kubeletDir }}/{{ .Values.driverName }}"
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: {{ .Values.registrationDir }}
+            path: {{ .Values.kubeletDir }}/plugins_registry
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: {{ .Values.pluginDir }}
+            path: {{ .Values.kubeletDir }}/plugins
             type: Directory
         - name: mountpoint-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.kubeletDir }}/pods
             type: DirectoryOrCreate
         - name: host-dev
           hostPath:

--- a/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
@@ -40,12 +40,6 @@ spec:
       readOnly: false
     - pathPrefix: '/lib/modules'
       readOnly: true
-    - pathPrefix: '/var/lib/kubelet/pods'
-      readOnly: false
-    - pathPrefix: '{{ .Values.socketDir }}'
-      readOnly: false
-    - pathPrefix: '{{ .Values.registrationDir }}'
-      readOnly: false
-    - pathPrefix: '{{ .Values.pluginDir }}'
+    - pathPrefix: '{{ .Values.kubeletDir }}'
       readOnly: false
 {{- end }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -219,16 +219,12 @@ topology:
 # Variables for 'internal' use please use with caution! #
 #########################################################
 
-# The directory where the provisioner and pluginSocketFile will be mounted
-socketDir: /var/lib/kubelet/plugins/rbd.csi.ceph.com
 # The filename of the provisioner socket
 provisionerSocketFile: csi-provisioner.sock
 # The filename of the plugin socket
 pluginSocketFile: csi.sock
-# The directory where nodeplugin socket is created
-registrationDir: /var/lib/kubelet/plugins_registry
-# The nodeplugin plugins directory
-pluginDir: /var/lib/kubelet/plugins
+# kubelet working directory,can be set using `--root-dir` when starting kubelet.
+kubeletDir: /var/lib/kubelet
 # Name of the csi-driver
 driverName: rbd.csi.ceph.com
 # Name of the configmap used for state


### PR DESCRIPTION
removed unwanted extra arguments from the helm templates and added a single value kubeletDir to make the kubelet
root-dir configurable.

fixes: #1475
