### PR TITLE
rbd: copy passphrase for encrypted clones

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -281,6 +281,7 @@ var _ = Describe("RBD", func() {
 			appSmartClonePath := rbdExamplePath + "pod-clone.yaml"
 			appBlockSmartClonePath := rbdExamplePath + "block-pod-clone.yaml"
 			snapshotPath := rbdExamplePath + "snapshot.yaml"
+			defaultCloneCount := 10
 
 			By("checking provisioner deployment is running", func() {
 				err := waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
@@ -496,14 +497,14 @@ var _ = Describe("RBD", func() {
 			By("create a PVC clone and bind it to an app", func() {
 				// snapshot beta is only supported from v1.17+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
-					validatePVCSnapshot(pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, false, f)
+					validatePVCSnapshot(defaultCloneCount, pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, false, f)
 				}
 			})
 
 			By("create a PVC-PVC clone and bind it to an app", func() {
 				// pvc clone is only supported from v1.16+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
-					validatePVCClone(pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, false, f)
+					validatePVCClone(defaultCloneCount, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, false, f)
 				}
 			})
 
@@ -525,7 +526,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCSnapshot(pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, true, f)
+				validatePVCSnapshot(1, pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, true, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -555,7 +556,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCClone(pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, true, f)
+				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, true, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -580,7 +581,7 @@ var _ = Describe("RBD", func() {
 				}
 				// pvc clone is only supported from v1.16+
 				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
-					validatePVCClone(rawPvcPath, rawAppPath, pvcBlockSmartClonePath, appBlockSmartClonePath, false, f)
+					validatePVCClone(defaultCloneCount, rawPvcPath, rawAppPath, pvcBlockSmartClonePath, appBlockSmartClonePath, false, f)
 				}
 			})
 			By("create/delete multiple PVCs and Apps", func() {

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -136,6 +136,17 @@ func createRBDSnapshotClass(f *framework.Framework) error {
 	return err
 }
 
+func deleteRBDSnapshotClass() error {
+	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "snapshotclass.yaml")
+	sc := getSnapshotClass(scPath)
+
+	sclient, err := newSnapshotClient()
+	if err != nil {
+		return err
+	}
+	return sclient.SnapshotV1beta1().VolumeSnapshotClasses().Delete(context.TODO(), sc.Name, metav1.DeleteOptions{})
+}
+
 func createCephFSSnapshotClass(f *framework.Framework) error {
 	scPath := fmt.Sprintf("%s/%s", cephfsExamplePath, "snapshotclass.yaml")
 	sc := getSnapshotClass(scPath)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	scv1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -648,6 +649,262 @@ func validatePVCClone(sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPat
 		e2elog.Failf("deleting PVCs and applications failed, %d errors were logged", failed)
 	}
 
+	validateRBDImageCount(f, 0)
+}
+
+// nolint:gocyclo,gocognit // reduce complexity
+func validatePVCSnapshot(pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath string, validateEncryption bool, f *framework.Framework) {
+	var wg sync.WaitGroup
+	totalCount := 10
+	wgErrs := make([]error, totalCount)
+	chErrs := make([]error, totalCount)
+	wg.Add(totalCount)
+
+	err := createRBDSnapshotClass(f)
+	if err != nil {
+		e2elog.Failf("failed to create storageclass with error %v", err)
+	}
+	defer func() {
+		err = deleteRBDSnapshotClass()
+		if err != nil {
+			e2elog.Failf("failed to delete VolumeSnapshotClass: %v", err)
+		}
+	}()
+
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		e2elog.Failf("failed to load PVC with error %v", err)
+	}
+	label := make(map[string]string)
+	pvc.Namespace = f.UniqueName
+	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		e2elog.Failf("failed to create PVC with error %v", err)
+	}
+	app, err := loadApp(appPath)
+	if err != nil {
+		e2elog.Failf("failed to load app with error %v", err)
+	}
+	// write data in PVC
+	label[appKey] = appLabel
+	app.Namespace = f.UniqueName
+	app.Labels = label
+	opt := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
+	}
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	checkSum, err := writeDataAndCalChecksum(app, &opt, f)
+	if err != nil {
+		e2elog.Failf("failed to calculate checksum with error %v", err)
+	}
+	validateRBDImageCount(f, 1)
+	snap := getSnapshot(snapshotPath)
+	snap.Namespace = f.UniqueName
+	snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+	// create snapshot
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, s v1beta1.VolumeSnapshot) {
+			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = createSnapshot(&s, deployTimeout)
+			w.Done()
+		}(&wg, i, snap)
+	}
+	wg.Wait()
+
+	failed := 0
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to create snapshot (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		e2elog.Failf("creating snapshots failed, %d errors were logged", failed)
+	}
+
+	// total images in cluster is 1 parent rbd image+ total snaps
+	validateRBDImageCount(f, totalCount+1)
+	pvcClone, err := loadPVC(pvcClonePath)
+	if err != nil {
+		e2elog.Failf("failed to load PVC with error %v", err)
+	}
+	appClone, err := loadApp(appClonePath)
+	if err != nil {
+		e2elog.Failf("failed to load application with error %v", err)
+	}
+	pvcClone.Namespace = f.UniqueName
+	appClone.Namespace = f.UniqueName
+	pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s%d", f.UniqueName, 0)
+
+	// create multiple PVC from same snapshot
+	wg.Add(totalCount)
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			label := make(map[string]string)
+			label[appKey] = name
+			a.Labels = label
+			opt := metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
+			}
+			wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
+			if wgErrs[n] == nil {
+				filePath := a.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
+				checkSumClone := ""
+				e2elog.Logf("calculating checksum clone for filepath %s", filePath)
+				checkSumClone, chErrs[n] = calculateSHA512sum(f, &a, filePath, &opt)
+				e2elog.Logf("checksum value for the clone is %s with pod name %s", checkSumClone, name)
+				if chErrs[n] != nil {
+					e2elog.Logf("failed to calculte checksum for clone with error %s", chErrs[n])
+				}
+				if checkSumClone != checkSum {
+					e2elog.Logf("checksum value didn't match. checksum=%s and checksumclone=%s", checkSum, checkSumClone)
+				}
+			}
+			if wgErrs[n] == nil && validateEncryption {
+				wgErrs[n] = validateEncryptedPVC(f, &p, &a)
+			}
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to create PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		e2elog.Failf("creating PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	for i, err := range chErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to calculate checksum (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		e2elog.Failf("calculating checksum failed, %d errors were logged", failed)
+	}
+	// total images in cluster is 1 parent rbd image+ total
+	// snaps+ total clones
+	totalCloneCount := totalCount + totalCount + 1
+	validateRBDImageCount(f, totalCloneCount)
+	wg.Add(totalCount)
+	// delete clone and app
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			p.Spec.DataSource.Name = name
+			wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to delete PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		e2elog.Failf("deleting PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	// total images in cluster is 1 parent rbd image+ total
+	// snaps
+	validateRBDImageCount(f, totalCount+1)
+	// create clones from different snapshots and bind it to an
+	// app
+	wg.Add(totalCount)
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			p.Spec.DataSource.Name = name
+			wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to create PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		e2elog.Failf("creating PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	// total images in cluster is 1 parent rbd image+ total
+	// snaps+ total clones
+	totalCloneCount = totalCount + totalCount + 1
+	validateRBDImageCount(f, totalCloneCount)
+	// delete parent pvc
+	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		e2elog.Failf("failed to delete PVC with error %v", err)
+	}
+
+	// total images in cluster is total snaps+ total clones
+	totalSnapCount := totalCount + totalCount
+	validateRBDImageCount(f, totalSnapCount)
+	wg.Add(totalCount)
+	// delete snapshot
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, s v1beta1.VolumeSnapshot) {
+			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = deleteSnapshot(&s, deployTimeout)
+			w.Done()
+		}(&wg, i, snap)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to delete snapshot (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		e2elog.Failf("deleting snapshots failed, %d errors were logged", failed)
+	}
+
+	validateRBDImageCount(f, totalCount)
+	wg.Add(totalCount)
+	// delete clone and app
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			p.Spec.DataSource.Name = name
+			wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to delete PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		e2elog.Failf("deleting PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	// validate created backend rbd images
 	validateRBDImageCount(f, 0)
 }
 

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -504,8 +504,8 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 	return checkSum, nil
 }
 
-// nolint:gocyclo // reduce complexity
-func validatePVCClone(sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath string, f *framework.Framework) {
+// nolint:gocyclo,gocognit // reduce complexity
+func validatePVCClone(sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath string, validateEncryption bool, f *framework.Framework) {
 	var wg sync.WaitGroup
 	totalCount := 10
 	wgErrs := make([]error, totalCount)
@@ -581,6 +581,9 @@ func validatePVCClone(sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPat
 				if checkSumClone != checkSum {
 					e2elog.Logf("checksum didn't match. checksum=%s and checksumclone=%s", checkSum, checkSumClone)
 				}
+			}
+			if wgErrs[n] == nil && validateEncryption {
+				wgErrs[n] = validateEncryptedPVC(f, &p, &a)
 			}
 			w.Done()
 		}(&wg, i, *pvcClone, *appClone)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -506,9 +506,8 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 }
 
 // nolint:gocyclo,gocognit // reduce complexity
-func validatePVCClone(sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath string, validateEncryption bool, f *framework.Framework) {
+func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath string, validateEncryption bool, f *framework.Framework) {
 	var wg sync.WaitGroup
-	totalCount := 10
 	wgErrs := make([]error, totalCount)
 	chErrs := make([]error, totalCount)
 	pvc, err := loadPVC(sourcePvcPath)
@@ -653,9 +652,8 @@ func validatePVCClone(sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPat
 }
 
 // nolint:gocyclo,gocognit // reduce complexity
-func validatePVCSnapshot(pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath string, validateEncryption bool, f *framework.Framework) {
+func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath string, validateEncryption bool, f *framework.Framework) {
 	var wg sync.WaitGroup
-	totalCount := 10
 	wgErrs := make([]error, totalCount)
 	chErrs := make([]error, totalCount)
 	wg.Add(totalCount)

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -214,6 +214,12 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 		return err
 	}
 
+	if parentVol.isEncrypted() {
+		err = parentVol.copyEncryptionConfig(&rv.rbdImage)
+		if err != nil {
+			return fmt.Errorf("failed to copy encryption config for %q: %w", rv, err)
+		}
+	}
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to store volume %s: %v", rv, err)

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -46,7 +46,10 @@ import (
 func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) (bool, error) {
 	// generate temp cloned volume
 	tempClone := rv.generateTempClone()
+	defer tempClone.Destroy()
+
 	snap := &rbdSnapshot{}
+	defer snap.Destroy()
 	snap.RbdSnapName = rv.RbdImageName
 	snap.Pool = rv.Pool
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -559,8 +559,7 @@ func checkContentSource(ctx context.Context, req *csi.CreateVolumeRequest, cr *u
 		if volID == "" {
 			return nil, nil, status.Errorf(codes.NotFound, "volume ID cannot be empty")
 		}
-		// TODO need to support cloning for encrypted volume
-		rbdvol, err := genVolFromVolID(ctx, volID, cr, nil)
+		rbdvol, err := genVolFromVolID(ctx, volID, cr, req.GetSecrets())
 		if err != nil {
 			util.ErrorLog(ctx, "failed to get backend image for %s: %v", volID, err)
 			if !errors.Is(err, ErrImageNotFound) {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -447,7 +447,7 @@ func (cs *ControllerServer) createVolumeFromSnapshot(ctx context.Context, cr *ut
 	// create clone image and delete snapshot
 	err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rbdSnap, err)
+		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rbdVol, rbdSnap, err)
 		return err
 	}
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -928,6 +928,16 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 		}
 	}()
 
+	if parentVol.isEncrypted() {
+		cryptErr := parentVol.copyEncryptionConfig(&cloneRbd.rbdImage)
+		if cryptErr != nil {
+			util.WarningLog(ctx, "failed copy encryption "+
+				"config for %q: %v", cloneRbd.String(), cryptErr)
+			return ready, nil, status.Errorf(codes.Internal,
+				err.Error())
+		}
+	}
+
 	err = cloneRbd.createSnapshot(ctx, rbdSnap)
 	if err != nil {
 		// update rbd image name for logging

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -269,14 +269,6 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			}
 		}
 
-		if parentVol != nil && parentVol.isEncrypted() {
-			err = parentVol.copyEncryptionConfig(&rbdVol.rbdImage)
-			if err != nil {
-				util.ErrorLog(ctx, err.Error())
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-		}
-
 		return buildCreateVolumeResponse(req, rbdVol), nil
 	}
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -690,12 +690,6 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if rbdVol.isEncrypted() {
-		if err = rbdVol.encryption.RemoveDEK(rbdVol.VolID); err != nil {
-			util.WarningLog(ctx, "failed to clean the passphrase for volume %s: %s", rbdVol.VolID, err)
-		}
-	}
-
 	return &csi.DeleteVolumeResponse{}, nil
 }
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -266,6 +266,11 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			if err != nil {
 				return nil, err
 			}
+
+			err = rbdSnap.repairEncryptionConfig(&rbdVol.rbdImage)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return buildCreateVolumeResponse(req, rbdVol), nil

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -150,6 +150,27 @@ func (ri *rbdImage) copyEncryptionConfig(cp *rbdImage) error {
 	return nil
 }
 
+// repairEncryptionConfig checks the encryption state of the current rbdImage,
+// and makes sure that the destination rbdImage has the same configuration.
+func (ri *rbdImage) repairEncryptionConfig(dest *rbdImage) error {
+	if !ri.isEncrypted() {
+		return nil
+	}
+
+	// if ri is encrypted, copy its configuration in case it is missing
+	if !dest.isEncrypted() {
+		// dest needs to be connected to the cluster, otherwise it will
+		// not be possible to write any metadata
+		if dest.conn == nil {
+			dest.conn = ri.conn.Copy()
+		}
+
+		return ri.copyEncryptionConfig(dest)
+	}
+
+	return nil
+}
+
 func (ri *rbdImage) encryptDevice(ctx context.Context, devicePath string) error {
 	passphrase, err := ri.encryption.GetCryptoPassphrase(ri.VolID)
 	if err != nil {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -351,9 +351,14 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 	}
 	defer j.Destroy()
 
+	kmsID := ""
+	if rbdVol.isEncrypted() {
+		kmsID = rbdVol.encryption.GetID()
+	}
+
 	rbdSnap.ReservedID, rbdSnap.RbdSnapName, err = j.ReserveName(
 		ctx, rbdSnap.JournalPool, journalPoolID, rbdSnap.Pool, imagePoolID,
-		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, "", rbdSnap.ReservedID, rbdVol.Owner)
+		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, kmsID, rbdSnap.ReservedID, rbdVol.Owner)
 	if err != nil {
 		return err
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -475,6 +475,12 @@ func deleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 
 	util.DebugLog(ctx, "rbd: delete %s using mon %s, pool %s", image, pOpts.Monitors, pOpts.Pool)
 
+	if pOpts.isEncrypted() {
+		if err = pOpts.encryption.RemoveDEK(pOpts.VolID); err != nil {
+			util.WarningLog(ctx, "failed to clean the passphrase for volume %s: %s", pOpts.VolID, err)
+		}
+	}
+
 	err = pOpts.openIoctx()
 	if err != nil {
 		return err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -467,15 +467,17 @@ func addRbdManagerTask(ctx context.Context, pOpts *rbdVolume, arg []string) (boo
 // deleteImage deletes a ceph image with provision and volume options.
 func deleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) error {
 	image := pOpts.RbdImageName
+
+	util.DebugLog(ctx, "rbd: delete %s using mon %s, pool %s", image, pOpts.Monitors, pOpts.Pool)
+
 	// Support deleting the older rbd images whose imageID is not stored in omap
 	err := pOpts.getImageID()
 	if err != nil {
 		return err
 	}
 
-	util.DebugLog(ctx, "rbd: delete %s using mon %s, pool %s", image, pOpts.Monitors, pOpts.Pool)
-
 	if pOpts.isEncrypted() {
+		util.DebugLog(ctx, "rbd: going to remove DEK for %q", pOpts.String())
 		if err = pOpts.encryption.RemoveDEK(pOpts.VolID); err != nil {
 			util.WarningLog(ctx, "failed to clean the passphrase for volume %s: %s", pOpts.VolID, err)
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -251,6 +251,13 @@ func createImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 		return fmt.Errorf("failed to create rbd image: %w", err)
 	}
 
+	if pOpts.isEncrypted() {
+		err = pOpts.setupEncryption(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to setup encroption for image %s: %v", pOpts, err)
+		}
+	}
+
 	if pOpts.ThickProvision {
 		err = pOpts.allocate(0)
 		if err != nil {

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -243,7 +243,10 @@ func EncryptVolume(ctx context.Context, devicePath, passphrase string) error {
 // OpenEncryptedVolume opens volume so that it can be used by the client.
 func OpenEncryptedVolume(ctx context.Context, devicePath, mapperFile, passphrase string) error {
 	DebugLog(ctx, "Opening device %s with LUKS on %s", devicePath, mapperFile)
-	_, _, err := LuksOpen(devicePath, mapperFile, passphrase)
+	_, stderr, err := LuksOpen(devicePath, mapperFile, passphrase)
+	if err != nil {
+		WarningLog(ctx, "failed to open LUKS device %q: %s", devicePath, stderr)
+	}
 	return err
 }
 

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -185,13 +185,9 @@ func (i integratedDEK) DecryptDEK(volumeID, encyptedDEK string) (string, error) 
 	return encyptedDEK, nil
 }
 
-// StoreNewCryptoPassphrase generates a new passphrase and saves it in the KMS.
-func (ve *VolumeEncryption) StoreNewCryptoPassphrase(volumeID string) error {
-	passphrase, err := generateNewEncryptionPassphrase()
-	if err != nil {
-		return fmt.Errorf("failed to generate passphrase for %s: %w", volumeID, err)
-	}
-
+// StoreCryptoPassphrase takes an unencrypted passphrase, encrypts it and saves
+// it in the DEKStore.
+func (ve *VolumeEncryption) StoreCryptoPassphrase(volumeID, passphrase string) error {
 	encryptedPassphrase, err := ve.KMS.EncryptDEK(volumeID, passphrase)
 	if err != nil {
 		return fmt.Errorf("failed encrypt the passphrase for %s: %w", volumeID, err)
@@ -202,6 +198,16 @@ func (ve *VolumeEncryption) StoreNewCryptoPassphrase(volumeID string) error {
 		return fmt.Errorf("failed to save the passphrase for %s: %w", volumeID, err)
 	}
 	return nil
+}
+
+// StoreNewCryptoPassphrase generates a new passphrase and saves it in the KMS.
+func (ve *VolumeEncryption) StoreNewCryptoPassphrase(volumeID string) error {
+	passphrase, err := generateNewEncryptionPassphrase()
+	if err != nil {
+		return fmt.Errorf("failed to generate passphrase for %s: %w", volumeID, err)
+	}
+
+	return ve.StoreCryptoPassphrase(volumeID, passphrase)
 }
 
 // GetCryptoPassphrase Retrieves passphrase to encrypt volume.

--- a/internal/util/kms.go
+++ b/internal/util/kms.go
@@ -67,7 +67,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 	section, ok := config[kmsID]
 	if !ok {
 		return nil, fmt.Errorf("could not get KMS configuration "+
-			"for %q", kmsID)
+			"for %q (have %v)", kmsID, getKeys(config))
 	}
 
 	// kmsConfig can have additional sub-sections

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -319,3 +319,17 @@ func contains(s []string, key string) bool {
 
 	return false
 }
+
+// getKeys takes a map that uses strings for keys and returns a slice with the
+// keys.
+func getKeys(m map[string]interface{}) []string {
+	keys := make([]string, len(m))
+
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+
+	return keys
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -332,4 +333,13 @@ func getKeys(m map[string]interface{}) []string {
 	}
 
 	return keys
+}
+
+// CallStack returns the stack of the calls in the current goroutine. Useful
+// for debugging or reporting errors. This is a friendly alternative to
+// assert() or panic().
+func CallStack() string {
+	stack := make([]byte, 2048)
+	_ = runtime.Stack(stack, false)
+	return string(stack)
 }


### PR DESCRIPTION
When a source volume is encrypted, the passphrase needs to be copied and
stored for the newly cloned volume.

This requires the `rbdImage.encryption` component to be configured, and that
is what most of the changes in this PR make possible.

Fixes: #1470

## Notes for reviewers

This PR contains a large number of commits. The easiest to review these is by going to https://github.com/ceph/ceph-csi/pull/1918/commits and clicking the title of the 1st change. Then use the `[next]` button in the top blue bar where the subject of the change is written to go to the next commit.

Each single commit is relatively simple, reviewing all changes at once will be close to impossible.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
