### PR TITLE
build: libcephfs-devel is not needed

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -24,7 +24,7 @@ RUN source /build.env && \
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 
 RUN dnf -y install \
-	libcephfs-devel librados-devel librbd-devel \
+	librados-devel librbd-devel \
 	/usr/bin/cc \
 	make \
 	git \

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -24,8 +24,8 @@ it is **highly** encouraged to:
 * Ceph-CSI uses the native Ceph libraries through the [go-ceph
    package](https://github.com/ceph/go-ceph). It is required to install the
    Ceph C headers in order to compile Ceph-CSI. The packages are called
-   `libcephfs-devel`, `librados-devel` and `librbd-devel` on many Linux
-   distributions. See the [go-ceph installaton
+   `librados-devel` and `librbd-devel` on many Linux distributions. See the
+   [go-ceph installaton
    instructions](https://github.com/ceph/go-ceph#installation) for more
    details.
 * Run

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -43,9 +43,9 @@ if [ -n "$(command -v go)" ]; then
 	# based systems.
 	if ! go run -mod=vendor "${LIBCHECK}" > /dev/null; then
 		if [ -n "${RPM_CMD}" ]; then
-			echo "Packages libcephfs-devel librbd-devel librados-devel need to be installed"
+			echo "Packages librbd-devel librados-devel need to be installed"
 		elif [ -n "${DPKG_CMD}" ]; then
-			echo "Packages libcephfs-dev librbd-dev librados-dev need to be installed"
+			echo "Packages librbd-dev librados-dev need to be installed"
 		else
 			fail "error can't verify Ceph development headers"
 		fi


### PR DESCRIPTION
go-ceph does not  use CephFS development headers, so there is no need to
install libcephfs-devel.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
