### PR TITLE
ci: fix running ceph -s in toolbox pod

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -58,4 +58,4 @@ log kubectl -n rook-ceph describe CephFilesystem
 # run "ceph -s" in the toolbox
 log kubectl -n rook-ceph exec \
     "$(kubectl -n rook-ceph get pod -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')" \
-    ceph -s
+    -- ceph -s


### PR DESCRIPTION
we need to pass `--` when executing a command in the container or else it will fail.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

kubectl exec usage

```
 kubectl exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...] [options]
```

Failed log

```log
###
### execution finished: kubectl -n rook-ceph describe CephFilesystem
###
###
### going to execute: kubectl -n rook-ceph exec rook-ceph-tools-5949d6759-6xwdr ceph -s
###
Error: flag needs an argument: 's' in -s
See 'kubectl exec --help' for usage.
###
### execution finished: kubectl -n rook-ceph exec rook-ceph-tools-5949d6759-6xwdr ceph -s
###
```