### PR TITLE
util: remove unwanted import string from module dependencies

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/util"
 
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
-	config "k8s.io/kubernetes/test/e2e/framework/config"
+	"k8s.io/kubernetes/test/e2e/framework/config"
 )
 
 func init() {

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -22,7 +22,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 
 	"github.com/ceph/ceph-csi/internal/util"
 )

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -27,7 +27,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 )
 

--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -29,7 +29,7 @@ import (
 	"github.com/kube-storage/spec/lib/go/replication"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 
 	"github.com/ceph/ceph-csi/internal/util"
 )

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 func parseEndpoint(ep string) (string, string, error) {

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 // enum defining logging levels.


### PR DESCRIPTION
There is no need for an extra import string when the go mod package
itself declared in the same.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

