### PR TITLE
e2e: fix kubectl_retry to not return a stale error

### DIFF
--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -66,6 +66,10 @@ kubectl_retry() {
 	echo "kubectl_retry ${*} failed, will retry in ${KUBECTL_RETRY_DELAY} seconds"
 
         sleep ${KUBECTL_RETRY_DELAY}
+
+	# reset ret so that a next working kubectl does not cause a non-zero
+	# return of the function
+        ret=0
     done
 
     # write output so that calling functions can consume it


### PR DESCRIPTION
While deploying Rook, there can be issues when the environment is not
completely settled yet. On occasion the 1st kubectl command fails with

    The connection to the server ... was refused - did you specify the right host or port?

This would set the 'ret' variable to a non-zero value, before the next
retry of the kubectl command is done. In case the kubectl command
succeeds, the 'ret' variable still contains the old non-zero value, and
kubectl_retry returns the incorrect result.

By setting the 'ret' variable to 0 before calling kubectl again, this
problem is prevented.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
