### PR TITLE
doc: update dev standup timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ More details are available [here](https://github.com/ceph/ceph-csi/issues/463)
 
 A regular dev standup takes place every other [Monday,Tuesday,Thursday at
 2:00 PM UTC](https://redhat.bluejeans.com/702977652). Convert to your local
-timezone by executing command `date -d 14:00 UTC` on terminal
+timezone by executing command `date -d "14:00 UTC"` on terminal
 
 Any changes to the meeting schedule will be added to the [agenda
 doc](https://docs.google.com/document/d/1K1aerdMpraIh56-skdoEoVF9RZrO4NUcbHtjN-f3u1s).

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ More details are available [here](https://github.com/ceph/ceph-csi/issues/463)
 ## Dev standup
 
 A regular dev standup takes place every other [Monday,Tuesday,Thursday at
-2:00 PM UTC](https://redhat.bluejeans.com/702977652). Convert to your local
-timezone by executing command `date -d "14:00 UTC"` on terminal
+12:00 PM UTC](https://redhat.bluejeans.com/702977652). Convert to your local
+timezone by executing command `date -d "12:00 UTC"` on terminal
 
 Any changes to the meeting schedule will be added to the [agenda
 doc](https://docs.google.com/document/d/1K1aerdMpraIh56-skdoEoVF9RZrO4NUcbHtjN-f3u1s).


### PR DESCRIPTION
The Dev standup was preponed 2 hours from 14:00 UTC
to 12:00 UTC.
Updating the same in upstream.

Signed-off-by: Yug <yuggupta27@gmail.com>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
