### PR TITLE
ci: apply standard Mergify rules for release branches too

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,7 +15,7 @@ defaults:
 pull_request_rules:
   - name: remove outdated approvals
     conditions:
-      - base=devel
+      - base~='^(devel)|(release-.+)$'
     actions:
       dismiss_reviews:
         approved: true
@@ -32,7 +32,7 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - label!=DNM
-      - base=devel
+      - base~='^(devel)|(release-.+)$'
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=codespell"
@@ -58,7 +58,7 @@ pull_request_rules:
     conditions:
       - label!=DNM
       - label=ready-to-merge
-      - base=devel
+      - base~='^(devel)|(release-.+)$'
       - "#approved-reviews-by>=1"
       - "status-success=codespell"
       - "status-success=multi-arch-build"


### PR DESCRIPTION
It is not always possible to automatically backport PRs to release
branches. That also means that these backport PRs are not created by the
mergify[bot] account. Because of this, it is needed to manually merge
PRs, as Mergify refuses to do it.

By changing the `base=` option to match a regular expression that
includes both `devel` and `release-*` branches, Mergify should assist
with merging PRs to release branches too.

Note that the `ci/centos` branch is different, as runs other tests than
the normal branches.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
