### PR TITLE
cleanup: fix warnings in golangci-lint

### DIFF
--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -541,7 +541,7 @@ func validateThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, siz
 	}
 
 	// expanding the PVC should thick-allocate the expansion
-	// nolint:mnd // we want 2x the size so that extending is done
+	// nolint:gomnd // we want 2x the size so that extending is done
 	newSize := du.ProvisionedSize * 2
 	err = expandPVCSize(f.ClientSet, pvc, fmt.Sprintf("%d", newSize), deployTimeout)
 	if err != nil {

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -125,7 +125,7 @@ func checkContentSource(ctx context.Context, req *csi.CreateVolumeRequest, cr *u
 }
 
 // CreateVolume creates a reservation and the volume in backend, if it is not already present.
-// nolint:gocognit:gocyclo // TODO: reduce complexity
+// nolint:gocognit,gocyclo,nestif // TODO: reduce complexity
 func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	if err := cs.validateCreateVolumeRequest(req); err != nil {
 		util.ErrorLog(ctx, "CreateVolumeRequest validation failed: %v", err)
@@ -193,7 +193,6 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 					// All errors other than ErrVolumeNotFound should return an error back to the caller
 					if !errors.Is(purgeErr, ErrVolumeNotFound) {
 						return nil, status.Error(codes.Internal, purgeErr.Error())
-
 					}
 				}
 				errUndo := undoVolReservation(ctx, volOptions, *vID, secret)

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -55,7 +55,7 @@ because, the order of omap creation and deletion are inverse of each other, and 
 request name lock, and hence any stale omaps are leftovers from incomplete transactions and are
 hence safe to garbage collect.
 */
-// nolint:gocognit:gocyclo // TODO: reduce complexity
+// nolint:gocognit,gocyclo,nestif // TODO: reduce complexity
 func checkVolExists(ctx context.Context,
 	volOptions,
 	parentVolOpt *volumeOptions,


### PR DESCRIPTION
# Describe what this PR does #

Fixes no-lint directive linter name and format issues which cause golangci-lint to throw following warning.
`level=warning msg="[runner/nolint] Found unknown linters in //nolint directives: gocognit:gocyclo, mnd"`

---
<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
