### PR TITLE
ci: pull BASE_IMAGE from local registry

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -131,9 +131,10 @@ node('cico-workspace') {
 						script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 						returnStdout: true
 					).trim()
+					def d_io_regex = ~"^docker.io/"
 
-					// base_image is like ceph/ceph:v15
-					podman_pull(ci_registry, "docker.io", "${base_image}")
+					// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
+					podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
 				}
 			}
 		}

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -116,13 +116,14 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
+			def d_io_regex = ~"^docker.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
-			// base_image is like ceph/ceph:v15
-			podman_pull(ci_registry, "docker.io", "${base_image}")
+			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
+			podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 		}

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -113,13 +113,14 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
+			def d_io_regex = ~"^docker.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
-			// base_image is like ceph/ceph:v15
-			podman_pull(ci_registry, "docker.io", "${base_image}")
+			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
+			podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 		}

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -113,13 +113,14 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
+			def d_io_regex = ~"^docker.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
 			}
 
-			// base_image is like ceph/ceph:v15
-			podman_pull(ci_registry, "docker.io", "${base_image}")
+			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
+			podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 		}


### PR DESCRIPTION
The CI scripts pull all container images from the local CI registry. If
the image name starts with "docker.io/", the images will be pushed into
the test environment as "docker.io/docker.io/ceph/ceph:v15". This image
will not be used by the tests, so things can still fail in case Docker
Hub has reached the pull rate-limit.

By dropping the additional "docker.io/" from the BASE_IMAGE name, the
image gets pushed as "docker.io/ceph/ceph:v15" so the tests will use it
automatically.

Groovy-syntax: https://www.baeldung.com/groovy-remove-string-prefix#using-regex

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
