### PR TITLE
ci: use "-T" to display the filesystem type

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -36,5 +36,5 @@ log minikube_ssh top -b -c -n1 -w
 log minikube_ssh journalctl --boot
 
 # filesystem status for host and VM
-log df -h
-log minikube_ssh df -h
+log df -hT
+log minikube_ssh df -hT


### PR DESCRIPTION
Provide filesystem type information with logs

Updates: https://github.com/ceph/ceph-csi/pull/2073#issuecomment-839443273

Signed-off-by: Yug <yuggupta27@gmail.com>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
