### PR TITLE
rebase: update golang version to v1.15.5

### DIFF
--- a/build.env
+++ b/build.env
@@ -16,7 +16,7 @@ BASE_IMAGE=docker.io/ceph/ceph:v15
 CEPH_VERSION=nautilus
 
 # standard Golang options
-GOLANG_VERSION=1.15
+GOLANG_VERSION=1.15.5
 GO111MODULE=on
 
 # static checks and linters


### PR DESCRIPTION
To fix math/big CVE, this version of golang has the fix
for this vulnerability.
[CVE-2020-28362](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-28362) cephcsi-container: golang: math/big: panic during recursive division of very large numbers

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>
