### PR TITLE
Continue thick-provisioning of RBD images on CreateVolume restart

### DIFF
--- a/internal/rbd/controllerserver_test.go
+++ b/internal/rbd/controllerserver_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+func TestIsThickProvisionRequest(t *testing.T) {
+	cs := &ControllerServer{}
+	req := &csi.CreateVolumeRequest{
+		Name: "fake",
+		Parameters: map[string]string{
+			"unkownOption": "not-set",
+		},
+	}
+
+	// pass disabled/invalid values for "thickProvision" option
+	if cs.isThickProvisionRequest(req) {
+		t.Error("request is not for thick-provisioning")
+	}
+
+	req.Parameters["thickProvision"] = ""
+	if cs.isThickProvisionRequest(req) {
+		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
+	}
+
+	req.Parameters["thickProvision"] = "false"
+	if cs.isThickProvisionRequest(req) {
+		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
+	}
+
+	req.Parameters["thickProvision"] = "off"
+	if cs.isThickProvisionRequest(req) {
+		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
+	}
+
+	req.Parameters["thickProvision"] = "no"
+	if cs.isThickProvisionRequest(req) {
+		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
+	}
+
+	req.Parameters["thickProvision"] = "**true**"
+	if cs.isThickProvisionRequest(req) {
+		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
+	}
+
+	// only "true" should enable thick provisioning
+	req.Parameters["thickProvision"] = "true"
+	if !cs.isThickProvisionRequest(req) {
+		t.Errorf("request should be for thick-provisioning: %s", req.Parameters["thickProvision"])
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #

In case CreateVolume gets interrupted (by provisioner pod restart, or similar) the slow thick-provisioning is aborted. The RBD image will not have the `thick-provisioned` metadata set. Restarting CreateVolume will detect the RBD image, and return the volume which is not completely thick-provisioned.

By validating that the CreateVolume request intends to thick-provision the volume, it is possible to detect the need for the `thick-provisioned` metadata in the RBD image. When the metadata is missing, start allocating the image again.

## Is there anything that requires special attention ##

If the RBD image has watchers (`isInUse()` returns true), assume that the allocating of the image is still in progress. Because thick-provisioning is slow, Kubernetes tends to time-out the initial CreateVolume request(s). It is expected that the `not going to restart thick-provisioning of in-use image` is reported when Kubernetes restarts the CreateVolume request.

## Related issues ##

Fixes: https://bugzilla.redhat.com/1961647

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
