### PR TITLE
ci: provide k8s-e2e-external-storage jobs for different k8s versions

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -1,6 +1,16 @@
 ---
-- job:
+- project:
     name: k8s-e2e-external-storage
+    k8s_version:
+      - '1.20':
+          only_run_on_request: false
+      - '1.21':
+          only_run_on_request: true
+    jobs:
+      - 'k8s-e2e-external-storage-{k8s_version}'
+
+- job-template:
+    name: k8s-e2e-external-storage-{k8s_version}
     project-type: pipeline
     concurrent: true
     properties:
@@ -9,10 +19,11 @@
       - build-discarder:
           days-to-keep: 7
           artifact-days-to-keep: 7
+    k8s_version: '<unset>'
     parameters:
       - string:
           name: k8s_version
-          default: '1.20'
+          default: '{k8s_version}'
           description: Kubernetes version to deploy in the test cluster.
     pipeline-scm:
       scm:
@@ -25,11 +36,11 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-url: ${RUN_DISPLAY_URL}
-          status-context: ci/centos/k8s-e2e-external-storage
+          status-url: $RUN_DISPLAY_URL
+          status-context: 'ci/centos/k8s-e2e-external-storage/{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/k8s-e2e-external-storage'
-          only-trigger-phrase: false
+          trigger-phrase: '/(re)?test ((all)|(ci/centos/k8s-e2e-external-storage(/{k8s_version})?))'
+          only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
           black-list-target-branches:


### PR DESCRIPTION
The Kubernetes e2e external storage tests from v1.21 do not work yet
with Ceph-CSI. In order to address the issues, the job is now provided
and can be run with:

     /test ci/centos/k8s-e2e-external-storage/1.21

The job for v1.20 is enabled by default, and identified by the
ci/centos/k8s-e2e-external-storage/1.20 context in PRs.

Updates: #2017

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
