### PR TITLE
cephfs: add stderr to mount function errors

### DIFF
--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -168,7 +168,7 @@ func mountFuse(ctx context.Context, mountPoint string, cr *util.Credentials, vol
 
 	_, stderr, err := util.ExecCommand(ctx, "ceph-fuse", args[:]...)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w stderr: %s", err, stderr)
 	}
 
 	// Parse the output:
@@ -227,7 +227,11 @@ func mountKernel(ctx context.Context, mountPoint string, cr *util.Credentials, v
 
 	args = append(args, "-o", optionsStr)
 
-	return execCommandErr(ctx, "mount", args[:]...)
+	_, stderr, err := util.ExecCommand(ctx, "mount", args[:]...)
+	if err != nil {
+		return fmt.Errorf("%w stderr: %s", err, stderr)
+	}
+	return err
 }
 
 func (m *kernelMounter) mount(ctx context.Context, mountPoint string, cr *util.Credentials, volOptions *volumeOptions) error {


### PR DESCRIPTION
# Describe what this PR does #

This commit appends stderr to error in both kernel and ceph-fuse mounter functions to better be able to debug
errors.

Signed-off-by: Rakshith R <rar@redhat.com>


<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
