### PR TITLE
Rename "master" branch to "devel"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/master/docs/development-guide.md#Code-contribution-workflow)
+<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
 documentation before submitting a Pull Request!
 Thank you for contributing to ceph-csi! -->
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@
 pull_request_rules:
   - name: remove outdated approvals
     conditions:
-      - base=master
+      - base=devel
     actions:
       dismiss_reviews:
         approved: true
@@ -19,7 +19,7 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - label!=DNM
-      - base=master
+      - base=devel
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=codespell"
@@ -51,7 +51,7 @@ pull_request_rules:
     conditions:
       - label!=DNM
       - label=ready-to-merge
-      - base=master
+      - base=devel
       - "#approved-reviews-by>=1"
       - "status-success=codespell"
       - "status-success=multi-arch-build"
@@ -81,7 +81,7 @@ pull_request_rules:
       delete_head_branch: {}
   - name: backport patches to release v1.2.0 branch
     conditions:
-      - base=master
+      - base=devel
       - label=backport-to-release-v1.2.0
     actions:
       backport:
@@ -107,7 +107,7 @@ pull_request_rules:
       delete_head_branch: {}
   - name: backport patches to release-v2.0 branch
     conditions:
-      - base=master
+      - base=devel
       - label=backport-to-release-v2.0
     actions:
       backport:
@@ -133,7 +133,7 @@ pull_request_rules:
       delete_head_branch: {}
   - name: backport patches to release-v2.1 branch
     conditions:
-      - base=master
+      - base=devel
       - label=backport-to-release-v2.1
     actions:
       backport:
@@ -159,7 +159,7 @@ pull_request_rules:
       delete_head_branch: {}
   - name: backport patches to release-v3.0 branch
     conditions:
-      - base=master
+      - base=devel
       - label=backport-to-release-v3.0
     actions:
       backport:
@@ -185,7 +185,7 @@ pull_request_rules:
       delete_head_branch: {}
   - name: backport patches to release-v3.1 branch
     conditions:
-      - base=master
+      - base=devel
       - label=backport-to-release-v3.1
     actions:
       backport:
@@ -220,7 +220,7 @@ pull_request_rules:
       delete_head_branch: {}
   - name: backport patches to release-v3.2 branch
     conditions:
-      - base=master
+      - base=devel
       - label=backport-to-release-v3.2
     actions:
       backport:

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 
 # Pass GIT_SINCE for the range of commits to test. Used with the commitlint
 # target.
-GIT_SINCE := origin/master
+GIT_SINCE := origin/devel
 
 SELINUX := $(shell getenforce 2>/dev/null)
 ifeq ($(SELINUX),Enforcing)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Report
 Card](https://goreportcard.com/badge/github.com/ceph/ceph-csi)](https://goreportcard.com/report/github.com/ceph/ceph-csi)
 [![Build
-Status](https://travis-ci.org/ceph/ceph-csi.svg?branch=master)](https://travis-ci.org/ceph/ceph-csi)
+Status](https://travis-ci.org/ceph/ceph-csi.svg?branch=devel)](https://travis-ci.org/ceph/ceph-csi)
 
 - [Ceph CSI](#ceph-csi)
   - [Overview](#overview)
@@ -33,9 +33,9 @@ attaching them to workloads.
 Independent CSI plugins are provided to support RBD and CephFS backed volumes,
 
 - For details about configuration and deployment of RBD plugin, please refer
-  [rbd doc](https://github.com/ceph/ceph-csi/blob/master/docs/deploy-rbd.md) and
+  [rbd doc](https://github.com/ceph/ceph-csi/blob/devel/docs/deploy-rbd.md) and
   for CephFS plugin configuration and deployment please
-  refer [cephfs doc](https://github.com/ceph/ceph-csi/blob/master/docs/deploy-cephfs.md).
+  refer [cephfs doc](https://github.com/ceph/ceph-csi/blob/devel/docs/deploy-cephfs.md).
 - For example usage of RBD and CephFS CSI plugins, see examples in `examples/`.
 - Stale resource cleanup, please refer [cleanup doc](docs/resource-cleanup.md).
 
@@ -119,8 +119,8 @@ in the Kubernetes documentation.
 
 ## Contributing to this repo
 
-Please follow [development-guide](<https://github.com/ceph/ceph-csi/tree/master/docs/development-guide.md>)
-and [coding style guidelines](<https://github.com/ceph/ceph-csi/tree/master/docs/coding.md>)
+Please follow [development-guide](<https://github.com/ceph/ceph-csi/tree/devel/docs/development-guide.md>)
+and [coding style guidelines](<https://github.com/ceph/ceph-csi/tree/devel/docs/coding.md>)
 if you are interested to contribute to this repo.
 
 ## Troubleshooting

--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -11,5 +11,5 @@ keywords:
   - ceph-csi
 home: https://github.com/ceph/ceph-csi
 sources:
-  - https://github.com/ceph/ceph-csi/tree/master/charts/ceph-csi-cephfs
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/master/assets/ceph-logo.png
+  - https://github.com/ceph/ceph-csi/tree/devel/charts/ceph-csi-cephfs
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/devel/assets/ceph-logo.png

--- a/charts/ceph-csi-cephfs/templates/NOTES.txt
+++ b/charts/ceph-csi-cephfs/templates/NOTES.txt
@@ -1,2 +1,2 @@
 Examples on how to configure a storage class and start using the driver are here:
-https://github.com/ceph/ceph-csi/tree/master/examples/cephfs
+https://github.com/ceph/ceph-csi/tree/devel/examples/cephfs

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -18,7 +18,7 @@ serviceAccounts:
     name:
 
 # Configuration for the CSI to connect to the cluster
-# Ref: https://github.com/ceph/ceph-csi/blob/master/examples/README.md
+# Ref: https://github.com/ceph/ceph-csi/blob/devel/examples/README.md
 # Example:
 # csiConfig:
 #   - clusterID: "<cluster-id>"

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -11,5 +11,5 @@ keywords:
   - ceph-csi
 home: https://github.com/ceph/ceph-csi
 sources:
-  - https://github.com/ceph/ceph-csi/tree/master/charts/ceph-csi-rbd
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/master/assets/ceph-logo.png
+  - https://github.com/ceph/ceph-csi/tree/devel/charts/ceph-csi-rbd
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/devel/assets/ceph-logo.png

--- a/charts/ceph-csi-rbd/templates/NOTES.txt
+++ b/charts/ceph-csi-rbd/templates/NOTES.txt
@@ -1,2 +1,2 @@
 Examples on how to configure a storage class and start using the driver are here:
-https://github.com/ceph/ceph-csi/tree/master/examples/rbd
+https://github.com/ceph/ceph-csi/tree/devel/examples/rbd

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -18,7 +18,7 @@ serviceAccounts:
     name:
 
 # Configuration for the CSI to connect to the cluster
-# Ref: https://github.com/ceph/ceph-csi/blob/master/examples/README.md
+# Ref: https://github.com/ceph/ceph-csi/blob/devel/examples/README.md
 # Example:
 # csiConfig:
 #   - clusterID: "<cluster-id>"
@@ -28,7 +28,7 @@ serviceAccounts:
 csiConfig: []
 
 # Configuration for the encryption KMS
-# Ref: https://github.com/ceph/ceph-csi/blob/master/docs/deploy-rbd.md
+# Ref: https://github.com/ceph/ceph-csi/blob/devel/docs/deploy-rbd.md
 # Example:
 # encryptionKMSConfig:
 #   vault-unique-id-1:

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,18 +9,18 @@ push_helm_charts() {
 	CHARTDIR=$2
 	VERSION=${CSI_IMAGE_VERSION//v/} # Set version (without v prefix)
 
-	# update information in Chart.yaml if the branch is not master
-	if [ "$TRAVIS_BRANCH" != "master" ]; then
+	# update information in Chart.yaml if the branch is not devel
+	if [ "$TRAVIS_BRANCH" != "devel" ]; then
 		# Replace appVersion: canary and version: *-canary with the actual version
 		sed -i "s/\(\s.*canary\)/ $VERSION/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
 
 		if [[ "$VERSION" == *"canary"* ]]; then
-			# Replace master with the version branch
-			sed -i "s/master/$TRAVIS_BRANCH/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
+			# Replace devel with the version branch
+			sed -i "s/devel/$TRAVIS_BRANCH/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
 		else
-			# This is not a canary release, replace master with the tagged branch
-			sed -i "s/master/v$VERSION/" "charts/ceph-csi-$PACKAGE/templates/NOTES.txt"
-			sed -i "s/master/v$VERSION/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
+			# This is not a canary release, replace devel with the tagged branch
+			sed -i "s/devel/v$VERSION/" "charts/ceph-csi-$PACKAGE/templates/NOTES.txt"
+			sed -i "s/devel/v$VERSION/" "charts/ceph-csi-$PACKAGE/Chart.yaml"
 
 		fi
 	fi

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -83,11 +83,11 @@ to upgrade from cephcsi v3.0 to v3.1
 
 ## Upgrading from v3.1 to v3.2
 
-**Ceph-csi releases from master are expressly unsupported.** It is strongly
+**Ceph-csi releases from devel are expressly unsupported.** It is strongly
 recommended that you use [official
 releases](https://github.com/ceph/ceph-csi/releases) of Ceph-csi. Unreleased
-versions from the master branch are subject to changes and incompatibilities
-that will not be supported in the official releases. Builds from the master
+versions from the devel branch are subject to changes and incompatibilities
+that will not be supported in the official releases. Builds from the devel
 branch can have functionality changed and even removed at any time without
 compatibility support and without prior notice.
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -189,7 +189,7 @@ Here is a short guide on how to work on a new patch.  In this example, we will
 work on a patch called *hellopatch*:
 
 ```console
-git checkout master
+git checkout devel
 git pull
 git checkout -b hellopatch
 ```
@@ -263,22 +263,22 @@ need to be met before it will be merged:
   community feedback.
 * The 24 working hours counts hours occurring Mon-Fri in the local timezone
   of the submitter.
-* Each PR must be fully updated to master and tests must have passed
+* Each PR must be fully updated to devel and tests must have passed
 * If the PR is having trivial changes or the reviewer is confident enough that
   PR doesn't need a second review, the reviewer can set `ready-to-merge` label
   on the PR. The bot will merge the PR if it's having one approval and the
   label `ready-to-merge`.
 
 When the criteria are met, a project maintainer can merge your changes into
-the project's master branch.
+the project's devel branch.
 
 ### Backport a Fix to a Release Branch
 
 The flow for getting a fix into a release branch is:
 
-1. Open a PR to merge the changes to master following the process outlined above.
+1. Open a PR to merge the changes to devel following the process outlined above.
 1. Add the backport label to that PR such as `backport-to-release-vX.Y.Z`
-1. After your PR is merged to master, the mergify bot will automatically open a
+1. After your PR is merged to devel, the mergify bot will automatically open a
    PR with your commits backported to the release branch
 1. If there are any conflicts you will need to resolve them by pulling the
    branch, resolving the conflicts and force push back the branch

--- a/docs/snap-clone.md
+++ b/docs/snap-clone.md
@@ -60,7 +60,7 @@ The snapshot is created on/for an existing PVC. You should
 have a PVC in bound state before creating snapshot from it.
 It is recommended to create a volume snapshot or a PVC clone
 only when the PVC is not in use.
-Please refer pvc creation [doc](https://github.com/ceph/ceph-csi/blob/master/docs/deploy-cephfs.md)
+Please refer pvc creation [doc](https://github.com/ceph/ceph-csi/blob/devel/docs/deploy-cephfs.md)
 for more information on how to create a PVC.
 
 - Verify if PVC is in Bound state


### PR DESCRIPTION
This PR renames all occasions of "master" to "devel" where the reference is relevant to Ceph-CSI.

Once this PR is merged, an admin of the GitHub project will need to rename the branch before next PRs can get merged. The GitHub documentation describes that all the existing PRs for the "master" branch will automatically be updated to the new "devel" branch.

Backport-of: #1890

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
