### PR TITLE
rbd: fix issue in ENV variable check

### DIFF
--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -133,11 +133,11 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 		// If the configmap is not mounted to the CSI pods read the configmap
 		// the kubernetes.
 		namespace := os.Getenv(podNamespace)
-		if namespace != "" {
+		if namespace == "" {
 			return nil, fmt.Errorf("%q is not set", podNamespace)
 		}
 		name := os.Getenv(kmsConfigMapName)
-		if name != "" {
+		if name == "" {
 			name = defaultConfigMapToRead
 		}
 		config, err = getVaultConfiguration(namespace, name)


### PR DESCRIPTION
Currently, cephcsi is returning an issue if the ENV variable is set, but it should not. This commit fixes the POD_NAMESPACE env variable issue and as well as the KMS_CONFIG_NAME ENV variable.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

