### PR TITLE
build: install diffutils in test container image

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -31,6 +31,7 @@ RUN source /build.env \
 	ShellCheck \
 	yamllint \
 	npm \
+	diffutils \
       python3-prettytable \
       pylint \
     && dnf -y update \


### PR DESCRIPTION
Depending on the local changes, running 'make containerized-test' fails
with an error like:

    level=error msg="Running error: gofmt: error computing diff: exec: \"diff\": executable file not found in $PATH"

Installing the diffutils package makes sure 'go fmt' finds the
executable.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
