### PR TITLE
Use Mergify's defaults section for configuring common options

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,10 @@ defaults:
       bot_account: ceph-csi-bot
     merge:
       bot_account: ceph-csi-bot
+      method: rebase
+      rebase_fallback: merge
+      strict: smart
+      strict_method: rebase
     rebase:
       bot_account: ceph-csi-bot
 
@@ -48,11 +52,7 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label
@@ -79,11 +79,7 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release v1.2.0 branch
@@ -104,11 +100,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "status-success=continuous-integration/travis-ci/pr"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v2.0 branch
@@ -129,11 +121,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "status-success=continuous-integration/travis-ci/pr"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v2.1 branch
@@ -154,11 +142,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "status-success=continuous-integration/travis-ci/pr"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v3.0 branch
@@ -179,11 +163,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "status-success=continuous-integration/travis-ci/pr"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v3.1 branch
@@ -213,11 +193,7 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v3.2 branch
@@ -253,11 +229,7 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: remove outdated approvals on ci/centos
@@ -277,11 +249,7 @@ pull_request_rules:
       - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label on ci/centos
@@ -295,10 +263,6 @@ pull_request_rules:
       - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-        strict_method: rebase
+      merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,13 @@
 ---
+defaults:
+  actions:
+    comment:
+      bot_account: ceph-csi-bot
+    merge:
+      bot_account: ceph-csi-bot
+    rebase:
+      bot_account: ceph-csi-bot
+
 pull_request_rules:
   - name: remove outdated approvals
     conditions:
@@ -42,7 +51,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -74,7 +82,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -90,7 +97,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v1.2.0
     conditions:
-      - author=mergify[bot]
+      - author=ceph-csi-bot
       - base=release-v1.2.0
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -100,7 +107,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -116,7 +122,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v2.0
     conditions:
-      - author=mergify[bot]
+      - author=ceph-csi-bot
       - base=release-v2.0
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -126,7 +132,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -142,7 +147,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v2.1
     conditions:
-      - author=mergify[bot]
+      - author=ceph-csi-bot
       - base=release-v2.1
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -152,7 +157,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -168,7 +172,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v3.0
     conditions:
-      - author=mergify[bot]
+      - author=ceph-csi-bot
       - base=release-v3.0
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -178,7 +182,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -194,7 +197,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v3.1
     conditions:
-      - author=mergify[bot]
+      - author=ceph-csi-bot
       - base=release-v3.1
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -213,7 +216,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -229,7 +231,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v3.2
     conditions:
-      - author=mergify[bot]
+      - author=ceph-csi-bot
       - base=release-v3.2
       - label!=DNM
       - "#approved-reviews-by>=1"
@@ -254,7 +256,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -279,7 +280,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}
@@ -298,7 +298,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        bot_account: ceph-csi-bot
         strict: smart
         strict_method: rebase
       dismiss_reviews: {}


### PR DESCRIPTION
Mergify now supports a `defaults:` section. It can be used to list the common options for actions. By using the `defaults:` section, the configurations file becomes simpler to understand as repetitive options are listed only once.

The updated configuration makes sure to the the @ceph-csi-bot for all actions, and sets the common defaults for the `merge` action.

See-also: https://docs.mergify.io/configuration.html#defaults

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
