### PR TITLE
util: add nil check to default ControllerGetCapabilities()

### DIFF
--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -60,7 +60,9 @@ func (cs *DefaultControllerServer) GetCapacity(ctx context.Context, req *csi.Get
 // Default supports all capabilities.
 func (cs *DefaultControllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 	util.TraceLog(ctx, "Using default ControllerGetCapabilities")
-
+	if cs.Driver == nil {
+		return nil, status.Error(codes.Unimplemented, "Controller server is not enabled")
+	}
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: cs.Driver.capabilities,
 	}, nil


### PR DESCRIPTION
# Describe what this PR does #

Currently default ControllerGetCapabilities function is being used which throws `runtime error: invalid memory address or
nil pointer dereference` when `--controllerServer=true` is not set in provisioner deployment args.
This commit adds a check to prevent it.

Fixes: #1925

Signed-off-by: Rakshith R <rar@redhat.com>
---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
