### PR TITLE
e2e: pass namespace once in deletePodWithLabel()

### DIFF
--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -212,7 +212,7 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 }
 
 func deletePodWithLabel(label, ns string, skipNotFound bool) error {
-	_, err := framework.RunKubectl(cephCSINamespace, "delete", "po", "-l", label, fmt.Sprintf("--ignore-not-found=%t", skipNotFound), fmt.Sprintf("--namespace=%s", ns))
+	_, err := framework.RunKubectl(ns, "delete", "po", "-l", label, fmt.Sprintf("--ignore-not-found=%t", skipNotFound))
 	if err != nil {
 		e2elog.Logf("failed to delete pod %v", err)
 	}


### PR DESCRIPTION
Currently framework.RunKubectl() adds `--namespace=...` 2x to the
kubectl command. Once is sufficient.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
