### PR TITLE
revert: cleanup: update mergify.yml to use merge_bot_account option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ defaults:
     comment:
       bot_account: ceph-csi-bot
     merge:
-      merge_bot_account: ceph-csi-bot
+      bot_account: ceph-csi-bot
       method: rebase
       rebase_fallback: merge
       strict: smart


### PR DESCRIPTION
This reverts commit 31634ede3d96b82cff034720bffc469c4de7d3e0.

```text
Merge with `merge_bot_account` set is unavailable
warning The subscription needs to be updated to enable this feature
```

Reverting back the changes done in https://github.com/ceph/ceph-csi/pull/1976 to avoid the auto-merge issue 
https://github.com/ceph/ceph-csi/runs/2352376340 as a temporary fix to fix auto merging

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

