### PR TITLE
ci: read ROOK_CEPH_CLUSTER_IMAGE from build.env if available

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -70,6 +70,7 @@ function set_env() {
     # downloading rook images is sometimes slow, extend timeout to 15 minutes
     export ROOK_VERSION=${ROOK_VERSION:-'v1.3.9'}
     export ROOK_DEPLOY_TIMEOUT=900
+    export ROOK_CEPH_CLUSTER_IMAGE="${ROOK_CEPH_CLUSTER_IMAGE}"
     # use podman for minikube.sh, Docker is not installed on the host
     export CONTAINER_CMD='podman'
 


### PR DESCRIPTION
In case ROOK_CEPH_CLUSTER_IMAGE is set in build.env, use the
version from there.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>
