### PR TITLE
cleanup: update mergify.yml to remove bot_account option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,16 +1,19 @@
 ---
 defaults:
   actions:
+    # mergify.io has removed bot_account from its free open source plan.
     comment:
-      bot_account: ceph-csi-bot
+    # bot_account: ceph-csi-bot # mergify[bot] will be commenting.
     merge:
-      bot_account: ceph-csi-bot
+      # merge_bot_account: ceph-csi-bot #mergify[bot] will be merging prs.
+      # update_bot_account: ceph-csi-bot #mergify will randomly pick and use
+      # credentials of users with write access to repo to rebase prs.
       method: rebase
       rebase_fallback: merge
       strict: smart
       strict_method: rebase
     rebase:
-      bot_account: ceph-csi-bot
+    # bot_account: ceph-csi-bot # same as update_bot_account.
 
 pull_request_rules:
   - name: remove outdated approvals


### PR DESCRIPTION
# Describe what this PR does #

Mergify.io has removed bot_account from its free open source plan.
This commit removes bot_account option from comment, merge and rebase actions default and documenting the implications going forward.

Signed-off-by: Rakshith R <rar@redhat.com>

Tested it out here https://github.com/Rakshith-R/tmp/pull/1  with https://github.com/Rakshith-R/tmp/blob/main/.mergify.yml

- [x] waiting for a reply from mergifyio https://github.com/Mergifyio/mergify-engine/discussions/2437 regarding `update_bot_account`

 
---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
