### PR TITLE
[RBD Async DR] Fix resize/Delete volume when it moved to another cluster

### DIFF
--- a/charts/ceph-csi-rbd/templates/csi-volumeid-mapping.yaml
+++ b/charts/ceph-csi-rbd/templates/csi-volumeid-mapping.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-volumeid-mapping
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  mapping.json: |-
+    []

--- a/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
@@ -50,7 +50,7 @@ rules:
     verbs: ["update"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch", "update"]
 {{- if .Values.provisioner.resizer.enabled }}
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -176,6 +176,8 @@ spec:
               mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: volumeid-mapping
+              mountPath: /etc/ceph-csi-volumeid
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
 {{- if .Values.provisioner.deployController }}
@@ -260,6 +262,9 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
+        - name: volumeid-mapping
+          configMap:
+            name: ceph-csi-volumeid-mapping
 {{- if .Values.provisioner.affinity }}
       affinity:
 {{ toYaml .Values.provisioner.affinity | indent 8 -}}

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -54,7 +54,7 @@ rules:
     verbs: ["update"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch", "update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -159,6 +159,8 @@ spec:
               mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: volumeid-mapping
+              mountPath: /etc/ceph-csi-volumeid
         - name: csi-rbdplugin-controller
           securityContext:
             privileged: true
@@ -219,6 +221,9 @@ spec:
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config
+        - name: volumeid-mapping
+          configMap:
+            name: ceph-csi-volumeid-mapping
         - name: ceph-csi-encryption-kms-config
           configMap:
             name: ceph-csi-encryption-kms-config

--- a/deploy/rbd/kubernetes/csi-volumeid-mapping.yaml
+++ b/deploy/rbd/kubernetes/csi-volumeid-mapping.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-volumeid-mapping
+data:
+  mapping.json: |-
+    []

--- a/examples/csi-volumeid-mapping.yaml
+++ b/examples/csi-volumeid-mapping.yaml
@@ -1,0 +1,11 @@
+---
+# This is a sample configmap that holds the information when PVC's are moved
+# from one cluster to another and the newly generated volumeID is different
+# from the original volumeID.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-volumeid-mapping
+data:
+  mapping.json: |-
+    []

--- a/examples/rbd/plugin-deploy.sh
+++ b/examples/rbd/plugin-deploy.sh
@@ -10,7 +10,7 @@ fi
 
 pushd "${deployment_base}" >/dev/null || exit 1
 
-objects=(csi-provisioner-rbac csi-nodeplugin-rbac csi-config-map csi-rbdplugin-provisioner csi-rbdplugin)
+objects=(csi-provisioner-rbac csi-nodeplugin-rbac csi-config-map csi-rbdplugin-provisioner csi-rbdplugin csi-volumeid-mapping)
 
 for obj in "${objects[@]}"; do
 	kubectl create -f "./${obj}.yaml"

--- a/examples/rbd/plugin-teardown.sh
+++ b/examples/rbd/plugin-teardown.sh
@@ -10,7 +10,7 @@ fi
 
 pushd "${deployment_base}" >/dev/null || exit 1
 
-objects=(csi-rbdplugin-provisioner csi-rbdplugin csi-config-map csi-provisioner-rbac csi-nodeplugin-rbac)
+objects=(csi-rbdplugin-provisioner csi-rbdplugin csi-config-map csi-provisioner-rbac csi-nodeplugin-rbac csi-volumeid-mapping)
 
 for obj in "${objects[@]}"; do
 	kubectl delete -f "./${obj}.yaml"

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -820,13 +820,14 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 	defer j.Destroy()
 
 	// check is there any volumeID mapping exists.
-	id, err := j.CheckNewUUIDMapping(ctx, rbdVol.JournalPool, volumeID)
+	vol, err := j.CheckNewUUIDMapping(volumeID)
 	if err != nil {
 		return rbdVol, fmt.Errorf("failed to get volume id %s mapping %w",
 			volumeID, err)
 	}
-	if id != "" {
-		rbdVol.VolID = id
+	if vol != nil {
+		util.DebugLogMsg("found volumeID mapping %s %s", rbdVol.VolID, vol.NewVolumeID)
+		rbdVol.VolID = vol.NewVolumeID
 		err = vi.DecomposeCSIID(rbdVol.VolID)
 		if err != nil {
 			return rbdVol, fmt.Errorf("%w: error decoding volume ID (%s) (%s)",


### PR DESCRIPTION
In the case of the Async DR, the volumeID will not be the same if the clusterID or the PoolID is different, With Earlier implementation, it is expected that the new volumeID mapping is stored in the rados omap pool. In the case of the   ControllerExpand or the DeleteVolume Request, the only volumeID will be sent it's not possible to find the corresponding poolID in the new cluster.

With This Change, it works as below

The csi-rbdplugin-controller will watch for the PV objects, when there are any PV objects created it will check the omap already exists, If the omap doesn't exist it will generate the new volumeID and it checks for the volumeID mapping entry in the new configmap, if the mapping does not exist, it will add the new entry to the configmap. the controller also does a periodic cleanup to remove the stale volumeID mappings from the configmap.

The configmap will be mounted as a volume to the csi-rbdplugin provisioner, when cephcsi receives a request for the volume it will check for the volumeID mapping in the mounted file, if the mapping exists it will
use the new volumeID for further operations.

fixes: #1936

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>