### PR TITLE
[RBD DR] Fix force promoteVolume

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -283,11 +283,6 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 		}
 		return nil, err
 	}
-	// extract the force option
-	force, err := getForceOption(ctx, req.GetParameters())
-	if err != nil {
-		return nil, err
-	}
 
 	mirroringInfo, err := rbdVol.getImageMirroringInfo()
 	if err != nil {
@@ -301,7 +296,7 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 
 	// promote secondary to primary
 	if !mirroringInfo.Primary {
-		err = rbdVol.promoteImage(force)
+		err = rbdVol.promoteImage(req.Force)
 		if err != nil {
 			util.ErrorLog(ctx, err.Error())
 			return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
In the case of the DR, the image on the primary site cannot be demoted as the cluster is down, during failover the image needs to be force promoted. RBD returns `Device or resource busy` error message if the image cannot be promoted for the above reason.
Return FailedPrecondition so that the replication operator can send a request to force promote the volume.


Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>