### PR TITLE
ci: do not re-checkout current branch

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -29,7 +29,9 @@ node('cico-workspace') {
 		}
 
 		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
-		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		if (ref != git_since) {
+			sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		}
 	}
 
 	stage('check doc-only change') {

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -47,7 +47,9 @@ node('cico-workspace') {
 		}
 
 		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
-		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		if (ref != git_since) {
+			sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		}
 	}
 
 	stage('check doc-only change') {

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -57,7 +57,9 @@ node('cico-workspace') {
 		}
 
 		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
-		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		if (ref != git_since) {
+			sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		}
 	}
 
 	stage('check doc-only change') {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -73,7 +73,9 @@ node('cico-workspace') {
 		}
 
 		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
-		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		if (ref != git_since) {
+			sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		}
 	}
 
 	stage('check doc-only change') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -70,7 +70,9 @@ node('cico-workspace') {
 		}
 
 		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
-		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		if (ref != git_since) {
+			sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		}
 	}
 
 	stage('check doc-only change') {

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -70,7 +70,9 @@ node('cico-workspace') {
 		}
 
 		sh "git clone --depth=1 --branch='${git_since}' '${git_repo}' ~/build/ceph-csi"
-		sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		if (ref != git_since) {
+			sh "cd ~/build/ceph-csi && git fetch origin ${ref} && git checkout -b ${ref} FETCH_HEAD"
+		}
 	}
 
 	stage('check doc-only change') {


### PR DESCRIPTION
When tests are started manually (through the Jenkins webui), there is no
PR associated with the job. That means the `git_since` and `ref` are
equal. Trying to create a new branch named `ref` will not work, as the
branch was already created when cloning the repository with `git_since`.

With this change, Jenkins jobs can be started manually. This makes it
possible to run regular/nightly jobs as well.

Updates: #1963

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
