### PR TITLE
build: regenerate scripts/golangci.yml if build.env was updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ mod-check: check-env
 	@echo 'running: go mod verify'
 	@go mod verify && [ "$(shell sha512sum go.mod)" = "`sha512sum go.mod`" ] || ( echo "ERROR: go.mod was modified by 'go mod verify'" && false )
 
-scripts/golangci.yml: scripts/golangci.yml.in
+scripts/golangci.yml: build.env scripts/golangci.yml.in
 	sed "s/@@CEPH_VERSION@@/$(CEPH_VERSION)/g" < scripts/golangci.yml.in > scripts/golangci.yml
 
 go-lint: scripts/golangci.yml


### PR DESCRIPTION
In case build.env was updated, scripts/golangci.yml needs to be
regenerated. It contains a reference to the build-tag that is used to
identify the Ceph version to link against. Failing to update the
scripts/golangci.yml configuration, may cause running tests fail.

Developers systems that have the cephcsi:test container built
before #1877 might be affected.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
