### PR TITLE
Add `kubectl` to the start of command

### DIFF
--- a/charts/ceph-csi-cephfs/README.md
+++ b/charts/ceph-csi-cephfs/README.md
@@ -35,7 +35,7 @@ To install the Chart into your Kubernetes cluster
     Create the namespace where Helm should install the components with
 
     ```bash
-     create namespace ceph-csi-cephfs
+    kubectl create namespace ceph-csi-cephfs
     ```
 
     Run the installation


### PR DESCRIPTION
Fixes documentation to add `kubectl` to the start of the command.
