### PR TITLE
ci: add missing ci_registry k8s-e2e-external-storage groovy

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -9,6 +9,7 @@ def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
 def namespace = 'k8s-e2e-storage-' + UUID.randomUUID().toString().split('-')[-1]
+def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
 
 def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"


### PR DESCRIPTION
added missing ci_registry variable to the k8s-e2e-external-storage groovy file.

see https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/k8s-e2e-external-storage/detail/k8s-e2e-external-storage/35/pipeline for error.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

