### PR TITLE
ci: Disable containerized-tests job

### DIFF
--- a/jobs/containerized-tests.yaml
+++ b/jobs/containerized-tests.yaml
@@ -22,7 +22,8 @@
       - github-pull-request:
           status-url: ${RUN_DISPLAY_URL}
           status-context: ci/centos/containerized-tests
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/containerized-tests))'
+          trigger-phrase: '/(re)?test ci/centos/containerized-tests'
+          only-trigger-phrase: true
           permit-all: true
           github-hooks: true
           black-list-target-branches:


### PR DESCRIPTION
The containerized-test job should run only if
manually triggered.

Updates: #1958
Closes: #1779 
Signed-off-by: Yug <yuggupta27@gmail.com>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
