### PR TITLE
e2e: add a test case for rbd-nbd mounter

### DIFF
--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -204,7 +204,7 @@ func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOpti
 	return stdOut, stdErr, err
 }
 
-func execCommandInContainer(f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions) (string, string, error) {
+func execCommandInContainer(f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions) (string, string, error) { //nolint:unparam,lll // cn can be used with different inputs later
 	podOpt, err := getCommandInPodOpts(f, c, ns, cn, opt)
 	if err != nil {
 		return "", "", err
@@ -304,7 +304,7 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 	})
 }
 
-func deletePodWithLabel(label, ns string, skipNotFound bool) error {
+func deletePodWithLabel(label, ns string, skipNotFound bool) error { //nolint:unparam // skipNotFound can be used with different inputs later
 	_, err := framework.RunKubectl(ns, "delete", "po", "-l", label, fmt.Sprintf("--ignore-not-found=%t", skipNotFound))
 	if err != nil {
 		e2elog.Logf("failed to delete pod %v", err)

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -349,6 +349,31 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("create a PVC and bind it to an app using rbd-nbd mounter", func() {
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"mounter": "rbd-nbd"}, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+				err = validatePVCAndAppBinding(pvcPath, appPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0)
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+			})
+
 			By("create a PVC and bind it to an app with encrypted RBD volume", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -727,17 +727,28 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
-			// TODO: enable this test when we support rbd-nbd mounter in E2E.
-			// nbd module should be present on the host machine to run use the
-			// rbd-nbd mounter.
-
-			// By("create a PVC and Bind it to an app with journaling/exclusive-lock image-features and rbd-nbd mounter", func() {
-			// 	deleteResource(rbdExamplePath + "storageclass.yaml")
-			// 	createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"})
-			// 	validatePVCAndAppBinding(pvcPath, appPath, f)
-			// 	deleteResource(rbdExamplePath + "storageclass.yaml")
-			// 	createRBDStorageClass(f.ClientSet, f, nil, make(map[string]string))
-			// })
+			By("create a PVC and Bind it to an app with journaling/exclusive-lock image-features and rbd-nbd mounter", func() {
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"}, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+				err = validatePVCAndAppBinding(pvcPath, appPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+				}
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+			})
 
 			By("create a PVC clone and bind it to an app", func() {
 				// snapshot beta is only supported from v1.17+


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Validate the basic working of rbd-nbd

**Test cases:**
1. Create a PV with rbd-nbd backend and start the application pod using it
2. After the application pod is started, restart the node plugin and expect the IO to fail as the rbd-nbd process is killed
3. After restarting the node plugin, restart the rbd-nbd process by reattaching/re-mapping the device connection and expect the IO from the application pod to continue


### Dependencies ###
- [x] Requires `ceph/ceph:pacific` which is not yet released
- [x] Depends on `nbd.ko` in minikube, see https://github.com/kubernetes/minikube/pull/10217

Updates: #667