### PR TITLE
VaultToken Tenants should be able to (re)configure the connection to the Vault Service

### DIFF
--- a/examples/kms/vault/tenant-config.yaml
+++ b/examples/kms/vault/tenant-config.yaml
@@ -1,0 +1,12 @@
+---
+# This is an optional (re)configuration of the connection to the Vault
+# Service that can be created in a Kubernetes Namespace for a Tenant.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-kms-config
+data:
+  vaultAddress: "http://vault.default.svc.cluster.local:8200"
+  vaultBackendPath: "secret/"
+  vaultTLSServerName: "vault.default.svc.cluster.local"
+  vaultCAVerify: "false"


### PR DESCRIPTION
Add support for overloading configuration options from a Tenants ConfigMap.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
