### PR TITLE
ci: set imagePullPolicy for Vault to IfNotPresent

### DIFF
--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
         - name: vault
           image: docker.io/library/vault:latest
+          imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 100
           env:


### PR DESCRIPTION
Deploying Vault still fails on occasion. It seems that the
imagePullPolicy has not been configured for the container yet.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
