### PR TITLE
ci: have mergify set the component/build label on PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -342,6 +342,13 @@ pull_request_rules:
       label:
         add:
           - rebase
+  - name: title contains build
+    conditions:
+      - "title~=build: "
+    actions:
+      label:
+        add:
+          - component/build
   - name: title indicates a bug fix
     conditions:
       - title~=(bug)|(fix)


### PR DESCRIPTION
Quite a few PRs have the `build:` prefix. It would be good to teach
Mergify to set the label for those.

In addition to the useful-ness of this change, it tests enhancement https://github.com/Mergifyio/mergify-engine/discussions/2546#discussioncomment-737358 of Mergify itself.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
