### PR TITLE
ci: update mergify config for labelling PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -321,9 +321,9 @@ pull_request_rules:
       label:
         add:
           - component/rbd
-  - name: title contains CI or testing
+  - name: title contains CI, testing or e2e
     conditions:
-      - "title~=(ci)|(testing): "
+      - "title~=(ci: )|(testing: )|(e2e)"
     actions:
       label:
         add:
@@ -363,4 +363,12 @@ pull_request_rules:
       label:
         add:
           - component/docs
+          - ci/skip/e2e
+  - name: title contains Mergify
+    conditions:
+      - "title~=mergify"
+    actions:
+      label:
+        add:
+          - Repo activity
           - ci/skip/e2e


### PR DESCRIPTION
When the configuration for Mergify itself gets updated, there is not
need to run the e2e tests.

It seems that the `(ci)` part of matching a title for ci/testing PRs
would match partial words like 'capacity'. This is not intended, so
rephrasing the regex and adding `e2e` as match too.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
