### PR TITLE
ci: in case of a failure, return error after logging system status

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -10,6 +10,7 @@ def doc_change = 0
 def k8s_release = 'latest'
 def namespace = 'k8s-e2e-storage-' + UUID.randomUUID().toString().split('-')[-1]
 def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def failure = null
 
 def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
@@ -182,6 +183,8 @@ node('cico-workspace') {
 	}
 
 	catch (err) {
+		failure = err
+
 		stage('log system status') {
 			ssh './system-status.sh'
 		}
@@ -190,6 +193,10 @@ node('cico-workspace') {
 	finally {
 		stage('return bare-metal machine') {
 			sh 'cico node done ${CICO_SSID}'
+		}
+
+		if (failure) {
+			throw failure
 		}
 	}
 }

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -10,6 +10,7 @@ def doc_change = 0
 def k8s_release = 'latest'
 def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
 def namespace = 'cephcsi-e2e-' + UUID.randomUUID().toString().split('-')[-1]
+def failure = null
 
 // ssh executes a given command on the reserved bare-metal machine
 // NOTE: do not pass " symbols on the command line, use ' only.
@@ -189,6 +190,8 @@ node('cico-workspace') {
 	}
 
 	catch (err) {
+		failure = err
+
 		stage('log system status') {
 			ssh './system-status.sh'
 		}
@@ -197,6 +200,10 @@ node('cico-workspace') {
 	finally {
 		stage('return bare-metal machine') {
 			sh 'cico node done ${CICO_SSID}'
+		}
+
+		if (failure) {
+			throw failure
 		}
 	}
 }

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -9,6 +9,7 @@ def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
 def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def failure = null
 
 def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
@@ -172,6 +173,8 @@ node('cico-workspace') {
 	}
 
 	catch (err) {
+		failure = err
+
 		stage('log system status') {
 			ssh './system-status.sh'
 		}
@@ -180,6 +183,10 @@ node('cico-workspace') {
 	finally {
 		stage('return bare-metal machine') {
 			sh 'cico node done ${CICO_SSID}'
+		}
+
+		if (failure) {
+			throw failure
 		}
 	}
 }

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -9,6 +9,7 @@ def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
 def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def failure = null
 
 def ssh(cmd) {
 	sh "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} '${cmd}'"
@@ -176,6 +177,8 @@ node('cico-workspace') {
 	}
 
 	catch (err) {
+		failure = err
+
 		stage('log system status') {
 			ssh './system-status.sh'
 		}
@@ -184,6 +187,10 @@ node('cico-workspace') {
 	finally {
 		stage('return bare-metal machine') {
 			sh 'cico node done ${CICO_SSID}'
+		}
+
+		if (failure) {
+			throw failure
 		}
 	}
 }


### PR DESCRIPTION
It seems that it is required to re-throw the error after a catch{..}
block. Without this, and a successful execution of system-status.sh, the
CI jobs get marked as SUCCESS, even when there was a failure.

Fixes: e36155283 "ci: run system-status.sh in case a job fails"

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
