### PR TITLE
rbd: set encryption passphrase on CreateVolume

### DIFF
--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -189,7 +189,8 @@ possible to encrypt them with ceph-csi by using LUKS encryption.
 
 * create volume request received
 * volume requested to be created in Ceph
-* encrypted state "requiresEncryption" is saved in image-meta in Ceph
+* new passphrase is generated and stored in selected KMS if KMS is in use
+* encrypted state "encryptionPrepared" is saved in image-meta in Ceph
 
 **Attach volume**:
 
@@ -197,8 +198,8 @@ possible to encrypt them with ceph-csi by using LUKS encryption.
 * volume is attached to provisioner container
 * on first time attachment
   (no file system on the attached device, checked with blkid)
-  * new passphrase is generated and stored in selected KMS if KMS is in use
-  * device is encrypted with LUKS using a passphrase from K8s secrets.
+  * passphrase is retrieved from selected KMS if KMS is in use
+  * device is encrypted with LUKS using a passphrase from K8s Secret or KMS
   * image-meta updated to "encrypted" in Ceph
 * passphrase is retrieved from selected KMS if KMS is in use
 * device is open and device path is changed to use a mapper device

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1137,24 +1137,3 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		NodeExpansionRequired: nodeExpansion,
 	}, nil
 }
-
-// setupEncryption configures the metadata of the RBD image for encryption:
-// - the Data-Encryption-Key (DEK) will be generated stored for use by the KMS;
-// - the RBD image will be marked to support encryption in its metadata.
-func (rv *rbdVolume) setupEncryption(ctx context.Context) error {
-	err := util.StoreNewCryptoPassphrase(rv.VolID, rv.KMS)
-	if err != nil {
-		util.ErrorLog(ctx, "failed to save encryption passphrase for "+
-			"image %s: %s", rv.String(), err)
-		return err
-	}
-
-	err = rv.ensureEncryptionMetadataSet(rbdImageRequiresEncryption)
-	if err != nil {
-		util.ErrorLog(ctx, "failed to save encryption status, deleting "+
-			"image %s: %s", rv.String(), err)
-		return err
-	}
-
-	return nil
-}

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ceph/ceph-csi/internal/util"
+)
+
+type rbdEncryptionState string
+
+const (
+	// Encryption statuses for RbdImage
+	rbdImageEncryptionUnknown  = rbdEncryptionState("")
+	rbdImageEncrypted          = rbdEncryptionState("encrypted")
+	rbdImageRequiresEncryption = rbdEncryptionState("requiresEncryption")
+
+	// image metadata key for encryption
+	encryptionMetaKey = ".rbd.csi.ceph.com/encrypted"
+)
+
+// checkRbdImageEncrypted verifies if rbd image was encrypted when created.
+func (rv *rbdVolume) checkRbdImageEncrypted(ctx context.Context) (rbdEncryptionState, error) {
+	value, err := rv.GetMetadata(encryptionMetaKey)
+	if err != nil {
+		util.ErrorLog(ctx, "checking image %s encrypted state metadata failed: %s", rv, err)
+		return rbdImageEncryptionUnknown, err
+	}
+
+	encrypted := rbdEncryptionState(strings.TrimSpace(value))
+	util.DebugLog(ctx, "image %s encrypted state metadata reports %q", rv, encrypted)
+	return encrypted, nil
+}
+
+func (rv *rbdVolume) ensureEncryptionMetadataSet(status rbdEncryptionState) error {
+	err := rv.SetMetadata(encryptionMetaKey, string(status))
+	if err != nil {
+		return fmt.Errorf("failed to save encryption status for %s: %w", rv, err)
+	}
+
+	return nil
+}
+
+// setupEncryption configures the metadata of the RBD image for encryption:
+// - the Data-Encryption-Key (DEK) will be generated stored for use by the KMS;
+// - the RBD image will be marked to support encryption in its metadata.
+func (rv *rbdVolume) setupEncryption(ctx context.Context) error {
+	err := util.StoreNewCryptoPassphrase(rv.VolID, rv.KMS)
+	if err != nil {
+		util.ErrorLog(ctx, "failed to save encryption passphrase for "+
+			"image %s: %s", rv.String(), err)
+		return err
+	}
+
+	err = rv.ensureEncryptionMetadataSet(rbdImageRequiresEncryption)
+	if err != nil {
+		util.ErrorLog(ctx, "failed to save encryption status, deleting "+
+			"image %s: %s", rv.String(), err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -830,7 +830,7 @@ func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rb
 }
 
 func encryptDevice(ctx context.Context, rbdVol *rbdVolume, devicePath string) error {
-	passphrase, err := util.GetCryptoPassphrase(ctx, rbdVol.VolID, rbdVol.KMS)
+	passphrase, err := util.GetCryptoPassphrase(rbdVol.VolID, rbdVol.KMS)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get crypto passphrase for %s: %v",
 			rbdVol, err)
@@ -853,7 +853,7 @@ func encryptDevice(ctx context.Context, rbdVol *rbdVolume, devicePath string) er
 }
 
 func openEncryptedDevice(ctx context.Context, volOptions *rbdVolume, devicePath string) (string, error) {
-	passphrase, err := util.GetCryptoPassphrase(ctx, volOptions.VolID, volOptions.KMS)
+	passphrase, err := util.GetCryptoPassphrase(volOptions.VolID, volOptions.KMS)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get passphrase for encrypted device %s: %v",
 			volOptions, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -53,12 +53,6 @@ const (
 	rbdTaskRemoveCmdInvalidString1      = "no valid command found"
 	rbdTaskRemoveCmdInvalidString2      = "Error EINVAL: invalid command"
 	rbdTaskRemoveCmdAccessDeniedMessage = "Error EACCES:"
-
-	// Encryption statuses for RbdImage
-	rbdImageEncrypted          = "encrypted"
-	rbdImageRequiresEncryption = "requiresEncryption"
-	// image metadata key for encryption
-	encryptionMetaKey = ".rbd.csi.ceph.com/encrypted"
 )
 
 // rbdVolume represents a CSI volume and its RBD image specifics.
@@ -1193,28 +1187,6 @@ func (rv *rbdVolume) SetMetadata(key, value string) error {
 	defer image.Close()
 
 	return image.SetMetadata(key, value)
-}
-
-// checkRbdImageEncrypted verifies if rbd image was encrypted when created.
-func (rv *rbdVolume) checkRbdImageEncrypted(ctx context.Context) (string, error) {
-	value, err := rv.GetMetadata(encryptionMetaKey)
-	if err != nil {
-		util.ErrorLog(ctx, "checking image %s encrypted state metadata failed: %s", rv, err)
-		return "", err
-	}
-
-	encrypted := strings.TrimSpace(value)
-	util.DebugLog(ctx, "image %s encrypted state metadata reports %q", rv, encrypted)
-	return encrypted, nil
-}
-
-func (rv *rbdVolume) ensureEncryptionMetadataSet(status string) error {
-	err := rv.SetMetadata(encryptionMetaKey, status)
-	if err != nil {
-		return fmt.Errorf("failed to save encryption status for %s: %w", rv, err)
-	}
-
-	return nil
 }
 
 func (rv *rbdVolume) listSnapshots() ([]librbd.SnapInfo, error) {

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -67,11 +67,6 @@ type EncryptionKMS interface {
 	GetID() string
 }
 
-// MissingPassphrase is an error instructing to generate new passphrase.
-type MissingPassphrase struct {
-	error
-}
-
 // SecretsKMS is default KMS implementation that means no KMS is in use.
 type SecretsKMS struct {
 	passphrase string

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -331,9 +331,7 @@ func (vc *vaultConnection) GetID() string {
 // data.data.passphrase structure.
 func (kms *VaultKMS) GetPassphrase(key string) (string, error) {
 	s, err := kms.secrets.GetSecret(filepath.Join(kms.vaultPassphrasePath, key), kms.keyContext)
-	if errors.Is(err, loss.ErrInvalidSecretId) {
-		return "", MissingPassphrase{err}
-	} else if err != nil {
+	if err != nil {
 		return "", err
 	}
 

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/vault/api"
-	loss "github.com/libopenstorage/secrets"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -351,9 +350,7 @@ func (kms *VaultTokensKMS) initCertificates(config map[string]interface{}) error
 // data.data.passphrase structure.
 func (kms *VaultTokensKMS) GetPassphrase(key string) (string, error) {
 	s, err := kms.secrets.GetSecret(key, kms.keyContext)
-	if errors.Is(err, loss.ErrInvalidSecretId) {
-		return "", MissingPassphrase{err}
-	} else if err != nil {
+	if err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Have the provisioner create the passphrase for the volume, instead of
doing it lazily at the time the volume is used for the 1st time. This
prevents potential races where pods on different nodes try to store
different passphrases at the (almost) same time.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
