### PR TITLE
cleanup: fix author in mergifyio backport conditions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -91,7 +91,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v1.2.0
     conditions:
-      - author=ceph-csi-bot
+      - author=mergify[bot]
       - base=release-v1.2.0
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -112,7 +112,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v2.0
     conditions:
-      - author=ceph-csi-bot
+      - author=mergify[bot]
       - base=release-v2.0
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -133,7 +133,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v2.1
     conditions:
-      - author=ceph-csi-bot
+      - author=mergify[bot]
       - base=release-v2.1
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -154,7 +154,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v3.0
     conditions:
-      - author=ceph-csi-bot
+      - author=mergify[bot]
       - base=release-v3.0
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -175,7 +175,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v3.1
     conditions:
-      - author=ceph-csi-bot
+      - author=mergify[bot]
       - base=release-v3.1
       - label!=DNM
       - "#changes-requested-reviews-by=0"
@@ -204,7 +204,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v3.2
     conditions:
-      - author=ceph-csi-bot
+      - author=mergify[bot]
       - base=release-v3.2
       - label!=DNM
       - "#approved-reviews-by>=1"
@@ -239,7 +239,7 @@ pull_request_rules:
   # automerge backports if CI successfully ran
   - name: automerge backport release-v3.3
     conditions:
-      - author=ceph-csi-bot
+      - author=mergify[bot]
       - base=release-v3.3
       - label!=DNM
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
# Describe what this PR does #

All backport prs are authored by mergify[bot] not ceph-csi-bot
and there is no support for bot_account to create backport pr
currently.
Fixes: #1994

Signed-off-by: Rakshith R <rar@redhat.com>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
