### PR TITLE
ci: get logs from all pods, not only the 1st

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -45,7 +45,7 @@ log minikube_ssh sudo tar c /var/lib/rook | tar xvO
 # gets status of the Rook deployment
 log kubectl -n rook-ceph get events
 log kubectl -n rook-ceph get pods
-for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[0].metadata.name}')
+for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[*].metadata.name}')
 do
     log kubectl -n rook-ceph describe pod "${POD}"
     log kubectl -n rook-ceph logs "${POD}" --all-containers


### PR DESCRIPTION
The JSON formatting will return the name of the first pod, not all pods
on the list. By useing `items[*]` the names of all pods will be
returned. This causes all logs to be fetched, instead of only the logs
from the 1st pod.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
