### PR TITLE
ci: capture more logs from the rook-ceph namespace on failure

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -43,6 +43,7 @@ log minikube_ssh df -hT
 log minikube_ssh sudo tar c /var/lib/rook | tar xvO
 
 # gets status of the Rook deployment
+log kubectl -n rook-ceph get events
 log kubectl -n rook-ceph get pods
 for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[0].metadata.name}')
 do

--- a/system-status.sh
+++ b/system-status.sh
@@ -44,7 +44,7 @@ log minikube_ssh sudo tar c /var/lib/rook | tar xvO
 
 # gets status of the Rook deployment
 log kubectl -n rook-ceph get pods
-for POD in $(kubectl -n rook-ceph get pod -l rook_cluster=rook-ceph -o jsonpath='{.items[0].metadata.name}')
+for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[0].metadata.name}')
 do
     log kubectl -n rook-ceph describe pod "${POD}"
     log kubectl -n rook-ceph logs "${POD}"


### PR DESCRIPTION
It will be useful to have the events from the rook-ceph namespace to see why pods are restarted.

Also, the logs from Pods with the `rook_cluster: rook-ceph` label are very sparse. Getting the logs from all pods in the rook-ceph namespace might be more useful.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
