### PR TITLE
ci: fix k8s-e2e-external-storage fails

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -153,13 +153,13 @@ node('cico-workspace') {
 				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
 			}
 
-			// busy box is used in external storage testing
-			podman_pull(ci_registry, "docker.io", "library/busybox:1.29")
-			ssh "./podman2minikube.sh docker.io/library/busybox:1.29"
-
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
+
+			// busybox is used in external storage testing
+			podman_pull(ci_registry, "docker.io", "library/busybox:1.29")
+			ssh "./podman2minikube.sh docker.io/library/busybox:1.29"
 		}
 		stage('deploy ceph-csi through helm') {
 			timeout(time: 30, unit: 'MINUTES') {


### PR DESCRIPTION
# Describe what this PR does #

Minikube needs to be started before calling
./podman2minikube.sh.

Signed-off-by: Rakshith R <rar@redhat.com>




### Provide some context for the reviewer

k8s-e2e-external-storage fails with logs at https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/k8s-e2e-external-storage/detail/k8s-e2e-external-storage/47/pipeline
```
+ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@n62.pufty.ci.centos.org './podman2minikube.sh docker.io/library/busybox:1.29'
Warning: Permanently added 'n62.pufty.ci.centos.org,172.19.3.126' (ECDSA) to the list of known hosts.
./podman2minikube.sh: line 16: minikube: command not found
./podman2minikube.sh: line 16: minikube: command not found
Warning: Identity file  not accessible: No such file or directory.
ssh: Could not resolve hostname : Name or service not known
Copying blob sha256:23bc2b70b2014dec0ac22f27bb93e9babd08cdd6f1115d0c955b9ff22b382f5a
script returned exit code 255
```

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
