### PR TITLE
cleanup: update mergify.yml to use merge_bot_account option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ defaults:
     comment:
       bot_account: ceph-csi-bot
     merge:
-      bot_account: ceph-csi-bot
+      merge_bot_account: ceph-csi-bot
       method: rebase
       rebase_fallback: merge
       strict: smart


### PR DESCRIPTION
# Describe what this PR does #

New version of mergifyio requires the use `merge_bot_account`
instead of `bot_accout` configuration option.

Signed-off-by: Rakshith R <rar@redhat.com>



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
