### PR TITLE
cleanup: correct misspelling

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -654,7 +654,7 @@ var _ = Describe("RBD", func() {
 					// total images in cluster is 1 parent rbd image+ total
 					// snaps
 					validateRBDImageCount(f, totalCount+1)
-					// create clones from different snapshosts and bind it to an
+					// create clones from different snapshots and bind it to an
 					// app
 					wg.Add(totalCount)
 					for i := 0; i < totalCount; i++ {


### PR DESCRIPTION
Correct `snapshots` spelling in rbd.go

Signed-off-by: Yug <yuggupta27@gmail.com>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
