### PR TITLE
rbd: read configuration from the configmap

### DIFF
--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -133,6 +133,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # - name: POD_NAMESPACE
+            #   valueFrom:
+            #     fieldRef:
+            #       fieldPath: spec.namespace
+            # - name: KMS_CONFIGMAP_NAME
+            #   value: encryptionConfig
             - name: CSI_ENDPOINT
               value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -69,6 +69,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # - name: POD_NAMESPACE
+            #   valueFrom:
+            #     fieldRef:
+            #       fieldPath: spec.namespace
+            # - name: KMS_CONFIGMAP_NAME
+            #   value: encryptionConfig
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
           imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
if the KMS encryption configmap is not mounted as a volume to the CSI pods, add the code to read the configuration from the kubernetes. Later the code to fetch the configmap will be moved to the new sidecar which is will talk to the respective CO to fetch the encryption configurations.

The k8s configmap uses the standard vault specific names to add the configurations. this will be converted
back to the CSI configurations.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

TODO:
* update the templates to pass the pod_namespace and config name
* Add documentation for configmap