### PR TITLE
rbd: introduce rbdImage as base for rbdVolume and rbdSnapshot

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -46,10 +46,10 @@ import (
 func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) (bool, error) {
 	// generate temp cloned volume
 	tempClone := rv.generateTempClone()
-	snap := &rbdSnapshot{
-		RbdSnapName: rv.RbdImageName,
-		Pool:        rv.Pool,
-	}
+	snap := &rbdSnapshot{}
+	snap.RbdSnapName = rv.RbdImageName
+	snap.Pool = rv.Pool
+
 	// check if cloned image exists
 	err := rv.getImageInfo()
 	if err == nil {
@@ -145,18 +145,17 @@ func (rv *rbdVolume) generateTempClone() *rbdVolume {
 func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVolume) error {
 	// generate temp cloned volume
 	tempClone := rv.generateTempClone()
-	tempSnap := &rbdSnapshot{
-		// snapshot name is same as temporary cloned image, This helps to
-		// flatten the temporary cloned images as we cannot have more than 510
-		// snapshots on an rbd image
-		RbdSnapName: tempClone.RbdImageName,
-		Pool:        rv.Pool,
-	}
+	// snapshot name is same as temporary cloned image, This helps to
+	// flatten the temporary cloned images as we cannot have more than 510
+	// snapshots on an rbd image
+	tempSnap := &rbdSnapshot{}
+	tempSnap.RbdSnapName = tempClone.RbdImageName
+	tempSnap.Pool = rv.Pool
 
-	cloneSnap := &rbdSnapshot{
-		RbdSnapName: rv.RbdImageName,
-		Pool:        rv.Pool,
-	}
+	cloneSnap := &rbdSnapshot{}
+	cloneSnap.RbdSnapName = rv.RbdImageName
+	cloneSnap.Pool = rv.Pool
+
 	var (
 		errClone   error
 		errFlatten error

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -467,13 +467,13 @@ func (cs *ControllerServer) createBackingImage(ctx context.Context, cr *util.Cre
 
 	switch {
 	case rbdSnap != nil:
-		if err = cs.OperationLocks.GetRestoreLock(rbdSnap.SnapID); err != nil {
+		if err = cs.OperationLocks.GetRestoreLock(rbdSnap.VolID); err != nil {
 			util.ErrorLog(ctx, err.Error())
 			return status.Error(codes.Aborted, err.Error())
 		}
-		defer cs.OperationLocks.ReleaseRestoreLock(rbdSnap.SnapID)
+		defer cs.OperationLocks.ReleaseRestoreLock(rbdSnap.VolID)
 
-		err = cs.createVolumeFromSnapshot(ctx, cr, rbdVol, rbdSnap.SnapID)
+		err = cs.createVolumeFromSnapshot(ctx, cr, rbdVol, rbdSnap.VolID)
 		if err != nil {
 			return err
 		}
@@ -813,7 +813,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			return &csi.CreateSnapshotResponse{
 				Snapshot: &csi.Snapshot{
 					SizeBytes:      rbdSnap.SizeBytes,
-					SnapshotId:     rbdSnap.SnapID,
+					SnapshotId:     rbdSnap.VolID,
 					SourceVolumeId: rbdSnap.SourceVolumeID,
 					CreationTime:   rbdSnap.CreatedAt,
 					ReadyToUse:     false,
@@ -831,7 +831,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		return &csi.CreateSnapshotResponse{
 			Snapshot: &csi.Snapshot{
 				SizeBytes:      rbdSnap.SizeBytes,
-				SnapshotId:     rbdSnap.SnapID,
+				SnapshotId:     rbdSnap.VolID,
 				SourceVolumeId: rbdSnap.SourceVolumeID,
 				CreationTime:   rbdSnap.CreatedAt,
 				ReadyToUse:     true,

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -171,7 +171,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 	rbdSnap.CreatedAt = vol.CreatedAt
 	rbdSnap.SizeBytes = vol.VolSize
 	// found a snapshot already available, process and return its information
-	rbdSnap.SnapID, err = util.GenerateVolID(ctx, rbdSnap.Monitors, cr, snapData.ImagePoolID, rbdSnap.Pool,
+	rbdSnap.VolID, err = util.GenerateVolID(ctx, rbdSnap.Monitors, cr, snapData.ImagePoolID, rbdSnap.Pool,
 		rbdSnap.ClusterID, snapUUID, volIDVersion)
 	if err != nil {
 		return false, err
@@ -208,7 +208,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 	}
 
 	util.DebugLog(ctx, "found existing image (%s) with name (%s) for request (%s)",
-		rbdSnap.SnapID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
+		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
 	return true, nil
 }
 
@@ -349,14 +349,14 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 		return err
 	}
 
-	rbdSnap.SnapID, err = util.GenerateVolID(ctx, rbdSnap.Monitors, cr, imagePoolID, rbdSnap.Pool,
+	rbdSnap.VolID, err = util.GenerateVolID(ctx, rbdSnap.Monitors, cr, imagePoolID, rbdSnap.Pool,
 		rbdSnap.ClusterID, rbdSnap.ReservedID, volIDVersion)
 	if err != nil {
 		return err
 	}
 
 	util.DebugLog(ctx, "generated Volume ID (%s) and image name (%s) for request name (%s)",
-		rbdSnap.SnapID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
+		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
 
 	return nil
 }

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -491,7 +491,8 @@ func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName strin
 	)
 
 	options = make(map[string]string)
-	rbdVol = &rbdVolume{VolID: volumeID}
+	rbdVol = &rbdVolume{}
+	rbdVol.VolID = volumeID
 
 	err := vi.DecomposeCSIID(rbdVol.VolID)
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -116,7 +116,7 @@ type rbdSnapshot struct {
 	// SourceVolumeID is the volume ID of RbdImageName, that is exchanged with CSI drivers
 	// RbdImageName is the name of the RBD image, that is this rbdSnapshot's source image
 	// RbdSnapName is the name of the RBD snapshot backing this rbdSnapshot
-	// SnapID is the snapshot ID that is exchanged with CSI drivers, identifying this rbdSnapshot
+	// VolID is the snapshot ID that is exchanged with CSI drivers, identifying this rbdSnapshot
 	// RequestName is the CSI generated snapshot name for the rbdSnapshot
 	// JournalPool is the ceph pool in which the CSI snapshot Journal is stored
 	// Pool is where the image snapshot journal and snapshot is stored, and could be the same as `JournalPool`
@@ -126,7 +126,7 @@ type rbdSnapshot struct {
 	ReservedID     string
 	NamePrefix     string
 	RbdSnapName    string
-	SnapID         string
+	VolID          string
 	ImageID        string
 	Monitors       string
 	JournalPool    string
@@ -696,11 +696,11 @@ func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID str
 	)
 	options = make(map[string]string)
 
-	rbdSnap.SnapID = snapshotID
+	rbdSnap.VolID = snapshotID
 
-	err := vi.DecomposeCSIID(rbdSnap.SnapID)
+	err := vi.DecomposeCSIID(rbdSnap.VolID)
 	if err != nil {
-		util.ErrorLog(ctx, "error decoding snapshot ID (%s) (%s)", err, rbdSnap.SnapID)
+		util.ErrorLog(ctx, "error decoding snapshot ID (%s) (%s)", err, rbdSnap.VolID)
 		return err
 	}
 

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -82,7 +82,7 @@ func cleanUpSnapshot(ctx context.Context, parentVol *rbdVolume, rbdSnap *rbdSnap
 func generateVolFromSnap(rbdSnap *rbdSnapshot) *rbdVolume {
 	vol := new(rbdVolume)
 	vol.ClusterID = rbdSnap.ClusterID
-	vol.VolID = rbdSnap.SnapID
+	vol.VolID = rbdSnap.VolID
 	vol.Monitors = rbdSnap.Monitors
 	vol.Pool = rbdSnap.Pool
 	vol.JournalPool = rbdSnap.JournalPool


### PR DESCRIPTION
Because rbdVolume and rbdSnapshot are very similar, they can be based
off a common struct rbdImage that contains the common attributes and
functions.

This makes it possible to re-use functions for snapshots, and prevents
further duplication or code.

Updates: #1470

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
