### PR TITLE
Move RBD encryption functionality into encryption.go

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -818,7 +818,7 @@ func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rb
 
 		switch existingFormat {
 		case "":
-			err = encryptDevice(ctx, volOptions, devicePath)
+			err = volOptions.encryptDevice(ctx, devicePath)
 			if err != nil {
 				return "", fmt.Errorf("failed to encrypt rbd image %s: %w", imageSpec, err)
 			}
@@ -844,29 +844,6 @@ func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rb
 	}
 
 	return devicePath, nil
-}
-
-func encryptDevice(ctx context.Context, rbdVol *rbdVolume, devicePath string) error {
-	passphrase, err := util.GetCryptoPassphrase(rbdVol.VolID, rbdVol.KMS)
-	if err != nil {
-		util.ErrorLog(ctx, "failed to get crypto passphrase for %s: %v",
-			rbdVol, err)
-		return err
-	}
-
-	if err = util.EncryptVolume(ctx, devicePath, passphrase); err != nil {
-		err = fmt.Errorf("failed to encrypt volume %s: %w", rbdVol, err)
-		util.ErrorLog(ctx, err.Error())
-		return err
-	}
-
-	err = rbdVol.ensureEncryptionMetadataSet(rbdImageEncrypted)
-	if err != nil {
-		util.ErrorLog(ctx, err.Error())
-		return err
-	}
-
-	return nil
 }
 
 // xfsSupportsReflink checks if mkfs.xfs supports the "-m reflink=0|1"


### PR DESCRIPTION
This is is an initial PR that introduces `internal/rbd/encryption.go` where functions for encrypted RBD volumes will live.
The current KMS support with RBD images is spread over many different files and functions. Grouping them together, combined with small helper functions will make the code easier to understand and better to maintain.

Other PRs will use this change as a base.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
