### PR TITLE
rbd: fix namespace json parser for xbdDeviceInfo

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1184,12 +1184,22 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
+
 				// Resize Block PVC and check Device size within the namespace
 				// Block PVC resize is supported in kubernetes 1.16+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					err = resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
 					if err != nil {
 						e2elog.Failf("failed to resize block PVC with error %v", err)
+					}
+				}
+
+				// Resize Filesystem PVC and check application directory size
+				// Resize 0.3.0 is only supported from v1.15+
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 15) {
+					err := resizePVCAndValidateSize(pvcPath, appPath, f)
+					if err != nil {
+						e2elog.Failf("failed to resize filesystem PVC %v", err)
 					}
 				}
 

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -59,7 +59,7 @@ func init() {
 type rbdDeviceInfo struct {
 	ID             string `json:"id"`
 	Pool           string `json:"pool"`
-	RadosNamespace string `json:"radosNamespace"`
+	RadosNamespace string `json:"namespace"`
 	Name           string `json:"name"`
 	Device         string `json:"device"`
 }
@@ -71,7 +71,7 @@ type rbdDeviceInfo struct {
 type nbdDeviceInfo struct {
 	ID             int64  `json:"id"`
 	Pool           string `json:"pool"`
-	RadosNamespace string `json:"radosNamespace"`
+	RadosNamespace string `json:"namespace"`
 	Name           string `json:"image"`
 	Device         string `json:"device"`
 }


### PR DESCRIPTION
# Describe what this PR does #

Fix namespace json parser for xbdDeviceInfo. rbd device list --format=json returns namespace as a namespace not radosNamespace

```console
$ rbd device list --format=json
[{"id":"0","pool":"replicapool","namespace":"","name":"csi-vol-ed073622-4e3a-11eb-b337-0242ac110005","snap":"-","device":"/dev/rbd0"}]
```
## Is there anything that requires special attention ##

I don't know the nbd return type but I guess it would be `namespace` too :D
