### PR TITLE
ci: get status from all namespaces

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -42,14 +42,18 @@ log minikube_ssh df -hT
 # fetch all logs from /var/lib/rook in the VM and write them to stdout
 log minikube_ssh sudo tar c /var/lib/rook | tar xvO
 
-# gets status of the Rook deployment
-log kubectl -n rook-ceph get events
-log kubectl -n rook-ceph get pods
-for POD in $(kubectl -n rook-ceph get pods -o jsonpath='{.items[*].metadata.name}')
+# gets status from all namespaces
+for NAMESPACE in $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
 do
-    log kubectl -n rook-ceph describe pod "${POD}"
-    log kubectl -n rook-ceph logs "${POD}" --all-containers
-    log kubectl -n rook-ceph logs "${POD}" --all-containers --previous=true
+    log kubectl describe namespace "${NAMESPACE}"
+    log kubectl -n "${NAMESPACE}" get events
+    log kubectl -n "${NAMESPACE}" get pods
+    for POD in $(kubectl -n "${NAMESPACE}" get pods -o jsonpath='{.items[*].metadata.name}')
+    do
+        log kubectl -n "${NAMESPACE}" describe pod "${POD}"
+        log kubectl -n "${NAMESPACE}" logs "${POD}" --all-containers
+        log kubectl -n "${NAMESPACE}" logs "${POD}" --all-containers --previous=true
+    done
 done
 log kubectl -n rook-ceph describe CephCluster
 log kubectl -n rook-ceph describe CephBlockPool


### PR DESCRIPTION
This commit adds capability to get events, pods,
and logs from all namespaces.

Signed-off-by: Rakshith R <rar@redhat.com>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
