### PR TITLE
build: add CSI_IMAGE_VERSION to build.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CPUS?=$(shell nproc --ignore=1)
 CPUSET?=--cpuset-cpus=0-${CPUS}
 
 CSI_IMAGE_NAME=$(if $(ENV_CSI_IMAGE_NAME),$(ENV_CSI_IMAGE_NAME),quay.io/cephcsi/cephcsi)
-CSI_IMAGE_VERSION=$(if $(ENV_CSI_IMAGE_VERSION),$(ENV_CSI_IMAGE_VERSION),canary)
+CSI_IMAGE_VERSION=$(shell . $(CURDIR)/build.env ; echo $${CSI_IMAGE_VERSION})
 CSI_IMAGE=$(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION)
 
 # Pass USE_PULLED_IMAGE=yes to skip building a new :test or :devel image.

--- a/build.env
+++ b/build.env
@@ -8,6 +8,8 @@
 # shell scripts consume this file. Variables that reference variables may not
 # get proporly expanded.
 #
+# cephcsi image version
+CSI_IMAGE_VERSION=canary
 
 # Ceph version to use
 BASE_IMAGE=docker.io/ceph/ceph:v15

--- a/deploy.sh
+++ b/deploy.sh
@@ -83,9 +83,7 @@ build_push_images() {
 	make push-manifest
 }
 
-if [ "${TRAVIS_BRANCH}" == 'master' ]; then
-	export ENV_CSI_IMAGE_VERSION='canary'
-else
+if [ "${TRAVIS_BRANCH}" != 'master' ]; then
 	echo "!!! Branch ${TRAVIS_BRANCH} is not a deployable branch; exiting"
 	exit 0 # Exiting 0 so that this isn't marked as failing
 fi


### PR DESCRIPTION
CSI_IMAGE_VERSION is needed by the centos CI to push the image to the minikube VM.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

