### PR TITLE
util: store EnvVaultInsecure as string, not bool

### DIFF
--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -175,7 +175,7 @@ func (vc *vaultConnection) initConnection(kmsID string, config map[string]interf
 		if err != nil {
 			return fmt.Errorf("failed to parse 'vaultCAVerify': %w", err)
 		}
-		vaultConfig[api.EnvVaultInsecure] = !vaultCAVerify
+		vaultConfig[api.EnvVaultInsecure] = strconv.FormatBool(!vaultCAVerify)
 	}
 
 	vaultCAFromSecret := "" // optional


### PR DESCRIPTION
The configuration option `EnvVaultInsecure` is expected to be a string,
not a boolean. By converting the bool back to a string (after
verification), it is now possible to skip the certificate validation
check by setting `vaultCAVerify: false` in the Vault configuration.

Fixes: #1852

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
