### PR TITLE
Add csidriver object for cephfs and rbd

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -1,10 +1,11 @@
-{{- if not .Values.provisioner.attacher.enabled -}}
-apiVersion: storage.k8s.io/v1beta1
+{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: storage.k8s.io/v1
+{{ else }}
+apiVersion: storage.k8s.io/v1betav1
+{{ end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.driverName }}
-  namespace: {{ .Release.Namespace }}
 spec:
-  attachRequired: false
+  attachRequired: true
   podInfoOnMount: false
-{{- end -}}

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -1,10 +1,11 @@
-{{- if not .Values.provisioner.attacher.enabled -}}
-apiVersion: storage.k8s.io/v1beta1
+{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: storage.k8s.io/v1
+{{ else }}
+apiVersion: storage.k8s.io/betav1
+{{ end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.driverName }}
-  namespace: {{ .Release.Namespace }}
 spec:
-  attachRequired: false
+  attachRequired: true
   podInfoOnMount: false
-{{- end -}}

--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -1,0 +1,10 @@
+---
+# if Kubernetes version is less than 1.18 change
+# apiVersion to storage.k8s.io/v1betav1
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: cephfs.csi.ceph.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -1,0 +1,10 @@
+---
+# if Kubernetes version is less than 1.18 change
+# apiVersion to storage.k8s.io/v1betav1
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: rbd.csi.ceph.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false


### PR DESCRIPTION
csidriver object can be created on the kubernetes for the below reason.

If a CSI driver creates a CSIDriver object, Kubernetes users can easily discover the CSI Drivers installed on their cluster (simply by issuing kubectl get CSIDriver)

Ref: https://kubernetes-csi.github.io/docs/csi-driver-object.html#what-is-the-csidriver-object

attachRequired is always required to be set to true to avoid issues on RWO PVC. more details about it at https://github.com/rook/rook/pull/4332

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
