### PR TITLE
cleanup: update description to generic

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -74,11 +74,11 @@ type rbdImage struct {
 	VolID string `json:"volID"`
 
 	Monitors string
-	// JournalPool is the ceph pool in which the CSI snapshot Journal is
+	// JournalPool is the ceph pool in which the CSI Journal/CSI snapshot Journal is
 	// stored
 	JournalPool string
-	// Pool is where the image snapshot journal and snapshot is stored, and
-	// could be the same as `JournalPool` (retained as Pool instead of
+	// Pool is where the image journal/image snapshot journal and image/snapshot
+	// is stored, and could be the same as `JournalPool` (retained as Pool instead of
 	// renaming to ImagePool or such, as this is referenced in the code
 	// extensively)
 	Pool           string


### PR DESCRIPTION
Since rbdImage is a common struct for
rbdVolume and rbdSnapshot, it's description
was matching only in reference to snapshots.
This commit makes the comments generic for
both volumes and snapshots.

Signed-off-by: Yug <yuggupta27@gmail.com>



Updates: #1917 


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
