### PR TITLE
ci: log all containers in a pod

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -48,7 +48,7 @@ log kubectl -n rook-ceph get pods
 for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[0].metadata.name}')
 do
     log kubectl -n rook-ceph describe pod "${POD}"
-    log kubectl -n rook-ceph logs "${POD}"
+    log kubectl -n rook-ceph logs "${POD}" --all-containers
 done
 log kubectl -n rook-ceph describe CephCluster
 log kubectl -n rook-ceph describe CephBlockPool


### PR DESCRIPTION
there are few pods in `rook-ceph` namespace which contains multiple containers. Logging all the containers in the rook-ceph namespace.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

