### PR TITLE
build: Fix helm chart pushing

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -28,7 +28,6 @@ push_helm_charts() {
 	mkdir -p "$CHARTDIR/csi-charts/docs/$PACKAGE"
 	cp -R "./charts/ceph-csi-$PACKAGE" "$CHARTDIR/csi-charts/docs/$PACKAGE"
 	pushd "$CHARTDIR/csi-charts/docs/$PACKAGE" >/dev/null
-	helm init --client-only
 	helm package "ceph-csi-$PACKAGE"
 	popd >/dev/null
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -105,7 +105,7 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
 
 	pushd "$CSI_CHARTS_DIR" >/dev/null
 
-	curl -L https://git.io/get_helm.sh | bash
+	curl -L https://git.io/get_helm.sh | bash -s -- --version "${HELM_VERSION}"
 
 	build_step "cloning ceph/csi-charts repository"
 	git clone https://github.com/ceph/csi-charts


### PR DESCRIPTION
Removed helm init commands as helm v3.x does not have the `init` command see https://github.com/helm/helm/issues/6996 and also install the helm from the version specified in the build.env

resolves https://github.com/ceph/ceph-csi/issues/2006

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
