### PR TITLE
ci: update mini-e2e-helm job as per script changes

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -177,7 +177,7 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='--deploy-cephfs=false --deploy-rbd=false'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='--deploy-cephfs=false --deploy-rbd=false --helm-test=true'"
 			}
 		}
 		stage('cleanup ceph-csi deployment') {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -172,7 +172,7 @@ node('cico-workspace') {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh up'
 				ssh "kubectl create namespace '${namespace}'"
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh install-cephcsi '${namespace}'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh install-cephcsi --namespace '${namespace}'"
 			}
 		}
 		stage('run e2e') {
@@ -182,7 +182,7 @@ node('cico-workspace') {
 		}
 		stage('cleanup ceph-csi deployment') {
 			timeout(time: 30, unit: 'MINUTES') {
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh cleanup-cephcsi '${namespace}'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh cleanup-cephcsi --namespace '${namespace}'"
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh clean'
 				ssh "kubectl delete namespace '${namespace}'"
 			}


### PR DESCRIPTION
Since we are adding support for deployment of sc and
secret via flags (see #1786 ), to help script recognize when an
unknown string is passed as a namespace, use
--namespace flag before entering the namespace.

Updates: #1786 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
