### PR TITLE
Cleanup error returns, include original error type and standardize format

### DIFF
--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -243,13 +243,13 @@ func (m *kernelMounter) name() string { return "Ceph kernel client" }
 func bindMount(ctx context.Context, from, to string, readOnly bool, mntOptions []string) error {
 	mntOptionSli := strings.Join(mntOptions, ",")
 	if err := execCommandErr(ctx, "mount", "-o", mntOptionSli, from, to); err != nil {
-		return fmt.Errorf("failed to bind-mount %s to %s: %v", from, to, err)
+		return fmt.Errorf("failed to bind-mount %s to %s: %w", from, to, err)
 	}
 
 	if readOnly {
 		mntOptionSli = util.MountOptionsAdd(mntOptionSli, "remount")
 		if err := execCommandErr(ctx, "mount", "-o", mntOptionSli, to); err != nil {
-			return fmt.Errorf("failed read-only remount of %s: %v", to, err)
+			return fmt.Errorf("failed read-only remount of %s: %w", to, err)
 		}
 	}
 

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -92,7 +92,7 @@ func (r *ReconcilePersistentVolume) getCredentials(name, namespace string) (*uti
 	secret := &corev1.Secret{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, secret)
 	if err != nil {
-		return nil, fmt.Errorf("error getting secret %s in namespace %s: %v", name, namespace, err)
+		return nil, fmt.Errorf("error getting secret %s in namespace %s: %w", name, namespace, err)
 	}
 
 	credentials := map[string]string{}

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -100,7 +100,7 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 		err = rv.cloneRbdImageFromSnapshot(ctx, snap)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
-			err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
+			err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", rv.RbdImageName, snap.RbdSnapName, err)
 			return false, err
 		}
 		err = tempClone.deleteSnapshot(ctx, snap)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -182,7 +182,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		var imageAttributes *journal.ImageAttributes
 		err = vi.DecomposeCSIID(volID)
 		if err != nil {
-			err = fmt.Errorf("error decoding volume ID (%s) (%s)", err, volID)
+			err = fmt.Errorf("error decoding volume ID (%s): %w", volID, err)
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 
@@ -196,7 +196,7 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		imageAttributes, err = j.GetImageAttributes(
 			ctx, volOptions.Pool, vi.ObjectUUID, false)
 		if err != nil {
-			err = fmt.Errorf("error fetching image attributes for volume ID (%s) (%s)", err, volID)
+			err = fmt.Errorf("error fetching image attributes for volume ID (%s): %w", volID, err)
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 		volOptions.RbdImageName = imageAttributes.ImageName

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -796,14 +796,14 @@ func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rb
 		var existingFormat string
 		existingFormat, err = diskMounter.GetDiskFormat(devicePath)
 		if err != nil {
-			return "", fmt.Errorf("failed to get disk format for path %s, error: %v", devicePath, err)
+			return "", fmt.Errorf("failed to get disk format for path %s: %w", devicePath, err)
 		}
 
 		switch existingFormat {
 		case "":
 			err = encryptDevice(ctx, volOptions, devicePath)
 			if err != nil {
-				return "", fmt.Errorf("failed to encrypt rbd image %s: %v", imageSpec, err)
+				return "", fmt.Errorf("failed to encrypt rbd image %s: %w", imageSpec, err)
 			}
 		case "crypt":
 			util.WarningLog(ctx, "rbd image %s is encrypted, but encryption state was not updated",

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -838,7 +838,7 @@ func encryptDevice(ctx context.Context, rbdVol *rbdVolume, devicePath string) er
 	}
 
 	if err = util.EncryptVolume(ctx, devicePath, passphrase); err != nil {
-		err = fmt.Errorf("failed to encrypt volume %s: %v", rbdVol, err)
+		err = fmt.Errorf("failed to encrypt volume %s: %w", rbdVol, err)
 		util.ErrorLog(ctx, err.Error())
 		return err
 	}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -735,7 +735,7 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	resizer := resizefs.NewResizeFs(diskMounter)
 	ok, err := resizer.Resize(devicePath, volumePath)
 	if !ok {
-		return nil, fmt.Errorf("rbd: resize failed on path %s, error: %v", req.GetVolumePath(), err)
+		return nil, status.Errorf(codes.Internal, "rbd: resize failed on path %s, error: %v", req.GetVolumePath(), err)
 	}
 	return &csi.NodeExpandVolumeResponse{}, nil
 }

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -87,7 +87,7 @@ func rbdGetDeviceList(ctx context.Context, accessType string) ([]rbdDeviceInfo, 
 
 	stdout, _, err := util.ExecCommand(ctx, rbd, "device", "list", "--format="+"json", "--device-type", accessType)
 	if err != nil {
-		return nil, fmt.Errorf("error getting device list from rbd for devices of type (%s): (%v)", accessType, err)
+		return nil, fmt.Errorf("error getting device list from rbd for devices of type (%s): %w", accessType, err)
 	}
 
 	if accessType == accessTypeKRbd {
@@ -96,7 +96,7 @@ func rbdGetDeviceList(ctx context.Context, accessType string) ([]rbdDeviceInfo, 
 		err = json.Unmarshal([]byte(stdout), &nbdDeviceList)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error to parse JSON output of device list for devices of type (%s): (%v)", accessType, err)
+		return nil, fmt.Errorf("error to parse JSON output of device list for devices of type (%s): %w", accessType, err)
 	}
 
 	// convert output to a rbdDeviceInfo list for consumers

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -330,7 +330,7 @@ func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, i
 			util.TraceLog(ctx, "image or device spec (%s) not mapped", imageOrDeviceSpec)
 			return nil
 		}
-		return fmt.Errorf("rbd: unmap for spec (%s) failed (%v): (%s)", imageOrDeviceSpec, err, stderr)
+		return fmt.Errorf("rbd: unmap for spec (%s) failed (%w): (%s)", imageOrDeviceSpec, err, stderr)
 	}
 
 	return nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1097,13 +1097,13 @@ func stashRBDImageMetadata(volOptions *rbdVolume, path string) error {
 
 	encodedBytes, err := json.Marshal(imgMeta)
 	if err != nil {
-		return fmt.Errorf("failed to marshall JSON image metadata for image (%s): (%v)", volOptions, err)
+		return fmt.Errorf("failed to marshall JSON image metadata for image (%s): %w", volOptions, err)
 	}
 
 	fPath := filepath.Join(path, stashFileName)
 	err = ioutil.WriteFile(fPath, encodedBytes, 0600)
 	if err != nil {
-		return fmt.Errorf("failed to stash JSON image metadata for image (%s) at path (%s): (%v)", volOptions, fPath, err)
+		return fmt.Errorf("failed to stash JSON image metadata for image (%s) at path (%s): %w", volOptions, fPath, err)
 	}
 
 	return nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1135,7 +1135,7 @@ func lookupRBDImageMetadataStash(path string) (rbdImageMetadataStash, error) {
 func cleanupRBDImageMetadataStash(path string) error {
 	fPath := filepath.Join(path, stashFileName)
 	if err := os.Remove(fPath); err != nil {
-		return fmt.Errorf("failed to cleanup stashed JSON data (%s): (%v)", fPath, err)
+		return fmt.Errorf("failed to cleanup stashed JSON data (%s): %w", fPath, err)
 	}
 
 	return nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -828,7 +828,7 @@ func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[st
 			kmsID := volOptions["encryptionKMSID"]
 			rbdVol.KMS, err = util.GetKMS(kmsID, credentials)
 			if err != nil {
-				return nil, fmt.Errorf("invalid encryption kms configuration: %s", err)
+				return nil, fmt.Errorf("invalid encryption kms configuration: %w", err)
 			}
 		}
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1196,7 +1196,7 @@ func (rv *rbdVolume) checkRbdImageEncrypted(ctx context.Context) (string, error)
 func (rv *rbdVolume) ensureEncryptionMetadataSet(status string) error {
 	err := rv.SetMetadata(encryptionMetaKey, status)
 	if err != nil {
-		return fmt.Errorf("failed to save encryption status for %s: %v", rv, err)
+		return fmt.Errorf("failed to save encryption status for %s: %w", rv, err)
 	}
 
 	return nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1022,7 +1022,7 @@ func (rv *rbdVolume) updateVolWithImageInfo() error {
 	if stdout != "" {
 		err = json.Unmarshal([]byte(stdout), &imgInfo)
 		if err != nil {
-			return fmt.Errorf("unmarshal failed: %+v.  raw buffer response: %s", err, stdout)
+			return fmt.Errorf("unmarshal failed (%w), raw buffer response: %s", err, stdout)
 		}
 		rv.Primary = imgInfo.Mirroring.Primary
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1117,7 +1117,7 @@ func lookupRBDImageMetadataStash(path string) (rbdImageMetadataStash, error) {
 	encodedBytes, err := ioutil.ReadFile(fPath) // #nosec - intended reading from fPath
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return imgMeta, fmt.Errorf("failed to read stashed JSON image metadata from path (%s): (%v)", fPath, err)
+			return imgMeta, fmt.Errorf("failed to read stashed JSON image metadata from path (%s): %w", fPath, err)
 		}
 
 		return imgMeta, util.JoinErrors(ErrMissingStash, err)
@@ -1125,7 +1125,7 @@ func lookupRBDImageMetadataStash(path string) (rbdImageMetadataStash, error) {
 
 	err = json.Unmarshal(encodedBytes, &imgMeta)
 	if err != nil {
-		return imgMeta, fmt.Errorf("failed to unmarshall stashed JSON image metadata from path (%s): (%v)", fPath, err)
+		return imgMeta, fmt.Errorf("failed to unmarshall stashed JSON image metadata from path (%s): %w", fPath, err)
 	}
 
 	return imgMeta, nil

--- a/internal/util/credentials.go
+++ b/internal/util/credentials.go
@@ -42,7 +42,7 @@ type Credentials struct {
 func storeKey(key string) (string, error) {
 	tmpfile, err := ioutil.TempFile(tmpKeyFileLocation, tmpKeyFileNamePrefix)
 	if err != nil {
-		return "", fmt.Errorf("error creating a temporary keyfile (%s)", err)
+		return "", fmt.Errorf("error creating a temporary keyfile: %w", err)
 	}
 	defer func() {
 		if err != nil {
@@ -52,17 +52,17 @@ func storeKey(key string) (string, error) {
 	}()
 
 	if _, err = tmpfile.Write([]byte(key)); err != nil {
-		return "", fmt.Errorf("error writing key to temporary keyfile (%s)", err)
+		return "", fmt.Errorf("error writing key to temporary keyfile: %w", err)
 	}
 
 	keyFile := tmpfile.Name()
 	if keyFile == "" {
-		err = fmt.Errorf("error reading temporary filename for key (%s)", err)
+		err = fmt.Errorf("error reading temporary filename for key: %w", err)
 		return "", err
 	}
 
 	if err = tmpfile.Close(); err != nil {
-		return "", fmt.Errorf("error closing temporary filename (%s)", err)
+		return "", fmt.Errorf("error closing temporary filename: %w", err)
 	}
 
 	return keyFile, nil

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -150,11 +150,11 @@ func GetCryptoPassphrase(ctx context.Context, volumeID string, kms EncryptionKMS
 			volumeID)
 		passphrase, err = generateNewEncryptionPassphrase()
 		if err != nil {
-			return "", fmt.Errorf("failed to generate passphrase for %s: %s", volumeID, err)
+			return "", fmt.Errorf("failed to generate passphrase for %s: %w", volumeID, err)
 		}
 		err = kms.SavePassphrase(volumeID, passphrase)
 		if err != nil {
-			return "", fmt.Errorf("failed to save the passphrase for %s: %s", volumeID, err)
+			return "", fmt.Errorf("failed to save the passphrase for %s: %w", volumeID, err)
 		}
 		return passphrase, nil
 	}

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -71,13 +71,13 @@ func readClusterInfo(pathToConfig, clusterID string) (*ClusterInfo, error) {
 	// #nosec
 	content, err := ioutil.ReadFile(pathToConfig)
 	if err != nil {
-		err = fmt.Errorf("error fetching configuration for cluster ID (%s). (%s)", clusterID, err)
+		err = fmt.Errorf("error fetching configuration for cluster ID %q: %w", clusterID, err)
 		return nil, err
 	}
 
 	err = json.Unmarshal(content, &config)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal failed: %v. raw buffer response: %s",
+		return nil, fmt.Errorf("unmarshal failed (%w), raw buffer response: %s",
 			err, string(content))
 	}
 
@@ -87,7 +87,7 @@ func readClusterInfo(pathToConfig, clusterID string) (*ClusterInfo, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("missing configuration for cluster ID (%s)", clusterID)
+	return nil, fmt.Errorf("missing configuration for cluster ID %q", clusterID)
 }
 
 // Mons returns a comma separated MON list from the csi config for the given clusterID.

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -35,7 +35,7 @@ func k8sGetNodeLabels(nodeName string) (map[string]string, error) {
 	client := NewK8sClient()
 	node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get node (%s) information : %v", nodeName, err)
+		return nil, fmt.Errorf("failed to get node %q information: %w", nodeName, err)
 	}
 
 	return node.GetLabels(), nil

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -53,13 +53,13 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 	topologyPrefix := strings.ToLower("topology." + driverName)
 	const lenLimit = 63
 	if len(topologyPrefix) > lenLimit {
-		return nil, fmt.Errorf("computed topology label prefix (%s) for node exceeds length limits", topologyPrefix)
+		return nil, fmt.Errorf("computed topology label prefix %q for node exceeds length limits", topologyPrefix)
 	}
 	// driverName is validated, and we are adding a lowercase "topology." to it, so no validation for conformance
 
 	// Convert passed in labels to a map, and check for uniqueness
 	labelsToRead := strings.SplitN(domainLabels, labelSeparator, -1)
-	DefaultLog("passed in node labels for processing : %+v", labelsToRead)
+	DefaultLog("passed in node labels for processing: %+v", labelsToRead)
 
 	labelsIn := make(map[string]bool)
 	labelCount := 0
@@ -67,7 +67,7 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 		// as we read the labels from k8s, and check for missing labels,
 		// no label conformance checks here
 		if _, ok := labelsIn[label]; ok {
-			return nil, fmt.Errorf("duplicate label (%s) found in domain labels", label)
+			return nil, fmt.Errorf("duplicate label %q found in domain labels", label)
 		}
 
 		labelsIn[label] = true
@@ -102,10 +102,10 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 				missingLabels = append(missingLabels, key)
 			}
 		}
-		return nil, fmt.Errorf("missing domain labels %v on node (%s)", missingLabels, nodeName)
+		return nil, fmt.Errorf("missing domain labels %v on node %q", missingLabels, nodeName)
 	}
 
-	DefaultLog("list of domains processed : %+v", domainMap)
+	DefaultLog("list of domains processed: %+v", domainMap)
 
 	topology := make(map[string]string)
 	for domain, value := range domainMap {

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -202,11 +202,11 @@ func (kms *VaultKMS) GetPassphrase(key string) (string, error) {
 
 	data, ok := s["data"].(map[string]interface{})
 	if !ok {
-		return "", fmt.Errorf("failed parsing data for get passphrase request for %s", key)
+		return "", fmt.Errorf("failed parsing data for get passphrase request for %q", key)
 	}
 	passphrase, ok := data["passphrase"].(string)
 	if !ok {
-		return "", fmt.Errorf("failed parsing passphrase for get passphrase request for %s", key)
+		return "", fmt.Errorf("failed parsing passphrase for get passphrase request for %q", key)
 	}
 
 	return passphrase, nil


### PR DESCRIPTION
This PR uses `%w` to include the original error in return values. Some errors are not conforming the usual format, so adjusted that as well.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
