### PR TITLE
deploy: Changes needed to migrate from v1beta1 to v1 snapshot APIs

### DIFF
--- a/build.env
+++ b/build.env
@@ -25,7 +25,7 @@ GOSEC_VERSION=v2.3.0
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases
-SNAPSHOT_VERSION=v3.0.1
+SNAPSHOT_VERSION=v4.0.0
 
 # "go test" configuration
 # set to stdout or html to enable coverage reporting, disabled by default

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -76,7 +76,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.2
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -63,7 +63,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.2
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -52,11 +52,20 @@ fuse client or rbd-nbd as of now.
 This guide will walk you through the steps to upgrade the software in a cluster
 from v3.0 to v3.1
 
-### snapshot-controller and snapshot Beta CRD
+### Snapshot-controller
 
 Its kubernetes distributor responsibility to install new snapshot
-controller and snapshot beta CRD. more info can be found
+controller and snapshot CRD. more info can be found
 [here](https://github.com/kubernetes-csi/external-snapshotter/tree/master#usage)
+
+#### Snapshot API version support matrix
+
+| Snapshot API version | Kubernetes Version   | Snapshot-Controller + CRDs Version | Sidecar Version        |
+| -------------------- | -------------------- | ---------------------------------- | ---------------------- |
+| v1beta1              | v1.17 =< k8s < v1.20 | v2.x =< snapshot-controller < v4.x | sidecar >= v2.x        |
+| v1                   | k8s >= v1.20         | snapshot-controller >= v4.x        | sidecar >= v2.x        |
+
+**Note:** We recommend to use {sidecar, controller, crds} of same version
 
 ## Upgrading from v1.2 to v2.0
 

--- a/docs/snap-clone.md
+++ b/docs/snap-clone.md
@@ -33,7 +33,7 @@
     `SNAPSHOT_VERSION` variable, for example:
 
     ```console
-    SNAPSHOT_VERSION="v3.0.1" ./scripts/install-snapshot.sh install
+    SNAPSHOT_VERSION="v4.0.0" ./scripts/install-snapshot.sh install
     ```
 
   - In the future, you can choose to cleanup by running

--- a/examples/cephfs/snapshot.yaml
+++ b/examples/cephfs/snapshot.yaml
@@ -1,5 +1,13 @@
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+# Snapshot API version compatibility matrix:
+# v1betav1:
+#   v1.17 =< k8s < v1.20
+#   2.x =< snapshot-controller < v4.x
+# v1:
+#   k8s >= v1.20
+#   snapshot-controller >= v4.x
+# We recommend to use {sidecar, controller, crds} of same version
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: cephfs-pvc-snapshot

--- a/examples/cephfs/snapshotclass.yaml
+++ b/examples/cephfs/snapshotclass.yaml
@@ -1,5 +1,13 @@
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+# Snapshot API version compatibility matrix:
+# v1betav1:
+#   v1.17 =< k8s < v1.20
+#   2.x =< snapshot-controller < v4.x
+# v1:
+#   k8s >= v1.20
+#   snapshot-controller >= v4.x
+# We recommend to use {sidecar, controller, crds} of same version
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-cephfsplugin-snapclass

--- a/examples/rbd/snapshot.yaml
+++ b/examples/rbd/snapshot.yaml
@@ -1,5 +1,13 @@
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+# Snapshot API version compatibility matrix:
+# v1betav1:
+#   v1.17 =< k8s < v1.20
+#   2.x =< snapshot-controller < v4.x
+# v1:
+#   k8s >= v1.20
+#   snapshot-controller >= v4.x
+# We recommend to use {sidecar, controller, crds} of same version
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: rbd-pvc-snapshot

--- a/examples/rbd/snapshotclass.yaml
+++ b/examples/rbd/snapshotclass.yaml
@@ -1,5 +1,13 @@
 ---
-apiVersion: snapshot.storage.k8s.io/v1beta1
+# Snapshot API version compatibility matrix:
+# v1betav1:
+#   v1.17 =< k8s < v1.20
+#   2.x =< snapshot-controller < v4.x
+# v1:
+#   k8s >= v1.20
+#   snapshot-controller >= v4.x
+# We recommend to use {sidecar, controller, crds} of same version
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-rbdplugin-snapclass

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(dirname "${0}")"
 # shellcheck source=build.env
 source "${SCRIPT_DIR}/../build.env"
 
-SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v3.0.1"}
+SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v4.0.0"}
 
 TEMP_DIR="$(mktemp -d)"
 SNAPSHOTTER_URL="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOT_VERSION}"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
As the [external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter) is moving towards [v1 from v1betav1](https://github.com/kubernetes-csi/external-snapshotter/blob/master/CHANGELOG/CHANGELOG-4.0.md#api-changes) snapshot APIs, we need to update our snapshot (Controller, CRDs at CI) and sidecar image versions, and docs

## Is there anything that requires special attention ##
Is the change backward compatible?

Here is the list of scenarios and their respective steps that I have validated:

Scenario 1:
---
**Setup:** k8s-1.20 | sidecar v3.x  | controller v3.x (only with v1beta1 API)
* Create few snapshots with {k1.20, sidecar v3.x, controller v3.x} setup
* Try to restore to pvc on the same

Scenario 2:
---
**Setup:** k8s-1.20 | sidecar v3.x  | controller v4.x  (with v1 and v1beta1 APIs)
* Create few snapshots on {k1.20, sidecar v3.x, controller v3.x} setup
* Upgrade controller+crds from v3.x-> v4.x, try to restore pvc
* Create new snapshots with v1beta API (of VolumeSnapshot) and try to restore pvc
* Create new snapshots with v1 API (both v1 of VolumeSnapshotClass and VolumeSnapshot) versions and try to restore pvc

Scenario 3:
---
**Setup:** k8s-1.20 | sidecar v4.x | controller v4.x (with v1 and v1beta1 APIs)
* Create few snapshots on {k1.20, sidecar v3.x, controller v3.x using v1beta1 snapshot API} and {k1.20, sidecar v3.x, controller v4.x, using v1 and v1beta1 snapshot API} setups
* Upgrade controller+crds and sidecar from v3.x-> v4.x, try to restore to pvc from snapshot created on   {k1.20, sidecar v3.x, controller v3.x using v1beta1 snapshot API} and {k1.20, sidecar v3.x, controller v4.x, using v1 and v1beta1 snapshot API} setups
* Create new snapshots with v1beta API (of VolumeSnapshot) and try to restore pvc
* Create new snapshots with v1 API (both v1 of VolumeSnapshotClass and VolumeSnapshot) versions and try to restore pvc

Scenario 4:
---
**Setup:** k8s-1.19 | sidecar v3.x  | controller v3.x (only with v1beta1 API)
* Create few snapshots with {k1.19, sidecar v3.x, controller v3.x} setup
* Try to restore to pvc on the same

Please find the validation results history and command outputs here [ValidateIssue#1803.txt](https://github.com/ceph/ceph-csi/files/6129023/ValidateIssue.1803.txt)

## Related issues ##

Fixes: #1803
