### PR TITLE
ci: rebuild infra container images after merge

### DIFF
--- a/jobs/jjb-deploy.yaml
+++ b/jobs/jjb-deploy.yaml
@@ -20,6 +20,14 @@
           artifact-days-to-keep: 7
     dsl: |
       node {
+        stage('build-images') {
+          parallel jjb: {
+            sh "oc start-build --follow jjb"
+          },
+          mirror_images: {
+            sh 'oc start-build --follow mirror-images'
+          }
+        }
         stage('checkout ci repository') {
           git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
         }


### PR DESCRIPTION
When the `ci/centos` branch has been merged, the container images that
are built from it may need to be rebuilt. Instead of conditionally
rebuilding images only on a change, just rebuild them always, as there
are very few changes in the CI branch anyway.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
