### PR TITLE
rbd: write max 1gb per WriteSame() operation

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -333,15 +333,52 @@ func (rv *rbdVolume) allocate(offset uint64) error {
 		return err
 	}
 
-	// zeroBlock is the stripe-period: size of the object-size multiplied
+	// blockSize is the stripe-period: size of the object-size multiplied
 	// by the stripe-count
-	zeroBlock := make([]byte, sc*(1<<st.Order))
+	blockSize := sc * (1 << st.Order)
+	zeroBlock := make([]byte, blockSize)
 
 	// the actual size of the image as available in the pool, can be
 	// marginally different from the requested image size
-	_, err = image.WriteSame(offset, st.Size-offset, zeroBlock, rados.OpFlagNone)
+	size := st.Size - offset
 
-	return err
+	// In case the remaining space on the volume is smaller than blockSize,
+	// write a partial block with WriteAt() after this loop.
+	for size > blockSize {
+		writeSize := size
+		// write a maximum of 1GB per WriteSame() call
+		if size > helpers.GiB {
+			writeSize = helpers.GiB
+		}
+
+		// round down to the size of a zeroBlock
+		if (writeSize % blockSize) != 0 {
+			writeSize = (writeSize / blockSize) * blockSize
+		}
+
+		_, err = image.WriteSame(offset, writeSize, zeroBlock,
+			rados.OpFlagNone)
+		if err != nil {
+			return fmt.Errorf("failed to allocate %d/%d bytes at "+
+				"offset %d: %w", writeSize, blockSize, offset, err)
+		}
+
+		// write succeeded
+		size -= writeSize
+		offset += writeSize
+	}
+
+	// write the last remaining bytes, in case the image size can not be
+	// written with the optimal blockSize
+	if size != 0 {
+		_, err = image.WriteAt(zeroBlock[:size], int64(offset))
+		if err != nil {
+			return fmt.Errorf("failed to allocate %d bytes at "+
+				"offset %d: %w", size, offset, err)
+		}
+	}
+
+	return nil
 }
 
 // isInUse checks if there is a watcher on the image. It returns true if there


### PR DESCRIPTION
# Describe what this PR does #

It seems that writing more than 1 GiB per WriteSame() operation causes
an EINVAL (22) "Invalid argument" error. Splitting the writes in blocks
of maximum 1 GiB should prevent that from happening.

Not all volumes are of a size that is the multiple of the stripe-size.
WriteSame() needs to write full blocks of data, so in case there is a
small left-over, it will be filled with WriteAt().

## Testing ##

Manual testing with thick-provisioning was done with different sizes of
volumes, ranging from 50 MB to 250 GB. This uncovered an other issue
when the size of the volume is not a multiple of the stripe-size.

Large thick-provisioned volumes are slow in getting to the Bound state.
Warnings might be logged as Kubernetes Events. These warnings may
not be fatal, provisioning the volume will continue in the background (as
long as the provisioner Pod is not restarted).

Example of the Events:
```
2m31s       Normal    ExternalProvisioning    persistentvolumeclaim/thick-50gb   waiting for a volume to be created, either by external provisioner "rbd.csi.ceph.com" or manually created by system administrator
95s         Normal    Provisioning            persistentvolumeclaim/thick-50gb   External provisioner is provisioning volume for claim "default/thick-50gb"
5m49s       Warning   ProvisioningFailed      persistentvolumeclaim/thick-50gb   failed to provision volume with StorageClass "ceph-rbd-thick": rpc error: code = DeadlineExceeded desc = context deadline exceeded
3m43s       Warning   ProvisioningFailed      persistentvolumeclaim/thick-50gb   failed to provision volume with StorageClass "ceph-rbd-thick": rpc error: code = Aborted desc = an operation with the given Volume ID pvc-ebc02ff0-7e54-4bff-9157-0e7ce4120818 already exists
95s         Normal    ProvisioningSucceeded   persistentvolumeclaim/thick-50gb   Successfully provisioned volume pvc-ebc02ff0-7e54-4bff-9157-0e7ce4120818
```

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
