### PR TITLE
cephfs: enable ceph-fuse big_writes by default

### DIFF
--- a/internal/util/cephconf.go
+++ b/internal/util/cephconf.go
@@ -28,6 +28,11 @@ auth_client_required = cephx
 
 # Workaround for http://tracker.ceph.com/issues/23446
 fuse_set_user_groups = false
+
+# ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
+# adding 'fuse_big_writes = true' option by default to override this limit
+# see https://github.com/ceph/ceph-csi/issues/1928
+fuse_big_writes = true
 `)
 
 const (


### PR DESCRIPTION
By default, the write buffer size in libfuse2 is 2KiB `-o big_writes` option is used to override this limit to increase performance.
This commit makes `-o big_writes` option as default for ceph-fuse mounter.

Closes: #1928

Signed-off-by: Rakshith R <rar@redhat.com>