### PR TITLE
util: add support for vault certificates

### DIFF
--- a/docs/design/proposals/encryption-with-vault-tokens.md
+++ b/docs/design/proposals/encryption-with-vault-tokens.md
@@ -180,8 +180,73 @@ data:
   vaultBackendPath: "secret/ceph-csi-encryption/"
   vaultTLSServerName: "vault.infosec.example.org"
   vaultCAFromSecret: "vault-infosec-ca"
+  vaultClientCertFromSecret: "vault-client-cert"
+  vaultClientCertKeyFromSecret: "vault-client-cert-key"
   vaultCAVerify: "true"
 ```
 
 Only parameters with the `vault`-prefix may be changed in the Kubernetes
 ConfigMap of the Tenant.
+
+### Certificates stored in the Tenants Kubernetes Namespace
+
+The `vaultCAFromSecret` , `vaultClientCertFromSecret` and
+`vaultClientCertKeyFromSecret` secrets should be created in the namespace where
+Ceph-CSI is deployed. The sample of secrets for the CA and client Certificate.
+
+#### CA Certificate to verify Vault server TLS certificate
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-infosec-ca
+stringData:
+  ca.cert: |
+    MIIC2DCCAcCgAwIBAgIBATANBgkqh...
+```
+
+#### Client Certificate for Vault connection
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-client-cert
+stringData:
+  tls.cert: |
+    BATANBgkqcCgAwIBAgIBATANBAwI...
+```
+
+#### Client Certificate key for Vault connection
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-client-cert-key
+stringData:
+  tls.key: |
+    KNSC2DVVXcCgkqcCgAwIBAgIwewrvx...
+```
+
+Its also possible that a user can create a single secret for the certificates
+and update the configuration to fetch certificates from a secret.
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-certificates
+stringData:
+  ca.cert: |
+    MIIC2DCCAcCgAwIBAgIBATANBgkqh...
+  tls.cert: |
+    BATANBgkqcCgAwIBAgIBATANBAwI...
+  tls.key: |
+    KNSC2DVVXcCgkqcCgAwIBAgIwewrvx...
+```

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -141,7 +141,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 	case kmsTypeVault:
 		return InitVaultKMS(kmsID, kmsConfig, secrets)
 	case kmsTypeVaultTokens:
-		return InitVaultTokensKMS(tenant, kmsID, kmsConfig, secrets)
+		return InitVaultTokensKMS(tenant, kmsID, kmsConfig)
 	}
 	return nil, fmt.Errorf("unknown encryption KMS type %s", kmsType)
 }

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -26,10 +26,9 @@ func TestParseConfig(t *testing.T) {
 	kms := VaultTokensKMS{}
 
 	config := make(map[string]interface{})
-	secrets := make(map[string]string)
 
 	// empty config map
-	err := kms.parseConfig(config, secrets)
+	err := kms.parseConfig(config)
 	if !errors.Is(err, errConfigOptionMissing) {
 		t.Errorf("unexpected error (%T): %s", err, err)
 	}
@@ -40,7 +39,7 @@ func TestParseConfig(t *testing.T) {
 	config["tenantTokenName"] = vaultTokensDefaultTokenName
 
 	// parsing with all required options
-	err = kms.parseConfig(config, secrets)
+	err = kms.parseConfig(config)
 	switch {
 	case err != nil:
 		t.Errorf("unexpected error: %s", err)
@@ -53,7 +52,7 @@ func TestParseConfig(t *testing.T) {
 	// tenant "bob" uses a different kms.ConfigName
 	bob := make(map[string]interface{})
 	bob["tenantConfigName"] = "the-config-from-bob"
-	err = kms.parseConfig(bob, secrets)
+	err = kms.parseConfig(bob)
 	switch {
 	case err != nil:
 		t.Errorf("unexpected error: %s", err)
@@ -75,10 +74,9 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	}
 
 	config := make(map[string]interface{})
-	secrets := make(map[string]string)
 
 	// empty config map
-	_, err := InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err := InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if !errors.Is(err, errConfigOptionMissing) {
 		t.Errorf("unexpected error (%T): %s", err, err)
 	}
@@ -87,7 +85,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	config["vaultAddress"] = "https://vault.default.cluster.svc"
 
 	// parsing with all required options
-	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -97,7 +95,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	config["tenants"] = tenants
 
 	// empty tenants list
-	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -107,7 +105,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	config["tenants"].(map[string]interface{})["bob"] = bob
 	bob["vaultAddress"] = "https://vault.bob.example.org"
 
-	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
 		t.Errorf("unexpected error: %s", err)
 	}


### PR DESCRIPTION
Added an option to pass the client certificate and the client certificate key for the vault token based encryption.

fixes https://github.com/ceph/ceph-csi/issues/1648

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

