### PR TITLE
util: use transformed Vault Tokens config for initialization

### DIFF
--- a/internal/util/kms.go
+++ b/internal/util/kms.go
@@ -135,9 +135,9 @@ func getKMSConfigMap() (map[string]interface{}, error) {
 
 	// convert cm.Data from map[string]interface{}
 	kmsConfig := make(map[string]interface{})
-	for kmsID, data := range cm.BinaryData {
+	for kmsID, data := range cm.Data {
 		section := make(map[string]interface{})
-		err = json.Unmarshal(data, &section)
+		err = json.Unmarshal([]byte(data), &section)
 		if err != nil {
 			return nil, fmt.Errorf("could not convert contents "+
 				"of %q to s config section", kmsID)

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -199,7 +199,7 @@ func initVaultTokensKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 	}
 
 	kms := &VaultTokensKMS{}
-	err = kms.initConnection(args.Config)
+	err = kms.initConnection(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
 	}


### PR DESCRIPTION
After translating options from the ConfigMap into the common Vault
parameters, the generated configuration is not used. Instead, the
untranslated version of the configuration is passed on to the
vaultConnection initialization function, which then can detects missing
options.

By passing the right configuration to the initialization function,
things work as intended.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
