### PR TITLE
ci: get the logs from the Ceph cluster pods

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -44,7 +44,11 @@ log minikube_ssh sudo tar c /var/lib/rook | tar xvO
 
 # gets status of the Rook deployment
 log kubectl -n rook-ceph get pods
-log kubectl -n rook-ceph describe pods
+for POD in $(kubectl -n rook-ceph get pod -l rook_cluster=rook-ceph -o jsonpath='{.items[0].metadata.name}')
+do
+    log kubectl -n rook-ceph describe pod "${POD}"
+    log kubectl -n rook-ceph logs "${POD}"
+done
 log kubectl -n rook-ceph describe CephCluster
 log kubectl -n rook-ceph describe CephBlockPool
 log kubectl -n rook-ceph describe CephFilesystem


### PR DESCRIPTION
It seems that `/var/log/rook` inside the VM does not contain any files.
Getting the logs from the Pods through kubectl may not be as stable, but
it should get some logs when minikube is still/again available.

Updates: #1969

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
