### PR TITLE
util: use ClusterConnection.Copy() for re-using connections

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -127,7 +127,7 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 
 func (rv *rbdVolume) generateTempClone() *rbdVolume {
 	tempClone := rbdVolume{}
-	tempClone.conn = rv.conn
+	tempClone.conn = rv.conn.Copy()
 	// The temp clone image need to have deep flatten feature
 	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
 	tempClone.imageFeatureSet = librbd.FeatureSetFromNames(f)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -496,7 +496,7 @@ func (rv *rbdVolume) getCloneDepth(ctx context.Context) (uint, error) {
 	vol.Pool = rv.Pool
 	vol.Monitors = rv.Monitors
 	vol.RbdImageName = rv.RbdImageName
-	vol.conn = rv.conn
+	vol.conn = rv.conn.Copy()
 
 	err := vol.openIoctx()
 	if err != nil {
@@ -666,7 +666,7 @@ func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint
 	vol.RadosNamespace = rv.RadosNamespace
 	vol.Monitors = rv.Monitors
 	vol.RbdImageName = rv.RbdImageName
-	vol.conn = rv.conn
+	vol.conn = rv.conn.Copy()
 
 	err := vol.openIoctx()
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -493,6 +493,8 @@ func deleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 func (rv *rbdVolume) getCloneDepth(ctx context.Context) (uint, error) {
 	var depth uint
 	vol := rbdVolume{}
+	defer vol.Destroy()
+
 	vol.Pool = rv.Pool
 	vol.Monitors = rv.Monitors
 	vol.RbdImageName = rv.RbdImageName
@@ -503,9 +505,6 @@ func (rv *rbdVolume) getCloneDepth(ctx context.Context) (uint, error) {
 		return depth, err
 	}
 
-	defer func() {
-		vol.ioctx.Destroy()
-	}()
 	for {
 		if vol.RbdImageName == "" {
 			return depth, nil
@@ -662,6 +661,8 @@ func (rv *rbdVolume) hasFeature(feature uint64) bool {
 
 func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint64) (bool, error) {
 	vol := rbdVolume{}
+	defer vol.Destroy()
+
 	vol.Pool = rv.Pool
 	vol.RadosNamespace = rv.RadosNamespace
 	vol.Monitors = rv.Monitors
@@ -672,7 +673,6 @@ func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint
 	if err != nil {
 		return false, err
 	}
-	defer vol.ioctx.Destroy()
 
 	for {
 		if vol.RbdImageName == "" {

--- a/internal/util/conn_pool.go
+++ b/internal/util/conn_pool.go
@@ -168,6 +168,22 @@ func (cp *ConnPool) Get(monitors, user, keyfile string) (*rados.Conn, error) {
 	return conn, nil
 }
 
+// Copy adds an extra reference count to the used ConnEntry and returns the
+// *rados.Conn if it was found.
+func (cp *ConnPool) Copy(conn *rados.Conn) *rados.Conn {
+	cp.lock.Lock()
+	defer cp.lock.Unlock()
+
+	for _, ce := range cp.conns {
+		if ce.conn == conn {
+			ce.get()
+			return ce.conn
+		}
+	}
+
+	return nil
+}
+
 // Put reduces the reference count of the rados.Conn object that was returned with
 // ConnPool.Get().
 func (cp *ConnPool) Put(conn *rados.Conn) {

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -68,6 +68,22 @@ func (cc *ClusterConnection) Destroy() {
 	}
 }
 
+// Copy creates a copy of the ClusterConnection. This is needed when an other
+// object needs to use the existing connection.
+// It is required to call Destroy() once the (copied) connection is not used
+// anymore.
+func (cc *ClusterConnection) Copy() *ClusterConnection {
+	if cc.conn == nil {
+		return nil
+	}
+
+	c := ClusterConnection{}
+	c.discardOnZeroedWriteSameDisabled = cc.discardOnZeroedWriteSameDisabled
+	c.conn = connPool.Copy(cc.conn)
+
+	return &c
+}
+
 func (cc *ClusterConnection) GetIoctx(pool string) (*rados.IOContext, error) {
 	if cc.conn == nil {
 		return nil, errors.New("cluster is not connected yet")


### PR DESCRIPTION
Connections are reference counted, so just assigning the connection to
an other object for re-use is not correct. This can cause connections to
be garbage collected while something else is still using it.

rbdVolumes can have several resources that get allocated during its
usage. Only destroying the IOContext may not be sufficient and can
cause resource leaks.

Use rbdVolume.Destroy() when the rbdVolume is not used anymore.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
