### PR TITLE
ci: enable running of k8s-e2e-external-storage job by default

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -29,7 +29,7 @@
           status-context: ci/centos/k8s-e2e-external-storage
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ci/centos/k8s-e2e-external-storage'
-          only-trigger-phrase: true
+          only-trigger-phrase: false
           permit-all: true
           github-hooks: true
           black-list-target-branches:


### PR DESCRIPTION
The job seems stable, and can be run by default now. Once it has been
run on several PRs, the `ci/centos/k8s-e2e-external-storage` job ID
can be added to the Mergify configuration.

See-also: https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/k8s-e2e-external-storage/activity
Updates: #2015 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
