### PR TITLE
Fix rbd Volume Resync and omap error handling for DR

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -872,7 +872,6 @@ func generateVolumeFromVolumeID(ctx context.Context, volumeID string, cr *util.C
 	if err != nil {
 		return rbdVol, err
 	}
-
 	rbdVol.RequestName = imageAttributes.RequestName
 	rbdVol.RbdImageName = imageAttributes.ImageName
 	rbdVol.ReservedID = vi.ObjectUUID
@@ -908,7 +907,7 @@ func generateVolumeFromVolumeID(ctx context.Context, volumeID string, cr *util.C
 // the structure with elements from on-disk image metadata as well.
 func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials, secrets map[string]string) (*rbdVolume, error) {
 	vol, err := generateVolumeFromVolumeID(ctx, volumeID, cr, secrets)
-	if !errors.Is(err, util.ErrKeyNotFound) && !errors.Is(err, util.ErrPoolNotFound) {
+	if !errors.Is(err, util.ErrKeyNotFound) && !errors.Is(err, util.ErrPoolNotFound) && !errors.Is(err, ErrImageNotFound) {
 		return vol, err
 	}
 


### PR DESCRIPTION
This PR fixes the below items
* incase if the image is promoted and demoted, the image state will be set to up+unknown if the image on the remote cluster is still in the demoted state.  when the user changes the state from primary to secondary and still the image is in the demoted (secondary) state in the remote cluster. the image state on both the cluster will be in an unknown state.

* rbd: check volumeID in PV if image not found
If the pool or few keys are missing in the omap. The GetImageAttributes function returns a nil error message and few empty items in imageAttributes struct. if the image is not found then use the volumeId present on the PV annotation and check we are able to get the OMAP data from new ID for further operations.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>