### PR TITLE
build: use docker.io/ceph/ceph:v15 as BASE_IMAGE

### DIFF
--- a/build.env
+++ b/build.env
@@ -10,7 +10,7 @@
 #
 
 # Ceph version to use
-BASE_IMAGE=ceph/ceph:v15
+BASE_IMAGE=docker.io/ceph/ceph:v15
 CEPH_VERSION=nautilus
 
 # standard Golang options


### PR DESCRIPTION
Use a qualified image name, including the registry where it should come
from. This makes it possible to pull the image from the right location,
and consume it in CI jobs without trying to pull again.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
