### PR TITLE
Add support for a KMS configuration that uses Vault Tokens

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.create -}}
-{{- if .Values.topology.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -11,8 +10,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
+{{- if .Values.topology.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
 {{- end }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 {{- end -}}

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -12,6 +12,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -12,7 +12,25 @@ data:
         "vaultPassphraseRoot": "/v1/secret",
         "vaultPassphrasePath": "ceph-csi/",
         "vaultCAVerify": "false"
-      }
+      },
+      "vault-tokens-test": {
+          "encryptionKMSType": "vaulttokens",
+          "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+          "vaultBackendPath": "secret/",
+          "vaultTLSServerName": "vault.default.svc.cluster.local",
+          "vaultCAVerify": "false",
+          "tenantConfigName": "ceph-csi-kms-config",
+          "tenantTokenName": "ceph-csi-kms-token",
+          "tenants": {
+              "my-app": {
+                  "vaultAddress": "https://vault.example.com",
+                  "vaultCAVerify": "true"
+              },
+              "an-other-app": {
+                  "tenantTokenName": "storage-encryption-token"
+              }
+          }
+       }
     }
 metadata:
   name: ceph-csi-encryption-kms-config

--- a/examples/kms/vault/tenant-token.yaml
+++ b/examples/kms/vault/tenant-token.yaml
@@ -1,0 +1,9 @@
+---
+# This is the Vault Token that can be created in a Kubernetes Namespace
+# (Tenant) for encrypting PVCs with the "vaulttokens" encryptionKMSType.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ceph-csi-kms-token
+stringData:
+  token: "sample_root_token_id"

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -740,7 +740,7 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 
 	if imageAttributes.KmsID != "" {
 		rbdVol.Encrypted = true
-		rbdVol.KMS, err = util.GetKMS(imageAttributes.KmsID, secrets)
+		rbdVol.KMS, err = util.GetKMS(rbdVol.Owner, imageAttributes.KmsID, secrets)
 		if err != nil {
 			return rbdVol, err
 		}
@@ -838,7 +838,7 @@ func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[st
 			// deliberately ignore if parsing failed as GetKMS will return default
 			// implementation of kmsID is empty
 			kmsID := volOptions["encryptionKMSID"]
-			rbdVol.KMS, err = util.GetKMS(kmsID, credentials)
+			rbdVol.KMS, err = util.GetKMS(rbdVol.Owner, kmsID, credentials)
 			if err != nil {
 				return nil, fmt.Errorf("invalid encryption kms configuration: %w", err)
 			}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -169,6 +169,9 @@ func (rv *rbdVolume) Destroy() {
 	if rv.conn != nil {
 		rv.conn.Destroy()
 	}
+	if rv.KMS != nil {
+		rv.KMS.Destroy()
+	}
 }
 
 // String returns the image-spec (pool/{namespace/}image) format of the image.

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -51,6 +51,7 @@ const (
 // EncryptionKMS provides external Key Management System for encryption
 // passphrases storage.
 type EncryptionKMS interface {
+	Destroy()
 	GetPassphrase(key string) (string, error)
 	SavePassphrase(key, value string) error
 	DeletePassphrase(key string) error
@@ -73,6 +74,11 @@ func initSecretsKMS(secrets map[string]string) (EncryptionKMS, error) {
 		return nil, errors.New("missing encryption passphrase in secrets")
 	}
 	return SecretsKMS{passphrase: passphraseValue}, nil
+}
+
+// Destroy frees all used resources.
+func (kms SecretsKMS) Destroy() {
+	// nothing to do
 }
 
 // GetPassphrase returns passphrase from Kubernetes secrets.

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -97,7 +97,13 @@ func (kms SecretsKMS) GetID() string {
 }
 
 // GetKMS returns an instance of Key Management System.
-func GetKMS(kmsID string, secrets map[string]string) (EncryptionKMS, error) {
+//
+// - tenant is the owner of the Volume, used to fetch the Vault Token from the
+//   Kubernetes Namespace where the PVC lives
+// - kmsID is the service name of the KMS configuration
+// - secrets contain additional details, like TLS certificates to connect to
+//   the KMS
+func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, error) {
 	if kmsID == "" || kmsID == defaultKMSType {
 		return initSecretsKMS(secrets)
 	}

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -138,7 +138,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 	}
 
 	switch kmsType {
-	case "vault":
+	case kmsTypeVault:
 		return InitVaultKMS(kmsID, kmsConfig, secrets)
 	case kmsTypeVaultTokens:
 		return InitVaultTokensKMS(tenant, kmsID, kmsConfig, secrets)

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -137,8 +137,11 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 		return nil, fmt.Errorf("encryption KMS configuration for %s is missing KMS type", kmsID)
 	}
 
-	if kmsType == "vault" {
+	switch kmsType {
+	case "vault":
 		return InitVaultKMS(kmsID, kmsConfig, secrets)
+	case kmsTypeVaultTokens:
+		return InitVaultTokensKMS(tenant, kmsID, kmsConfig, secrets)
 	}
 	return nil, fmt.Errorf("unknown encryption KMS type %s", kmsType)
 }

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -115,17 +115,9 @@ func GetKMS(kmsID string, secrets map[string]string) (EncryptionKMS, error) {
 		return nil, fmt.Errorf("failed to parse kms configuration: %s", err)
 	}
 
-	kmsConfigData, ok := config[kmsID].(map[string]interface{})
+	kmsConfig, ok := config[kmsID].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("missing encryption KMS configuration with %s", kmsID)
-	}
-	kmsConfig := make(map[string]string)
-	for key, value := range kmsConfigData {
-		kmsConfig[key], ok = value.(string)
-		if !ok {
-			return nil, fmt.Errorf("broken KMS config: '%s' for '%s' is not a string",
-				value, key)
-		}
 	}
 
 	kmsType, ok := kmsConfig[kmsTypeKey]

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -107,7 +107,7 @@ func setConfigString(option *string, config map[string]interface{}, key string) 
 	return nil
 }
 
-func (vc *vaultConnection) initConnection(kmsID string, config, secrets map[string]string) error {
+func (vc *vaultConnection) initConnection(kmsID string, config map[string]interface{}, secrets map[string]string) error {
 	vaultConfig := make(map[string]interface{})
 	keyContext := make(map[string]string)
 
@@ -165,7 +165,7 @@ func (vc *vaultConnection) initConnection(kmsID string, config, secrets map[stri
 }
 
 // InitVaultKMS returns an interface to HashiCorp Vault KMS.
-func InitVaultKMS(kmsID string, config, secrets map[string]string) (EncryptionKMS, error) {
+func InitVaultKMS(kmsID string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
 	kms := &VaultKMS{}
 	err := kms.initConnection(kmsID, config, secrets)
 	if err != nil {

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -31,6 +31,8 @@ import (
 )
 
 const (
+	kmsTypeVault = "vault"
+
 	// path to service account token that will be used to authenticate with Vault
 	// #nosec
 	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -167,7 +167,6 @@ func (vc *vaultConnection) initConnection(kmsID string, config map[string]interf
 		if err != nil {
 			return fmt.Errorf("failed to create temporary file for Vault CA: %w", err)
 		}
-		// TODO: delete f.Name() when vaultConnection is destroyed
 	}
 
 	// update the existing config only if no config is available yet
@@ -199,6 +198,18 @@ func (vc *vaultConnection) connectVault() error {
 	vc.secrets = v
 
 	return nil
+}
+
+// Destroy frees allocated resources. For a vaultConnection that means removing
+// the created temporary files.
+func (vc *vaultConnection) Destroy() {
+	if vc.vaultConfig != nil {
+		tmpFile, ok := vc.vaultConfig[api.EnvVaultCACert]
+		if ok {
+			// ignore error on failure to remove tmpfile (gosec complains)
+			_ = os.Remove(tmpFile.(string))
+		}
+	}
 }
 
 // InitVaultKMS returns an interface to HashiCorp Vault KMS.

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2020 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/vault/api"
+	loss "github.com/libopenstorage/secrets"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kmsTypeVaultTokens = "vaulttokens"
+
+	// vaultTokensDefaultConfigName is the name of the Kubernetes ConfigMap
+	// that contains the Vault connection configuration for the tenant.
+	// This ConfigMap is located in the Kubernetes Namespace where the
+	// tenant created the PVC.
+	//
+	// #nosec:G101, value not credential, just references token.
+	vaultTokensDefaultConfigName = "ceph-csi-kms-config"
+
+	// vaultTokensDefaultTokenName is the name of the Kubernetes Secret
+	// that contains the Vault Token for the tenant.  This Secret is
+	// located in the Kubernetes Namespace where the tenant created the
+	// PVC.
+	//
+	// #nosec:G101, value not credential, just references token.
+	vaultTokensDefaultTokenName = "ceph-csi-kms-token"
+
+	// vaultTokenSecretKey refers to the key in the Kubernetes Secret that
+	// contains the VAULT_TOKEN.
+	vaultTokenSecretKey = "token"
+)
+
+/*
+VaultTokens represents a Hashicorp Vault KMS configuration that provides a
+Token per tenant.
+
+Example JSON structure in the KMS config is,
+{
+    "vault-with-tokens": {
+        "encryptionKMSType": "vaulttokens",
+        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackendPath": "secret/",
+        "vaultTLSServerName": "vault.default.svc.cluster.local",
+        "vaultCAFromSecret": "vault-ca",
+        "vaultCAVerify": "false",
+        "tenantConfigName": "ceph-csi-kms-config",
+        "tenantTokenName": "ceph-csi-kms-token",
+        "tenants": {
+            "my-app": {
+                "vaultAddress": "https://vault.example.com",
+                "vaultCAVerify": "true"
+            },
+            "an-other-app": {
+                "tenantTokenName": "storage-encryption-token"
+            }
+	},
+	...
+}.
+*/
+type VaultTokensKMS struct {
+	vaultConnection
+
+	// Tenant is the name of the owner of the volume
+	Tenant string
+	// ConfigName is the name of the ConfigMap in the Tenants Kubernetes Namespace
+	ConfigName string
+	// TokenName is the name of the Secret in the Tenants Kubernetes Namespace
+	TokenName string
+}
+
+// InitVaultTokensKMS returns an interface to HashiCorp Vault KMS.
+func InitVaultTokensKMS(tenant, kmsID string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
+	kms := &VaultTokensKMS{}
+	err := kms.initConnection(kmsID, config, secrets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
+	}
+
+	// set default values for optional config options
+	kms.ConfigName = vaultTokensDefaultConfigName
+	kms.TokenName = vaultTokensDefaultTokenName
+
+	err = kms.parseConfig(config, secrets)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch the configuration for the tenant
+	if tenant != "" {
+		tenantsMap, ok := config["tenants"]
+		if ok {
+			// tenants is a map per tenant, containing key/values
+			tenants, ok := tenantsMap.(map[string]map[string]interface{})
+			if ok {
+				// get the map for the tenant of the current operation
+				tenantConfig, ok := tenants[tenant]
+				if ok {
+					// override connection details from the tenant
+					err = kms.parseConfig(tenantConfig, secrets)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+	}
+
+	// fetch the Vault Token from the Secret (TokenName) in the Kubernetes
+	// Namespace (tenant)
+	kms.vaultConfig[api.EnvVaultToken], err = getToken(tenant, kms.TokenName)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching token from %s/%s: %w", tenant, kms.TokenName, err)
+	}
+
+	// connect to the Vault service
+	err = kms.connectVault()
+	if err != nil {
+		return nil, err
+	}
+
+	return kms, nil
+}
+
+// parseConfig updates the kms.vaultConfig with the options from config and
+// secrets. This method can be called multiple times, i.e. to override
+// configuration options from tenants.
+func (kms *VaultTokensKMS) parseConfig(config map[string]interface{}, secrets map[string]string) error {
+	err := kms.initConnection(kms.EncryptionKMSID, config, secrets)
+	if err != nil {
+		return err
+	}
+
+	err = setConfigString(&kms.ConfigName, config, "tenantConfigName")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+
+	err = setConfigString(&kms.TokenName, config, "tenantTokenName")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+
+	return nil
+}
+
+// GetPassphrase returns passphrase from Vault. The passphrase is stored in a
+// data.data.passphrase structure.
+func (kms *VaultTokensKMS) GetPassphrase(key string) (string, error) {
+	s, err := kms.secrets.GetSecret(key, kms.keyContext)
+	if errors.Is(err, loss.ErrInvalidSecretId) {
+		return "", MissingPassphrase{err}
+	} else if err != nil {
+		return "", err
+	}
+
+	data, ok := s["data"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("failed parsing data for get passphrase request for %s", key)
+	}
+	passphrase, ok := data["passphrase"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed parsing passphrase for get passphrase request for %s", key)
+	}
+
+	return passphrase, nil
+}
+
+// SavePassphrase saves new passphrase in Vault.
+func (kms *VaultTokensKMS) SavePassphrase(key, value string) error {
+	data := map[string]interface{}{
+		"data": map[string]string{
+			"passphrase": value,
+		},
+	}
+
+	err := kms.secrets.PutSecret(key, data, kms.keyContext)
+	if err != nil {
+		return fmt.Errorf("saving passphrase at %s request to vault failed: %w", key, err)
+	}
+
+	return nil
+}
+
+// DeletePassphrase deletes passphrase from Vault.
+func (kms *VaultTokensKMS) DeletePassphrase(key string) error {
+	err := kms.secrets.DeleteSecret(key, kms.keyContext)
+	if err != nil {
+		return fmt.Errorf("delete passphrase at %s request to vault failed: %w", key, err)
+	}
+
+	return nil
+}
+
+func getToken(tenant, tokenName string) (string, error) {
+	c := NewK8sClient()
+	secret, err := c.CoreV1().Secrets(tenant).Get(context.TODO(), tokenName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	token, ok := secret.Data[vaultTokenSecretKey]
+	if !ok {
+		return "", errors.New("failed to parse token")
+	}
+
+	return string(token), nil
+}

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	kms := VaultTokensKMS{}
+
+	config := make(map[string]interface{})
+	secrets := make(map[string]string)
+
+	// empty config map
+	err := kms.parseConfig(config, secrets)
+	if !errors.Is(err, errConfigOptionMissing) {
+		t.Errorf("unexpected error (%T): %s", err, err)
+	}
+
+	// fill default options (normally done in InitVaultTokensKMS)
+	config["vaultAddress"] = "https://vault.default.cluster.svc"
+	config["tenantConfigName"] = vaultTokensDefaultConfigName
+	config["tenantTokenName"] = vaultTokensDefaultTokenName
+
+	// parsing with all required options
+	err = kms.parseConfig(config, secrets)
+	switch {
+	case err != nil:
+		t.Errorf("unexpected error: %s", err)
+	case kms.ConfigName != vaultTokensDefaultConfigName:
+		t.Errorf("ConfigName contains unexpected value: %s", kms.ConfigName)
+	case kms.TokenName != vaultTokensDefaultTokenName:
+		t.Errorf("TokenName contains unexpected value: %s", kms.TokenName)
+	}
+
+	// tenant "bob" uses a different kms.ConfigName
+	bob := make(map[string]interface{})
+	bob["tenantConfigName"] = "the-config-from-bob"
+	err = kms.parseConfig(bob, secrets)
+	switch {
+	case err != nil:
+		t.Errorf("unexpected error: %s", err)
+	case kms.ConfigName != "the-config-from-bob":
+		t.Errorf("ConfigName contains unexpected value: %s", kms.ConfigName)
+	}
+}
+
+// TestInitVaultTokensKMS verifies that passing partial and complex
+// configurations get applied correctly.
+//
+// When vault.New() is called at the end of InitVaultTokensKMS(), errors will
+// mention the missing VAULT_TOKEN, and that is expected.
+func TestInitVaultTokensKMS(t *testing.T) {
+	if true {
+		// FIXME: testing only works when KUBE_CONFIG is set to a
+		// cluster that has a working Vault deployment
+		return
+	}
+
+	config := make(map[string]interface{})
+	secrets := make(map[string]string)
+
+	// empty config map
+	_, err := InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if !errors.Is(err, errConfigOptionMissing) {
+		t.Errorf("unexpected error (%T): %s", err, err)
+	}
+
+	// fill required options
+	config["vaultAddress"] = "https://vault.default.cluster.svc"
+
+	// parsing with all required options
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// fill tenants
+	tenants := make(map[string]interface{})
+	config["tenants"] = tenants
+
+	// empty tenants list
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// add tenant "bob"
+	bob := make(map[string]interface{})
+	config["tenants"].(map[string]interface{})["bob"] = bob
+	bob["vaultAddress"] = "https://vault.bob.example.org"
+
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}


### PR DESCRIPTION
Add new KMS type _VaultTokensKMS_ as described in #1743.

Closes: #1559
Fixes: #1500 

### TODO
- [x] e2e test
- [x] user documentation (#1783)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
