### PR TITLE
ci: use "top -w" for untruncated wide output

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -30,7 +30,7 @@ log minikube status
 log minikube logs
 
 # get the status of processes in the VM
-log minikube_ssh top -b -c -n1
+log minikube_ssh top -b -c -n1 -w
 
 # get the logs from the VM
 log minikube_ssh journalctl --boot


### PR DESCRIPTION
Without the `-w` argument, the output of `top` gets truncated, and the
commandline of the processes is not comlete. It would be useful to eb
able to tell which command uses 100% CPU in an output like:

```
  17377 root      20   0  110.8m   8.2m   0.0   0.1   0:00.89 S  `- containerd+
  17414 167       20   0 1036.7m  59.6m   0.0   0.4   0:03.47 S      `- ceph-o+
  40875 root      20   0  283.9m  30.4m 100.0   0.2   0:00.23 R      `- ceph
```

Updates: #1969

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
