### PR TITLE
build: template changes for release v3.2.2

### DIFF
--- a/build.env
+++ b/build.env
@@ -10,7 +10,7 @@
 #
 
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.2-canary
+CSI_IMAGE_VERSION=v3.2.2
 
 # Ceph version to use
 BASE_IMAGE=docker.io/ceph/ceph:v15

--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.2-canary
+appVersion: v3.2.2
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
-version: 3.2-canary
+version: 3.2.2-canary
 keywords:
   - ceph
   - cephfs

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -80,7 +80,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.2-canary
+      tag: v3.2.2
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
-appVersion: v3.2-canary
+appVersion: v3.2.2
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter, and attacher for Ceph RBD"
 name: ceph-csi-rbd
-version: 3.2-canary
+version: 3.2.2-canary
 keywords:
   - ceph
   - rbd

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -92,7 +92,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.2-canary
+      tag: v3.2.2
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -109,7 +109,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -145,7 +145,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -46,7 +46,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -96,7 +96,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -112,7 +112,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -157,7 +157,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--type=controller"
             - "--v=5"
@@ -175,7 +175,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -47,7 +47,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -99,7 +99,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.2-canary
+          image: quay.io/cephcsi/cephcsi:v3.2.2
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -280,7 +280,7 @@ teardown-rook)
     ;;
 cephcsi)
     echo "copying the cephcsi image"
-    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2-canary "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2-canary
+    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2.2 "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.2.2
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"


### PR DESCRIPTION
Updated the required files to make cephcsi v3.2.2 for bugfix release which includes ceph CVE fix https://docs.ceph.com/en/latest/security/CVE-2021-20288/

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

