### PR TITLE
ci: add optional Kubernetes 1.21 job

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,12 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.19'
-      - '1.20'
+      - '1.19':
+          only_run_on_request: false
+      - '1.20':
+          only_run_on_request: false
+      - '1.21':
+          only_run_on_request: true
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'
@@ -41,6 +45,7 @@
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-{k8s_version})?))'
+          only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
           black-list-target-branches:
@@ -81,6 +86,7 @@
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e-helm(/k8s-{k8s_version})?))'
+          only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
           black-list-target-branches:

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -13,6 +13,7 @@ FROM fedora:latest
 ARG GOLANGCI_VERSION=v1.21.0
 ARG GOSEC_VERSION=2.0.0
 ARG GOPATH=/go
+ARG HELM_VERSION=v3.1.2
 
 ENV \
  GOPATH=${GOPATH} \
@@ -37,7 +38,7 @@ RUN dnf -y install \
        | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
     && curl -sfL "https://raw.githubusercontent.com/securego/gosec/master/install.sh" \
        | sh -s -- -b $GOPATH/bin "${GOSEC_VERSION}" \
-    && curl -L https://git.io/get_helm.sh | bash \
+    && curl -L https://git.io/get_helm.sh | bash -s -- --version "${HELM_VERSION}" \
     && mkdir /opt/commitlint && pushd /opt/commitlint \
     && npm init -y \
     && npm install @commitlint/cli \


### PR DESCRIPTION
To test a PR with Kubernetes 1.21, leave a comment in the PR like:

    /test ci/centos/mini-e2e-helm/k8s-1.21

The status of the job will be recorded in the PR, but running this job
is not required (yet).

Updates: #1963

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
