### PR TITLE
deploy: update rook to 1.6.2 and disable liveness probe on mon,mds,mgr

### DIFF
--- a/build.env
+++ b/build.env
@@ -41,7 +41,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.4.9
+ROOK_VERSION=v1.6.2
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=docker.io/ceph/ceph:v16
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -93,7 +93,7 @@ are available while running tests:
 | deploy-rbd        | Deploy rbd csi driver as part of E2E (default: true)                          |
 | test-cephfs       | Test cephfs csi driver as part of E2E (default: true)                         |
 | upgrade-testing   | Perform upgrade testing (default: false)                                      |
-| upgrade-version   | Target version for upgrade testing (default: "v2.1.2")                        |
+| upgrade-version   | Target version for upgrade testing (default: "v3.3.1")                        |
 | test-rbd          | Test rbd csi driver as part of E2E (default: true)                            |
 | cephcsi-namespace | The namespace in which cephcsi driver will be created (default: "default")    |
 | rook-namespace    | The namespace in which rook operator is installed (default: "rook-ceph")      |

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -23,7 +23,7 @@ func init() {
 	flag.BoolVar(&testCephFS, "test-cephfs", true, "test cephfs csi driver")
 	flag.BoolVar(&testRBD, "test-rbd", true, "test rbd csi driver")
 	flag.BoolVar(&upgradeTesting, "upgrade-testing", false, "perform upgrade testing")
-	flag.StringVar(&upgradeVersion, "upgrade-version", "v2.1.2", "target version for upgrade testing")
+	flag.StringVar(&upgradeVersion, "upgrade-version", "v3.3.1", "target version for upgrade testing")
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
 	setDefaultKubeconfig()

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -101,7 +101,8 @@ function deploy_rook() {
             curl -o "${TEMP_DIR}"/cluster-test.yaml "${ROOK_URL}/cluster-test.yaml"
             sed -i "s|image.*|${ROOK_CEPH_CLUSTER_VERSION_IMAGE_PATH}|g" "${TEMP_DIR}"/cluster-test.yaml
             sed -i "s/config: |/config: |\n    \[mon\]\n    mon_warn_on_insecure_global_id_reclaim_allowed = false/g" "${TEMP_DIR}"/cluster-test.yaml
-            cat  "${TEMP_DIR}"/cluster-test.yaml
+            sed -i "s/healthCheck:/healthCheck:\n    livenessProbe:\n      mon:\n        disabled: true\n      mgr:\n        disabled: true\n      mds:\n        disabled: true/g" "${TEMP_DIR}"/cluster-test.yaml
+			cat  "${TEMP_DIR}"/cluster-test.yaml
             kubectl_retry create -f "${TEMP_DIR}/cluster-test.yaml"
             rm -rf "${TEMP_DIR}"
         fi


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

- update rook to 1.6.2 
- update e2e upgrade-version to v3.3.1
- disable liveness probe on mon,mds,mgr

