### PR TITLE
e2e: fix error handling for goerr113 linter

### DIFF
--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -167,5 +167,3 @@ linters:
     - wsl
     - funlen
     - testpackage
-    # TODO: enable goerr113, see: https://github.com/ceph/ceph-csi/issues/1227
-    - goerr113


### PR DESCRIPTION
goerr113 is a golang linter to check the errors handling
expressions. It warns about using wrapped static errors in
place of dynamic at multiple places. Issue reported: err113:
do not define dynamic errors, use wrapped static errors instead
So, err113 reports every == and != comparison for exact error type
variables except comparison to nil and io.EOF.
Also, any call of errors.New() and fmt.Errorf() methods are reported
except the calls used to initialise package-level variables and the
fmt.Errorf() calls wrapping the other errors.

Updates: #1227

Signed-off-by: Yati Padia <ypadia@redhat.com>