### PR TITLE
e2e: error out in case deploying Hashicorp Vault fails

### DIFF
--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -45,7 +45,7 @@ func deleteVault() {
 func createORDeleteVault(action string) {
 	data, err := replaceNamespaceInTemplate(vaultExamplePath + vaultServicePath)
 	if err != nil {
-		e2elog.Logf("failed to read content from %s %v", vaultExamplePath+vaultServicePath, err)
+		e2elog.Failf("failed to read content from %s %v", vaultExamplePath+vaultServicePath, err)
 	}
 
 	data = strings.ReplaceAll(data, "vault.default", "vault."+cephCSINamespace)
@@ -53,34 +53,34 @@ func createORDeleteVault(action string) {
 	data = strings.ReplaceAll(data, "value: default", "value: "+cephCSINamespace)
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
 	if err != nil {
-		e2elog.Logf("failed to %s vault statefulset %v", action, err)
+		e2elog.Failf("failed to %s vault statefulset %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(vaultExamplePath + vaultRBACPath)
 	if err != nil {
-		e2elog.Logf("failed to read content from %s %v", vaultExamplePath+vaultRBACPath, err)
+		e2elog.Failf("failed to read content from %s %v", vaultExamplePath+vaultRBACPath, err)
 	}
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
 	if err != nil {
-		e2elog.Logf("failed to %s vault statefulset %v", action, err)
+		e2elog.Failf("failed to %s vault statefulset %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(vaultExamplePath + vaultConfigPath)
 	if err != nil {
-		e2elog.Logf("failed to read content from %s %v", vaultExamplePath+vaultConfigPath, err)
+		e2elog.Failf("failed to read content from %s %v", vaultExamplePath+vaultConfigPath, err)
 	}
 	data = strings.ReplaceAll(data, "default", cephCSINamespace)
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
 	if err != nil {
-		e2elog.Logf("failed to %s vault configmap %v", action, err)
+		e2elog.Failf("failed to %s vault configmap %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(vaultExamplePath + vaultPSPPath)
 	if err != nil {
-		e2elog.Logf("failed to read content from %s %v", vaultExamplePath+vaultPSPPath, err)
+		e2elog.Failf("failed to read content from %s %v", vaultExamplePath+vaultPSPPath, err)
 	}
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
 	if err != nil {
-		e2elog.Logf("failed to %s vault psp %v", action, err)
+		e2elog.Failf("failed to %s vault psp %v", action, err)
 	}
 }


### PR DESCRIPTION
Failures when deploying Hashicorp Vault are logged as informative. This
means that testing will continue, even if Vault will not be available.

Instead of logging the errors as INFO, use FAIL so that tests are not
run and the problems are identified early and obviously.

Updates: #1795

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
