### PR TITLE
e2e: use full-qualified-image-name for vault-init-job

### DIFF
--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -125,7 +125,7 @@ spec:
             name: init-scripts
       containers:
         - name: vault-init-job
-          image: vault
+          image: docker.io/library/vault:latest
           volumeMounts:
             - mountPath: /init-scripts
               name: init-scripts-volume


### PR DESCRIPTION
On occasion deploying Vault fails. It seems the vault-init-job batch job
does not use a full-qualified-image-name for the "vault" container.

Updates: #1693

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
