### PR TITLE
rbd: Address rbd mirroring TODO's

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -28,7 +28,6 @@ import (
 
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kube-storage/spec/lib/go/replication"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,11 +41,6 @@ const (
 // controller server spec.
 type ControllerServer struct {
 	*csicommon.DefaultControllerServer
-	// added UnimplementedControllerServer as a member of
-	// ControllerServer. if replication spec add more RPC services in the proto
-	// file, then we don't need to add all RPC methods leading to forward
-	// compatibility.
-	*replication.UnimplementedControllerServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID/volume name) return an Aborted error
 	VolumeLocks *util.VolumeLocks

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -118,6 +118,12 @@ type imageMirrorStatus struct {
 	State       string `json:"state"` // rbd image state
 	Description string `json:"description"`
 	LastUpdate  string `json:"last_update"`
+	PeerSites   []struct {
+		SiteName    string `json:"site_name"`
+		State       string `json:"state"`
+		Description string `json:"description"`
+		LastUpdate  string `json:"last_update"`
+	} `json:"peer_sites"`
 }
 
 // FIXME: once https://github.com/ceph/go-ceph/issues/460 is fixed use go-ceph.

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -405,11 +405,10 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 
 	mirroringInfo, err := rbdVol.getImageMirroringInfo()
 	if err != nil {
-		// TODO: check if the image is not found return valid error message
 		// in case of Resync the image will get deleted and gets recreated and
-		// it takes time for this operation
+		// it takes time for this operation.
 		util.ErrorLog(ctx, err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(codes.Aborted, err.Error())
 	}
 
 	if mirroringInfo.State != librbd.MirrorImageEnabled {

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -59,37 +59,16 @@ const (
 	forceKey = "force"
 )
 
-// getVolumeFromID gets the rbd image details from the volumeID.
-// TODO: move this to controllerserver.go and reuse it wherever its applicable.
-func (cs *ControllerServer) getVolumeFromID(ctx context.Context, volumeID string, secrets map[string]string) (*rbdVolume, *util.Credentials, error) {
-	// validate the volume ID
-	cr, err := util.NewUserCredentials(secrets)
-	if err != nil {
-		return nil, nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if volumeID == "" {
-		return nil, cr, status.Error(codes.InvalidArgument, "empty volume ID in request")
-	}
-
-	if acquired := cs.VolumeLocks.TryAcquire(volumeID); !acquired {
-		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
-		return nil, cr, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
-	}
-
-	var rbdVol = &rbdVolume{}
-	rbdVol, err = genVolFromVolID(ctx, volumeID, cr, secrets)
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrImageNotFound):
-			err = status.Errorf(codes.NotFound, "volume %s not found", volumeID)
-		case errors.Is(err, util.ErrPoolNotFound):
-			err = status.Errorf(codes.NotFound, "pool %s not found for %s", rbdVol.Pool, volumeID)
-		default:
-			err = status.Errorf(codes.Internal, err.Error())
-		}
-	}
-	return rbdVol, cr, err
+// ReplicationServer struct of rbd CSI driver with supported methods of Replication
+// controller server spec.
+type ReplicationServer struct {
+	// added UnimplementedControllerServer as a member of
+	// ControllerServer. if replication spec add more RPC services in the proto
+	// file, then we don't need to add all RPC methods leading to forward
+	// compatibility.
+	*replication.UnimplementedControllerServer
+	// Embed ControllerServer as it implements helper functions
+	*ControllerServer
 }
 
 // getForceOption extracts the force option from the GRPC request parameters.
@@ -126,30 +105,39 @@ func getMirroringMode(ctx context.Context, parameters map[string]string) (librbd
 	return mirroringMode, nil
 }
 
-// cleanup performs below resource cleanup operations.
-func (cs *ControllerServer) cleanup(rbdVol *rbdVolume, cr *util.Credentials) {
-	if cr != nil {
-		// destroy the credential file
-		cr.DeleteCredentials()
-	}
-	if rbdVol != nil {
-		// release the volume lock
-		cs.VolumeLocks.Release(rbdVol.VolID)
-		// destroy the cluster connection
-		rbdVol.Destroy()
-	}
-}
-
 // EnableVolumeReplication extracts the RBD volume information from the
 // volumeID, If the image is present it will enable the mirroring based on the
 // user provided information.
-// TODO: create new Replication controller struct for the replication operations.
-func (cs *ControllerServer) EnableVolumeReplication(ctx context.Context,
+func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	req *replication.EnableVolumeReplicationRequest,
 ) (*replication.EnableVolumeReplicationResponse, error) {
-	rbdVol, cr, err := cs.getVolumeFromID(ctx, req.GetVolumeId(), req.GetSecrets())
-	defer cs.cleanup(rbdVol, cr)
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	}
+	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer rs.VolumeLocks.Release(volumeID)
+
+	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	defer rbdVol.Destroy()
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrImageNotFound):
+			err = status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+		case errors.Is(err, util.ErrPoolNotFound):
+			err = status.Errorf(codes.NotFound, "pool %s not found for %s", rbdVol.Pool, volumeID)
+		default:
+			err = status.Errorf(codes.Internal, err.Error())
+		}
 		return nil, err
 	}
 	// extract the mirroring mode
@@ -177,15 +165,38 @@ func (cs *ControllerServer) EnableVolumeReplication(ctx context.Context,
 // DisableVolumeReplication extracts the RBD volume information from the
 // volumeID, If the image is present and the mirroring is enabled on the RBD
 // image it will disable the mirroring.
-func (cs *ControllerServer) DisableVolumeReplication(ctx context.Context,
+func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	req *replication.DisableVolumeReplicationRequest,
 ) (*replication.DisableVolumeReplicationResponse, error) {
-	rbdVol, cr, err := cs.getVolumeFromID(ctx, req.GetVolumeId(), req.GetSecrets())
-	defer cs.cleanup(rbdVol, cr)
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	}
+	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer rs.VolumeLocks.Release(volumeID)
+
+	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	defer rbdVol.Destroy()
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrImageNotFound):
+			err = status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+		case errors.Is(err, util.ErrPoolNotFound):
+			err = status.Errorf(codes.NotFound, "pool %s not found for %s", rbdVol.Pool, volumeID)
+		default:
+			err = status.Errorf(codes.Internal, err.Error())
+		}
 		return nil, err
 	}
-
 	// extract the force option
 	force, err := getForceOption(ctx, req.GetParameters())
 	if err != nil {
@@ -224,15 +235,38 @@ func (cs *ControllerServer) DisableVolumeReplication(ctx context.Context,
 // image is present, mirroring is enabled and the image is in demoted state it
 // will promote the volume as primary.
 // If the image is already primary it will return success.
-func (cs *ControllerServer) PromoteVolume(ctx context.Context,
+func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	req *replication.PromoteVolumeRequest,
 ) (*replication.PromoteVolumeResponse, error) {
-	rbdVol, cr, err := cs.getVolumeFromID(ctx, req.GetVolumeId(), req.GetSecrets())
-	defer cs.cleanup(rbdVol, cr)
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	}
+	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer rs.VolumeLocks.Release(volumeID)
+
+	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	defer rbdVol.Destroy()
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrImageNotFound):
+			err = status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+		case errors.Is(err, util.ErrPoolNotFound):
+			err = status.Errorf(codes.NotFound, "pool %s not found for %s", rbdVol.Pool, volumeID)
+		default:
+			err = status.Errorf(codes.Internal, err.Error())
+		}
 		return nil, err
 	}
-
 	// extract the force option
 	force, err := getForceOption(ctx, req.GetParameters())
 	if err != nil {
@@ -265,15 +299,38 @@ func (cs *ControllerServer) PromoteVolume(ctx context.Context,
 // volumeID, If the image is present, mirroring is enabled and the
 // image is in promoted state it will demote the volume as secondary.
 // If the image is already secondary it will return success.
-func (cs *ControllerServer) DemoteVolume(ctx context.Context,
+func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	req *replication.DemoteVolumeRequest,
 ) (*replication.DemoteVolumeResponse, error) {
-	rbdVol, cr, err := cs.getVolumeFromID(ctx, req.GetVolumeId(), req.GetSecrets())
-	defer cs.cleanup(rbdVol, cr)
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	}
+	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer rs.VolumeLocks.Release(volumeID)
+
+	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	defer rbdVol.Destroy()
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrImageNotFound):
+			err = status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+		case errors.Is(err, util.ErrPoolNotFound):
+			err = status.Errorf(codes.NotFound, "pool %s not found for %s", rbdVol.Pool, volumeID)
+		default:
+			err = status.Errorf(codes.Internal, err.Error())
+		}
 		return nil, err
 	}
-
 	mirroringInfo, err := rbdVol.getImageMirroringInfo()
 	if err != nil {
 		util.ErrorLog(ctx, err.Error())
@@ -298,12 +355,35 @@ func (cs *ControllerServer) DemoteVolume(ctx context.Context,
 // ResyncVolume extracts the RBD volume information from the volumeID, If the
 // image is present, mirroring is enabled and the image is in demoted state.
 // If yes it will resync the image to correct the split-brain.
-func (cs *ControllerServer) ResyncVolume(ctx context.Context,
+func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	req *replication.ResyncVolumeRequest,
 ) (*replication.ResyncVolumeResponse, error) {
-	rbdVol, cr, err := cs.getVolumeFromID(ctx, req.GetVolumeId(), req.GetSecrets())
-	defer cs.cleanup(rbdVol, cr)
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	}
+	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
+		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer rs.VolumeLocks.Release(volumeID)
+	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	defer rbdVol.Destroy()
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrImageNotFound):
+			err = status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+		case errors.Is(err, util.ErrPoolNotFound):
+			err = status.Errorf(codes.NotFound, "pool %s not found for %s", rbdVol.Pool, volumeID)
+		default:
+			err = status.Errorf(codes.Internal, err.Error())
+		}
 		return nil, err
 	}
 

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -214,6 +214,11 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	}
 
 	switch mirroringInfo.State {
+	// image is already in disabled state
+	case librbd.MirrorImageDisabled:
+	// image mirroring is still disabling
+	case librbd.MirrorImageDisabling:
+		return nil, status.Errorf(codes.Aborted, "%s is in disabling state", volumeID)
 	case librbd.MirrorImageEnabled:
 		if !force && !mirroringInfo.Primary {
 			return nil, status.Error(codes.InvalidArgument, "image is in non-primary state")
@@ -234,11 +239,6 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 			return nil, status.Errorf(codes.Aborted, "%s is in disabling state", volumeID)
 		}
 		return &replication.DisableVolumeReplicationResponse{}, nil
-	// image is already in disabled state
-	case librbd.MirrorImageDisabled:
-	// image mirroring is still disabling
-	case librbd.MirrorImageDisabling:
-		return nil, status.Errorf(codes.Aborted, "%s is in disabling state", volumeID)
 	default:
 		// TODO: use string instead of int for returning valid error message
 		return nil, status.Errorf(codes.InvalidArgument, "image is in %d Mode", mirroringInfo.State)


### PR DESCRIPTION
This PR fixes the TODO's mentioned in #1896 

updates #1896 

Below is the list of TODO's

- [x]  move getVolumeFromID to controllerserver.go and reuse it wherever it's applicable.
- [x] create a new Replication controller struct for the replication operations.
- [x] check do we need to return abort after disabling the mirroring
- [ ] use string instead of int for returning a valid error message
- [x] check if the image is not found return a valid error message
- [x] check the image state and return its ready to use or not
- [ ] recheck https://github.com/ceph/ceph-csi/pull/1877#discussion_r589327546
- [x] add unit tests for helper functions
- [ ] add e2e testing

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Note: AFAIK E2E cannot be added as we need two ceph clusters for testing mirroring