### PR TITLE
ci: update feature gates setting from minikube.sh

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -173,7 +173,7 @@ if [[ "${VM_DRIVER}" == "kvm2" ]]; then
 fi
 
 #feature-gates for kube
-K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-"BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,ExpandCSIVolumes=true"}
+K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-"ExpandCSIVolumes=true"}
 
 #extra-config for kube https://minikube.sigs.k8s.io/docs/reference/configuration/kubernetes/
 EXTRA_CONFIG=${EXTRA_CONFIG:-"--extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy"}


### PR DESCRIPTION
BlockVolume, CSIBlockVolume(GA since k8s v1.18) & VolumeSnapshotDataSource (GA since k8s v1.20) default to true and don't need to be set to true in feature gates setting.
Removing feature gates since some options are removed from newer versions of k8s.

Signed-off-by: Rakshith R <rar@redhat.com>

Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/ 

This should also fix e2e fails in #1963 for k8s v1.21.0. 
Updates: #1963 #1968 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
