### PR TITLE
ci: pre-pull busybox container image

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -152,6 +152,11 @@ node('cico-workspace') {
 				// single-node-k8s.sh pushes the image into minikube
 				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
 			}
+
+			// busy box is used in external storage testing
+			podman_pull(ci_registry, "docker.io", "library/busybox:1.29")
+			ssh "./podman2minikube.sh docker.io/library/busybox:1.29"
+
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}


### PR DESCRIPTION
pre-pull the required busy box container image in k8s-e2e-external-storage.

closes #2029

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

