### PR TITLE
ci: update rook.sh, rook version and ceph cluster version

### DIFF
--- a/build.env
+++ b/build.env
@@ -42,6 +42,8 @@ CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
 ROOK_VERSION=v1.3.9
+# Provide ceph image path
+#ROOK_CEPH_CLUSTER_IMAGE=docker.io/ceph/ceph:v14.2.12
 
 # e2e settings
 # - enable CEPH_CSI_RUN_ALL_TESTS when running tests with if it has root

--- a/build.env
+++ b/build.env
@@ -41,7 +41,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.3.9
+ROOK_VERSION=v1.4.9
 # Provide ceph image path
 #ROOK_CEPH_CLUSTER_IMAGE=docker.io/ceph/ceph:v14.2.12
 

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -E
 
-ROOK_VERSION=${ROOK_VERSION:-"v1.2.7"}
+ROOK_VERSION=${ROOK_VERSION:-"v1.4.9"}
 ROOK_DEPLOY_TIMEOUT=${ROOK_DEPLOY_TIMEOUT:-300}
 ROOK_URL="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/cluster/examples/kubernetes/ceph"
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}


### PR DESCRIPTION
Changes:
1. Add a variable in build.env for rook ceph cluster version.
2. Modify rook.sh to make sure it deploys ceph cluster with
   desirable version rather than the one which rook installs
   by default.
3. Remove the code no longer required:
   a. Code which was added to test snapshot feature.
   b. Code which was required because
      https://github.com/rook/rook/pull/5925 was not fixed.
4. Updated rook version to v1.4.9

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

