### PR TITLE
cleanup: remove unnecessary calling of .String() when logging

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -900,7 +900,7 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 		cryptErr := parentVol.copyEncryptionConfig(&cloneRbd.rbdImage)
 		if cryptErr != nil {
 			util.WarningLog(ctx, "failed copy encryption "+
-				"config for %q: %v", cloneRbd.String(), cryptErr)
+				"config for %q: %v", cloneRbd, cryptErr)
 			return ready, nil, status.Errorf(codes.Internal,
 				err.Error())
 		}

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -30,13 +30,13 @@ import (
 func (ri *rbdImage) enableImageMirroring(mode librbd.ImageMirrorMode) error {
 	image, err := ri.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
 	}
 	defer image.Close()
 
 	err = image.MirrorEnable(mode)
 	if err != nil {
-		return fmt.Errorf("failed to enable mirroring on %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to enable mirroring on %q with error: %w", ri, err)
 	}
 	return nil
 }
@@ -45,13 +45,13 @@ func (ri *rbdImage) enableImageMirroring(mode librbd.ImageMirrorMode) error {
 func (ri *rbdImage) disableImageMirroring(force bool) error {
 	image, err := ri.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
 	}
 	defer image.Close()
 
 	err = image.MirrorDisable(force)
 	if err != nil {
-		return fmt.Errorf("failed to disable mirroring on %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to disable mirroring on %q with error: %w", ri, err)
 	}
 	return nil
 }
@@ -60,13 +60,13 @@ func (ri *rbdImage) disableImageMirroring(force bool) error {
 func (ri *rbdImage) getImageMirroringInfo() (*librbd.MirrorImageInfo, error) {
 	image, err := ri.open()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open image %q with error: %w", ri.String(), err)
+		return nil, fmt.Errorf("failed to open image %q with error: %w", ri, err)
 	}
 	defer image.Close()
 
 	info, err := image.GetMirrorImageInfo()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get mirroring info of %q with error: %w", ri.String(), err)
+		return nil, fmt.Errorf("failed to get mirroring info of %q with error: %w", ri, err)
 	}
 	return info, nil
 }
@@ -75,12 +75,12 @@ func (ri *rbdImage) getImageMirroringInfo() (*librbd.MirrorImageInfo, error) {
 func (ri *rbdImage) promoteImage(force bool) error {
 	image, err := ri.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
 	}
 	defer image.Close()
 	err = image.MirrorPromote(force)
 	if err != nil {
-		return fmt.Errorf("failed to promote image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to promote image %q with error: %w", ri, err)
 	}
 	return nil
 }
@@ -89,12 +89,12 @@ func (ri *rbdImage) promoteImage(force bool) error {
 func (ri *rbdImage) demoteImage() error {
 	image, err := ri.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
 	}
 	defer image.Close()
 	err = image.MirrorDemote()
 	if err != nil {
-		return fmt.Errorf("failed to demote image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to demote image %q with error: %w", ri, err)
 	}
 	return nil
 }
@@ -103,12 +103,12 @@ func (ri *rbdImage) demoteImage() error {
 func (ri *rbdImage) resyncImage() error {
 	image, err := ri.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
 	}
 	defer image.Close()
 	err = image.MirrorResync()
 	if err != nil {
-		return fmt.Errorf("failed to resync image %q with error: %w", ri.String(), err)
+		return fmt.Errorf("failed to resync image %q with error: %w", ri, err)
 	}
 	return nil
 }

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -256,7 +256,7 @@ func createPath(ctx context.Context, volOpt *rbdVolume, cr *util.Credentials) (s
 	// check if the image should stay thick-provisioned
 	isThick, err := volOpt.isThickProvisioned()
 	if err != nil {
-		util.WarningLog(ctx, "failed to detect if image %q is thick-provisioned: %v", volOpt.String(), err)
+		util.WarningLog(ctx, "failed to detect if image %q is thick-provisioned: %v", volOpt, err)
 	}
 
 	mapArgs = appendDeviceTypeAndOptions(mapArgs, isNbd, isThick, volOpt.MapOptions)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -485,7 +485,7 @@ func deleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 	}
 
 	if pOpts.isEncrypted() {
-		util.DebugLog(ctx, "rbd: going to remove DEK for %q", pOpts.String())
+		util.DebugLog(ctx, "rbd: going to remove DEK for %q", pOpts)
 		if err = pOpts.encryption.RemoveDEK(pOpts.VolID); err != nil {
 			util.WarningLog(ctx, "failed to clean the passphrase for volume %s: %s", pOpts.VolID, err)
 		}
@@ -554,7 +554,7 @@ func (rv *rbdVolume) getCloneDepth(ctx context.Context) (uint, error) {
 			if errors.Is(err, ErrImageNotFound) {
 				return depth, nil
 			}
-			util.ErrorLog(ctx, "failed to check depth on image %s: %s", vol.String(), err)
+			util.ErrorLog(ctx, "failed to check depth on image %s: %s", &vol, err)
 			return depth, err
 		}
 		if vol.ParentName != "" {
@@ -807,14 +807,14 @@ func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID str
 	}()
 	if err != nil {
 		return fmt.Errorf("failed to connect to %q: %w",
-			rbdSnap.String(), err)
+			rbdSnap, err)
 	}
 
 	if imageAttributes.KmsID != "" {
 		err = rbdSnap.configureEncryption(imageAttributes.KmsID, secrets)
 		if err != nil {
 			return fmt.Errorf("failed to configure encryption for "+
-				"%q: %w", rbdSnap.String(), err)
+				"%q: %w", rbdSnap, err)
 		}
 	}
 
@@ -1119,7 +1119,7 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *r
 		if deleteClone {
 			err = librbd.RemoveImage(rv.ioctx, rv.RbdImageName)
 			if err != nil {
-				util.ErrorLog(ctx, "failed to delete temporary image %q: %v", rv.String(), err)
+				util.ErrorLog(ctx, "failed to delete temporary image %q: %v", rv, err)
 			}
 		}
 	}()
@@ -1254,7 +1254,7 @@ func (rv *rbdVolume) checkSnapExists(rbdSnap *rbdSnapshot) error {
 		}
 	}
 
-	return fmt.Errorf("%w: snap %s not found", ErrSnapNotFound, rbdSnap.String())
+	return fmt.Errorf("%w: snap %s not found", ErrSnapNotFound, rbdSnap)
 }
 
 // rbdImageMetadataStash strongly typed JSON spec for stashed RBD image metadata.
@@ -1416,7 +1416,7 @@ func (ri *rbdImage) SetMetadata(key, value string) error {
 func (rv *rbdVolume) setThickProvisioned() error {
 	err := rv.SetMetadata(thickProvisionMetaKey, "true")
 	if err != nil {
-		return fmt.Errorf("failed to set metadata %q for %q: %w", thickProvisionMetaKey, rv.String(), err)
+		return fmt.Errorf("failed to set metadata %q for %q: %w", thickProvisionMetaKey, rv, err)
 	}
 
 	return nil
@@ -1431,7 +1431,7 @@ func (rv *rbdVolume) isThickProvisioned() (bool, error) {
 		if err == librbd.ErrNotFound {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to get metadata %q for %q: %w", thickProvisionMetaKey, rv.String(), err)
+		return false, fmt.Errorf("failed to get metadata %q for %q: %w", thickProvisionMetaKey, rv, err)
 	}
 
 	thick, err := strconv.ParseBool(value)


### PR DESCRIPTION
# Describe what this PR does #

This commit removes calling of .String() when logging
since `%s`,`%v` or `%q` will call an existing .String() function
automatically.

Fixes: #2051

Signed-off-by: Rakshith R <rar@redhat.com>

golang playgroud: https://play.golang.org/p/HbvOxWI5Ri-



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
