### PR TITLE
helm: fix k8s version string for csidriver crds semverCompare

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -1,4 +1,4 @@
-{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+{{ if semverCompare ">=1.18.0-beta.1" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
 {{ else }}
 apiVersion: storage.k8s.io/v1betav1

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -1,4 +1,4 @@
-{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+{{ if semverCompare ">=1.18.0-beta.1" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
 {{ else }}
 apiVersion: storage.k8s.io/betav1


### PR DESCRIPTION
# Describe what this PR does #
Current implementation of semvercompare fails against
pre-release versions. This commit fixes it by using
the entire version string at which csidriver api became GA.

s|">=1.18"|">=1.18.0-beta.1"

Fixes: #2039

Signed-off-by: Rakshith R <rar@redhat.com>

For reference: https://github.com/ceph/ceph-csi/issues/2039#issuecomment-836448191



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
