### PR TITLE
ci: add jobs with Kubernetes v1.20

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -12,7 +12,7 @@
     parameters:
       - string:
           name: k8s_version
-          default: '1.19'
+          default: '1.20'
           description: Kubernetes version to deploy in the test cluster.
     pipeline-scm:
       scm:

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -4,6 +4,7 @@
     k8s_version:
       - '1.18'
       - '1.19'
+      - '1.20'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
Add CI jobs for Kubernetes v1.20 testing. These jobs will run, but are
not (yet) required before changes get merged.

Updates: #1784

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
