### PR TITLE
Remove losetup workaround in minikube VM

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -130,17 +130,6 @@ function disable_storage_addons() {
     ${minikube} addons disable storage-provisioner 2>/dev/null || true
 }
 
-# minikube has the Busybox losetup, and that does not work with raw-block PVCs.
-# Copy the host losetup executable and hope it works.
-#
-# See https://github.com/kubernetes/minikube/issues/8284
-function minikube_losetup() {
-    # scp should not ask for any confirmation
-    scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$(${minikube} ssh-key)" /sbin/losetup docker@"$(${minikube} ip)":losetup
-    # replace /sbin/losetup symlink with the executable
-    ${minikube} ssh 'sudo sh -c "rm -f /sbin/losetup && cp ~docker/losetup /sbin"'
-}
-
 function minikube_supports_psp() {
     local MINIKUBE_MAJOR
     local MINIKUBE_MINOR
@@ -234,7 +223,6 @@ up)
         wait_for_ssh
         # shellcheck disable=SC2086
         ${minikube} ssh "sudo mkdir -p /mnt/${DISK}/var/lib/rook;sudo ln -s /mnt/${DISK}/var/lib/rook /var/lib/rook"
-        minikube_losetup
     fi
     ${minikube} kubectl -- cluster-info
     ;;


### PR DESCRIPTION
# Describe what this PR does #

Currently the `losetup` executable is copied into the minikube VM because the version of `losetup` inside the VM does not support the `-j` option which is required for BlockMode volumes.

## Related issues ##

See-also: kubernetes/minikube#8284 and kubernetes/minikube#10255

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
