### PR TITLE
ci: use mergify to add labels to PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -297,3 +297,70 @@ pull_request_rules:
       merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
+  ##
+  ## Automatically set/remove labels
+  ##
+  - name: title contains DNM
+    conditions:
+      - title~=DNM
+    actions:
+      label:
+        add:
+          - DNM
+  - name: title contains CephFS
+    conditions:
+      - "title~=cephfs: "
+    actions:
+      label:
+        add:
+          - component/cephfs
+  - name: title contains RBD
+    conditions:
+      - "title~=rbd: "
+    actions:
+      label:
+        add:
+          - component/rbd
+  - name: title contains CI or testing
+    conditions:
+      - "title~=(ci)|(testing): "
+    actions:
+      label:
+        add:
+          - component/testing
+  - name: title contains Helm
+    conditions:
+      - title~=helm
+    actions:
+      label:
+        add:
+          - component/deployment
+  - name: title contains rebase
+    conditions:
+      - "title~=rebase: "
+    actions:
+      label:
+        add:
+          - rebase
+  - name: title indicates a bug fix
+    conditions:
+      - title~=(bug)|(fix)
+    actions:
+      label:
+        add:
+          - bug
+  - name: title contains cleanup
+    conditions:
+      - "title~=cleanup: "
+    actions:
+      label:
+        add:
+          - cleanup
+  - name: title contains doc
+    conditions:
+      - "title~=doc: "
+    actions:
+      label:
+        add:
+          - component/docs
+          - ci/skip/e2e


### PR DESCRIPTION
Adding labels to Pull-Requests can be done by Mergify. It is very useful
to filter PRs on their labels so that experts in certain areas can
identify PRs to review.

Adding labels is currently a complete manual process, this adds some
automation for it. There is no intention of it being complete, this is
mostly for getting started and trying things out.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
