### PR TITLE
deploy, helm: enable secret watch in rbac

### DIFF
--- a/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -15,7 +15,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]


### PR DESCRIPTION
Enables secret 'watch' rbac permission for ceph-csi-rbd-provisioner role in both deploy and helm manifests.

Fixes #1841.

Signed-off-by: Madhu Rajanna (mrajanna@redhat.com)
