### PR TITLE
ci: pre-pull ROOK_CEPH_CLUSTER_IMAGE if set

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -144,6 +144,17 @@ node('cico-workspace') {
 				podman_pull(ci_registry, "docker.io", "rook/ceph:${rook_version}")
 			}
 
+			def rook_ceph_cluster_image = sh(
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_CEPH_CLUSTER_IMAGE}\'',
+				returnStdout: true
+			).trim()
+			def d_io_regex = ~"^docker.io/"
+
+			if (rook_ceph_cluster_image != '') {
+				// single-node-k8s.sh pushes the image into minikube
+				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
+			}
+
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -141,6 +141,17 @@ node('cico-workspace') {
 				podman_pull(ci_registry, "docker.io", "rook/ceph:${rook_version}")
 			}
 
+			def rook_ceph_cluster_image = sh(
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_CEPH_CLUSTER_IMAGE}\'',
+				returnStdout: true
+			).trim()
+			def d_io_regex = ~"^docker.io/"
+
+			if (rook_ceph_cluster_image != '') {
+				// single-node-k8s.sh pushes the image into minikube
+				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
+			}
+
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}

--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -142,6 +142,12 @@ then
     ./podman2minikube.sh "${BASE_IMAGE}"
 fi
 
+# Rook also uses ceph/ceph:v15 (build.env:ROOK_CEPH_CLUSTER_IMAGE), so push it into the VM
+if [ -n "${ROOK_CEPH_CLUSTER_IMAGE}" ] && podman inspect "${ROOK_CEPH_CLUSTER_IMAGE}" > /dev/null
+then
+    ./podman2minikube.sh "${ROOK_CEPH_CLUSTER_IMAGE}"
+fi
+
 deploy_rook
 
 # running e2e.test requires librados and librbd


### PR DESCRIPTION
After the introduction of ROOK_CEPH_CLUSTER_IMAGE in build.env, the
additional image needs to get pulled from the CI registry mirror and
pushed into the minikube VM.

Without this addition, the Docker Hub pull limits may prevent deploying
Rook.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
