### PR TITLE
Rbd: Fix image flattening when snapshot and parent PVC is deleted

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -238,6 +238,7 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	var err error
 	var readOnly bool
 	var feature bool
+	var depth uint
 
 	var cr *util.Credentials
 	cr, err = util.NewUserCredentials(req.GetSecrets())
@@ -272,7 +273,11 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 		if err != nil {
 			return transaction, err
 		}
-		if feature {
+		depth, err = volOptions.getCloneDepth(ctx)
+		if err != nil {
+			return transaction, err
+		}
+		if feature || depth != 0 {
 			err = volOptions.flattenRbdImage(ctx, cr, true, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 			if err != nil {
 				return transaction, err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -726,7 +726,7 @@ func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint
 			if errors.Is(err, ErrImageNotFound) {
 				return false, nil
 			}
-			util.ErrorLog(ctx, "failed to get image info for %s: %s", vol, err)
+			util.ErrorLog(ctx, "failed to get image info for %s: %s", vol.String(), err)
 			return false, err
 		}
 		if f := vol.hasFeature(feature); f {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -719,6 +719,13 @@ func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint
 		}
 		err = vol.getImageInfo()
 		if err != nil {
+			// call to getImageInfo returns the parent name even if the parent
+			// is in the trash, when we try to open the parent image to get its
+			// information it fails because it is already in trash. We should
+			// treat error as nil if the parent is not found.
+			if errors.Is(err, ErrImageNotFound) {
+				return false, nil
+			}
 			util.ErrorLog(ctx, "failed to get image info for %s: %s", vol, err)
 			return false, err
 		}


### PR DESCRIPTION
For flattening we call checkImageChainHasFeature which internally calls to `getImageInfo` returns the parent name even if the parent is in the trash when we try to open the parent image to get its information it fails as the image not found. we should treat the error as nil if the parent is not found.

flatten the image if the deep-flatten feature is present on the images in the chain or if the images in the chain are not zero, as we cannot check the deep-flatten feature of the images which are in the trash.
    
resolves #2044 
resolves #1544 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>