### PR TITLE
helm: Add storage class and secret deployment 

### DIFF
--- a/charts/ceph-csi-cephfs/templates/secret.yaml
+++ b/charts/ceph-csi-cephfs/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-cephfs.name" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+stringData:
+  adminID: {{ .Values.secret.adminID }}
+  adminKey: {{ .Values.secret.adminKey }}
+{{- end -}}

--- a/charts/ceph-csi-cephfs/templates/storageclass.yaml
+++ b/charts/ceph-csi-cephfs/templates/storageclass.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.storageClass.create -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: {{ .Values.storageClass.name }}
+   namespace: {{ .Release.Namespace }}
+   labels:
+     app: {{ include "ceph-csi-cephfs.name" . }}
+     chart: {{ include "ceph-csi-cephfs.chart" . }}
+     release: {{ .Release.Name }}
+     heritage: {{ .Release.Service }}
+provisioner: {{ .Values.driverName }}
+parameters:
+  clusterID: {{ .Values.storageClass.clusterID }}
+  fsName: {{ .Values.storageClass.fsName }}
+{{- if .Values.storageClass.pool }}
+  pool: {{ .Values.storageClass.pool }}
+{{- end }}
+{{- if .Values.storageClass.fuseMountOptions }}
+  fuseMountOptions: "{{ .Values.storageClass.fuseMountOptions }}"
+{{- end }}
+{{- if .Values.storageClass.kernelMountOptions }}
+  kernelMountOptions: "{{ .Values.storageClass.kernelMountOptions }}"
+{{- end }}
+{{- if .Values.storageClass.mounter }}
+  mounter: "{{ .Values.storageClass.mounter }}"
+{{- end }}
+{{- if .Values.storageClass.volumeNamePrefix }}
+  volumeNamePrefix: "{{ .Values.storageClass.volumeNamePrefix }}"
+{{- end }}
+  csi.storage.k8s.io/provisioner-secret-name: {{ .Values.storageClass.provisionerSecret }}
+{{- if .Values.storageClass.provisionerSecretNamespace }}
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ .Values.storageClass.provisionerSecretNamespace }}
+{{ else }}
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ .Release.Namespace }}
+{{- end }}
+  csi.storage.k8s.io/controller-expand-secret-name: {{ .Values.storageClass.controllerExpandSecret }}
+{{- if .Values.storageClass.controllerExpandSecretNamespace }}
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ .Values.storageClass.controllerExpandSecretNamespace }}
+{{ else }}
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ .Release.Namespace }}
+{{- end }}
+  csi.storage.k8s.io/node-stage-secret-name: {{ .Values.storageClass.nodeStageSecret }}
+{{- if .Values.storageClass.nodeStageSecretNamespace }}
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ .Values.storageClass.nodeStageSecretNamespace }}
+{{ else }}
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ .Release.Namespace }}
+{{- end }}
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
+{{- if .Values.storageClass.mountOptions }}
+mountOptions:
+  {{- range .Values.storageClass.mountOptions }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -205,6 +205,68 @@ topology:
     - failure-domain/region
     - failure-domain/zone
 
+storageClass:
+  # Specifies whether the Storage class should be created
+  create: false
+  name: csi-cephfs-sc
+  # String representing a Ceph cluster to provision storage from.
+  # Should be unique across all Ceph clusters in use for provisioning,
+  # cannot be greater than 36 bytes in length, and should remain immutable for
+  # the lifetime of the StorageClass in use.
+  clusterID: <cluster-ID>
+  # (required) CephFS filesystem name into which the volume shall be created
+  # eg: fsName: myfs
+  fsName: myfs
+  # (optional) Ceph pool into which volume data shall be stored
+  # pool: <cephfs-data-pool>
+  # For eg:
+  # pool: "replicapool"
+  pool: ""
+  # (optional) Comma separated string of Ceph-fuse mount options.
+  # For eg:
+  # fuseMountOptions: debug
+  fuseMountOptions: ""
+  # (optional) Comma separated string of Cephfs kernel mount options.
+  # Check man mount.ceph for mount options. For eg:
+  # kernelMountOptions: readdir_max_bytes=1048576,norbytes
+  kernelMountOptions: ""
+  # (optional) The driver can use either ceph-fuse (fuse) or
+  # ceph kernelclient (kernel).
+  # If omitted, default volume mounter will be used - this is
+  # determined by probing for ceph-fuse and mount.ceph
+  # mounter: kernel
+  mounter: ""
+  # (optional) Prefix to use for naming subvolumes.
+  # If omitted, defaults to "csi-vol-".
+  # volumeNamePrefix: "foo-bar-"
+  volumeNamePrefix: ""
+  # The secrets have to contain user and/or Ceph admin credentials.
+  provisionerSecret: csi-cephfs-secret
+  # If the Namespaces are not specified, the secrets are assumed to
+  # be in the Release namespace.
+  provisionerSecretNamespace: ""
+  controllerExpandSecret: csi-cephfs-secret
+  controllerExpandSecretNamespace: ""
+  nodeStageSecret: csi-cephfs-secret
+  nodeStageSecretNamespace: ""
+  reclaimPolicy: Delete
+  allowVolumeExpansion: true
+  mountOptions: []
+  # Mount Options
+  # Example:
+  # mountOptions:
+  #   - discard
+
+secret:
+  # Specifies whether the secret should be created
+  create: false
+  name: csi-cephfs-secret
+  # Key values correspond to a user name and its key, as defined in the
+  # ceph cluster. User ID should have required access to the 'pool'
+  # specified in the storage class
+  adminID: <plaintext ID>
+  adminKey: <Ceph auth key corresponding to ID above>
+
 #########################################################
 # Variables for 'internal' use please use with caution! #
 #########################################################

--- a/charts/ceph-csi-rbd/templates/secret.yaml
+++ b/charts/ceph-csi-rbd/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+stringData:
+  userID: {{ .Values.secret.userID }}
+  userKey: {{ .Values.secret.userKey }}
+
+  encryptionPassphrase: {{ .Values.secret.encryptionPassphrase }}
+{{- end -}}

--- a/charts/ceph-csi-rbd/templates/storageclass.yaml
+++ b/charts/ceph-csi-rbd/templates/storageclass.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.storageClass.create -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: {{ .Values.storageClass.name }}
+   namespace: {{ .Release.Namespace }}
+   labels:
+     app: {{ include "ceph-csi-rbd.name" . }}
+     chart: {{ include "ceph-csi-rbd.chart" . }}
+     release: {{ .Release.Name }}
+     heritage: {{ .Release.Service }}
+provisioner: {{ .Values.driverName }}
+parameters:
+  clusterID: {{ .Values.storageClass.clusterID }}
+  pool: {{ .Values.storageClass.pool }}
+  imageFeatures: {{ .Values.storageClass.imageFeatures }}
+  thickProvision: {{ .Values.storageClass.thickProvision | quote}}
+{{- if .Values.storageClass.mounter }}
+  mounter: {{ .Values.storageClass.mounter }}
+{{- end }}
+{{- if .Values.storageClass.dataPool }}
+  dataPool: {{ .Values.storageClass.dataPool }}
+{{- end }}
+{{- if .Values.storageClass.volumeNamePrefix }}
+  volumeNamePrefix: "{{ .Values.storageClass.volumeNamePrefix }}"
+{{- end }}
+{{- if .Values.storageClass.encrypted }}
+  encrypted: "{{ .Values.storageClass.encrypted }}"
+{{- end }}
+{{- if .Values.storageClass.encryptionKMSID }}
+  encryptionKMSID: {{ .Values.storageClass.encryptionKMSID }}
+{{- end }}
+{{- if .Values.storageClass.topologyConstrainedPools }}
+  topologyConstrainedPools:
+  {{ toYaml .Values.storageClass.topologyConstrainedPools | indent 4 -}}
+{{- end }}
+{{- if .Values.storageClass.mapOptions }}
+  mapOptions: {{ .Values.storageClass.mapOptions }}
+{{- end }}
+{{- if .Values.storageClass.unmapOptions }}
+  unmapOptions: {{ .Values.storageClass.unmapOptions }}
+{{- end }}
+  csi.storage.k8s.io/provisioner-secret-name: {{ .Values.storageClass.provisionerSecret }}
+{{- if .Values.storageClass.provisionerSecretNamespace }}
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ .Values.storageClass.provisionerSecretNamespace }}
+{{ else }}
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ .Release.Namespace }}
+{{- end }}
+  csi.storage.k8s.io/controller-expand-secret-name: {{ .Values.storageClass.controllerExpandSecret }}
+{{- if .Values.storageClass.controllerExpandSecretNamespace }}
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ .Values.storageClass.controllerExpandSecretNamespace }}
+{{ else }}
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ .Release.Namespace }}
+{{- end }}
+  csi.storage.k8s.io/node-stage-secret-name: {{ .Values.storageClass.nodeStageSecret }}
+{{- if .Values.storageClass.nodeStageSecretNamespace }}
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ .Values.storageClass.nodeStageSecretNamespace }}
+{{ else }}
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ .Release.Namespace }}
+{{- end }}
+  csi.storage.k8s.io/fstype: {{ .Values.storageClass.fstype }}
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
+{{- if .Values.storageClass.mountOptions }}
+mountOptions:
+  {{- range .Values.storageClass.mountOptions }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -232,6 +232,128 @@ topology:
     - failure-domain/region
     - failure-domain/zone
 
+storageClass:
+  # Specifies whether the storageclass should be created
+  create: false
+  name: csi-rbd-sc
+  # (required) String representing a Ceph cluster to provision storage from.
+  # Should be unique across all Ceph clusters in use for provisioning,
+  # cannot be greater than 36 bytes in length, and should remain immutable for
+  # the lifetime of the StorageClass in use.
+  clusterID: <cluster-ID>
+
+  # (optional) If you want to use erasure coded pool with RBD, you need to
+  # create two pools. one erasure coded and one replicated.
+  # You need to specify the replicated pool here in the `pool` parameter, it is
+  # used for the metadata of the images.
+  # The erasure coded pool must be set as the `dataPool` parameter below.
+  # dataPool: <ec-data-pool>
+  dataPool: ""
+
+  # (required) Ceph pool into which the RBD image shall be created
+  # eg: pool: replicapool
+  pool: replicapool
+
+  # Set thickProvision to true if you want RBD images to be fully allocated on
+  # creation (thin provisioning is the default).
+  thickProvision: false
+
+  # (required) RBD image features, CSI creates image with image-format 2
+  # CSI RBD currently supports `layering`, `journaling`, `exclusive-lock`
+  # features. If `journaling` is enabled, must enable `exclusive-lock` too.
+  # imageFeatures: layering,journaling,exclusive-lock
+  imageFeatures: layering
+
+  # (optional) uncomment the following to use rbd-nbd as mounter
+  # on supported nodes
+  # mounter: rbd-nbd
+  mounter: ""
+
+  # (optional) Prefix to use for naming RBD images.
+  # If omitted, defaults to "csi-vol-".
+  # volumeNamePrefix: "foo-bar-"
+  volumeNamePrefix: ""
+
+  # (optional) Instruct the plugin it has to encrypt the volume
+  # By default it is disabled. Valid values are "true" or "false".
+  # A string is expected here, i.e. "true", not true.
+  # encrypted: "true"
+  encrypted: ""
+
+  # (optional) Use external key management system for encryption passphrases by
+  # specifying a unique ID matching KMS ConfigMap. The ID is only used for
+  # correlation to configmap entry.
+  encryptionKMSID: ""
+
+  # Add topology constrained pools configuration, if topology based pools
+  # are setup, and topology constrained provisioning is required.
+  # For further information read TODO<doc>
+  # topologyConstrainedPools: |
+  #   [{"poolName":"pool0",
+  #     "dataPool":"ec-pool0" # optional, erasure-coded pool for data
+  #     "domainSegments":[
+  #       {"domainLabel":"region","value":"east"},
+  #       {"domainLabel":"zone","value":"zone1"}]},
+  #    {"poolName":"pool1",
+  #     "dataPool":"ec-pool1" # optional, erasure-coded pool for data
+  #     "domainSegments":[
+  #       {"domainLabel":"region","value":"east"},
+  #       {"domainLabel":"zone","value":"zone2"}]},
+  #    {"poolName":"pool2",
+  #     "dataPool":"ec-pool2" # optional, erasure-coded pool for data
+  #     "domainSegments":[
+  #       {"domainLabel":"region","value":"west"},
+  #       {"domainLabel":"zone","value":"zone1"}]}
+  #   ]
+  topologyConstrainedPools: []
+
+  # (optional) mapOptions is a comma-separated list of map options.
+  # For krbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+  # For nbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+  mapOptions: ""
+
+  # (optional) unmapOptions is a comma-separated list of unmap options.
+  # For krbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+  # For nbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+  unmapOptions: ""
+
+  # The secrets have to contain Ceph credentials with required access
+  # to the 'pool'.
+  provisionerSecret: csi-rbd-secret
+  # If Namespaces are left empty, the secrets are assumed to be in the
+  # Release namespace.
+  provisionerSecretNamespace: ""
+  controllerExpandSecret: csi-rbd-secret
+  controllerExpandSecretNamespace: ""
+  nodeStageSecret: csi-rbd-secret
+  nodeStageSecretNamespace: ""
+  # Specify the filesystem type of the volume. If not specified,
+  # csi-provisioner will set default as `ext4`.
+  fstype: ext4
+  reclaimPolicy: Delete
+  allowVolumeExpansion: true
+  mountOptions: []
+  # Mount Options
+  # Example:
+  # mountOptions:
+  #   - discard
+
+secret:
+  # Specifies whether the secret should be created
+  create: false
+  name: csi-rbd-secret
+  # Key values correspond to a user name and its key, as defined in the
+  # ceph cluster. User ID should have required access to the 'pool'
+  # specified in the storage class
+  userID: <plaintext ID>
+  userKey: <Ceph auth key corresponding to userID above>
+  # Encryption passphrase
+  encryptionPassphrase: test_passphrase
+
 #########################################################
 # Variables for 'internal' use please use with caution! #
 #########################################################

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -280,6 +280,25 @@ var _ = Describe("cephfs", func() {
 				}
 			})
 
+			// test only if ceph-csi is deployed via helm
+			if helmTest {
+				By("verify PVC and app binding on helm installation", func() {
+					err := validatePVCAndAppBinding(pvcPath, appPath, f)
+					if err != nil {
+						e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+					}
+					//  Deleting the storageclass and secret created by helm
+					err = deleteResource(cephfsExamplePath + "storageclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+					}
+					err = deleteResource(cephfsExamplePath + "secret.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+					}
+				})
+			}
+
 			By("check static PVC", func() {
 				scPath := cephfsExamplePath + "secret.yaml"
 				err := validateCephFsStaticPV(f, appPath, scPath)

--- a/scripts/travis-helmtest.sh
+++ b/scripts/travis-helmtest.sh
@@ -47,7 +47,7 @@ fi
 # set up helm
 scripts/install-helm.sh up
 # install cephcsi helm charts
-scripts/install-helm.sh install-cephcsi ${NAMESPACE}
+scripts/install-helm.sh install-cephcsi --namespace ${NAMESPACE}
 # functional tests
 make run-e2e NAMESPACE="${NAMESPACE}" E2E_ARGS="--deploy-cephfs=false --deploy-rbd=false ${*}"
 
@@ -57,7 +57,7 @@ if [[ "${KUBE_MAJOR}" -ge 1 ]] && [[ "${KUBE_MINOR}" -ge 17 ]]; then
     # delete snapshot CRD
     scripts/install-snapshot.sh cleanup
 fi
-scripts/install-helm.sh cleanup-cephcsi ${NAMESPACE}
+scripts/install-helm.sh cleanup-cephcsi --namespace ${NAMESPACE}
 scripts/install-helm.sh clean
 kubectl delete ns ${NAMESPACE}
 sudo scripts/minikube.sh clean


### PR DESCRIPTION
Deploy the Storage Class and Secret during 
cephfs and rbd helm chart installation.
TODO:
- [ ] Remove `mini-e2e-helm-sc` job in centos-ci

Closes: #1483 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
