### PR TITLE
ci: add script and config to mirror images to local CI registry

### DIFF
--- a/mirror/Containerfile
+++ b/mirror/Containerfile
@@ -1,0 +1,14 @@
+FROM centos:latest
+
+RUN true \
+ && yum -y install skopeo \
+ && yum -y clean all \
+ && true
+
+ADD images.txt /opt/mirror/
+ADD mirror-images.sh /opt/mirror/
+
+ENV HOME=/opt/mirror
+WORKDIR /opt/mirror
+
+CMD ["./mirror-images.sh"]

--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -1,0 +1,20 @@
+# images.txt
+#
+# These lists contain the images that need to get mirrored from public
+# registries to the local CI registry.
+#
+# format: <full-image-spec> <short-name>
+#
+
+# ceph-csi v3.4
+docker.io/ceph/ceph:v16		ceph/ceph:v16
+docker.io/rook/ceph:v1.6.2	rook/ceph:v1.6.2
+
+# ceph-csi v3.3
+docker.io/ceph/ceph:v15		ceph/ceph:v15
+docker.io/rook/ceph:v1.4.9	rook/ceph:v1.4.9
+
+# e2e testing
+docker.io/library/busybox:1.29	library/busybox:1.29
+docker.io/library/nginx:latest	library/nginx:latest
+docker.io/library/vault:latest	library/vault:latest

--- a/mirror/mirror-buildconfig.yaml
+++ b/mirror/mirror-buildconfig.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: mirror-images
+  labels:
+    app: mirror-images
+spec:
+  tags:
+    - name: latest
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: mirror-images
+  labels:
+    app: mirror-images
+spec:
+  runPolicy: Serial
+  source:
+    git:
+      uri: https://github.com/ceph/ceph-csi
+      ref: ci/centos
+    contextDir: mirror
+  strategy:
+    dockerStrategy:
+      dockerfilePath: Containerfile
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mirror-images:latest

--- a/mirror/mirror-cronjob.yaml
+++ b/mirror/mirror-cronjob.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: mirror-images
+  labels:
+    app: mirror-images
+spec:
+  schedule: '@daily'
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: mirror-images
+        spec:
+          containers:
+            - name: mirror-images
+              image: image-registry.openshift-image-registry.svc:5000/ceph-csi/mirror-images:latest
+              env:
+                - name: DOCKER_CONFIG_JSON
+                  valueFrom:
+                    secretKeyRef:
+                      name: cephcsibot-docker-io
+                      key: .dockerconfigjson
+                - name: CI_REGISTRY_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: container-registry-auth
+                      key: username
+                - name: CI_REGISTRY_PASSWD
+                  valueFrom:
+                    secretKeyRef:
+                      name: container-registry-auth
+                      key: passwd
+          restartPolicy: OnFailure

--- a/mirror/mirror-images.sh
+++ b/mirror/mirror-images.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Mirror images listed in images.txt to the internal CI registry.
+#
+# Set DOCKER_CONFIG_JSON to the contents of ~/.docker/config.json to use the
+# authentication details from a cached configuration file.
+#
+# Set CI_REGISTRY_USER and CI_REGISTRY_PASSWD with the login details for the CI
+# registry.
+#
+
+CI_REGISTRY='registry-ceph-csi.apps.ocp.ci.centos.org'
+
+# get_image_entries returns the contents of images.txt without comments or empty lines
+function get_image_entries() {
+	grep -v -e '^#' -e '^$' images.txt
+}
+
+# create a temporary containers/auth.json for skopeo usage
+REGISTRY_AUTH_FILE="$(mktemp -t)"
+export REGISTRY_AUTH_FILE
+
+# make the temporary containers/auth.json a valid json file
+echo '{}' > "${REGISTRY_AUTH_FILE}"
+
+# if DOCKER_CONFIG_JSON is non-empty, use the credentials from there
+if [ -n "${DOCKER_CONFIG_JSON}" ]
+then
+	echo 'using ~/docker/config.json from env:DOCKER_CONFIG_JSON'
+	echo "${DOCKER_CONFIG_JSON}" > "${REGISTRY_AUTH_FILE}"
+fi
+
+# login on the CI registry if the user/passwd are available
+if [ -n "${CI_REGISTRY_USER}" ] && [ -n "${CI_REGISTRY_PASSWD}" ]
+then
+	echo 'using CI registry login from env:CI_REGISTRY_USER and env:CI_REGISTRY_PASSWD'
+	skopeo login \
+		--username="${CI_REGISTRY_USER}" \
+		--password="${CI_REGISTRY_PASSWD}" \
+		"${CI_REGISTRY}"
+fi
+
+# read each line from get_image_entries() into an array
+while read -r -a IMAGE_ENTRY
+do
+	# 1st entry in the array is the source
+	# 2nd entry in the array is the destination in the CI registry
+	SRC="docker://${IMAGE_ENTRY[0]}"
+	DST="docker://${CI_REGISTRY}/${IMAGE_ENTRY[1]}"
+	echo "going to copy ${SRC} to ${DST}" 
+	skopeo copy "${SRC}" "${DST}"
+done <<< "$(get_image_entries)"


### PR DESCRIPTION
By adding a new CronJob in the OpenShift deployment, container images can now get automatically updated (and added) to the local CI registry.

This is currently active in our OCP project already. A successful test has been run (based on my github repo/branch) and can be seen at https://console-openshift-console.apps.ocp.ci.centos.org/k8s/ns/ceph-csi/cronjobs/mirror-images by the contributors that have permissions to login on the OpenShift environment.

Updates: #1693 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
