### PR TITLE
cephfs: add subvolume path to volume context

### DIFF
--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -138,3 +138,16 @@ func listCephFSSubVolumes(f *framework.Framework, filesystem, groupname string) 
 	}
 	return subVols, nil
 }
+
+// getSubvolumepath validates whether subvolumegroup is present.
+func getSubvolumePath(f *framework.Framework, filesystem, subvolgrp, subvolume string) (string, error) {
+	cmd := fmt.Sprintf("ceph fs subvolume getpath %s %s --group_name=%s", filesystem, subvolume, subvolgrp)
+	stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+	if err != nil {
+		return "", err
+	}
+	if stdErr != "" {
+		return "", fmt.Errorf("failed to getpath for subvolume %s with error %s", subvolume, stdErr)
+	}
+	return strings.TrimSpace(stdOut), nil
+}


### PR DESCRIPTION
There are many use-cases with adding the subvolume path to the PV object. the volume context returned in the createVolumeResponse is added to the PV object by the external provisioner.

More Details about the use cases are in the below link
https://github.com/rook/rook/issues/5471

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

