### PR TITLE
rbd: add support to create snapshot and clone from snapshot in different pools

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -954,6 +954,103 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("create rbd snapshots in different pool", func() {
+				// snapshot beta is only supported from v1.17+
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
+					err := deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+					snapshotPool := "snapshot-test"
+					// create pool for snapshots
+					err = createPool(f, snapshotPool)
+					if err != nil {
+						e2elog.Failf("failed to create pool %s with error %v", snapshotPool, err)
+					}
+					// create snapshotclass to with pool option
+					param := map[string]string{
+						"pool": snapshotPool,
+					}
+					err = createRBDSnapshotClass(f, param)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+					err = validateSnapshotInDifferentPool(f, snapshotPool, "", defaultRBDPool)
+					if err != nil {
+						e2elog.Failf("failed to validate snapshot in different pool with error %v", err)
+					}
+
+					err = deletePool(snapshotPool, false, f)
+					if err != nil {
+						e2elog.Failf("failed to delete pool %s with error %v", snapshotPool, err)
+					}
+					err = deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+					err = createRBDSnapshotClass(f, nil)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+				}
+			})
+
+			By("create rbd clones in different pool", func() {
+				// snapshot beta is only supported from v1.17+
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
+					err := deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+					clonePool := "clone-test"
+					// create pool for clones
+					err = createPool(f, clonePool)
+					if err != nil {
+						e2elog.Failf("failed to create pool %s with error %v", clonePool, err)
+					}
+					// create snapshotclass to with pool option
+					param := map[string]string{
+						"pool": defaultRBDPool,
+					}
+					err = createRBDSnapshotClass(f, param)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+					cloneSC := "clone-storageclass"
+					param = map[string]string{
+						"pool": clonePool,
+					}
+					// create new storageclass to with new pool
+					err = createRBDStorageClass(f.ClientSet, f, cloneSC, nil, param, deletePolicy)
+					if err != nil {
+						e2elog.Failf("failed to create storageclass with error %v", err)
+					}
+					err = validateSnapshotInDifferentPool(f, defaultRBDPool, cloneSC, clonePool)
+					if err != nil {
+						e2elog.Failf("failed to validate clone in different pool with error %v", err)
+					}
+
+					_, err = framework.RunKubectl(cephCSINamespace, "delete", "sc", cloneSC, "--ignore-not-found=true")
+					if err != nil {
+						e2elog.Failf("failed to delete storageclass %s with error %v", cloneSC, err)
+					}
+
+					err = deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+
+					err = deletePool(clonePool, false, f)
+					if err != nil {
+						e2elog.Failf("failed to delete pool %s with error %v", clonePool, err)
+					}
+					err = createRBDSnapshotClass(f, nil)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+				}
+			})
+
 			By("create ROX PVC clone and mount it to multiple pods", func() {
 				// snapshot beta is only supported from v1.17+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -125,8 +125,8 @@ func createORDeleteRbdResouces(action string) {
 	}
 }
 
-func validateRBDImageCount(f *framework.Framework, count int) {
-	imageList, err := listRBDImages(f)
+func validateRBDImageCount(f *framework.Framework, count int, pool string) {
+	imageList, err := listRBDImages(f, pool)
 	if err != nil {
 		e2elog.Failf("failed to list rbd images with error %v", err)
 	}
@@ -265,7 +265,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app with normal user", func() {
@@ -274,7 +274,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate normal user pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app with ext4 as the FS ", func() {
@@ -291,7 +291,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -316,7 +316,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -345,7 +345,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -377,7 +377,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to create PVC with error %v", err)
 					}
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 					snap := getSnapshot(snapshotPath)
 					snap.Namespace = f.UniqueName
 					snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
@@ -404,7 +404,7 @@ var _ = Describe("RBD", func() {
 					}
 
 					// total images in cluster is 1 parent rbd image+ total snaps
-					validateRBDImageCount(f, totalCount+1)
+					validateRBDImageCount(f, totalCount+1, defaultRBDPool)
 					pvcClone, err := loadPVC(pvcClonePath)
 					if err != nil {
 						e2elog.Failf("failed to load PVC with error %v", err)
@@ -442,7 +442,7 @@ var _ = Describe("RBD", func() {
 					// total images in cluster is 1 parent rbd image+ total
 					// snaps+ total clones
 					totalCloneCount := totalCount + totalCount + 1
-					validateRBDImageCount(f, totalCloneCount)
+					validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 					wg.Add(totalCount)
 					// delete clone and app
 					for i := 0; i < totalCount; i++ {
@@ -468,7 +468,7 @@ var _ = Describe("RBD", func() {
 
 					// total images in cluster is 1 parent rbd image+ total
 					// snaps
-					validateRBDImageCount(f, totalCount+1)
+					validateRBDImageCount(f, totalCount+1, defaultRBDPool)
 					// create clones from different snapshosts and bind it to an
 					// app
 					wg.Add(totalCount)
@@ -496,7 +496,7 @@ var _ = Describe("RBD", func() {
 					// total images in cluster is 1 parent rbd image+ total
 					// snaps+ total clones
 					totalCloneCount = totalCount + totalCount + 1
-					validateRBDImageCount(f, totalCloneCount)
+					validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 					// delete parent pvc
 					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
@@ -505,7 +505,7 @@ var _ = Describe("RBD", func() {
 
 					// total images in cluster is total snaps+ total clones
 					totalSnapCount := totalCount + totalCount
-					validateRBDImageCount(f, totalSnapCount)
+					validateRBDImageCount(f, totalSnapCount, defaultRBDPool)
 					wg.Add(totalCount)
 					// delete snapshot
 					for i := 0; i < totalCount; i++ {
@@ -528,7 +528,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("deleting snapshots failed, %d errors were logged", failed)
 					}
 
-					validateRBDImageCount(f, totalCount)
+					validateRBDImageCount(f, totalCount, defaultRBDPool)
 					wg.Add(totalCount)
 					// delete clone and app
 					for i := 0; i < totalCount; i++ {
@@ -553,7 +553,7 @@ var _ = Describe("RBD", func() {
 					}
 
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -604,7 +604,7 @@ var _ = Describe("RBD", func() {
 
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, totalCount)
+				validateRBDImageCount(f, totalCount, defaultRBDPool)
 				// delete PVC and app
 				for i := 0; i < totalCount; i++ {
 					name := fmt.Sprintf("%s%d", f.UniqueName, i)
@@ -616,7 +616,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("check data persist after recreating pod", func() {
@@ -625,7 +625,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to check data persist with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("Resize Filesystem PVC and check application directory size", func() {
@@ -650,7 +650,7 @@ var _ = Describe("RBD", func() {
 
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -662,7 +662,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to resize block PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -684,7 +684,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 				// delete rbd nodeplugin pods
 				err = deletePodWithLabel("app=csi-rbdplugin", cephCSINamespace, false)
 				if err != nil {
@@ -701,7 +701,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create PVC in storageClass with volumeNamePrefix", func() {
@@ -726,10 +726,10 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 				// list RBD images and check if one of them has the same prefix
 				foundIt := false
-				images, err := listRBDImages(f)
+				images, err := listRBDImages(f, defaultRBDPool)
 				if err != nil {
 					e2elog.Failf("failed to list rbd images with error %v", err)
 				}
@@ -747,7 +747,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to  delete PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -768,7 +768,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate rbd static pv with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("validate RBD static Block PVC", func() {
@@ -777,7 +777,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate rbd block pv with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("validate mount options in app pod", func() {
@@ -787,7 +787,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to check mount options with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("creating an app with a PVC, using a topology constrained StorageClass", func() {
@@ -928,7 +928,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				// create an app and wait for 1 min for it to go to running state
 				err = createApp(f.ClientSet, app, 1)
@@ -941,7 +941,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -972,7 +972,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create PVC and application with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 					// delete pod as we should not create snapshot for in-use pvc
 					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 					if err != nil {
@@ -990,7 +990,7 @@ var _ = Describe("RBD", func() {
 					// validate created backend rbd images
 					// parent PVC + snapshot
 					totalImages := 2
-					validateRBDImageCount(f, totalImages)
+					validateRBDImageCount(f, totalImages, defaultRBDPool)
 					pvcClone, err := loadPVC(pvcClonePath)
 					if err != nil {
 						e2elog.Failf("failed to load PVC with error %v", err)
@@ -1006,7 +1006,7 @@ var _ = Describe("RBD", func() {
 					// validate created backend rbd images
 					// parent pvc+ snapshot + clone
 					totalImages = 3
-					validateRBDImageCount(f, totalImages)
+					validateRBDImageCount(f, totalImages, defaultRBDPool)
 
 					appClone, err := loadApp(appClonePath)
 					if err != nil {
@@ -1070,7 +1070,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to delete PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -1136,7 +1136,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 
 					snap := getSnapshot(snapshotPath)
 					snap.Namespace = f.UniqueName
@@ -1145,7 +1145,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to create snapshot with error %v", err)
 					}
-					validateRBDImageCount(f, 2)
+					validateRBDImageCount(f, 2, defaultRBDPool)
 
 					err = validatePVCAndAppBinding(pvcClonePath, appClonePath, f)
 					if err != nil {
@@ -1156,13 +1156,13 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to delete snapshot with error %v", err)
 					}
 					// as snapshot is deleted the image count should be one
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 
 					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to delete PVC with error %v", err)
 					}
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 
 				updateConfigMap("")
@@ -1194,7 +1194,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				opt := metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("app=%s", app.Name),
@@ -1213,7 +1213,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and Bind it to an app for mapped rbd image with options", func() {
@@ -1251,7 +1251,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate controller with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -363,7 +363,7 @@ var _ = Describe("RBD", func() {
 					totalCount := 10
 					wgErrs := make([]error, totalCount)
 					wg.Add(totalCount)
-					err := createRBDSnapshotClass(f)
+					err := createRBDSnapshotClass(f, nil)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -36,6 +36,19 @@ var (
 	nodeCSIZoneLabel    = "topology.rbd.csi.ceph.com/zone"
 	rbdTopologyPool     = "newrbdpool"
 	rbdTopologyDataPool = "replicapool" // NOTE: should be different than rbdTopologyPool for test to be effective
+
+	// yaml files required for
+	pvcPath                = rbdExamplePath + "pvc.yaml"
+	appPath                = rbdExamplePath + "pod.yaml"
+	rawPvcPath             = rbdExamplePath + "raw-block-pvc.yaml"
+	rawAppPath             = rbdExamplePath + "raw-block-pod.yaml"
+	pvcClonePath           = rbdExamplePath + "pvc-restore.yaml"
+	pvcSmartClonePath      = rbdExamplePath + "pvc-clone.yaml"
+	pvcBlockSmartClonePath = rbdExamplePath + "pvc-block-clone.yaml"
+	appClonePath           = rbdExamplePath + "pod-restore.yaml"
+	appSmartClonePath      = rbdExamplePath + "pod-clone.yaml"
+	appBlockSmartClonePath = rbdExamplePath + "block-pod-clone.yaml"
+	snapshotPath           = rbdExamplePath + "snapshot.yaml"
 )
 
 func deployRBDPlugin() {
@@ -233,17 +246,6 @@ var _ = Describe("RBD", func() {
 
 	Context("Test RBD CSI", func() {
 		It("Test RBD CSI", func() {
-			pvcPath := rbdExamplePath + "pvc.yaml"
-			appPath := rbdExamplePath + "pod.yaml"
-			rawPvcPath := rbdExamplePath + "raw-block-pvc.yaml"
-			rawAppPath := rbdExamplePath + "raw-block-pod.yaml"
-			pvcClonePath := rbdExamplePath + "pvc-restore.yaml"
-			pvcSmartClonePath := rbdExamplePath + "pvc-clone.yaml"
-			pvcBlockSmartClonePath := rbdExamplePath + "pvc-block-clone.yaml"
-			appClonePath := rbdExamplePath + "pod-restore.yaml"
-			appSmartClonePath := rbdExamplePath + "pod-clone.yaml"
-			appBlockSmartClonePath := rbdExamplePath + "block-pod-clone.yaml"
-			snapshotPath := rbdExamplePath + "snapshot.yaml"
 
 			By("checking provisioner deployment is running", func() {
 				err := waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -165,7 +165,7 @@ var _ = Describe("RBD", func() {
 		if err != nil {
 			e2elog.Failf("failed to create configmap with error %v", err)
 		}
-		err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+		err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 		if err != nil {
 			e2elog.Failf("failed to create storageclass with error %v", err)
 		}
@@ -282,7 +282,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"csi.storage.k8s.io/fstype": "ext4"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, map[string]string{"csi.storage.k8s.io/fstype": "ext4"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -296,7 +296,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -307,7 +307,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"encrypted": "true"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, map[string]string{"encrypted": "true"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -321,7 +321,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -336,7 +336,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -350,7 +350,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -640,7 +640,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to delete storageclass with error %v", err)
 					}
-					err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"csi.storage.k8s.io/fstype": "xfs"}, deletePolicy)
+					err = createRBDStorageClass(f.ClientSet, f, "", nil, map[string]string{"csi.storage.k8s.io/fstype": "xfs"}, deletePolicy)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}
@@ -710,7 +710,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"volumeNamePrefix": volumeNamePrefix}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, map[string]string{"volumeNamePrefix": volumeNamePrefix}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -753,7 +753,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -810,7 +810,7 @@ var _ = Describe("RBD", func() {
 				topologyConstraint := "[{\"poolName\":\"" + rbdTopologyPool + "\",\"domainSegments\":" +
 					"[{\"domainLabel\":\"region\",\"value\":\"" + regionValue + "\"}," +
 					"{\"domainLabel\":\"zone\",\"value\":\"" + zoneValue + "\"}]}]"
-				err = createRBDStorageClass(f.ClientSet, f,
+				err = createRBDStorageClass(f.ClientSet, f, "",
 					map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 					map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 				if err != nil {
@@ -859,7 +859,7 @@ var _ = Describe("RBD", func() {
 						"\",\"domainSegments\":" +
 						"[{\"domainLabel\":\"region\",\"value\":\"" + regionValue + "\"}," +
 						"{\"domainLabel\":\"zone\",\"value\":\"" + zoneValue + "\"}]}]"
-					err = createRBDStorageClass(f.ClientSet, f,
+					err = createRBDStorageClass(f.ClientSet, f, "",
 						map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 						map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 					if err != nil {
@@ -895,7 +895,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -908,7 +908,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, map[string]string{rbdmountOptions: "debug,invalidOption"}, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", map[string]string{rbdmountOptions: "debug,invalidOption"}, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -946,7 +946,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1221,7 +1221,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, map[string]string{
 					"mapOptions":   "lock_on_read,queue_depth=1024",
 					"unmapOptions": "force"}, deletePolicy)
 				if err != nil {
@@ -1235,7 +1235,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1252,7 +1252,7 @@ var _ = Describe("RBD", func() {
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -30,11 +30,14 @@ func rbdOptions(pool string) string {
 	return "--pool=" + pool
 }
 
-func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, scOptions, parameters map[string]string, policy v1.PersistentVolumeReclaimPolicy) error {
+func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, name string, scOptions, parameters map[string]string, policy v1.PersistentVolumeReclaimPolicy) error {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc, err := getStorageClass(scPath)
 	if err != nil {
 		return nil
+	}
+	if name != "" {
+		sc.Name = name
 	}
 	sc.Parameters["pool"] = defaultRBDPool
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = rookNamespace

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -299,6 +299,13 @@ func deletePool(name string, cephfs bool, f *framework.Framework) error {
 	return nil
 }
 
+func createPool(f *framework.Framework, name string) error {
+	// ceph osd pool create replicapool
+	cmd := fmt.Sprintf("ceph osd pool create %s", name)
+	_, _, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+	return err
+}
+
 func getPVCImageInfoInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, pool string) (string, error) {
 	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
 	if err != nil {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -240,11 +240,11 @@ func validateEncryptedPVCAndAppBinding(pvcPath, appPath, kms string, f *framewor
 	return nil
 }
 
-func listRBDImages(f *framework.Framework) ([]string, error) {
+func listRBDImages(f *framework.Framework, pool string) ([]string, error) {
 	var imgInfos []string
 
 	stdout, stdErr, err := execCommandInToolBoxPod(f,
-		fmt.Sprintf("rbd ls --format=json %s", rbdOptions(defaultRBDPool)), rookNamespace)
+		fmt.Sprintf("rbd ls --format=json %s", rbdOptions(pool)), rookNamespace)
 	if err != nil {
 		return imgInfos, err
 	}

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -113,7 +113,7 @@ func deleteSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 	})
 }
 
-func createRBDSnapshotClass(f *framework.Framework) error {
+func createRBDSnapshotClass(f *framework.Framework, param map[string]string) error {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "snapshotclass.yaml")
 	sc := getSnapshotClass(scPath)
 
@@ -128,6 +128,9 @@ func createRBDSnapshotClass(f *framework.Framework) error {
 	}
 	fsID = strings.Trim(fsID, "\n")
 	sc.Parameters["clusterID"] = fsID
+	for k, v := range param {
+		sc.Parameters[k] = v
+	}
 	sclient, err := newSnapshotClient()
 	if err != nil {
 		return err

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -63,7 +63,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to create configmap with error %v", err)
 		}
-		err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+		err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 		if err != nil {
 			e2elog.Failf("failed to create storageclass with error %v", err)
 		}

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -71,7 +71,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to create secret with error %v", err)
 		}
-		err = createRBDSnapshotClass(f)
+		err = createRBDSnapshotClass(f, nil)
 		if err != nil {
 			e2elog.Failf("failed to create snapshotclass with error %v", err)
 		}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -520,7 +520,7 @@ func validatePVCClone(sourcePvcPath, clonePvcPath, clonePvcAppPath string, f *fr
 		e2elog.Failf("failed to create PVC with error %v", err)
 	}
 	// validate created backend rbd images
-	validateRBDImageCount(f, 1)
+	validateRBDImageCount(f, 1, defaultRBDPool)
 	pvcClone, err := loadPVC(clonePvcPath)
 	if err != nil {
 		e2elog.Failf("failed to load PVC with error %v", err)
@@ -558,7 +558,7 @@ func validatePVCClone(sourcePvcPath, clonePvcPath, clonePvcAppPath string, f *fr
 	// total images in cluster is 1 parent rbd image+ total
 	// temporary clone+ total clones
 	totalCloneCount := totalCount + totalCount + 1
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
@@ -566,7 +566,7 @@ func validatePVCClone(sourcePvcPath, clonePvcPath, clonePvcAppPath string, f *fr
 	}
 
 	totalCloneCount = totalCount + totalCount
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
@@ -590,7 +590,7 @@ func validatePVCClone(sourcePvcPath, clonePvcPath, clonePvcAppPath string, f *fr
 		e2elog.Failf("deleting PVCs and applications failed, %d errors were logged", failed)
 	}
 
-	validateRBDImageCount(f, 0)
+	validateRBDImageCount(f, 0, defaultRBDPool)
 }
 
 // validateController simulates the required operations to validate the

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -611,7 +611,7 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	expandSize := "10Gi"
 	var err error
 	// create storageclass with retain
-	err = createRBDStorageClass(f.ClientSet, f, nil, nil, retainPolicy)
+	err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, retainPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass with error %v", err)
 	}
@@ -643,7 +643,7 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	if err != nil {
 		return fmt.Errorf("failed to delete storageclass with error %v", err)
 	}
-	err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+	err = createRBDStorageClass(f.ClientSet, f, "", nil, nil, deletePolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass with error %v", err)
 	}

--- a/examples/rbd/snapshotclass.yaml
+++ b/examples/rbd/snapshotclass.yaml
@@ -14,6 +14,12 @@ parameters:
   # represent the Ceph cluster in clusterID below
   clusterID: <cluster-id>
 
+  # (optional) Ceph pool into which the RBD image shall be created, if not
+  # specified RBD image will be created in the same pool where parent RBD image
+  # exists.
+  # eg: pool: rbdpool
+  # pool: <rbd-pool-name>
+
   # Prefix to use for naming RBD snapshots.
   # If omitted, defaults to "csi-snap-".
   # snapshotNamePrefix: "foo-bar-"

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -96,8 +96,8 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 		// snap will be create after we flatten the temporary cloned image,no
 		// need to check for flatten here.
 		// as the snap exists,create clone image and delete temporary snapshot
-		// and add task to flatten temporary cloned image
-		err = rv.cloneRbdImageFromSnapshot(ctx, snap)
+		// and add task to flatten temporary cloned
+		err = rv.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
 			err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -798,7 +798,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		vol := generateVolFromSnap(rbdSnap)
 		err = vol.Connect(cr)
 		if err != nil {
-			uErr := undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 			if uErr != nil {
 				util.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", req.GetName(), uErr)
 			}
@@ -819,7 +819,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			}, nil
 		}
 		if err != nil {
-			uErr := undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 			if uErr != nil {
 				util.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", req.GetName(), uErr)
 			}

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -158,7 +158,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 					return false, err
 				}
 			}
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 		}
 		return false, err
 	}
@@ -184,7 +184,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		sErr := vol.createSnapshot(ctx, rbdSnap)
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 	}
@@ -196,13 +196,13 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		sErr := vol.getImageID()
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to get image id %s: %v", vol, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 		sErr = j.StoreImageID(ctx, vol.JournalPool, vol.ReservedID, vol.ImageID)
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to store volume id %s: %v", vol, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -885,7 +885,7 @@ func (rv *rbdVolume) createSnapshot(ctx context.Context, pOpts *rbdSnapshot) err
 }
 
 func (rv *rbdVolume) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) error {
-	util.DebugLog(ctx, "rbd: snap rm %s using mon %s", pOpts, pOpts.Monitors)
+	util.DebugLog(ctx, "rbd: snap rm %s@%s using mon %s", rv, pOpts.RbdSnapName, pOpts.Monitors)
 	image, err := rv.open()
 	if err != nil {
 		return err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -88,6 +88,7 @@ type rbdVolume struct {
 	RadosNamespace      string
 	ImageID             string
 	ParentName          string
+	ParentPool          string
 	imageFeatureSet     librbd.FeatureSet
 	AdminID             string `json:"adminId"`
 	UserID              string `json:"userId"`
@@ -986,6 +987,7 @@ func (rv *rbdVolume) getImageInfo() error {
 		}
 	} else {
 		rv.ParentName = parentInfo.Image.ImageName
+		rv.ParentPool = parentInfo.Image.PoolName
 	}
 	// Get image creation time
 	tm, err := image.GetCreateTimestamp()

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -873,7 +873,7 @@ func (rv *rbdVolume) hasSnapshotFeature() bool {
 }
 
 func (rv *rbdVolume) createSnapshot(ctx context.Context, pOpts *rbdSnapshot) error {
-	util.DebugLog(ctx, "rbd: snap create %s using mon %s", pOpts, pOpts.Monitors)
+	util.DebugLog(ctx, "rbd: snap create %s@%s using mon %s", rv, pOpts.RbdSnapName, pOpts.Monitors)
 	image, err := rv.open()
 	if err != nil {
 		return err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -903,10 +903,9 @@ func (rv *rbdVolume) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) err
 	return err
 }
 
-func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *rbdSnapshot) error {
-	image := rv.RbdImageName
+func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *rbdSnapshot, parentVol *rbdVolume) error {
 	var err error
-	logMsg := "rbd: clone %s %s (features: %s) using mon %s"
+	logMsg := "rbd: clone %s@%s %s (features: %s) using mon %s"
 
 	options := librbd.NewRbdImageOptions()
 	defer options.Destroy()
@@ -920,7 +919,7 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *r
 	}
 
 	util.DebugLog(ctx, logMsg,
-		pSnapOpts, image, rv.imageFeatureSet.Names(), rv.Monitors)
+		parentVol, pSnapOpts.RbdSnapName, rv, rv.imageFeatureSet.Names(), rv.Monitors)
 
 	if rv.imageFeatureSet != 0 {
 		err = options.SetUint64(librbd.RbdImageOptionFeatures, uint64(rv.imageFeatureSet))
@@ -934,12 +933,18 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *r
 		return fmt.Errorf("failed to set image features: %w", err)
 	}
 
+	// As the clone is yet to be created, open the Ioctx.
 	err = rv.openIoctx()
 	if err != nil {
 		return fmt.Errorf("failed to get IOContext: %w", err)
 	}
+	// Destroy only the ioctx, connection is needed for other operations.
+	defer func() {
+		defer rv.ioctx.Destroy()
+		rv.ioctx = nil
+	}()
 
-	err = librbd.CloneImage(rv.ioctx, pSnapOpts.RbdImageName, pSnapOpts.RbdSnapName, rv.ioctx, rv.RbdImageName, options)
+	err = librbd.CloneImage(parentVol.ioctx, pSnapOpts.RbdImageName, pSnapOpts.RbdSnapName, rv.ioctx, rv.RbdImageName, options)
 	if err != nil {
 		return fmt.Errorf("failed to create rbd clone: %w", err)
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -860,6 +860,10 @@ func genSnapFromOptions(ctx context.Context, rbdVol *rbdVolume, snapOptions map[
 		rbdSnap.NamePrefix = namePrefix
 	}
 
+	if pool, ok := snapOptions["pool"]; ok {
+		rbdSnap.JournalPool = pool
+		rbdSnap.Pool = pool
+	}
 	return rbdSnap, nil
 }
 

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -33,7 +33,7 @@ func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap
 
 	snap.RbdImageName = parentVol.RbdImageName
 	// create clone image and delete snapshot
-	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap)
+	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
 		err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)


### PR DESCRIPTION
* Added support to create volumesnapshot in a different pool
   as cephcsi internally creates an rbd image when a user requested a snapshot, cephcsi can create an rbd image in a  different pool

* Added support to create pvc from snapshot to a different pool
   as cephcsi internally creates a clone from a snapshot its possible to clone to a new pool

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>