### PR TITLE
ci: log previous instance of the container in a pod

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -49,6 +49,7 @@ for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[0].metadata.name
 do
     log kubectl -n rook-ceph describe pod "${POD}"
     log kubectl -n rook-ceph logs "${POD}"
+    log kubectl -n rook-ceph logs "${POD}" --all-containers --previous=true
 done
 log kubectl -n rook-ceph describe CephCluster
 log kubectl -n rook-ceph describe CephBlockPool


### PR DESCRIPTION
if the pod is crashed and restarted the current logs are not helpful. Logging with `-p` might help us to log the previous container.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

