### PR TITLE
ci: log output of "docker image save"

### DIFF
--- a/podman2minikube.sh
+++ b/podman2minikube.sh
@@ -24,6 +24,7 @@ IMAGE="${1}"
 
 # import the image, save response in STDOUT
 STDOUT=$(podman image save "${IMAGE}" | minikube_ssh docker image load)
+echo "${STDOUT}"
 
 # check the name of the image that was imported in docker
 DOCKER_IMAGE=$(awk '/Loaded image/ {print $NF}' <<< "${STDOUT}")


### PR DESCRIPTION
When podman2minukube is called, the output to stdout is lost. This makes
debugging issues difficult. Log the output, so that the name of the
image that is pushed into minikube can be verified.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
