### PR TITLE
ci: run github work flow only for pull request

### DIFF
--- a/.github/workflows/build-multi-stage.yaml
+++ b/.github/workflows/build-multi-stage.yaml
@@ -2,7 +2,6 @@
 name: multi-arch-build
 # yamllint disable-line rule:truthy
 on:
-  push:
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -4,14 +4,9 @@
 name: Codespell
 # yamllint disable-line rule:truthy
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
   pull_request:
     branches:
-      - master
+      - '*'
 jobs:
   codespell:
     name: codespell


### PR DESCRIPTION
currently, GitHub actions are getting triggered for both pull and push request, this commits removes the
action for push events.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

