### PR TITLE
deploy: set topology feature gate to false for rbd provisioner by default

### DIFF
--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - "--timeout={{ .Values.provisioner.timeout }}"
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
+            - "--default-fstype={{ .Values.provisioner.defaultFSType }}"
 {{- if .Values.topology.enabled }}
             - "--feature-gates=Topology=true"
 {{- end }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -110,6 +110,8 @@ nodeplugin:
 provisioner:
   name: provisioner
   replicaCount: 3
+  # if fstype is not specified in storageclass, ext4 is default
+  defaultFSType: ext4
   # deployController to enable or disable the deployment of controller which
   # generates the OMAP data if its not Present.
   deployController: true

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -51,6 +51,8 @@ spec:
             - "--leader-election=true"
             #  set it to true to use topology based provisioning
             - "--feature-gates=Topology=false"
+            # if fstype is not specified in storageclass, ext4 is default
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -49,7 +49,8 @@ spec:
             - "--timeout=150s"
             - "--retry-interval-start=500ms"
             - "--leader-election=true"
-            - "--feature-gates=Topology=true"
+            #  set it to true to use topology based provisioning
+            - "--feature-gates=Topology=false"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -71,6 +71,7 @@ func createORDeleteRbdResouces(action string) {
 		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisioner, err)
 	}
 	data = oneReplicaDeployYaml(data)
+	data = enableTopologyInTemplate(data)
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
 	if err != nil {
 		e2elog.Failf("failed to %s rbd provisioner with error %v", action, err)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -505,6 +505,10 @@ func oneReplicaDeployYaml(template string) string {
 	return re.ReplaceAllString(template, `$1 1`)
 }
 
+func enableTopologyInTemplate(data string) string {
+	return strings.ReplaceAll(data, "--feature-gates=Topology=false", "--feature-gates=Topology=true")
+}
+
 func validatePVCClone(sourcePvcPath, clonePvcPath, clonePvcAppPath string, f *framework.Framework) {
 	var wg sync.WaitGroup
 	totalCount := 10


### PR DESCRIPTION
with csi-provisioner v2.x the topology based provisioning will not have any backward compatibility with the older version of kubernetes if the nodes are not labeled with topology keys, the pvc creation is going to get fail with error `accessibility requirements: no available topology found`, disabling the topology based provisioning by default if the user wants to use it he can always enable it.

It also adds the default-fstype flag to the provisioner sidecar.

fixes: #1473 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>