### PR TITLE
build: use latest pacific release of ceph

### DIFF
--- a/build.env
+++ b/build.env
@@ -12,7 +12,7 @@
 CSI_IMAGE_VERSION=canary
 
 # Ceph version to use
-BASE_IMAGE=docker.io/ceph/ceph:v15
+BASE_IMAGE=docker.io/ceph/ceph:v16
 CEPH_VERSION=octopus
 
 # standard Golang options


### PR DESCRIPTION

upgrade to ceph version 16.2.0 pacific (stable)
