### PR TITLE
deploy: Fix snapshot controller deployment

### DIFF
--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -60,15 +60,18 @@ function create_or_delete_resource() {
     local operation=$1
     local namespace=$2
     temp_rbac=${TEMP_DIR}/snapshot-rbac.yaml
+    temp_snap_controller=${TEMP_DIR}/snapshot-controller.yaml
     snapshotter_psp="${SCRIPT_DIR}/snapshot-controller-psp.yaml"
     mkdir -p "${TEMP_DIR}"
     curl -o "${temp_rbac}" "${SNAPSHOT_RBAC}"
+    curl -o "${temp_snap_controller}" "${SNAPSHOT_CONTROLLER}"
     sed -i "s/namespace: default/namespace: ${namespace}/g" "${temp_rbac}"
     sed -i "s/namespace: default/namespace: ${namespace}/g" "${snapshotter_psp}"
+    sed -i "s/canary/${SNAPSHOT_VERSION}/g" "${temp_snap_controller}"
 
     kubectl "${operation}" -f "${temp_rbac}"
     kubectl "${operation}" -f "${snapshotter_psp}"
-    kubectl "${operation}" -f "${SNAPSHOT_CONTROLLER}" -n "${namespace}"
+    kubectl "${operation}" -f "${temp_snap_controller}" -n "${namespace}"
     kubectl "${operation}" -f "${SNAPSHOTCLASS}"
     kubectl "${operation}" -f "${VOLUME_SNAPSHOT_CONTENT}"
     kubectl "${operation}" -f "${VOLUME_SNAPSHOT}"


### PR DESCRIPTION
Replace image from canary to the version mentioned
in build.env

Signed-off-by: Yug <yuggupta27@gmail.com>

Fixes: #1791 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
