### PR TITLE
rbd: return crypt error for the rpc return

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -811,13 +811,9 @@ func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnaps
 	if rbdVol.isEncrypted() {
 		// FIXME: vol.VolID should be different from rbdVol.VolID
 		vol.VolID = rbdVol.VolID
-		cryptErr := rbdVol.copyEncryptionConfig(&vol.rbdImage)
-		if cryptErr != nil {
-			util.WarningLog(ctx, "failed copy encryption "+
-				"config for %q: %v", vol.String(),
-				rbdSnap.RequestName, cryptErr)
-			return nil, status.Errorf(codes.Internal,
-				err.Error())
+		err = rbdVol.copyEncryptionConfig(&vol.rbdImage)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
 


### PR DESCRIPTION
at present we return the volume connect error if the clone
from snapshot fails when rbdvolume is encrypted, which is incorrect.
This patch correctly return the failed copy encryption error to the
caller

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
