### PR TITLE
ci: prevent parallel builds from causing conflicts

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -108,6 +108,8 @@ node('cico-workspace') {
 					if (rebuild_test_container == 10) {
 						// container needs rebuild, don't pull
 						use_test_image = 'USE_PULLED_IMAGE=no'
+						// build the test image
+						ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make CONTAINER_CMD=podman ENV_CSI_IMAGE_NAME=${ci_registry}/${cached_image} .test-container-id"
 						return
 					}
 
@@ -119,6 +121,8 @@ node('cico-workspace') {
 					if (rebuild_devel_container == 10) {
 						// container needs rebuild, don't pull
 						use_build_image = 'USE_PULLED_IMAGE=no'
+						// build the devel image
+						ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make CONTAINER_CMD=podman ENV_CSI_IMAGE_NAME=${ci_registry}/${cached_image} .devel-container-id"
 						return
 					}
 


### PR DESCRIPTION
When the container image needs to be rebuild, two parallel jobs will try
to attempt that. With recent versions of Podman, this now fails.

When the image needs to be rebuild, do so in the stage where it would
otherwise get pulled. This makes sure the image gets build only once.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
