### PR TITLE
e2e: log status of PVC when Status.Phase is empty

### DIFF
--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -101,6 +101,11 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 		e2elog.Logf("waiting for PVC %s in state %s to be deleted (%d seconds elapsed)", pvcToDelete.Name, pvcToDelete.Status.String(), int(time.Since(start).Seconds()))
 		pvcToDelete, err = c.CoreV1().PersistentVolumeClaims(pvcToDelete.Namespace).Get(context.TODO(), pvcToDelete.Name, metav1.GetOptions{})
 		if err == nil {
+			if pvcToDelete.Status.Phase == "" {
+				// this is unexpected, an empty Phase is not defined
+				// FIXME: see https://github.com/ceph/ceph-csi/issues/1874
+				e2elog.Logf("PVC %s is in a weird state: %s", pvcToDelete.Name, pvcToDelete.String())
+			}
 			return false, nil
 		}
 		if !apierrs.IsNotFound(err) {


### PR DESCRIPTION
When deleting a PVC fails, the following messages are repeated until a
timeout is hit:

    cephfs-80811 in state &PersistentVolumeClaimStatus{Phase:,AccessModes:[],Capacity:ResourceList{},Conditions:[]PersistentVolumeClaimCondition{},} to be deleted (600 seconds elapsed)

Because the Phase is not set, the PVC seems to be in a strange state. In
case this happens, log all details from the PVC so that we can identify
additional conditions to check for completed deletion.

Updates: #1874

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
