### PR TITLE
ci: detect latest version with "Kubernetes" prefix

### DIFF
--- a/scripts/get_patch_release.py
+++ b/scripts/get_patch_release.py
@@ -77,7 +77,7 @@ def get_releases(gh_releases):
     '''
     releases = list()
     for release in gh_releases:
-        releases.append(release['name'])
+        releases.append(release['name'].split()[-1])
     return releases
 
 


### PR DESCRIPTION
New Kubernetes versions are now prefixed with "Kubernetes", like:

    $ ./scripts/get_patch_release.py
    Kubernetes v1.18.13
    Kubernetes v1.17.15
    Kubernetes v1.19.5
    Kubernetes v1.20.0
    Kubernetes v1.20.0-rc.0
    v1.20.0-beta.2
    v1.18.12
    v1.19.4
    v1.17.14
    v1.20.0-beta.1
    v1.20.0-beta.0
    v1.20.0-alpha.3
    v1.18.10
    v1.17.13

The new "Kubernetes" prefix prevents the current logic to not match the
version. By splitting the returned version string on words, and
returning the last component in get_releases(), the script works as
intended again.

Updates: #1784

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
