### PR TITLE
deploy: use serviceAccountName instead of serviceAccount in yamls

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -39,7 +39,7 @@ spec:
                     values:
                       - csi-cephfsplugin-provisioner
               topologyKey: "kubernetes.io/hostname"
-      serviceAccount: cephfs-csi-provisioner
+      serviceAccountName: cephfs-csi-provisioner
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-provisioner

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: csi-cephfsplugin
     spec:
-      serviceAccount: cephfs-csi-nodeplugin
+      serviceAccountName: cephfs-csi-nodeplugin
       priorityClassName: system-node-critical
       hostNetwork: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -39,7 +39,7 @@ spec:
                     values:
                       - csi-rbdplugin-provisioner
               topologyKey: "kubernetes.io/hostname"
-      serviceAccount: rbd-csi-provisioner
+      serviceAccountName: rbd-csi-provisioner
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-provisioner

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: csi-rbdplugin
     spec:
-      serviceAccount: rbd-csi-nodeplugin
+      serviceAccountName: rbd-csi-nodeplugin
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -195,7 +195,7 @@ spec:
       labels:
         app: csi-cephfsplugin
     spec:
-      serviceAccount: cephfs-csi-nodeplugin
+      serviceAccountName: cephfs-csi-nodeplugin
 ```
 
 in the above template we have added `updateStrategy` and its `type` to the
@@ -313,7 +313,7 @@ spec:
       labels:
         app: csi-rbdplugin
     spec:
-      serviceAccount: rbd-csi-nodeplugin
+      serviceAccountName: rbd-csi-nodeplugin
 ```
 
 in the above template we have added `updateStrategy` and its `type` to the

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -119,7 +119,7 @@ spec:
     metadata:
       name: vault-init-job
     spec:
-      serviceAccount: rbd-csi-vault-token-review
+      serviceAccountName: rbd-csi-vault-token-review
       volumes:
         - name: init-scripts-volume
           configMap:


### PR DESCRIPTION
serviceAccount is the depricated alias for serviceAccountName, so it
is recommended/suggested to use serviceAccountName instead.

For ex. reference:
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

