### PR TITLE
ci: do not run jobs with Kubernetes v1.18 anymore

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,7 +2,6 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.18'
       - '1.19'
       - '1.20'
     jobs:

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.18'
+    k8s_version: '1.20'
     test_type:
       - 'cephfs'
       - 'rbd'


### PR DESCRIPTION
Kubernetes v1.20 has been released, so lets use that for testing. Note
that v1.18 is still maintained, but our CI jobs will not consume it
anymore.

Closes: #1784 (merge after #1805)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
