### PR TITLE
rbd: fix encryption of rbd image with VaultToken

### DIFF
--- a/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
@@ -48,6 +48,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
 {{- if .Values.provisioner.resizer.enabled }}
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -52,6 +52,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/design/proposals/encryption-with-vault-tokens.md
+++ b/docs/design/proposals/encryption-with-vault-tokens.md
@@ -203,7 +203,7 @@ kind: secret
 metadata:
   name: vault-infosec-ca
 stringData:
-  ca.cert: |
+  cert: |
     MIIC2DCCAcCgAwIBAgIBATANBgkqh...
 ```
 
@@ -216,7 +216,7 @@ kind: secret
 metadata:
   name: vault-client-cert
 stringData:
-  tls.cert: |
+  cert: |
     BATANBgkqcCgAwIBAgIBATANBAwI...
 ```
 
@@ -229,7 +229,7 @@ kind: secret
 metadata:
   name: vault-client-cert-key
 stringData:
-  tls.key: |
+  key: |
     KNSC2DVVXcCgkqcCgAwIBAgIwewrvx...
 ```
 
@@ -243,10 +243,10 @@ kind: secret
 metadata:
   name: vault-certificates
 stringData:
-  ca.cert: |
+  cert: |
     MIIC2DCCAcCgAwIBAgIBATANBgkqh...
-  tls.cert: |
+  cert: |
     BATANBgkqcCgAwIBAgIBATANBAwI...
-  tls.key: |
+  key: |
     KNSC2DVVXcCgkqcCgAwIBAgIwewrvx...
 ```

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -145,11 +145,11 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 			return nil, fmt.Errorf("failed to read kms configuration from configmap %s in namespace %s: %w",
 				namespace, name, err)
 		}
-	}
-
-	err = json.Unmarshal(content, &config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kms configuration: %w", err)
+	} else {
+		err = json.Unmarshal(content, &config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kms configuration: %w", err)
+		}
 	}
 
 	kmsConfig, ok := config[kmsID].(map[string]interface{})

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/vault/api"
 	loss "github.com/libopenstorage/secrets"
@@ -74,7 +75,7 @@ type vaultTokenConf struct {
 	VaultClientCertFromSecret    string `json:"vaultClientCertFromSecret"`
 	VaultClientCertKeyFromSecret string `json:"vaultClientCertKeyFromSecret"`
 	VaultNamespace               string `json:"vaultNamespace"`
-	VaultCAVerify                bool   `json:"vaultCAVerify"`
+	VaultCAVerify                string `json:"vaultCAVerify"`
 }
 
 func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
@@ -89,9 +90,9 @@ func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 
 	// by default the CA should get verified, only when VaultSkipVerify is
 	// set, verification should be disabled
-	v.VaultCAVerify = true
+	v.VaultCAVerify = "true"
 	if s.VaultSkipVerify != nil {
-		v.VaultCAVerify = *s.VaultSkipVerify
+		v.VaultCAVerify = strconv.FormatBool(*s.VaultSkipVerify)
 	}
 }
 

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -172,6 +172,7 @@ type VaultTokensKMS struct {
 // InitVaultTokensKMS returns an interface to HashiCorp Vault KMS.
 func InitVaultTokensKMS(tenant, kmsID string, config map[string]interface{}) (EncryptionKMS, error) {
 	kms := &VaultTokensKMS{}
+	kms.Tenant = tenant
 	err := kms.initConnection(kmsID, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -328,7 +328,7 @@ func (kms *VaultTokensKMS) initCertificates(config map[string]interface{}) error
 		// if the certificate is not present in tenant namespace get it from
 		// cephcsi pod namespace
 		if apierrs.IsNotFound(err) {
-			certKey, err = getCertificate(csiNamespace, vaultClientCertFromSecret, "key")
+			certKey, err = getCertificate(csiNamespace, vaultClientCertKeyFromSecret, "key")
 			if err != nil {
 				return fmt.Errorf("failed to get client certificate key from secret %s: %w", vaultCAFromSecret, err)
 			}

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -268,14 +268,14 @@ func (kms *VaultTokensKMS) initCertificates(config map[string]interface{}) error
 	}
 	// ignore errConfigOptionMissing, no default was set
 	if vaultCAFromSecret != "" {
-		cert, cErr := getCertificate(kms.Tenant, vaultCAFromSecret, "ca.cert")
+		cert, cErr := getCertificate(kms.Tenant, vaultCAFromSecret, "cert")
 		if cErr != nil && !apierrs.IsNotFound(err) {
 			return fmt.Errorf("failed to get CA certificate from secret %s: %w", vaultCAFromSecret, cErr)
 		}
 		// if the certificate is not present in tenant namespace get it from
 		// cephcsi pod namespace
 		if apierrs.IsNotFound(cErr) {
-			cert, cErr = getCertificate(csiNamespace, vaultCAFromSecret, "ca.cert")
+			cert, cErr = getCertificate(csiNamespace, vaultCAFromSecret, "cert")
 			if cErr != nil {
 				return fmt.Errorf("failed to get CA certificate from secret %s: %w", vaultCAFromSecret, cErr)
 			}
@@ -293,14 +293,14 @@ func (kms *VaultTokensKMS) initCertificates(config map[string]interface{}) error
 	}
 	// ignore errConfigOptionMissing, no default was set
 	if vaultClientCertFromSecret != "" {
-		cert, cErr := getCertificate(kms.Tenant, vaultClientCertFromSecret, "tls.cert")
+		cert, cErr := getCertificate(kms.Tenant, vaultClientCertFromSecret, "cert")
 		if cErr != nil && !apierrs.IsNotFound(cErr) {
 			return fmt.Errorf("failed to get client certificate from secret %s: %w", vaultClientCertFromSecret, cErr)
 		}
 		// if the certificate is not present in tenant namespace get it from
 		// cephcsi pod namespace
 		if apierrs.IsNotFound(cErr) {
-			cert, cErr = getCertificate(csiNamespace, vaultClientCertFromSecret, "tls.cert")
+			cert, cErr = getCertificate(csiNamespace, vaultClientCertFromSecret, "cert")
 			if cErr != nil {
 				return fmt.Errorf("failed to get client certificate from secret %s: %w", vaultCAFromSecret, cErr)
 			}
@@ -319,14 +319,14 @@ func (kms *VaultTokensKMS) initCertificates(config map[string]interface{}) error
 
 	// ignore errConfigOptionMissing, no default was set
 	if vaultClientCertKeyFromSecret != "" {
-		certKey, err := getCertificate(kms.Tenant, vaultClientCertKeyFromSecret, "tls.key")
+		certKey, err := getCertificate(kms.Tenant, vaultClientCertKeyFromSecret, "key")
 		if err != nil && !apierrs.IsNotFound(err) {
 			return fmt.Errorf("failed to get client certificate key from secret %s: %w", vaultClientCertKeyFromSecret, err)
 		}
 		// if the certificate is not present in tenant namespace get it from
 		// cephcsi pod namespace
 		if apierrs.IsNotFound(err) {
-			certKey, err = getCertificate(csiNamespace, vaultClientCertFromSecret, "tls.key")
+			certKey, err = getCertificate(csiNamespace, vaultClientCertFromSecret, "key")
 			if err != nil {
 				return fmt.Errorf("failed to get client certificate key from secret %s: %w", vaultCAFromSecret, err)
 			}

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -271,7 +271,7 @@ func (kms *VaultTokensKMS) initCertificates(config map[string]interface{}) error
 	// ignore errConfigOptionMissing, no default was set
 	if vaultCAFromSecret != "" {
 		cert, cErr := getCertificate(kms.Tenant, vaultCAFromSecret, "cert")
-		if cErr != nil && !apierrs.IsNotFound(err) {
+		if cErr != nil && !apierrs.IsNotFound(cErr) {
 			return fmt.Errorf("failed to get CA certificate from secret %s: %w", vaultCAFromSecret, cErr)
 		}
 		// if the certificate is not present in tenant namespace get it from


### PR DESCRIPTION
This PR fixes the below issues in the KMS encryption.

* Unmarshal the configuration only we read from the file
* Fix error check when reading vaultCAFromSecret
* Fix incorrect reading of client cert key
* Store VaultCAVerify as a string
* Set tenant in kms object
* Change key in secret for cert and tls

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>