### PR TITLE
rbd: fix omap generator

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -494,15 +494,8 @@ func (cs *ControllerServer) createBackingImage(ctx context.Context, cr *util.Cre
 			}
 		}
 	}()
-	err = rbdVol.getImageID()
+	err = rbdVol.storeImageID(ctx, j)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get volume id %s: %v", rbdVol, err)
-		return status.Error(codes.Internal, err.Error())
-	}
-
-	err = j.StoreImageID(ctx, rbdVol.JournalPool, rbdVol.ReservedID, rbdVol.ImageID)
-	if err != nil {
-		util.ErrorLog(ctx, "failed to reserve volume %s: %v", rbdVol, err)
 		return status.Error(codes.Internal, err.Error())
 	}
 

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -559,6 +559,8 @@ func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName strin
 			util.ErrorLog(ctx, "failed to add UUID mapping %s: %v", rbdVol, err)
 			return err
 		}
+		// As the omap already exists for this image ID return nil.
+		return nil
 	}
 
 	rbdVol.ReservedID, rbdVol.RbdImageName, err = j.ReserveName(

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -570,6 +570,15 @@ func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName strin
 		return err
 	}
 
+	defer func() {
+		if err != nil {
+			undoErr := j.UndoReservation(ctx, rbdVol.JournalPool, rbdVol.Pool,
+				rbdVol.RbdImageName, rbdVol.RequestName)
+			if undoErr != nil {
+				util.ErrorLog(ctx, "failed to undo reservation %s: %v", rbdVol, undoErr)
+			}
+		}
+	}()
 	rbdVol.VolID, err = util.GenerateVolID(ctx, rbdVol.Monitors, cr, imagePoolID, rbdVol.Pool,
 		rbdVol.ClusterID, rbdVol.ReservedID, volIDVersion)
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -752,14 +752,8 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 	}
 
 	if rbdVol.ImageID == "" {
-		err = rbdVol.getImageID()
+		err = rbdVol.storeImageID(ctx, j)
 		if err != nil {
-			util.ErrorLog(ctx, "failed to get image id %s: %v", rbdVol, err)
-			return rbdVol, err
-		}
-		err = j.StoreImageID(ctx, rbdVol.JournalPool, rbdVol.ReservedID, rbdVol.ImageID)
-		if err != nil {
-			util.ErrorLog(ctx, "failed to store volume id %s: %v", rbdVol, err)
 			return rbdVol, err
 		}
 	}


### PR DESCRIPTION
This PR fixes the below issues.

* If the volume is statically provisioned one which contains `staticVolume="true"` on PV spec, don't generate omap data.
* Undo Reservation if any operations fail after Reserving OMAP.
* If the omap already exists don't try to generate it again.
*  Code cleanup to reduce code complexity.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
