### PR TITLE
rbd: add support to create snapshot and clone from snapshot in different pools

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -958,7 +958,7 @@ var _ = Describe("RBD", func() {
 			By("create ROX PVC clone and mount it to multiple pods", func() {
 				// snapshot beta is only supported from v1.17+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
-					err := createRBDSnapshotClass(f)
+					err := createRBDSnapshotClass(f, nil)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}
@@ -1093,7 +1093,7 @@ var _ = Describe("RBD", func() {
 				if !k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
 					Skip("pvc restore is only supported from v1.17+")
 				}
-				err := createRBDSnapshotClass(f)
+				err := createRBDSnapshotClass(f, nil)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1298,7 +1298,7 @@ var _ = Describe("RBD", func() {
 				// Create a PVC clone and bind it to an app within the namespace
 				// snapshot beta is only supported from v1.17+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
-					err = createRBDSnapshotClass(f)
+					err = createRBDSnapshotClass(f, nil)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -956,6 +956,103 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("create rbd snapshots in different pool", func() {
+				// snapshot beta is only supported from v1.17+
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
+					err := deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+					snapshotPool := "snapshot-test"
+					// create pool for snapshots
+					err = createPool(f, snapshotPool)
+					if err != nil {
+						e2elog.Failf("failed to create pool %s with error %v", snapshotPool, err)
+					}
+					// create snapshotclass with pool option
+					param := map[string]string{
+						"pool": snapshotPool,
+					}
+					err = createRBDSnapshotClass(f, param)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+					err = validateSnapshotInDifferentPool(f, snapshotPool, "", defaultRBDPool)
+					if err != nil {
+						e2elog.Failf("failed to validate snapshot in different pool with error %v", err)
+					}
+
+					err = deletePool(snapshotPool, false, f)
+					if err != nil {
+						e2elog.Failf("failed to delete pool %s with error %v", snapshotPool, err)
+					}
+					err = deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+					err = createRBDSnapshotClass(f, nil)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+				}
+			})
+
+			By("create rbd clones in different pool", func() {
+				// snapshot beta is only supported from v1.17+
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
+					err := deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+					clonePool := "clone-test"
+					// create pool for clones
+					err = createPool(f, clonePool)
+					if err != nil {
+						e2elog.Failf("failed to create pool %s with error %v", clonePool, err)
+					}
+					// create snapshotclass with pool option
+					param := map[string]string{
+						"pool": defaultRBDPool,
+					}
+					err = createRBDSnapshotClass(f, param)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+					cloneSC := "clone-storageclass"
+					param = map[string]string{
+						"pool": clonePool,
+					}
+					// create new storageclass with new pool
+					err = createRBDStorageClass(f.ClientSet, f, cloneSC, nil, param, deletePolicy)
+					if err != nil {
+						e2elog.Failf("failed to create storageclass with error %v", err)
+					}
+					err = validateSnapshotInDifferentPool(f, defaultRBDPool, cloneSC, clonePool)
+					if err != nil {
+						e2elog.Failf("failed to validate clones in different pool with error %v", err)
+					}
+
+					_, err = framework.RunKubectl(cephCSINamespace, "delete", "sc", cloneSC, "--ignore-not-found=true")
+					if err != nil {
+						e2elog.Failf("failed to delete storageclass %s with error %v", cloneSC, err)
+					}
+
+					err = deleteResource(rbdExamplePath + "snapshotclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					}
+
+					err = deletePool(clonePool, false, f)
+					if err != nil {
+						e2elog.Failf("failed to delete pool %s with error %v", clonePool, err)
+					}
+					err = createRBDSnapshotClass(f, nil)
+					if err != nil {
+						e2elog.Failf("failed to create snapshotclass with error %v", err)
+					}
+				}
+			})
+
 			By("create ROX PVC clone and mount it to multiple pods", func() {
 				// snapshot beta is only supported from v1.17+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -181,7 +181,7 @@ var _ = Describe("RBD", func() {
 		if err != nil {
 			e2elog.Failf("failed to create configmap with error %v", err)
 		}
-		err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+		err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 		if err != nil {
 			e2elog.Failf("failed to create storageclass with error %v", err)
 		}
@@ -329,7 +329,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"csi.storage.k8s.io/fstype": "ext4"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"csi.storage.k8s.io/fstype": "ext4"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -343,7 +343,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -354,7 +354,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"encrypted": "true"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"encrypted": "true"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -368,7 +368,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -383,7 +383,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -397,7 +397,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -412,7 +412,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-tokens-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -447,7 +447,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -462,7 +462,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "secrets-metadata-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -476,7 +476,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -488,10 +488,10 @@ var _ = Describe("RBD", func() {
 
 			// By("create a PVC and Bind it to an app with journaling/exclusive-lock image-features and rbd-nbd mounter", func() {
 			// 	deleteResource(rbdExamplePath + "storageclass.yaml")
-			// 	createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"})
+			// 	createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"})
 			// 	validatePVCAndAppBinding(pvcPath, appPath, f)
 			// 	deleteResource(rbdExamplePath + "storageclass.yaml")
-			// 	createRBDStorageClass(f.ClientSet, f, nil, make(map[string]string))
+			// 	createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, make(map[string]string))
 			// })
 
 			By("create a PVC clone and bind it to an app", func() {
@@ -521,7 +521,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -532,7 +532,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -551,7 +551,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "secrets-metadata-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -562,7 +562,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -643,7 +643,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to delete storageclass with error %v", err)
 					}
-					err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"csi.storage.k8s.io/fstype": "xfs"}, deletePolicy)
+					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"csi.storage.k8s.io/fstype": "xfs"}, deletePolicy)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}
@@ -713,7 +713,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"volumeNamePrefix": volumeNamePrefix}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"volumeNamePrefix": volumeNamePrefix}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -756,7 +756,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -813,7 +813,7 @@ var _ = Describe("RBD", func() {
 				topologyConstraint := "[{\"poolName\":\"" + rbdTopologyPool + "\",\"domainSegments\":" +
 					"[{\"domainLabel\":\"region\",\"value\":\"" + regionValue + "\"}," +
 					"{\"domainLabel\":\"zone\",\"value\":\"" + zoneValue + "\"}]}]"
-				err = createRBDStorageClass(f.ClientSet, f,
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName,
 					map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 					map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 				if err != nil {
@@ -862,7 +862,7 @@ var _ = Describe("RBD", func() {
 						"\",\"domainSegments\":" +
 						"[{\"domainLabel\":\"region\",\"value\":\"" + regionValue + "\"}," +
 						"{\"domainLabel\":\"zone\",\"value\":\"" + zoneValue + "\"}]}]"
-					err = createRBDStorageClass(f.ClientSet, f,
+					err = createRBDStorageClass(f.ClientSet, f, defaultSCName,
 						map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 						map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 					if err != nil {
@@ -898,7 +898,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -911,7 +911,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, map[string]string{rbdmountOptions: "debug,invalidOption"}, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, map[string]string{rbdmountOptions: "debug,invalidOption"}, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -949,7 +949,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1259,7 +1259,7 @@ var _ = Describe("RBD", func() {
 				param["csi.storage.k8s.io/node-stage-secret-namespace"] = cephCSINamespace
 				param["csi.storage.k8s.io/node-stage-secret-name"] = rbdNodePluginSecretName
 
-				err = createRBDStorageClass(f.ClientSet, f, nil, param, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, param, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1372,7 +1372,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1432,7 +1432,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
 					"thickProvision": "true"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
@@ -1461,7 +1461,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1472,7 +1472,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
 					"mapOptions":   "lock_on_read,queue_depth=1024",
 					"unmapOptions": "force"}, deletePolicy)
 				if err != nil {
@@ -1486,7 +1486,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1503,7 +1503,7 @@ var _ = Describe("RBD", func() {
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -38,6 +38,20 @@ var (
 	nodeCSIZoneLabel    = "topology.rbd.csi.ceph.com/zone"
 	rbdTopologyPool     = "newrbdpool"
 	rbdTopologyDataPool = "replicapool" // NOTE: should be different than rbdTopologyPool for test to be effective
+
+	// yaml files required for deployment
+	pvcPath                = rbdExamplePath + "pvc.yaml"
+	appPath                = rbdExamplePath + "pod.yaml"
+	rawPvcPath             = rbdExamplePath + "raw-block-pvc.yaml"
+	rawAppPath             = rbdExamplePath + "raw-block-pod.yaml"
+	pvcClonePath           = rbdExamplePath + "pvc-restore.yaml"
+	pvcSmartClonePath      = rbdExamplePath + "pvc-clone.yaml"
+	pvcBlockSmartClonePath = rbdExamplePath + "pvc-block-clone.yaml"
+	appClonePath           = rbdExamplePath + "pod-restore.yaml"
+	appSmartClonePath      = rbdExamplePath + "pod-clone.yaml"
+	appBlockSmartClonePath = rbdExamplePath + "block-pod-clone.yaml"
+	snapshotPath           = rbdExamplePath + "snapshot.yaml"
+	defaultCloneCount      = 10
 )
 
 func deployRBDPlugin() {
@@ -270,19 +284,6 @@ var _ = Describe("RBD", func() {
 
 	Context("Test RBD CSI", func() {
 		It("Test RBD CSI", func() {
-			pvcPath := rbdExamplePath + "pvc.yaml"
-			appPath := rbdExamplePath + "pod.yaml"
-			rawPvcPath := rbdExamplePath + "raw-block-pvc.yaml"
-			rawAppPath := rbdExamplePath + "raw-block-pod.yaml"
-			pvcClonePath := rbdExamplePath + "pvc-restore.yaml"
-			pvcSmartClonePath := rbdExamplePath + "pvc-clone.yaml"
-			pvcBlockSmartClonePath := rbdExamplePath + "pvc-block-clone.yaml"
-			appClonePath := rbdExamplePath + "pod-restore.yaml"
-			appSmartClonePath := rbdExamplePath + "pod-clone.yaml"
-			appBlockSmartClonePath := rbdExamplePath + "block-pod-clone.yaml"
-			snapshotPath := rbdExamplePath + "snapshot.yaml"
-			defaultCloneCount := 10
-
 			By("checking provisioner deployment is running", func() {
 				err := waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -141,8 +141,8 @@ func createORDeleteRbdResouces(action string) {
 	}
 }
 
-func validateRBDImageCount(f *framework.Framework, count int) {
-	imageList, err := listRBDImages(f)
+func validateRBDImageCount(f *framework.Framework, count int, pool string) {
+	imageList, err := listRBDImages(f, pool)
 	if err != nil {
 		e2elog.Failf("failed to list rbd images with error %v", err)
 	}
@@ -303,7 +303,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate owner of pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app", func() {
@@ -312,7 +312,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app with normal user", func() {
@@ -321,7 +321,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate normal user pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app with ext4 as the FS ", func() {
@@ -338,7 +338,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -363,7 +363,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -392,7 +392,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -435,7 +435,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				// delete the Secret of the Tenant
 				err = c.CoreV1().Secrets(tenant).Delete(context.TODO(), token.Name, metav1.DeleteOptions{})
@@ -471,7 +471,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -607,7 +607,7 @@ var _ = Describe("RBD", func() {
 
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, totalCount)
+				validateRBDImageCount(f, totalCount, defaultRBDPool)
 				// delete PVC and app
 				for i := 0; i < totalCount; i++ {
 					name := fmt.Sprintf("%s%d", f.UniqueName, i)
@@ -619,7 +619,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("check data persist after recreating pod", func() {
@@ -628,7 +628,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to check data persist with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("Resize Filesystem PVC and check application directory size", func() {
@@ -653,7 +653,7 @@ var _ = Describe("RBD", func() {
 
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -665,7 +665,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to resize block PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -687,7 +687,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 				// delete rbd nodeplugin pods
 				err = deletePodWithLabel("app=csi-rbdplugin", cephCSINamespace, false)
 				if err != nil {
@@ -704,7 +704,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create PVC in storageClass with volumeNamePrefix", func() {
@@ -729,10 +729,10 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 				// list RBD images and check if one of them has the same prefix
 				foundIt := false
-				images, err := listRBDImages(f)
+				images, err := listRBDImages(f, defaultRBDPool)
 				if err != nil {
 					e2elog.Failf("failed to list rbd images with error %v", err)
 				}
@@ -750,7 +750,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to  delete PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -771,7 +771,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate rbd static pv with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("validate RBD static Block PVC", func() {
@@ -780,7 +780,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate rbd block pv with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("validate mount options in app pod", func() {
@@ -790,7 +790,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to check mount options with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("creating an app with a PVC, using a topology constrained StorageClass", func() {
@@ -931,7 +931,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				// create an app and wait for 1 min for it to go to running state
 				err = createApp(f.ClientSet, app, 1)
@@ -944,7 +944,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -986,7 +986,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create PVC and application with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 					// delete pod as we should not create snapshot for in-use pvc
 					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 					if err != nil {
@@ -1004,7 +1004,7 @@ var _ = Describe("RBD", func() {
 					// validate created backend rbd images
 					// parent PVC + snapshot
 					totalImages := 2
-					validateRBDImageCount(f, totalImages)
+					validateRBDImageCount(f, totalImages, defaultRBDPool)
 					pvcClone, err := loadPVC(pvcClonePath)
 					if err != nil {
 						e2elog.Failf("failed to load PVC with error %v", err)
@@ -1020,7 +1020,7 @@ var _ = Describe("RBD", func() {
 					// validate created backend rbd images
 					// parent pvc+ snapshot + clone
 					totalImages = 3
-					validateRBDImageCount(f, totalImages)
+					validateRBDImageCount(f, totalImages, defaultRBDPool)
 
 					appClone, err := loadApp(appClonePath)
 					if err != nil {
@@ -1084,7 +1084,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to delete PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -1121,7 +1121,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				snap := getSnapshot(snapshotPath)
 				snap.Namespace = f.UniqueName
@@ -1134,7 +1134,7 @@ var _ = Describe("RBD", func() {
 				// validate created backend rbd images
 				// parent PVC + snapshot
 				totalImages := 2
-				validateRBDImageCount(f, totalImages)
+				validateRBDImageCount(f, totalImages, defaultRBDPool)
 				pvcClone, err := loadPVC(pvcClonePath)
 				if err != nil {
 					e2elog.Failf("failed to load PVC with error %v", err)
@@ -1146,7 +1146,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				// create clone PVC
 				pvcClone.Namespace = f.UniqueName
@@ -1156,7 +1156,7 @@ var _ = Describe("RBD", func() {
 				}
 				// validate created backend rbd images = snapshot + clone
 				totalImages = 2
-				validateRBDImageCount(f, totalImages)
+				validateRBDImageCount(f, totalImages, defaultRBDPool)
 
 				// delete snapshot
 				err = deleteSnapshot(&snap, deployTimeout)
@@ -1166,7 +1166,7 @@ var _ = Describe("RBD", func() {
 
 				// validate created backend rbd images = clone
 				totalImages = 1
-				validateRBDImageCount(f, totalImages)
+				validateRBDImageCount(f, totalImages, defaultRBDPool)
 
 				appClone, err := loadApp(appClonePath)
 				if err != nil {
@@ -1191,7 +1191,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("ensuring all operations will work within a rados namespace", func() {
@@ -1269,7 +1269,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate owner of pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				// Create a PVC and bind it to an app within the namesapce
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
@@ -1321,7 +1321,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 
 					snap := getSnapshot(snapshotPath)
 					snap.Namespace = f.UniqueName
@@ -1330,7 +1330,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to create snapshot with error %v", err)
 					}
-					validateRBDImageCount(f, 2)
+					validateRBDImageCount(f, 2, defaultRBDPool)
 
 					err = validatePVCAndAppBinding(pvcClonePath, appClonePath, f)
 					if err != nil {
@@ -1341,13 +1341,13 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to delete snapshot with error %v", err)
 					}
 					// as snapshot is deleted the image count should be one
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 
 					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to delete PVC with error %v", err)
 					}
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 
 				// delete RBD provisioner secret
@@ -1405,7 +1405,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				opt := metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("app=%s", app.Name),
@@ -1424,7 +1424,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a thick-provisioned PVC", func() {
@@ -1502,7 +1502,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate controller with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -30,11 +30,14 @@ func rbdOptions(pool string) string {
 	return "--pool=" + pool
 }
 
-func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, scOptions, parameters map[string]string, policy v1.PersistentVolumeReclaimPolicy) error {
+func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, name string, scOptions, parameters map[string]string, policy v1.PersistentVolumeReclaimPolicy) error {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc, err := getStorageClass(scPath)
 	if err != nil {
 		return nil
+	}
+	if name != "" {
+		sc.Name = name
 	}
 	sc.Parameters["pool"] = defaultRBDPool
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = cephCSINamespace

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -303,11 +303,11 @@ func validateEncryptedImage(f *framework.Framework, rbdImageSpec string, app *v1
 	return nil
 }
 
-func listRBDImages(f *framework.Framework) ([]string, error) {
+func listRBDImages(f *framework.Framework, pool string) ([]string, error) {
 	var imgInfos []string
 
 	stdout, stdErr, err := execCommandInToolBoxPod(f,
-		fmt.Sprintf("rbd ls --format=json %s", rbdOptions(defaultRBDPool)), rookNamespace)
+		fmt.Sprintf("rbd ls --format=json %s", rbdOptions(pool)), rookNamespace)
 	if err != nil {
 		return imgInfos, err
 	}
@@ -554,7 +554,7 @@ func validateThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, siz
 	if err != nil {
 		return fmt.Errorf("failed to create PVC with error %w", err)
 	}
-	validateRBDImageCount(f, 1)
+	validateRBDImageCount(f, 1, defaultRBDPool)
 
 	// nothing has been written, but the image should be allocated
 	du, err := getRbdDu(f, pvc)
@@ -598,7 +598,7 @@ func validateThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, siz
 	if err != nil {
 		return fmt.Errorf("failed to delete PVC with error: %w", err)
 	}
-	validateRBDImageCount(f, 0)
+	validateRBDImageCount(f, 0, defaultRBDPool)
 
 	return nil
 }

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -419,6 +419,23 @@ func deletePool(name string, cephfs bool, f *framework.Framework) error {
 	return nil
 }
 
+func createPool(f *framework.Framework, name string) error {
+	var (
+		pgCount = 128
+		size    = 1
+	)
+	// ceph osd pool create replicapool
+	cmd := fmt.Sprintf("ceph osd pool create %s %d", name, pgCount)
+	_, _, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+	if err != nil {
+		return err
+	}
+	// ceph osd pool set replicapool size 1
+	cmd = fmt.Sprintf("ceph osd pool set %s size %d", name, size)
+	_, _, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
+	return err
+}
+
 func getPVCImageInfoInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, pool string) (string, error) {
 	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
 	if err != nil {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
+	"github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	scv1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -230,6 +232,162 @@ func validateImageOwner(pvcPath string, f *framework.Framework) error {
 
 func kmsIsVault(kms string) bool {
 	return kms == "vault"
+}
+
+// nolint:gocyclo // reduce complexity
+func validateSnapshotInDifferentPool(f *framework.Framework, snapshotPool, cloneSc, destImagePool string) error {
+	var wg sync.WaitGroup
+	totalCount := 10
+	wgErrs := make([]error, totalCount)
+	wg.Add(totalCount)
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC with error %v", err)
+	}
+
+	pvc.Namespace = f.UniqueName
+	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create PVC with error %v", err)
+	}
+	validateRBDImageCount(f, 1, defaultRBDPool)
+	snap := getSnapshot(snapshotPath)
+	snap.Namespace = f.UniqueName
+	snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+	// create snapshot
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, s v1beta1.VolumeSnapshot) {
+			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = createSnapshot(&s, deployTimeout)
+			w.Done()
+		}(&wg, i, snap)
+	}
+	wg.Wait()
+
+	failed := 0
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to create snapshot (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("creating snapshots failed, %d errors were logged", failed)
+	}
+
+	// delete parent pvc
+	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete PVC with error %v", err)
+	}
+
+	// validate the rbd images created for snapshots
+	validateRBDImageCount(f, totalCount, snapshotPool)
+
+	pvcClone, err := loadPVC(pvcClonePath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC with error %v", err)
+	}
+	appClone, err := loadApp(appClonePath)
+	if err != nil {
+		return fmt.Errorf("failed to load application with error %v", err)
+	}
+	pvcClone.Namespace = f.UniqueName
+	// if request is to create clone with different storage class
+	if cloneSc != "" {
+		pvcClone.Spec.StorageClassName = &cloneSc
+	}
+	appClone.Namespace = f.UniqueName
+	pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s%d", f.UniqueName, 0)
+	// create multiple PVCs from same snapshot
+	wg.Add(totalCount)
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to create PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("creating PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	// total images in pool is total snaps + total clones
+	if destImagePool == snapshotPool {
+		totalCloneCount := totalCount + totalCount
+		validateRBDImageCount(f, totalCloneCount, snapshotPool)
+	} else {
+		// if clones are created in different pool we will have only rbd images of
+		// count equal to totalCount
+		validateRBDImageCount(f, totalCount, destImagePool)
+	}
+	wg.Add(totalCount)
+	// delete clone and app
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			p.Spec.DataSource.Name = name
+			wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to delete PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("deleting PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	if destImagePool == snapshotPool {
+		// as we have deleted all clones total images in pool is total snaps
+		validateRBDImageCount(f, totalCount, snapshotPool)
+	} else {
+		// we have deleted all clones
+		validateRBDImageCount(f, 0, destImagePool)
+	}
+
+	wg.Add(totalCount)
+	// delete snapshot
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, s v1beta1.VolumeSnapshot) {
+			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = deleteSnapshot(&s, deployTimeout)
+			w.Done()
+		}(&wg, i, snap)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to delete snapshot (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("deleting snapshots failed, %d errors were logged", failed)
+	}
+	// validate all pools are empty
+	validateRBDImageCount(f, 0, snapshotPool)
+	validateRBDImageCount(f, 0, defaultRBDPool)
+	validateRBDImageCount(f, 0, destImagePool)
+	return nil
 }
 
 func validateEncryptedPVCAndAppBinding(pvcPath, appPath, kms string, f *framework.Framework) error {

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -112,7 +112,7 @@ func deleteSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 	})
 }
 
-func createRBDSnapshotClass(f *framework.Framework) error {
+func createRBDSnapshotClass(f *framework.Framework, param map[string]string) error {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "snapshotclass.yaml")
 	sc := getSnapshotClass(scPath)
 
@@ -128,6 +128,9 @@ func createRBDSnapshotClass(f *framework.Framework) error {
 	}
 	fsID = strings.Trim(fsID, "\n")
 	sc.Parameters["clusterID"] = fsID
+	for k, v := range param {
+		sc.Parameters[k] = v
+	}
 	sclient, err := newSnapshotClient()
 	if err != nil {
 		return err

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -85,7 +85,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to create node secret with error %v", err)
 		}
-		err = createRBDSnapshotClass(f)
+		err = createRBDSnapshotClass(f, nil)
 		if err != nil {
 			e2elog.Failf("failed to create snapshotclass with error %v", err)
 		}

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -63,7 +63,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to create configmap with error %v", err)
 		}
-		err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+		err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 		if err != nil {
 			e2elog.Failf("failed to create storageclass with error %v", err)
 		}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -26,8 +26,8 @@ import (
 
 /* #nosec:G101, values not credententials, just a reference to the location.*/
 const (
-	defaultNs = "default"
-
+	defaultNs     = "default"
+	defaultSCName = ""
 	// vaultBackendPath is the default VAULT_BACKEND_PATH for secrets
 	vaultBackendPath = "secret/"
 	// vaultPassphrasePath is an advanced configuration option, only
@@ -962,7 +962,7 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	expandSize := "10Gi"
 	var err error
 	// create storageclass with retain
-	err = createRBDStorageClass(f.ClientSet, f, nil, nil, retainPolicy)
+	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, retainPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass with error %v", err)
 	}
@@ -994,7 +994,7 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	if err != nil {
 		return fmt.Errorf("failed to delete storageclass with error %v", err)
 	}
-	err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass with error %v", err)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -661,7 +661,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	chErrs := make([]error, totalCount)
 	wg.Add(totalCount)
 
-	err := createRBDSnapshotClass(f)
+	err := createRBDSnapshotClass(f, nil)
 	if err != nil {
 		e2elog.Failf("failed to create storageclass with error %v", err)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -548,7 +548,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 		}
 	}
 	// validate created backend rbd images
-	validateRBDImageCount(f, 1)
+	validateRBDImageCount(f, 1, defaultRBDPool)
 	pvcClone, err := loadPVC(clonePvcPath)
 	if err != nil {
 		e2elog.Failf("failed to load PVC with error %v", err)
@@ -619,7 +619,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 	// total images in cluster is 1 parent rbd image+ total
 	// temporary clone+ total clones
 	totalCloneCount := totalCount + totalCount + 1
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
@@ -627,7 +627,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 	}
 
 	totalCloneCount = totalCount + totalCount
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
@@ -651,7 +651,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 		e2elog.Failf("deleting PVCs and applications failed, %d errors were logged", failed)
 	}
 
-	validateRBDImageCount(f, 0)
+	validateRBDImageCount(f, 0, defaultRBDPool)
 }
 
 // nolint:gocyclo,gocognit,nestif // reduce complexity
@@ -698,7 +698,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	if err != nil {
 		e2elog.Failf("failed to calculate checksum with error %v", err)
 	}
-	validateRBDImageCount(f, 1)
+	validateRBDImageCount(f, 1, defaultRBDPool)
 	snap := getSnapshot(snapshotPath)
 	snap.Namespace = f.UniqueName
 	snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
@@ -739,7 +739,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	}
 
 	// total images in cluster is 1 parent rbd image+ total snaps
-	validateRBDImageCount(f, totalCount+1)
+	validateRBDImageCount(f, totalCount+1, defaultRBDPool)
 	pvcClone, err := loadPVC(pvcClonePath)
 	if err != nil {
 		e2elog.Failf("failed to load PVC with error %v", err)
@@ -809,7 +809,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	// total images in cluster is 1 parent rbd image+ total
 	// snaps+ total clones
 	totalCloneCount := totalCount + totalCount + 1
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
@@ -835,7 +835,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 
 	// total images in cluster is 1 parent rbd image+ total
 	// snaps
-	validateRBDImageCount(f, totalCount+1)
+	validateRBDImageCount(f, totalCount+1, defaultRBDPool)
 	// create clones from different snapshots and bind it to an
 	// app
 	wg.Add(totalCount)
@@ -863,7 +863,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	// total images in cluster is 1 parent rbd image+ total
 	// snaps+ total clones
 	totalCloneCount = totalCount + totalCount + 1
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
@@ -872,7 +872,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 
 	// total images in cluster is total snaps+ total clones
 	totalSnapCount := totalCount + totalCount
-	validateRBDImageCount(f, totalSnapCount)
+	validateRBDImageCount(f, totalSnapCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete snapshot
 	for i := 0; i < totalCount; i++ {
@@ -916,7 +916,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 		e2elog.Failf("deleting snapshots failed, %d errors were logged", failed)
 	}
 
-	validateRBDImageCount(f, totalCount)
+	validateRBDImageCount(f, totalCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
@@ -941,7 +941,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	}
 
 	// validate created backend rbd images
-	validateRBDImageCount(f, 0)
+	validateRBDImageCount(f, 0, defaultRBDPool)
 }
 
 // validateController simulates the required operations to validate the

--- a/examples/rbd/snapshotclass.yaml
+++ b/examples/rbd/snapshotclass.yaml
@@ -22,6 +22,12 @@ parameters:
   # represent the Ceph cluster in clusterID below
   clusterID: <cluster-id>
 
+  # (optional) Ceph pool into which the RBD image shall be created, if not
+  # specified RBD image will be created in the same pool where parent RBD image
+  # exists.
+  # eg: pool: rbdpool
+  # pool: <rbd-pool-name>
+
   # Prefix to use for naming RBD snapshots.
   # If omitted, defaults to "csi-snap-".
   # snapshotNamePrefix: "foo-bar-"

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -101,7 +101,7 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 		// need to check for flatten here.
 		// as the snap exists,create clone image and delete temporary snapshot
 		// and add task to flatten temporary cloned image
-		err = rv.cloneRbdImageFromSnapshot(ctx, snap)
+		err = rv.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
 			err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", rv.RbdImageName, snap.RbdSnapName, err)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -800,7 +800,7 @@ func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnaps
 	vol := generateVolFromSnap(rbdSnap)
 	err := vol.Connect(cr)
 	if err != nil {
-		uErr := undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+		uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 		if uErr != nil {
 			util.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.RequestName, uErr)
 		}
@@ -824,7 +824,7 @@ func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnaps
 	if errors.Is(err, ErrFlattenInProgress) {
 		readyToUse = false
 	} else if err != nil {
-		uErr := undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+		uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 		if uErr != nil {
 			util.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.RequestName, uErr)
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -914,6 +914,20 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 		return ready, cloneRbd, err
 	}
 
+	defer func() {
+		// If we hit any error below, cleanup the snapshot created on the clone
+		if err != nil {
+			if !errors.Is(err, ErrFlattenInProgress) {
+				errCleaup := cloneRbd.deleteSnapshot(ctx, rbdSnap)
+				if errCleaup != nil {
+					if !errors.Is(errCleaup, ErrSnapNotFound) {
+						util.ErrorLog(ctx, "failed to delete snapshot: %v", errCleaup)
+					}
+				}
+			}
+		}
+	}()
+
 	err = cloneRbd.getImageID()
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get image id: %v", err)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -424,8 +424,12 @@ func (cs *ControllerServer) createVolumeFromSnapshot(ctx context.Context, cr *ut
 
 	// update parent name(rbd image name in snapshot)
 	rbdSnap.RbdImageName = rbdSnap.RbdSnapName
+	parentVol := generateVolFromSnap(rbdSnap)
+	// as we are operating on single cluster reuse the connection
+	parentVol.conn = rbdVol.conn.Copy()
+
 	// create clone image and delete snapshot
-	err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap)
+	err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap, parentVol)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rbdVol, rbdSnap, err)
 		return err

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -864,7 +864,9 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 	if value, ok := options["snapshotNamePrefix"]; ok && value == "" {
 		return status.Error(codes.InvalidArgument, "empty snapshot name prefix to provision snapshot from")
 	}
-
+	if value, ok := options["pool"]; ok && value == "" {
+		return status.Error(codes.InvalidArgument, "empty pool name in which rbd image will be created")
+	}
 	return nil
 }
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -948,7 +948,16 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 		return ready, cloneRbd, err
 	}
 
-	err = cloneRbd.flattenRbdImage(ctx, cr, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
+	forceFlatten := false
+	// As once the snapshot limit on a parent is reached we cannot flatten the
+	// images as we dont know the pool in which clones are created,
+	// if the parent image pool and clone pool are different flatten the image
+	// to break the clone chain.
+	if rbdSnap.Pool != parentVol.ParentPool {
+		forceFlatten = true
+	}
+
+	err = cloneRbd.flattenRbdImage(ctx, cr, forceFlatten, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 	if err != nil {
 		if errors.Is(err, ErrFlattenInProgress) {
 			return ready, cloneRbd, nil

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -119,6 +119,8 @@ deletion are inverse of each other, and protected by the request name lock, and
 hence any stale omaps are leftovers from incomplete transactions and are hence
 safe to garbage collect.
 */
+// FIXME: reduce complexity
+// nolint:gocyclo // reduce complexity
 func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rbdSnapshot, cr *util.Credentials) (bool, error) {
 	err := validateRbdSnap(rbdSnap)
 	if err != nil {
@@ -199,6 +201,24 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 	}
 	if err != nil {
 		return false, err
+	}
+
+	// As once the snapshot limit on a parent is reached we cannot flatten the
+	// cloned images as we dont know the pool in which clones are created,
+	// if the parent image pool and clone pool are different flatten the image
+	// to break the clone chain now only.
+	if rbdSnap.Pool != parentVol.ParentPool {
+		var d uint
+		d, err = vol.getCloneDepth(ctx)
+		if err != nil {
+			return false, err
+		}
+		if d != 0 {
+			err = vol.flattenRbdImage(ctx, cr, true, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
+			if err != nil {
+				return false, err
+			}
+		}
 	}
 
 	if vol.ImageID == "" {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -167,7 +167,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 					return false, err
 				}
 			}
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 		}
 		return false, err
 	}
@@ -193,7 +193,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		sErr := vol.createSnapshot(ctx, rbdSnap)
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 	}
@@ -205,13 +205,13 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		sErr := vol.getImageID()
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to get image id %s: %v", vol, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 		sErr = j.StoreImageID(ctx, vol.JournalPool, vol.ReservedID, vol.ImageID)
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to store volume id %s: %v", vol, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -114,8 +114,10 @@ type rbdVolume struct {
 	Topology            map[string]string
 	// DataPool is where the data for images in `Pool` are stored, this is used as the `--data-pool`
 	// 	 argument when the pool is created, and is not used anywhere else
-	DataPool           string
-	ParentName         string
+	DataPool   string
+	ParentName string
+	// Parent Pool is the pool that contains the parent image.
+	ParentPool         string
 	imageFeatureSet    librbd.FeatureSet
 	AdminID            string `json:"adminId"`
 	UserID             string `json:"userId"`
@@ -1177,6 +1179,7 @@ func (rv *rbdVolume) getImageInfo() error {
 		}
 	} else {
 		rv.ParentName = parentInfo.Image.ImageName
+		rv.ParentPool = parentInfo.Image.PoolName
 	}
 	// Get image creation time
 	tm, err := image.GetCreateTimestamp()

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1046,7 +1046,7 @@ func (rv *rbdVolume) hasSnapshotFeature() bool {
 }
 
 func (rv *rbdVolume) createSnapshot(ctx context.Context, pOpts *rbdSnapshot) error {
-	util.DebugLog(ctx, "rbd: snap create %s using mon %s", pOpts, pOpts.Monitors)
+	util.DebugLog(ctx, "rbd: snap create %s@%s using mon %s", rv, pOpts.String(), pOpts.Monitors)
 	image, err := rv.open()
 	if err != nil {
 		return err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1084,10 +1084,18 @@ func (rv *rbdVolume) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) err
 	return err
 }
 
-func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *rbdSnapshot) error {
-	image := rv.RbdImageName
+func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *rbdSnapshot, parentVol *rbdVolume) error {
 	var err error
 	logMsg := "rbd: clone %s %s (features: %s) using mon %s"
+
+	err = parentVol.openIoctx()
+	if err != nil {
+		return fmt.Errorf("failed to get parent IOContext: %w", err)
+	}
+	defer func() {
+		defer parentVol.ioctx.Destroy()
+		parentVol.ioctx = nil
+	}()
 
 	options := librbd.NewRbdImageOptions()
 	defer options.Destroy()
@@ -1101,7 +1109,7 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *r
 	}
 
 	util.DebugLog(ctx, logMsg,
-		pSnapOpts, image, rv.imageFeatureSet.Names(), rv.Monitors)
+		pSnapOpts.String(), rv, rv.imageFeatureSet.Names(), rv.Monitors)
 
 	if rv.imageFeatureSet != 0 {
 		err = options.SetUint64(librbd.RbdImageOptionFeatures, uint64(rv.imageFeatureSet))
@@ -1115,12 +1123,18 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *r
 		return fmt.Errorf("failed to set image features: %w", err)
 	}
 
+	// As the clone is yet to be created, open the Ioctx.
 	err = rv.openIoctx()
 	if err != nil {
 		return fmt.Errorf("failed to get IOContext: %w", err)
 	}
+	// Destroy only the ioctx, connection is needed for other operations.
+	defer func() {
+		defer rv.ioctx.Destroy()
+		rv.ioctx = nil
+	}()
 
-	err = librbd.CloneImage(rv.ioctx, pSnapOpts.RbdImageName, pSnapOpts.RbdSnapName, rv.ioctx, rv.RbdImageName, options)
+	err = librbd.CloneImage(parentVol.ioctx, pSnapOpts.RbdImageName, pSnapOpts.RbdSnapName, rv.ioctx, rv.RbdImageName, options)
 	if err != nil {
 		return fmt.Errorf("failed to create rbd clone: %w", err)
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -566,6 +566,7 @@ func (rv *rbdVolume) getCloneDepth(ctx context.Context) (uint, error) {
 			depth++
 		}
 		vol.RbdImageName = vol.ParentName
+		vol.Pool = vol.ParentPool
 	}
 }
 
@@ -741,6 +742,7 @@ func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint
 			return true, nil
 		}
 		vol.RbdImageName = vol.ParentName
+		vol.Pool = vol.ParentPool
 	}
 }
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1058,7 +1058,7 @@ func (rv *rbdVolume) createSnapshot(ctx context.Context, pOpts *rbdSnapshot) err
 }
 
 func (rv *rbdVolume) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) error {
-	util.DebugLog(ctx, "rbd: snap rm %s using mon %s", pOpts, pOpts.Monitors)
+	util.DebugLog(ctx, "rbd: snap rm %s@%s using mon %s", rv, pOpts.String(), pOpts.Monitors)
 	image, err := rv.open()
 	if err != nil {
 		return err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1033,6 +1033,10 @@ func genSnapFromOptions(ctx context.Context, rbdVol *rbdVolume, snapOptions map[
 		rbdSnap.NamePrefix = namePrefix
 	}
 
+	if pool, ok := snapOptions["pool"]; ok {
+		rbdSnap.JournalPool = pool
+		rbdSnap.Pool = pool
+	}
 	return rbdSnap, nil
 }
 

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -33,7 +33,7 @@ func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap
 
 	snap.RbdImageName = parentVol.RbdImageName
 	// create clone image and delete snapshot
-	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap)
+	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
 		err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)


### PR DESCRIPTION
Add support to create a snapshot to a different pool.
Also, create a pvc from a snapshot to a different pool.

Co-authored-by: Madhu Rajanna <madhupr007@gmail.com>
Closes: #1739 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
