### PR TITLE
e2e: log events from deployment namespace

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -164,6 +164,9 @@ var _ = Describe("cephfs", func() {
 			logsCSIPods("app=csi-cephfsplugin-provisioner", c)
 			// log node plugin
 			logsCSIPods("app=csi-cephfsplugin", c)
+
+			// log all details from the namespace where Ceph-CSI is deployed
+			framework.DumpAllNamespaceInfo(c, cephCSINamespace)
 		}
 		err := deleteConfigMap(cephfsDirPath)
 		if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -189,6 +189,9 @@ var _ = Describe("RBD", func() {
 			logsCSIPods("app=csi-rbdplugin-provisioner", c)
 			// log node plugin
 			logsCSIPods("app=csi-rbdplugin", c)
+
+			// log all details from the namespace where Ceph-CSI is deployed
+			framework.DumpAllNamespaceInfo(c, cephCSINamespace)
 		}
 
 		err := deleteConfigMap(rbdDirPath)

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -88,6 +88,9 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 			logsCSIPods("app=csi-cephfsplugin-provisioner", c)
 			// log node plugin
 			logsCSIPods("app=csi-cephfsplugin", c)
+
+			// log all details from the namespace where Ceph-CSI is deployed
+			framework.DumpAllNamespaceInfo(c, cephCSINamespace)
 		}
 		err = deleteConfigMap(cephfsDirPath)
 		if err != nil {

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -96,6 +96,9 @@ var _ = Describe("RBD Upgrade Testing", func() {
 			logsCSIPods("app=csi-rbdplugin-provisioner", c)
 			// log node plugin
 			logsCSIPods("app=csi-rbdplugin", c)
+
+			// log all details from the namespace where Ceph-CSI is deployed
+			framework.DumpAllNamespaceInfo(c, cephCSINamespace)
 		}
 
 		err := deleteConfigMap(rbdDirPath)


### PR DESCRIPTION
When tests run and something goes wrong during deployment, not all
information is available. Logging the events from the namespace where
Ceph-CSI (and Vault) is deployed, might help with troubleshooting.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
