### PR TITLE
deploy: add default-fstype flag in provisioner deployment

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -55,6 +55,7 @@ spec:
 {{- if .Values.topology.enabled }}
             - "--feature-gates=Topology=true"
 {{- end }}
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -55,6 +55,7 @@ spec:
 {{- if .Values.topology.enabled }}
             - "--feature-gates=Topology=true"
 {{- end }}
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -50,6 +50,7 @@ spec:
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
             - "--feature-gates=Topology=false"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -50,6 +50,7 @@ spec:
             - "--retry-interval-start=500ms"
             - "--leader-election=true"
             - "--feature-gates=Topology=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock


### PR DESCRIPTION
With the latest version of external provisioner, fstype can be
configured. Adding default-fstype flag in deployment files
for the same.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

Fixes: #1473 