### PR TITLE
ci: only abort on doc-change when running for PRs

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -40,7 +40,7 @@ node('cico-workspace') {
 			returnStatus: true)
 	}
 	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
-	if (doc_change == 1) {
+	if (doc_change == 1 && ref != git_since) {
 		currentBuild.result = 'SUCCESS'
 		return
 	}

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -58,7 +58,7 @@ node('cico-workspace') {
 			returnStatus: true)
 	}
 	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
-	if (doc_change == 1) {
+	if (doc_change == 1 && ref != git_since) {
 		currentBuild.result = 'SUCCESS'
 		return
 	}

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -68,7 +68,7 @@ node('cico-workspace') {
 			returnStatus: true)
 	}
 	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
-	if (doc_change == 1) {
+	if (doc_change == 1 && ref != git_since) {
 		currentBuild.result = 'SUCCESS'
 		return
 	}

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -84,7 +84,7 @@ node('cico-workspace') {
 			returnStatus: true)
 	}
 	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
-	if (doc_change == 1) {
+	if (doc_change == 1 && ref != git_since) {
 		currentBuild.result = 'SUCCESS'
 		return
 	}

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -81,7 +81,7 @@ node('cico-workspace') {
 			returnStatus: true)
 	}
 	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
-	if (doc_change == 1) {
+	if (doc_change == 1 && ref != git_since) {
 		currentBuild.result = 'SUCCESS'
 		return
 	}

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -81,7 +81,7 @@ node('cico-workspace') {
 			returnStatus: true)
 	}
 	// if doc_change (return value of skip-doc-change.sh is 1, do not run the other stages
-	if (doc_change == 1) {
+	if (doc_change == 1 && ref != git_since) {
 		currentBuild.result = 'SUCCESS'
 		return
 	}


### PR DESCRIPTION
In case a job has been started without a PR (manual, or timed), the
current checked out branch matches the original as there are not
additional changes in the tree. There is no need to abort the jobs when
the skip-doc-change.sh script did not detect any non-doc changes, as
there are no changes at all.

Updates: #1963

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
