### PR TITLE
Replace deprecated GitVersion with Version

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -1,4 +1,4 @@
-{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.GitVersion }}
+{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
 {{ else }}
 apiVersion: storage.k8s.io/v1betav1

--- a/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
@@ -45,7 +45,7 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
 {{- end -}}
-{{- if semverCompare ">=1.15" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.15" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.provisioner.resizer.enabled }}
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -103,7 +103,7 @@ spec:
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
 {{- end }}
-{{- if semverCompare ">=1.15" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.15" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.provisioner.resizer.enabled }}
         - name: csi-resizer
           image: "{{ .Values.provisioner.resizer.image.repository }}:{{ .Values.provisioner.resizer.image.tag }}"

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -1,4 +1,4 @@
-{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.GitVersion }}
+{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
 {{ else }}
 apiVersion: storage.k8s.io/betav1


### PR DESCRIPTION
This replaces the deprecated `GitVersion` with `Version`.

See https://github.com/helm/helm/blob/a499b4b179307c267bdf3ec49b880e3dbd2a5591/pkg/chartutil/capabilities.go#L71-L74