### PR TITLE
util: add API for KMS Provider plugins

### DIFF
--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -208,7 +208,7 @@ func (ri *rbdImage) configureEncryption(kmsID string, credentials map[string]str
 		return err
 	}
 
-	ri.encryption, err = util.NewVolumeEncryption(kms)
+	ri.encryption, err = util.NewVolumeEncryption(kmsID, kms)
 
 	// if the KMS can not store the DEK itself, we'll store it in the
 	// metadata of the RBD image itself

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -234,7 +234,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 
 	kmsID := ""
 	if rv.isEncrypted() {
-		kmsID = rv.encryption.KMS.GetID()
+		kmsID = rv.encryption.GetID()
 	}
 
 	j, err := volJournal.Connect(rv.Monitors, rv.RadosNamespace, rv.conn.Creds)
@@ -411,7 +411,7 @@ func reserveVol(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnapshot, cr
 
 	kmsID := ""
 	if rbdVol.isEncrypted() {
-		kmsID = rbdVol.encryption.KMS.GetID()
+		kmsID = rbdVol.encryption.GetID()
 	}
 
 	j, err := volJournal.Connect(rbdVol.Monitors, rbdVol.RadosNamespace, cr)

--- a/internal/util/crypto_test.go
+++ b/internal/util/crypto_test.go
@@ -58,11 +58,11 @@ func TestKMSWorkflow(t *testing.T) {
 	kms, err := GetKMS("tenant", defaultKMSType, secrets)
 	assert.NoError(t, err)
 	require.NotNil(t, kms)
-	assert.Equal(t, defaultKMSType, kms.GetID())
 
-	ve, err := NewVolumeEncryption(kms)
+	ve, err := NewVolumeEncryption("", kms)
 	assert.NoError(t, err)
 	require.NotNil(t, ve)
+	assert.Equal(t, defaultKMSType, ve.GetID())
 
 	volumeID := "volume-id"
 

--- a/internal/util/kms.go
+++ b/internal/util/kms.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// kmsProviderKey is the name of the KMS provider that is registered at
+	// the kmsManager. This is used in the ConfigMap configuration options.
+	kmsProviderKey = "KMS_PROVIDER"
+)
+
+// getKMSConfig returns the (.Data) contents of the ConfigMap.
+//
+// FIXME: Ceph-CSI should not talk to Kubernetes directly.
+func getKMSConfig(ns, configmap string) (map[string]string, error) {
+	c := NewK8sClient()
+	cm, err := c.CoreV1().ConfigMaps(ns).Get(context.Background(),
+		configmap, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return cm.Data, nil
+}
+
+// getKMSProvider inspects the configuration and tries to identify what
+// KMSProvider is expected to be used with it. This returns the
+// KMSProvider.UniqueID.
+func getKMSProvider(config map[string]interface{}) (string, error) {
+	var name string
+
+	providerName, ok := config[kmsTypeKey]
+	if ok {
+		name, ok = providerName.(string)
+		if !ok {
+			return "", fmt.Errorf("could not convert KMS provider"+
+				"type (%v) to string", providerName)
+		}
+		return name, nil
+	}
+
+	providerName, ok = config[kmsProviderKey]
+	if ok {
+		name, ok = providerName.(string)
+		if !ok {
+			return "", fmt.Errorf("could not convert KMS provider"+
+				"type (%v) to string", providerName)
+		}
+		return name, nil
+	}
+
+	return "", fmt.Errorf("failed to get KMS provider, missing"+
+		"configuration option %q or %q", kmsTypeKey, kmsProviderKey)
+}
+
+// KMSInitializerArgs get passed to KMSInitializerFunc when a new instance of a
+// KMSProvider is initialized.
+type KMSInitializerArgs struct {
+	Id, Tenant string
+	Config     map[string]interface{}
+	Secrets    map[string]string
+}
+
+// KMSInitializerFunc gets called when the KMSProvider needs to be
+// instantiated.
+type KMSInitializerFunc func(args KMSInitializerArgs) (EncryptionKMS, error)
+
+type KMSProvider struct {
+	UniqueID    string
+	Initializer KMSInitializerFunc
+}
+
+type kmsProviderList struct {
+	providers map[string]KMSProvider
+}
+
+// kmsManager is used to create instances for a KMS provider.
+var kmsManager = kmsProviderList{providers: map[string]KMSProvider{}}
+
+// RegisterKMSProvider uses kmsManager to register the given KMSProvider. The
+// KMSProvider.Initializer function will get called when a new instance of the
+// KMS is required.
+func RegisterKMSProvider(provider KMSProvider) bool {
+	// validate uniqueness of the UniqueID
+	if provider.UniqueID == "" {
+		panic("a provider MUST set a UniqueID")
+	}
+	_, ok := kmsManager.providers[provider.UniqueID]
+	if ok {
+		panic("duplicate tegistration of KMSProvider.UniqueID: " + provider.UniqueID)
+	}
+
+	// validate the Initializer
+	if provider.Initializer == nil {
+		panic("a provider MUST have an Initializer")
+	}
+
+	kmsManager.providers[provider.UniqueID] = provider
+
+	return true
+}
+
+func (kf *kmsProviderList) buildKMS(providerName, kmsID, tenant string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
+	provider, ok := kf.providers[providerName]
+	if !ok {
+		return nil, fmt.Errorf("could not find KMS provider %q",
+			providerName)
+	}
+
+	return provider.Initializer(KMSInitializerArgs{
+		Id:      kmsID,
+		Tenant:  tenant,
+		Config:  config,
+		Secrets: secrets,
+	})
+}

--- a/internal/util/kms.go
+++ b/internal/util/kms.go
@@ -76,7 +76,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 			"section: %s", kmsID)
 	}
 
-	return kmsManager.buildKMS(kmsID, tenant, kmsConfig, secrets)
+	return kmsManager.buildKMS(tenant, kmsConfig, secrets)
 }
 
 // getKMSConfiguration reads the configuration file from the filesystem, or if
@@ -181,9 +181,9 @@ func getKMSProvider(config map[string]interface{}) (string, error) {
 // KMSInitializerArgs get passed to KMSInitializerFunc when a new instance of a
 // KMSProvider is initialized.
 type KMSInitializerArgs struct {
-	ID, Tenant string
-	Config     map[string]interface{}
-	Secrets    map[string]string
+	Tenant  string
+	Config  map[string]interface{}
+	Secrets map[string]string
 }
 
 // KMSInitializerFunc gets called when the KMSProvider needs to be
@@ -225,7 +225,10 @@ func RegisterKMSProvider(provider KMSProvider) bool {
 	return true
 }
 
-func (kf *kmsProviderList) buildKMS(kmsID, tenant string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
+// buildKMS creates a new KMSProvider instance, based on the configuration that
+// was passed. This uses getKMSProvider() internally to identify the
+// KMSProvider to instantiate.
+func (kf *kmsProviderList) buildKMS(tenant string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
 	providerName, err := getKMSProvider(config)
 	if err != nil {
 		return nil, err
@@ -238,7 +241,6 @@ func (kf *kmsProviderList) buildKMS(kmsID, tenant string, config map[string]inte
 	}
 
 	return provider.Initializer(KMSInitializerArgs{
-		ID:      kmsID,
 		Tenant:  tenant,
 		Config:  config,
 		Secrets: secrets,

--- a/internal/util/kms_test.go
+++ b/internal/util/kms_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func noinitKMS(id, tenant string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
+	return nil, nil
+}
+
+func TestRegisterKMSProvider(t *testing.T) {
+	tests := []struct {
+		provider KMSProvider
+		panics   bool
+	}{{
+		KMSProvider{
+			UniqueID: "incomplete-provider",
+		},
+		true,
+	}, {
+		KMSProvider{
+			UniqueID:    "initializer-only",
+			Initializer: noinitKMS,
+		},
+		false,
+	}}
+
+	for _, test := range tests {
+		provider := test.provider
+		if test.panics {
+			assert.Panics(t, func() { RegisterKMSProvider(provider) })
+		} else {
+			assert.True(t, RegisterKMSProvider(provider))
+		}
+	}
+}

--- a/internal/util/kms_test.go
+++ b/internal/util/kms_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func noinitKMS(id, tenant string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
+func noinitKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 	return nil, nil
 }
 

--- a/internal/util/secretskms.go
+++ b/internal/util/secretskms.go
@@ -93,11 +93,16 @@ type SecretsMetadataKMS struct {
 	encryptionKMSID string
 }
 
+var _ = RegisterKMSProvider(KMSProvider{
+	UniqueID:    kmsTypeSecretsMetadata,
+	Initializer: initSecretsMetadataKMS,
+})
+
 // initSecretsMetadataKMS initializes a SecretsMetadataKMS that wraps a
 // SecretsKMS, so that the passphrase from the StorageClass secrets can be used
 // for encrypting/decrypting DEKs that are stored in a detached DEKStore.
-func initSecretsMetadataKMS(encryptionKMSID string, secrets map[string]string) (EncryptionKMS, error) {
-	eKMS, err := initSecretsKMS(secrets)
+func initSecretsMetadataKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
+	eKMS, err := initSecretsKMS(args.Secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +114,7 @@ func initSecretsMetadataKMS(encryptionKMSID string, secrets map[string]string) (
 
 	smKMS := SecretsMetadataKMS{}
 	smKMS.SecretsKMS = sKMS
-	smKMS.encryptionKMSID = encryptionKMSID
+	smKMS.encryptionKMSID = args.ID
 
 	return smKMS, nil
 }

--- a/internal/util/secretskms.go
+++ b/internal/util/secretskms.go
@@ -58,11 +58,6 @@ func initSecretsKMS(secrets map[string]string) (EncryptionKMS, error) {
 	return SecretsKMS{passphrase: passphraseValue}, nil
 }
 
-// GetID is returning ID representing default KMS `default`.
-func (kms SecretsKMS) GetID() string {
-	return defaultKMSType
-}
-
 // Destroy frees all used resources.
 func (kms SecretsKMS) Destroy() {
 	// nothing to do
@@ -89,8 +84,6 @@ func (kms SecretsKMS) RemoveDEK(key string) error {
 // Data-Encryption-Key (DEK) in the metadata of the volume.
 type SecretsMetadataKMS struct {
 	SecretsKMS
-
-	encryptionKMSID string
 }
 
 var _ = RegisterKMSProvider(KMSProvider{
@@ -114,14 +107,8 @@ func initSecretsMetadataKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 
 	smKMS := SecretsMetadataKMS{}
 	smKMS.SecretsKMS = sKMS
-	smKMS.encryptionKMSID = args.ID
 
 	return smKMS, nil
-}
-
-// GetID is returning ID representing the SecretsMetadataKMS.
-func (kms SecretsMetadataKMS) GetID() string {
-	return kms.encryptionKMSID
 }
 
 // Destroy frees all used resources.

--- a/internal/util/secretskms_test.go
+++ b/internal/util/secretskms_test.go
@@ -42,7 +42,6 @@ func TestGenerateCipher(t *testing.T) {
 
 func TestInitSecretsMetadataKMS(t *testing.T) {
 	args := KMSInitializerArgs{
-		ID:      "secrets-metadata-unit-test",
 		Tenant:  "tenant",
 		Config:  nil,
 		Secrets: map[string]string{},
@@ -59,7 +58,6 @@ func TestInitSecretsMetadataKMS(t *testing.T) {
 	kms, err = initSecretsMetadataKMS(args)
 	assert.NoError(t, err)
 	require.NotNil(t, kms)
-	assert.Equal(t, "secrets-metadata-unit-test", kms.GetID())
 	assert.Equal(t, DEKStoreMetadata, kms.requiresDEKStore())
 }
 
@@ -68,7 +66,6 @@ func TestWorkflowSecretsMetadataKMS(t *testing.T) {
 		encryptionPassphraseKey: "my-passphrase-from-kubernetes",
 	}
 	args := KMSInitializerArgs{
-		ID:      "secrets-metadata-unit-test",
 		Tenant:  "tenant",
 		Config:  nil,
 		Secrets: secrets,

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -71,10 +71,9 @@ Example JSON structure in the KMS config is,
 */
 
 type vaultConnection struct {
-	EncryptionKMSID string
-	secrets         loss.Secrets
-	vaultConfig     map[string]interface{}
-	keyContext      map[string]string
+	secrets     loss.Secrets
+	vaultConfig map[string]interface{}
+	keyContext  map[string]string
 }
 
 type VaultKMS struct {
@@ -114,11 +113,9 @@ func setConfigString(option *string, config map[string]interface{}, key string) 
 // vc.connectVault().
 //
 // nolint:gocyclo // iterating through many config options, not complex at all.
-func (vc *vaultConnection) initConnection(kmsID string, config map[string]interface{}) error {
+func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 	vaultConfig := make(map[string]interface{})
 	keyContext := make(map[string]string)
-
-	vc.EncryptionKMSID = kmsID
 
 	firstInit := (vc.vaultConfig == nil)
 
@@ -268,7 +265,7 @@ var _ = RegisterKMSProvider(KMSProvider{
 // InitVaultKMS returns an interface to HashiCorp Vault KMS.
 func initVaultKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 	kms := &VaultKMS{}
-	err := kms.initConnection(args.ID, args.Config)
+	err := kms.initConnection(args.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
 	}
@@ -326,11 +323,6 @@ func initVaultKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 	}
 
 	return kms, nil
-}
-
-// GetID is returning correlation ID to KMS configuration.
-func (vc *vaultConnection) GetID() string {
-	return vc.EncryptionKMSID
 }
 
 // FetchDEK returns passphrase from Vault. The passphrase is stored in a

--- a/internal/util/vault_test.go
+++ b/internal/util/vault_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetectAuthMountPath(t *testing.T) {
@@ -94,4 +96,9 @@ func TestSetConfigString(t *testing.T) {
 	case optionDefaultOverload != "non-default":
 		t.Error("optionDefaultOverload should have been updated")
 	}
+}
+
+func TestVaultKMSRegistered(t *testing.T) {
+	_, ok := kmsManager.providers[kmsTypeVault]
+	assert.True(t, ok)
 }

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -199,7 +199,7 @@ func initVaultTokensKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 	}
 
 	kms := &VaultTokensKMS{}
-	err = kms.initConnection(args.ID, args.Config)
+	err = kms.initConnection(args.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
 	}
@@ -263,7 +263,7 @@ func initVaultTokensKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 // secrets. This method can be called multiple times, i.e. to override
 // configuration options from tenants.
 func (kms *VaultTokensKMS) parseConfig(config map[string]interface{}) error {
-	err := kms.initConnection(kms.EncryptionKMSID, config)
+	err := kms.initConnection(config)
 	if err != nil {
 		return err
 	}

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -96,38 +96,44 @@ func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 	}
 }
 
-// getVaultConfiguration fetches the vault configuration from the kubernetes
-// configmap and converts the standard vault configuration (see json tag of
-// standardVault structure) to the CSI vault configuration.
-func getVaultConfiguration(namespace, name string) (map[string]interface{}, error) {
-	c := NewK8sClient()
-	cm, err := c.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
+// convertConfig takes the keys/values in standard Vault environment variable
+// format, and converts them to the format that is used in the configuration
+// file.
+// This uses JSON marshaling and unmarshaling to map the Vault environment
+// configuration into bytes, then in the standardVault struct, which is passed
+// through convertStdVaultToCSIConfig before converting back to a
+// map[string]interface{} configuration.
+//
+// FIXME: this can surely be simplified?!
+func transformConfig(svMap map[string]interface{}) (map[string]interface{}, error) {
+	// convert the map to JSON
+	data, err := json.Marshal(svMap)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to convert config %T to JSON: %w", svMap, err)
 	}
-	config := make(map[string]interface{})
-	// convert the standard vault configuration to CSI vault configuration and
-	// store it in the map that CSI expects
-	for k, v := range cm.Data {
-		sv := &standardVault{}
-		err = json.Unmarshal([]byte(v), sv)
-		if err != nil {
-			return nil, fmt.Errorf("failed to Unmarshal the vault configuration for %q: %w", k, err)
-		}
-		vc := vaultTokenConf{}
-		vc.convertStdVaultToCSIConfig(sv)
-		data, err := json.Marshal(vc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to Marshal the CSI vault configuration for %q: %w", k, err)
-		}
-		jsonMap := make(map[string]interface{})
-		err = json.Unmarshal(data, &jsonMap)
-		if err != nil {
-			return nil, fmt.Errorf("failed to Unmarshal the CSI vault configuration for %q: %w", k, err)
-		}
-		config[k] = jsonMap
+
+	// convert the JSON back to a standardVault struct
+	sv := &standardVault{}
+	err = json.Unmarshal(data, sv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Unmarshal the vault configuration: %w", err)
 	}
-	return config, nil
+
+	// convert the standardVault struct to a vaultTokenConf struct
+	vc := vaultTokenConf{}
+	vc.convertStdVaultToCSIConfig(sv)
+	data, err = json.Marshal(vc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal the CSI vault configuration: %w", err)
+	}
+
+	// convert the vaultTokenConf struct to a map[string]interface{}
+	jsonMap := make(map[string]interface{})
+	err = json.Unmarshal(data, &jsonMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Unmarshal the CSI vault configuration: %w", err)
+	}
+	return jsonMap, nil
 }
 
 /*
@@ -171,11 +177,29 @@ type VaultTokensKMS struct {
 	TokenName string
 }
 
+var _ = RegisterKMSProvider(KMSProvider{
+	UniqueID:    kmsTypeVaultTokens,
+	Initializer: initVaultTokensKMS,
+})
+
 // InitVaultTokensKMS returns an interface to HashiCorp Vault KMS.
-func InitVaultTokensKMS(tenant, kmsID string, config map[string]interface{}) (EncryptionKMS, error) {
+// InitVaultTokensKMS returns an interface to HashiCorp Vault KMS.
+func initVaultTokensKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
+	var err error
+
+	config := args.Config
+	_, ok := config[kmsProviderKey]
+	if ok {
+		// configuration comes from the ConfigMap, needs to be
+		// converted to vaultTokenConf type
+		config, err = transformConfig(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert configuration: %w", err)
+		}
+	}
+
 	kms := &VaultTokensKMS{}
-	kms.Tenant = tenant
-	err := kms.initConnection(kmsID, config)
+	err = kms.initConnection(args.ID, args.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
 	}
@@ -190,14 +214,15 @@ func InitVaultTokensKMS(tenant, kmsID string, config map[string]interface{}) (En
 	}
 
 	// fetch the configuration for the tenant
-	if tenant != "" {
+	if args.Tenant != "" {
+		kms.Tenant = args.Tenant
 		tenantsMap, ok := config["tenants"]
 		if ok {
 			// tenants is a map per tenant, containing key/values
 			tenants, ok := tenantsMap.(map[string]map[string]interface{})
 			if ok {
 				// get the map for the tenant of the current operation
-				tenantConfig, ok := tenants[tenant]
+				tenantConfig, ok := tenants[args.Tenant]
 				if ok {
 					// override connection details from the tenant
 					err = kms.parseConfig(tenantConfig)
@@ -216,9 +241,9 @@ func InitVaultTokensKMS(tenant, kmsID string, config map[string]interface{}) (En
 
 	// fetch the Vault Token from the Secret (TokenName) in the Kubernetes
 	// Namespace (tenant)
-	kms.vaultConfig[api.EnvVaultToken], err = getToken(tenant, kms.TokenName)
+	kms.vaultConfig[api.EnvVaultToken], err = getToken(args.Tenant, kms.TokenName)
 	if err != nil {
-		return nil, fmt.Errorf("failed fetching token from %s/%s: %w", tenant, kms.TokenName, err)
+		return nil, fmt.Errorf("failed fetching token from %s/%s: %w", args.Tenant, kms.TokenName, err)
 	}
 
 	err = kms.initCertificates(config)

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -78,7 +78,6 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	}
 
 	args := KMSInitializerArgs{
-		ID:      "vault-tokens-config",
 		Tenant:  "bob",
 		Config:  make(map[string]interface{}),
 		Secrets: nil,


### PR DESCRIPTION
The KMSProvider struct is a simple, extendable type that can be used to
register KMS providers with an internal kmsManager.

Helper functions for creating and configuring KMS providers will also be
located in the new kms.go file. This makes things more modular and
better maintainable.

## Future concerns ##

This work is preparing for adding an other KMS Provider, Amazon KMS through #1921.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
