### PR TITLE
deploy: allow rbd nodeplugin to read ConfigMaps from Tenants

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -15,7 +15,11 @@ rules:
     resources: ["nodes"]
     verbs: ["get"]
 {{- end }}
+  # allow to read Vault Token and connection options from the Tenants namespace
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
     verbs: ["get"]
 {{- end -}}

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -12,8 +12,12 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
+  # allow to read Vault Token and connection options from the Tenants namespace
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
     verbs: ["get"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Tenants can have their own ConfigMap that contains connection parameters
to the Vault Service where the PV encyption keys are located. It is
possible for a Tenant to use a different Vault Service than the one
configured by the Storage Admin who deployed Ceph-CSI.

For this, the node-plugin needs to be able to read the ConfigMap from
the Tenants namespace.

See-also: docs/design/proposals/encryption-with-vault-tokens.md

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
