### PR TITLE
build: use v3.2-canary after v3.2.1 release

### DIFF
--- a/build.env
+++ b/build.env
@@ -10,7 +10,7 @@
 #
 
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.2.1
+CSI_IMAGE_VERSION=v3.2-canary
 
 # Ceph version to use
 BASE_IMAGE=docker.io/ceph/ceph:v15

--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.2.1
+appVersion: v3.2-canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
-version: 3.2.1-canary
+version: 3.2-canary
 keywords:
   - ceph
   - cephfs

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -80,7 +80,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.2.1
+      tag: v3.2-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.2.1
+appVersion: v3.2-canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter, and attacher for Ceph RBD"
 name: ceph-csi-rbd
-version: 3.2.1-canary
+version: 3.2-canary
 keywords:
   - ceph
   - rbd

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -92,7 +92,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.2.1
+      tag: v3.2-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -109,7 +109,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -145,7 +145,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -46,7 +46,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -96,7 +96,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -112,7 +112,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -157,7 +157,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -175,7 +175,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -47,7 +47,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -99,7 +99,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.2.1
+          image: quay.io/cephcsi/cephcsi:v3.2-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -280,7 +280,7 @@ teardown-rook)
     ;;
 cephcsi)
     echo "copying the cephcsi image"
-    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2.1 "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2.1
+    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2-canary "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2-canary
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"


### PR DESCRIPTION
v3.2.1 has been released, so revert back to the v3.2-canary version for
HEAD of the release-v3.2 branch.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
