### PR TITLE
revert: update templates for v3.3.0 release

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.3.0
+CSI_IMAGE_VERSION=v3.3-canary
 
 # Ceph version to use
 BASE_IMAGE=docker.io/ceph/ceph:v15

--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.3.0
+appVersion: v3.3-canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
-version: 3.3.0-canary
+version: 3.3-canary
 keywords:
   - ceph
   - cephfs

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -84,7 +84,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.3.0
+      tag: v3.3-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.3.0
+appVersion: v3.3-canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter, and attacher for Ceph RBD"
 name: ceph-csi-rbd
-version: 3.3.0-canary
+version: 3.3-canary
 keywords:
   - ceph
   - rbd

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -95,7 +95,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.3.0
+      tag: v3.3-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -111,7 +111,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -147,7 +147,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -47,7 +47,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -97,7 +97,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -114,7 +114,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -165,7 +165,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -183,7 +183,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -48,7 +48,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -106,7 +106,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.3.0
+          image: quay.io/cephcsi/cephcsi:v3.3-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -281,7 +281,7 @@ teardown-rook)
     ;;
 cephcsi)
     echo "copying the cephcsi image"
-    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.3.0 "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.3.0
+    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.3-canary "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.3-canary
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"


### PR DESCRIPTION
This commit reverts back  the changes done for v3.3.0 release. With this change a release canary tagged image and helm charts
will get pushed.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

