### PR TITLE
ci: drop quotes for Mergify regex matching

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,7 +15,7 @@ defaults:
 pull_request_rules:
   - name: remove outdated approvals
     conditions:
-      - base~='^(devel)|(release-.+)$'
+      - base~=^(devel)|(release-.+)$
     actions:
       dismiss_reviews:
         approved: true
@@ -32,7 +32,7 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - label!=DNM
-      - base~='^(devel)|(release-.+)$'
+      - base~=^(devel)|(release-.+)$
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=codespell"
@@ -58,7 +58,7 @@ pull_request_rules:
     conditions:
       - label!=DNM
       - label=ready-to-merge
-      - base~='^(devel)|(release-.+)$'
+      - base~=^(devel)|(release-.+)$
       - "#approved-reviews-by>=1"
       - "status-success=codespell"
       - "status-success=multi-arch-build"


### PR DESCRIPTION
The matching with regexes on the `base=` configuration in Mergify does
not seem to work as intended. Possibly this is due the additional quotes
around the regex.

Fixes: 8d7c66363 (ci: apply standard Mergify rules for release branches too)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
