### PR TITLE
util: convert VAULT_SKIP_VERIFY to "vaultCAVerify" KMS option

### DIFF
--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -63,7 +63,7 @@ type standardVault struct {
 	VaultClientCert    string `json:"VAULT_CLIENT_CERT"`
 	VaultClientKey     string `json:"VAULT_CLIENT_KEY"`
 	VaultNamespace     string `json:"VAULT_NAMESPACE"`
-	VaultSkipVerify    *bool  `json:"VAULT_SKIP_VERIFY"`
+	VaultSkipVerify    string `json:"VAULT_SKIP_VERIFY"`
 }
 
 type vaultTokenConf struct {
@@ -91,8 +91,9 @@ func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 	// by default the CA should get verified, only when VaultSkipVerify is
 	// set, verification should be disabled
 	v.VaultCAVerify = "true"
-	if s.VaultSkipVerify != nil {
-		v.VaultCAVerify = strconv.FormatBool(*s.VaultSkipVerify)
+	verify, err := strconv.ParseBool(s.VaultSkipVerify)
+	if err == nil {
+		v.VaultCAVerify = strconv.FormatBool(!verify)
 	}
 }
 


### PR DESCRIPTION
"VAULT_SKIP_VERIFY" is a standard Hashicorp Vault environment variable
(a string) that needs to get converted to the "vaultCAVerify"
configuration option in the Ceph-CSI format.

The value of "VAULT_SKIP_VERIFY" means the reverse of "vaultCAVerify",
this part was missing in the original conversion too.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
