### PR TITLE
ci: request minikube VMs with 12GB RAM

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -65,7 +65,7 @@ function set_env() {
     export GO111MODULE="on"
     export TEST_COVERAGE="stdout"
     export VM_DRIVER="kvm2"
-    export MEMORY="8192"
+    export MEMORY="12288"
     export CEPH_CSI_RUN_ALL_TESTS=true
     # downloading rook images is sometimes slow, extend timeout to 15 minutes
     export ROOK_VERSION=${ROOK_VERSION:-'v1.3.9'}


### PR DESCRIPTION
There are timeouts happening where the logs do not show sufficient
output to diagnose the issue. These timeouts suggests that something
inside the minikube VM is not running as expected. Increasing the RAM to
12GB might help.

The bare-metal systems in the CentOS CI have a minimum of 16GB, so
running a single VM with 12GB should be possible.

See-also: https://wiki.centos.org/QaWiki/PubHardware
Updates: #1867

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
