### PR TITLE
helm: Fix plugin socket path

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           args:
             - "--v={{ .Values.logLevel }}"
             - "--csi-address=/csi/{{ .Values.pluginSocketFile }}"
-            - "--kubelet-registration-path={{ .Values.kubeletDir }}/{{ .Values.driverName }}/{{ .Values.pluginSocketFile }}"
+            - "--kubelet-registration-path={{ .Values.kubeletDir }}/plugins/{{ .Values.driverName }}/{{ .Values.pluginSocketFile }}"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -144,7 +144,7 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: "{{ .Values.kubeletDir }}/{{ .Values.driverName }}"
+            path: "{{ .Values.kubeletDir }}/plugins/{{ .Values.driverName }}"
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           args:
             - "--v={{ .Values.logLevel }}"
             - "--csi-address=/csi/{{ .Values.pluginSocketFile }}"
-            - "--kubelet-registration-path={{ .Values.kubeletDir }}/{{ .Values.driverName }}/{{ .Values.pluginSocketFile }}"
+            - "--kubelet-registration-path={{ .Values.kubeletDir }}/plugins/{{ .Values.driverName }}/{{ .Values.pluginSocketFile }}"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -144,7 +144,7 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: "{{ .Values.kubeletDir }}/{{ .Values.driverName }}"
+            path: "{{ .Values.kubeletDir }}/plugins/{{ .Values.driverName }}"
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:


### PR DESCRIPTION
PR #1736 made the kubelet path configurable. It also introduced a change in the path to the CSI socket. By default the path is now `/var/lib/kubelet/cephfs.csi.ceph.com/csi.sock` instead of `/var/lib/kubelet/plugins/cephfs.csi.ceph.com/csi.sock`. This PR restores the old default.