### PR TITLE
testing: enable nodeExpansion for k8s-storage rbd-rwo verification

### DIFF
--- a/scripts/k8s-storage/driver-rbd-rwo.yaml
+++ b/scripts/k8s-storage/driver-rbd-rwo.yaml
@@ -54,7 +54,7 @@ DriverInfo:
     controllerExpansion: false
 
     # Support for volume expansion in nodes
-    nodeExpansion: false
+    nodeExpansion: true
 
     # Support volume that an run on single node only (like hostpath)
     singleNodeVolume: false


### PR DESCRIPTION
RBD volumes support NodeExpansion, so we should enable that in the tests.

Updates: #2015

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
