### PR TITLE
build: only use --cpuset options when the cgroup controller is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,18 @@ CONTAINER_CMD?=$(shell podman version >/dev/null 2>&1 && echo podman)
 ifeq ($(CONTAINER_CMD),)
     CONTAINER_CMD=$(shell docker version >/dev/null 2>&1 && echo docker)
 endif
-CPUS?=$(shell nproc --ignore=1)
-CPUSET?=--cpuset-cpus=0-${CPUS}
+
+# Recent versions of Podman do not allow non-root to use --cpuset options.
+# Set HAVE_CPUSET to 1 when cpuset support is available.
+ifeq ($(UID),0)
+    HAVE_CPUSET ?= $(shell grep -c -w cpuset /sys/fs/cgroup/cgroup.controllers 2>/dev/null)
+else
+    HAVE_CPUSET ?= $(shell grep -c -w cpuset /sys/fs/cgroup/user.slice/user-$(UID).slice/cgroup.controllers 2>/dev/null)
+endif
+ifeq ($(HAVE_CPUSET),1)
+    CPUS ?= $(shell nproc --ignore=1)
+    CPUSET ?= --cpuset-cpus=0-${CPUS}
+endif
 
 CSI_IMAGE_NAME=$(if $(ENV_CSI_IMAGE_NAME),$(ENV_CSI_IMAGE_NAME),quay.io/cephcsi/cephcsi)
 CSI_IMAGE_VERSION=$(shell . $(CURDIR)/build.env ; echo $${CSI_IMAGE_VERSION})


### PR DESCRIPTION
`--cpuset-..` options only work when the user has permissions to use the cpuset cgroup controller. This adds detection for the availability of the cgroup controller for the running user.

Fixes: #1670

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
