### PR TITLE
Remove hostnetworking dependency

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -30,7 +30,6 @@ spec:
 {{- if .Values.nodeplugin.priorityClassName }}
       priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
 {{- end }}
-      hostNetwork: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
@@ -16,7 +16,6 @@ spec:
   fsGroup:
     rule: RunAsAny
   privileged: true
-  hostNetwork: true
   hostPID: true
   runAsUser:
     rule: RunAsAny

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -27,7 +27,6 @@ spec:
         heritage: {{ .Release.Service }}
     spec:
       serviceAccountName: {{ include "ceph-csi-rbd.serviceAccountName.nodeplugin" . }}
-      hostNetwork: true
       hostPID: true
 {{- if .Values.nodeplugin.priorityClassName }}
       priorityClassName: {{ .Values.nodeplugin.priorityClassName }}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
@@ -16,7 +16,6 @@ spec:
   fsGroup:
     rule: RunAsAny
   privileged: true
-  hostNetwork: true
   hostPID: true
   runAsUser:
     rule: RunAsAny

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -14,7 +14,6 @@ spec:
     spec:
       serviceAccountName: cephfs-csi-nodeplugin
       priorityClassName: system-node-critical
-      hostNetwork: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
@@ -10,7 +10,6 @@ spec:
   fsGroup:
     rule: RunAsAny
   privileged: true
-  hostNetwork: true
   hostPID: true
   runAsUser:
     rule: RunAsAny

--- a/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
@@ -33,13 +33,7 @@ spec:
       readOnly: false
     - pathPrefix: '/lib/modules'
       readOnly: true
-    - pathPrefix: '/var/lib/kubelet/pods'
-      readOnly: false
-    - pathPrefix: '/var/lib/kubelet/plugins/rbd.csi.ceph.com'
-      readOnly: false
-    - pathPrefix: '/var/lib/kubelet/plugins_registry'
-      readOnly: false
-    - pathPrefix: '/var/lib/kubelet/plugins'
+    - pathPrefix: '/var/lib/kubelet'
       readOnly: false
 
 ---

--- a/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
@@ -10,7 +10,6 @@ spec:
   fsGroup:
     rule: RunAsAny
   privileged: true
-  hostNetwork: true
   hostPID: true
   runAsUser:
     rule: RunAsAny

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -13,7 +13,6 @@ spec:
         app: csi-rbdplugin
     spec:
       serviceAccountName: rbd-csi-nodeplugin
-      hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -35,6 +35,23 @@ func getDaemonSetLabelSelector(f *framework.Framework, ns, daemonSetName string)
 	return s.String(), nil
 }
 
+// getDeploymentLabelSelector returns labels of deployment given name and namespace dynamically,
+// needed since labels are not same for helm and non-helm deployments.
+func getDeploymentLabelSelector(f *framework.Framework, ns, deploymentName string) (string, error) {
+	dp, err := f.ClientSet.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		e2elog.Logf("Error getting deployment with name %s in namespace %s", deploymentName, ns)
+		return "", err
+	}
+	s, err := metav1.LabelSelectorAsSelector(dp.Spec.Selector)
+	if err != nil {
+		e2elog.Logf("Error parsing %s deployment selector in namespace %s", deploymentName, ns)
+		return "", err
+	}
+	e2elog.Logf("LabelSelector for %s deployment in namespace %s: %s", deploymentName, ns, s.String())
+	return s.String(), nil
+}
+
 func waitForDaemonSets(name, ns string, c kubernetes.Interface, t int) error {
 	timeout := time.Duration(t) * time.Minute
 	start := time.Now()

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1104,10 +1104,23 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create rados namespace with error %v", err)
 					}
 					// delete csi pods
-					err = deletePodWithLabel("app in (ceph-csi-rbd, csi-rbdplugin, csi-rbdplugin-provisioner)",
-						cephCSINamespace, false)
+					selector, err := getDaemonSetLabelSelector(f, cephCSINamespace, rbdDaemonsetName)
 					if err != nil {
-						e2elog.Failf("failed to delete pods with labels with error %v", err)
+						e2elog.Failf("failed to get the daemonset labels with error %v", err)
+					}
+					// delete rbd nodeplugin pods
+					err = deletePodWithLabel(selector, cephCSINamespace, false)
+					if err != nil {
+						e2elog.Failf("fail to delete pod with error %v", err)
+					}
+					selector, err = getDeploymentLabelSelector(f, cephCSINamespace, rbdDeploymentName)
+					if err != nil {
+						e2elog.Failf("failed to get the deployment labels with error %v", err)
+					}
+					// delete rbd provisioner pods
+					err = deletePodWithLabel(selector, cephCSINamespace, false)
+					if err != nil {
+						e2elog.Failf("fail to delete pod with error %v", err)
 					}
 					// wait for csi pods to come up
 					err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)


### PR DESCRIPTION
Cephcsi RBD was using Hostnetworking due to the udev events required for the rbd map and unmap. with https://github.com/ceph/ceph-csi/pull/1450 we don't need hostNetworking for RBD anymore. 
However, CephFS works with pod networking.

