### PR TITLE
rbd: modified logic to check image watchers

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -439,10 +439,11 @@ func (rv *rbdVolume) isInUse() (bool, error) {
 	// because we opened the image, there is at least one watcher
 	defaultWatchers := 1
 	if rv.Primary {
-		// a watcher will be added by the rbd mirror daemon if the image is primary
+		// if rbd mirror daemon is running, a watcher will be added by the rbd
+		// mirror daemon for mirrored images.
 		defaultWatchers++
 	}
-	return len(watchers) != defaultWatchers, nil
+	return len(watchers) > defaultWatchers, nil
 }
 
 // addRbdManagerTask adds a ceph manager task to execute command


### PR DESCRIPTION
Before RBD map operation, we do check the watchers on the RBD image. In the case of RWO volume. cephcsi makes sure only one client is using the RBD image. If the rbd image is mirrored, by default mirroring daemon will add a watcher on the image and as we are using go-ceph a watcher will be added as we have opened the image So we will have two watchers on an image if
mirroring is enabled. This holds when the rbd mirror daemon is running, In case if the mirror daemon is not running there will be only one watcher on the rbd image (which is placed by go-ceph image open) we should not block the map operation if the mirroring daemon is not running as its Async mirroring. This commit adds a check to make sure no more than 2 watchers
if the image is mirrored or no more than 1 watcher if it is not mirrored image.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
