### PR TITLE
rbd: encrypted volumes can be of type "crypto_LUKS" too

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -823,7 +823,7 @@ func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rb
 			if err != nil {
 				return "", fmt.Errorf("failed to encrypt rbd image %s: %w", imageSpec, err)
 			}
-		case "crypt":
+		case "crypt", "crypto_LUKS":
 			util.WarningLog(ctx, "rbd image %s is encrypted, but encryption state was not updated",
 				imageSpec)
 			err = volOptions.ensureEncryptionMetadataSet(rbdImageEncrypted)


### PR DESCRIPTION
It seems that newer versions of some tools/libraries identify encrypted
filesystems with `crypto_LUKS` instead of `crypt`.

While working on #1470 I came across VolumeAttachment failures.
Debugging showed `crypto_LUKS` where `crypt` was expected. This is
a small change, and good to have in general. Getting it in before the
larger enhancement PR, makes reviewing a little easier.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
