### PR TITLE
ci: update upgrade-version to v3.3.1 for upgrade tests

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -5,7 +5,7 @@
     test_type:
       - 'cephfs'
       - 'rbd'
-    csi_upgrade_version: 'v3.1.0'
+    csi_upgrade_version: 'v3.3.1'
     jobs:
       - 'upgrade-tests-{test_type}'
 


### PR DESCRIPTION

# Describe what this PR does #
This commit updates `upgrade-version` to `v3.3.1` for e2e upgrade tests.

Signed-off-by: Rakshith R <rar@redhat.com>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
