### PR TITLE
ci: get logs from all containers in pod in system-status.sh

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -48,7 +48,7 @@ log kubectl -n rook-ceph get pods
 for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[0].metadata.name}')
 do
     log kubectl -n rook-ceph describe pod "${POD}"
-    log kubectl -n rook-ceph logs "${POD}"
+    log kubectl -n rook-ceph logs "${POD}" --all-containers
     log kubectl -n rook-ceph logs "${POD}" --all-containers --previous=true
 done
 log kubectl -n rook-ceph describe CephCluster


### PR DESCRIPTION
# Describe what this PR does #

This commit adds `--all-containers` option to get logs from all containers in system-status.sh

Signed-off-by: Rakshith R <rar@redhat.com>

Resolves this error from https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/rest/organizations/jenkins/pipelines/mini-e2e-helm_k8s-1.20/runs/872/nodes/107/log/?start=0
`error: a container name must be specified for pod csi-cephfsplugin-4n9w6, choose one of: [driver-registrar csi-cephfsplugin liveness-prometheus]`

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
