### PR TITLE
e2e: wait for upgraded pods to be running during upgrade-tests

### DIFF
--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -234,6 +234,16 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				}
 				deployCephfsPlugin()
 
+				err = waitForDeploymentComplete(cephfsDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("timeout waiting for upgraded deployment %s with error %v", cephfsDeploymentName, err)
+				}
+
+				err = waitForDaemonSets(cephfsDeamonSetName, cephCSINamespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("timeout waiting for upgraded daemonset %s with error %v", cephfsDeamonSetName, err)
+				}
+
 				app.Labels = label
 				// validate if the app gets bound to a pvc created by
 				// an earlier release.

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -251,6 +251,17 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				}
 
 				deployRBDPlugin()
+
+				err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("timeout waiting for upgraded deployment %s with error %v", rbdDeploymentName, err)
+				}
+
+				err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("timeout waiting for upgraded daemonset %s with error %v", rbdDaemonsetName, err)
+				}
+
 				// validate if the app gets bound to a pvc created by
 				// an earlier release.
 				app.Labels = label


### PR DESCRIPTION
This commit calls `waitForDaemonSets` and `waitForDeploymentComplete`
after upgrading to wait for csi driver pods to be in running state
for both rbd and cephfs upgrade tests.

Signed-off-by: Rakshith R <rar@redhat.com>

~**Changes in `rook.sh`,`build.env` and `minikube.sh` will be removed**~
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
