### PR TITLE
e2e: add function to exe commands inside plugin container

### DIFF
--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -125,6 +125,36 @@ func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOpti
 	return stdOut, stdErr, err
 }
 
+func execCommandInRbdPluginPod(f *framework.Framework, c, ns string) (string, string, error) {
+	opt := &metav1.ListOptions{
+		LabelSelector: rbdPluginPodLabel,
+	}
+	podPot, err := getCommandInPodOpts(f, c, ns, opt, rbdPluginContainerName)
+	if err != nil {
+		return "", "", err
+	}
+	stdOut, stdErr, err := f.ExecWithOptions(podPot)
+	if stdErr != "" {
+		e2elog.Logf("stdErr occurred: %v", stdErr)
+	}
+	return stdOut, stdErr, err
+}
+
+func execCommandInCephfsPluginPod(f *framework.Framework, c, ns string) (string, string, error) {
+	opt := &metav1.ListOptions{
+		LabelSelector: cephfsPluginPodLabel,
+	}
+	podPot, err := getCommandInPodOpts(f, c, ns, opt, cephfsPluginContainerName)
+	if err != nil {
+		return "", "", err
+	}
+	stdOut, stdErr, err := f.ExecWithOptions(podPot)
+	if stdErr != "" {
+		e2elog.Logf("stdErr occurred: %v", stdErr)
+	}
+	return stdOut, stdErr, err
+}
+
 func execCommandInToolBoxPod(f *framework.Framework, c, ns string) (string, string, error) {
 	opt := &metav1.ListOptions{
 		LabelSelector: rookTolBoxPodLabel,

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -28,8 +28,12 @@ const (
 	defaultNs     = "default"
 	vaultSecretNs = "/secret/ceph-csi/"
 
-	rookTolBoxPodLabel = "app=rook-ceph-tools"
-	rbdmountOptions    = "mountOptions"
+	rookTolBoxPodLabel        = "app=rook-ceph-tools"
+	rbdPluginPodLabel         = "app=csi-rbdplugin"
+	cephfsPluginPodLabel      = "app=csi-cephfsplugin"
+	rbdPluginContainerName    = "csi-rbdplugin"
+	cephfsPluginContainerName = "csi-cephfsplugin"
+	rbdmountOptions           = "mountOptions"
 
 	retainPolicy = v1.PersistentVolumeReclaimRetain
 	// deletePolicy is the default policy in E2E.


### PR DESCRIPTION
# Describe what this PR does #

* added support for container names in `getCommandInPodOpts`, Previously only provided execOptions for first container in list.
    Now optional argument containerName can be passed to get execOptions for a particular container.

* added `execCommandInRbdPluginPod` and  `execCommandInCephfsPluginPod`
    Added function to execute commands inside rbd and cephfs plugin
    containers.

## Is there anything that requires special attention ##

Provide any external context for the change, if any.

* https://github.com/ceph/ceph-csi/pull/1904 : need this function to add e2e to validate unmountvolume function.

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
