### PR TITLE
cleanup: address nlreturn linter issues

### DIFF
--- a/e2e/ceph_user.go
+++ b/e2e/ceph_user.go
@@ -37,6 +37,7 @@ func rbdNodePluginCaps(pool, rbdNamespace string) []string {
 	} else {
 		caps = append(caps, fmt.Sprintf("osd 'profile rbd pool=%s namespace=%s'", pool, rbdNamespace))
 	}
+
 	return caps
 }
 
@@ -50,6 +51,7 @@ func rbdProvisionerCaps(pool, rbdNamespace string) []string {
 	} else {
 		caps = append(caps, fmt.Sprintf("osd 'profile rbd pool=%s namespace=%s'", pool, rbdNamespace))
 	}
+
 	return caps
 }
 
@@ -62,6 +64,7 @@ func cephFSNodePluginCaps() []string {
 		"osd", "'allow rw tag cephfs *=*'",
 		"mds", "'allow rw'",
 	}
+
 	return caps
 }
 
@@ -71,6 +74,7 @@ func cephFSProvisionerCaps() []string {
 		"mgr", "'allow rw'",
 		"osd", "'allow rw tag cephfs metadata=*'",
 	}
+
 	return caps
 }
 
@@ -83,11 +87,13 @@ func createCephUser(f *framework.Framework, user string, caps []string) (string,
 	if stdErr != "" {
 		return "", fmt.Errorf("failed to create user %s with error %v", cmd, stdErr)
 	}
+
 	return strings.TrimSpace(stdOut), nil
 }
 
 func deleteCephUser(f *framework.Framework, user string) error {
 	cmd := fmt.Sprintf("ceph auth del client.%s", user)
 	_, _, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+
 	return err
 }

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -165,6 +165,7 @@ func validateSubvolumePath(f *framework.Framework, pvcName, pvcNamespace, fileSy
 			subVolumePath,
 			subVolumePathInPV)
 	}
+
 	return nil
 }
 
@@ -354,6 +355,7 @@ var _ = Describe("cephfs", func() {
 					fmt.Printf("Checking prefix on %s\n", subVol)
 					if strings.HasPrefix(subVol.Name, volumeNamePrefix) {
 						foundIt = true
+
 						break
 					}
 				}

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -34,6 +34,7 @@ func validateSubvolumegroup(f *framework.Framework, subvolgrp string) error {
 	if stdOut != expectedGrpPath {
 		return fmt.Errorf("error unexpected group path. Found: %s", stdOut)
 	}
+
 	return nil
 }
 
@@ -84,6 +85,7 @@ func createCephfsStorageClass(
 	}
 	sc.Namespace = cephCSINamespace
 	_, err = c.StorageV1().StorageClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
+
 	return err
 }
 
@@ -102,6 +104,7 @@ func createCephfsSecret(f *framework.Framework, secretName, userName, userKey st
 	delete(sc.StringData, "userKey")
 	sc.Namespace = cephCSINamespace
 	_, err = f.ClientSet.CoreV1().Secrets(cephCSINamespace).Create(context.TODO(), &sc, metav1.CreateOptions{})
+
 	return err
 }
 
@@ -110,6 +113,7 @@ func unmountCephFSVolume(f *framework.Framework, appName, pvcName string) error 
 	pod, err := f.ClientSet.CoreV1().Pods(f.UniqueName).Get(context.TODO(), appName, metav1.GetOptions{})
 	if err != nil {
 		e2elog.Logf("Error occurred getting pod %s in namespace %s", appName, f.UniqueName)
+
 		return fmt.Errorf("failed to get pod: %w", err)
 	}
 	pvc, err := f.ClientSet.CoreV1().
@@ -117,6 +121,7 @@ func unmountCephFSVolume(f *framework.Framework, appName, pvcName string) error 
 		Get(context.TODO(), pvcName, metav1.GetOptions{})
 	if err != nil {
 		e2elog.Logf("Error occurred getting PVC %s in namespace %s", pvcName, f.UniqueName)
+
 		return fmt.Errorf("failed to get pvc: %w", err)
 	}
 	cmd := fmt.Sprintf(
@@ -133,6 +138,7 @@ func unmountCephFSVolume(f *framework.Framework, appName, pvcName string) error 
 	if stdErr != "" {
 		e2elog.Logf("StdErr occurred: %s", stdErr)
 	}
+
 	return err
 }
 
@@ -150,6 +156,7 @@ func deleteBackingCephFSVolume(f *framework.Framework, pvc *v1.PersistentVolumeC
 	if stdErr != "" {
 		return fmt.Errorf("error deleting backing volume %s %v", imageData.imageName, stdErr)
 	}
+
 	return nil
 }
 
@@ -174,6 +181,7 @@ func listCephFSSubVolumes(f *framework.Framework, filesystem, groupname string) 
 	if err != nil {
 		return subVols, err
 	}
+
 	return subVols, nil
 }
 
@@ -187,6 +195,7 @@ func getSubvolumePath(f *framework.Framework, filesystem, subvolgrp, subvolume s
 	if stdErr != "" {
 		return "", fmt.Errorf("failed to getpath for subvolume %s with error %s", subvolume, stdErr)
 	}
+
 	return strings.TrimSpace(stdOut), nil
 }
 
@@ -211,6 +220,7 @@ func getSnapName(snapNamespace, snapName string) (string, error) {
 	snapID := snapIDRegex.FindString(*sc.Status.SnapshotHandle)
 	snapshotName := fmt.Sprintf("csi-snap-%s", snapID)
 	e2elog.Logf("snapshotName= %s", snapshotName)
+
 	return snapshotName, nil
 }
 
@@ -239,5 +249,6 @@ func deleteBackingCephFSSubvolumeSnapshot(
 	if stdErr != "" {
 		return fmt.Errorf("error deleting backing snapshot %s %v", snapshotName, stdErr)
 	}
+
 	return nil
 }

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -21,6 +21,7 @@ func deleteConfigMap(pluginPath string) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -120,5 +121,6 @@ func createCustomConfigMap(c kubernetes.Interface, pluginPath string, subvolgrpI
 	if err != nil {
 		return fmt.Errorf("failed to update configmap: %w", err)
 	}
+
 	return nil
 }

--- a/e2e/kms.go
+++ b/e2e/kms.go
@@ -104,5 +104,6 @@ func (vc *vaultConfig) getPassphrase(f *framework.Framework, key string) (string
 		LabelSelector: "app=vault",
 	}
 	stdOut, stdErr := execCommandInPodAndAllowFail(f, cmd, cephCSINamespace, &opt)
+
 	return strings.TrimSpace(stdOut), strings.TrimSpace(stdErr)
 }

--- a/e2e/log.go
+++ b/e2e/log.go
@@ -33,6 +33,7 @@ func logsCSIPods(label string, c clientset.Interface) {
 	podList, err := c.CoreV1().Pods(cephCSINamespace).List(context.TODO(), opt)
 	if err != nil {
 		e2elog.Logf("failed to list pods with selector %s %v", label, err)
+
 		return
 	}
 
@@ -72,5 +73,6 @@ func getPreviousPodLogs(c clientset.Interface, namespace, podName, containerName
 	if strings.Contains(string(logs), "Internal Error") {
 		return "", fmt.Errorf("fetched log contains \"Internal Error\": %q", string(logs))
 	}
+
 	return string(logs), err
 }

--- a/e2e/namespace.go
+++ b/e2e/namespace.go
@@ -37,8 +37,10 @@ func createNamespace(c kubernetes.Interface, name string) error {
 			if isRetryableAPIError(err) {
 				return false, nil
 			}
+
 			return false, err
 		}
+
 		return true, nil
 	})
 }
@@ -49,6 +51,7 @@ func deleteNamespace(c kubernetes.Interface, name string) error {
 	if err != nil && !apierrs.IsNotFound(err) {
 		return fmt.Errorf("failed to delete namespace: %w", err)
 	}
+
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		_, err = c.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
@@ -59,8 +62,10 @@ func deleteNamespace(c kubernetes.Interface, name string) error {
 			if isRetryableAPIError(err) {
 				return false, nil
 			}
+
 			return false, err
 		}
+
 		return false, nil
 	})
 }
@@ -70,5 +75,6 @@ func replaceNamespaceInTemplate(filePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return strings.ReplaceAll(string(read), "namespace: default", fmt.Sprintf("namespace: %s", cephCSINamespace)), nil
 }

--- a/e2e/node.go
+++ b/e2e/node.go
@@ -21,6 +21,7 @@ func createNodeLabel(f *framework.Framework, labelKey, labelValue string) error 
 	for i := range nodes.Items {
 		framework.AddOrUpdateLabelOnNode(f.ClientSet, nodes.Items[i].Name, labelKey, labelValue)
 	}
+
 	return nil
 }
 
@@ -32,6 +33,7 @@ func deleteNodeLabel(c kubernetes.Interface, labelKey string) error {
 	for i := range nodes.Items {
 		framework.RemoveLabelOffNode(c, nodes.Items[i].Name, labelKey)
 	}
+
 	return nil
 }
 
@@ -43,6 +45,7 @@ func checkNodeHasLabel(c kubernetes.Interface, labelKey, labelValue string) erro
 	for i := range nodes.Items {
 		framework.ExpectNodeHasLabel(c, nodes.Items[i].Name, labelKey, labelValue)
 	}
+
 	return nil
 }
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -522,9 +522,11 @@ var _ = Describe("RBD", func() {
 							reason = fmt.Sprintf("failed to run ps cmd : %v, stdErr: %v", err, stdErr)
 						}
 						e2elog.Logf("%s", reason)
+
 						return false, nil
 					}
 					e2elog.Logf("attach command running after restart, runningAttachCmd: %v", runningAttachCmd)
+
 					return true, nil
 				})
 
@@ -1213,6 +1215,7 @@ var _ = Describe("RBD", func() {
 					fmt.Printf("Checking prefix on %s\n", imgName)
 					if strings.HasPrefix(imgName, volumeNamePrefix) {
 						foundIt = true
+
 						break
 					}
 				}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -30,6 +30,7 @@ func imageSpec(pool, image string) string {
 	if radosNamespace != "" {
 		return pool + "/" + radosNamespace + "/" + image
 	}
+
 	return pool + "/" + image
 }
 
@@ -37,6 +38,7 @@ func rbdOptions(pool string) string {
 	if radosNamespace != "" {
 		return "--pool=" + pool + " --namespace " + radosNamespace
 	}
+
 	return "--pool=" + pool
 }
 
@@ -92,6 +94,7 @@ func createRBDStorageClass(
 	}
 	sc.ReclaimPolicy = &policy
 	_, err = c.StorageV1().StorageClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
+
 	return err
 }
 
@@ -133,6 +136,7 @@ func createRadosNamespace(f *framework.Framework) error {
 			return fmt.Errorf("error creating rbd namespace %v", stdErr)
 		}
 	}
+
 	return nil
 }
 
@@ -149,6 +153,7 @@ func createRBDSecret(f *framework.Framework, secretName, userName, userKey strin
 	sc.StringData["userKey"] = userKey
 	sc.Namespace = cephCSINamespace
 	_, err = f.ClientSet.CoreV1().Secrets(cephCSINamespace).Create(context.TODO(), &sc, metav1.CreateOptions{})
+
 	return err
 }
 
@@ -184,6 +189,7 @@ func getImageInfoFromPVC(pvcNamespace, pvcName string, f *framework.Framework) (
 		csiVolumeHandle: pv.Spec.CSI.VolumeHandle,
 		pvName:          pv.Name,
 	}
+
 	return imageData, nil
 }
 
@@ -196,6 +202,7 @@ func getImageMeta(rbdImageSpec, metaKey string, f *framework.Framework) (string,
 	if stdErr != "" {
 		return strings.TrimSpace(stdOut), fmt.Errorf(stdErr)
 	}
+
 	return strings.TrimSpace(stdOut), nil
 }
 
@@ -262,6 +269,7 @@ func logErrors(f *framework.Framework, msg string, wgErrs []error) int {
 			failures++
 		}
 	}
+
 	return failures
 }
 
@@ -388,6 +396,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	validateRBDImageCount(f, 0, snapshotPool)
 	validateRBDImageCount(f, 0, defaultRBDPool)
 	validateRBDImageCount(f, 0, destImagePool)
+
 	return nil
 }
 
@@ -427,6 +436,7 @@ func validateEncryptedPVCAndAppBinding(pvcPath, appPath string, kms kmsConfig, f
 			return fmt.Errorf("passphrase found in vault while should be deleted: %s", stdOut)
 		}
 	}
+
 	return nil
 }
 
@@ -457,6 +467,7 @@ func isThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.P
 	if err != nil {
 		return fmt.Errorf("failed to validate thick image: %w", err)
 	}
+
 	return nil
 }
 
@@ -474,6 +485,7 @@ func validateThickImageMetadata(f *framework.Framework, pvc *v1.PersistentVolume
 	if thickState == "" {
 		return fmt.Errorf("image metadata is set for %s", rbdImageSpec)
 	}
+
 	return nil
 }
 
@@ -518,6 +530,7 @@ func listRBDImages(f *framework.Framework, pool string) ([]string, error) {
 	if err != nil {
 		return imgInfos, err
 	}
+
 	return imgInfos, nil
 }
 
@@ -529,6 +542,7 @@ func deleteBackingRBDImage(f *framework.Framework, pvc *v1.PersistentVolumeClaim
 
 	cmd := fmt.Sprintf("rbd rm %s %s", rbdOptions(defaultRBDPool), imageData.imageName)
 	_, _, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
+
 	return err
 }
 
@@ -586,6 +600,7 @@ func sparsifyBackingRBDImage(f *framework.Framework, pvc *v1.PersistentVolumeCla
 
 	cmd := fmt.Sprintf("rbd sparsify %s %s", rbdOptions(defaultRBDPool), imageData.imageName)
 	_, _, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
+
 	return err
 }
 
@@ -615,6 +630,7 @@ func deletePool(name string, cephfs bool, f *framework.Framework) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -632,6 +648,7 @@ func createPool(f *framework.Framework, name string) error {
 	// ceph osd pool set replicapool size 1
 	cmd = fmt.Sprintf("ceph osd pool set %s size %d --yes-i-really-mean-it", name, size)
 	_, _, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
+
 	return err
 }
 
@@ -876,6 +893,7 @@ func listRBDImagesInTrash(f *framework.Framework, poolName string) ([]trashInfo,
 	if err != nil {
 		return trashInfos, err
 	}
+
 	return trashInfos, nil
 }
 
@@ -892,11 +910,13 @@ func waitToRemoveImagesFromTrash(f *framework.Framework, poolName string, t int)
 		}
 		errReason = fmt.Errorf("found %d images found in trash. Image details %v", len(imagesInTrash), imagesInTrash)
 		e2elog.Logf(errReason.Error())
+
 		return false, nil
 	})
 
 	if errors.Is(err, wait.ErrWaitTimeout) {
 		err = errReason
 	}
+
 	return err
 }

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -20,6 +20,7 @@ func getSnapshotClass(path string) snapapi.VolumeSnapshotClass {
 	sc := snapapi.VolumeSnapshotClass{}
 	err := unmarshal(path, &sc)
 	Expect(err).Should(BeNil())
+
 	return sc
 }
 
@@ -27,6 +28,7 @@ func getSnapshot(path string) snapapi.VolumeSnapshot {
 	sc := snapapi.VolumeSnapshot{}
 	err := unmarshal(path, &sc)
 	Expect(err).Should(BeNil())
+
 	return sc
 }
 
@@ -39,6 +41,7 @@ func newSnapshotClient() (*snapclient.SnapshotV1Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating snapshot client: %w", err)
 	}
+
 	return c, err
 }
 
@@ -74,6 +77,7 @@ func createSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 			if apierrs.IsNotFound(err) {
 				return false, nil
 			}
+
 			return false, fmt.Errorf("failed to get volumesnapshot: %w", err)
 		}
 		if snaps.Status == nil || snaps.Status.ReadyToUse == nil {
@@ -83,6 +87,7 @@ func createSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 			return true, nil
 		}
 		e2elog.Logf("snapshot %s in %v state", snap.Name, *snaps.Status.ReadyToUse)
+
 		return false, nil
 	})
 }
@@ -149,6 +154,7 @@ func createRBDSnapshotClass(f *framework.Framework) error {
 		return err
 	}
 	_, err = sclient.VolumeSnapshotClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
+
 	return err
 }
 
@@ -160,6 +166,7 @@ func deleteRBDSnapshotClass() error {
 	if err != nil {
 		return err
 	}
+
 	return sclient.VolumeSnapshotClasses().Delete(context.TODO(), sc.Name, metav1.DeleteOptions{})
 }
 
@@ -185,6 +192,7 @@ func createCephFSSnapshotClass(f *framework.Framework) error {
 	if err != nil {
 		return fmt.Errorf("failed to create volumesnapshotclass: %w", err)
 	}
+
 	return err
 }
 
@@ -207,5 +215,6 @@ func getVolumeSnapshotContent(namespace, snapshotName string) (*snapapi.VolumeSn
 	if err != nil {
 		return nil, fmt.Errorf("failed to get volumesnapshotcontent: %w", err)
 	}
+
 	return volumeSnapshotContent, nil
 }

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -184,6 +184,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 
 	cmd = fmt.Sprintf("rbd rm %s %s", rbdImageName, rbdOptions(defaultRBDPool))
 	_, _, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
+
 	return err
 }
 

--- a/e2e/upgrade.go
+++ b/e2e/upgrade.go
@@ -22,6 +22,7 @@ func upgradeCSI(version string) error {
 	if err != nil {
 		return fmt.Errorf("unable to switch directory : %w", err)
 	}
+
 	return nil
 }
 
@@ -38,5 +39,6 @@ func upgradeAndDeployCSI(version, testtype string) error {
 	default:
 		return errors.New("incorrect test type, can be cephfs/rbd")
 	}
+
 	return nil
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -83,12 +83,14 @@ func getMons(ns string, c kubernetes.Interface) ([]string, error) {
 			svcList.Items[i].Spec.Ports[0].Port)
 		services = append(services, s)
 	}
+
 	return services, nil
 }
 
 func getStorageClass(path string) (scv1.StorageClass, error) {
 	sc := scv1.StorageClass{}
 	err := unmarshal(path, &sc)
+
 	return sc, err
 }
 
@@ -102,6 +104,7 @@ func getSecret(path string) (v1.Secret, error) {
 			return sc, err
 		}
 	}
+
 	return sc, nil
 }
 
@@ -114,6 +117,7 @@ func deleteResource(scPath string) error {
 	if err != nil {
 		e2elog.Logf("failed to delete %s %v", scPath, err)
 	}
+
 	return err
 }
 
@@ -128,6 +132,7 @@ func unmarshal(fileName string, obj interface{}) error {
 	}
 
 	err = json.Unmarshal(data, obj)
+
 	return err
 }
 
@@ -149,6 +154,7 @@ func createPVCAndApp(
 		return err
 	}
 	err = createApp(f.ClientSet, app, deployTimeout)
+
 	return err
 }
 
@@ -166,6 +172,7 @@ func deletePVCAndApp(name string, f *framework.Framework, pvc *v1.PersistentVolu
 		return err
 	}
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+
 	return err
 }
 
@@ -199,6 +206,7 @@ func validatePVCAndAppBinding(pvcPath, appPath string, f *framework.Framework) e
 		return err
 	}
 	err = deletePVCAndApp("", f, pvc, app)
+
 	return err
 }
 
@@ -214,6 +222,7 @@ func getMountType(appName, appNamespace, mountPath string, f *framework.Framewor
 	if stdErr != "" {
 		return strings.TrimSpace(stdOut), fmt.Errorf(stdErr)
 	}
+
 	return strings.TrimSpace(stdOut), nil
 }
 
@@ -306,6 +315,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 	}
 
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+
 	return err
 }
 
@@ -393,6 +403,7 @@ func checkDataPersist(pvcPath, appPath string, f *framework.Framework) error {
 	}
 
 	err = deletePVCAndApp("", f, pvc, app)
+
 	return err
 }
 
@@ -429,6 +440,7 @@ func pvcDeleteWhenPoolNotFound(pvcPath string, cephfs bool, f *framework.Framewo
 		}
 	}
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+
 	return err
 }
 
@@ -471,6 +483,7 @@ func checkMountOptions(pvcPath, appPath string, f *framework.Framework, mountFla
 	}
 
 	err = deletePVCAndApp("", f, pvc, app)
+
 	return err
 }
 
@@ -481,6 +494,7 @@ func addTopologyDomainsToDSYaml(template, labels string) string {
 
 func oneReplicaDeployYaml(template string) string {
 	re := regexp.MustCompile(`(\s+replicas:) \d+`)
+
 	return re.ReplaceAllString(template, `$1 1`)
 }
 
@@ -494,12 +508,14 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 	err := writeDataInPod(app, opt, f)
 	if err != nil {
 		e2elog.Logf("failed to write data in the pod with error %v", err)
+
 		return "", err
 	}
 
 	checkSum, err := calculateSHA512sum(f, app, filePath, opt)
 	if err != nil {
 		e2elog.Logf("failed to calculate checksum with error %v", err)
+
 		return checkSum, err
 	}
 
@@ -507,6 +523,7 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 	if err != nil {
 		e2elog.Failf("failed to delete pod with error %v", err)
 	}
+
 	return checkSum, nil
 }
 
@@ -1131,6 +1148,7 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	if err != nil {
 		return err
 	}
+
 	return deleteResource(rbdExamplePath + "storageclass.yaml")
 }
 
@@ -1172,6 +1190,7 @@ func waitForJobCompletion(c kubernetes.Interface, ns, job string, timeout int) e
 			if isRetryableAPIError(err) {
 				return false, nil
 			}
+
 			return false, fmt.Errorf("failed to get Job: %w", err)
 		}
 
@@ -1183,6 +1202,7 @@ func waitForJobCompletion(c kubernetes.Interface, ns, job string, timeout int) e
 		e2elog.Logf(
 			"Job %s/%s has not completed yet (%d seconds elapsed)",
 			ns, job, int(time.Since(start).Seconds()))
+
 		return false, nil
 	})
 }
@@ -1211,6 +1231,7 @@ func retryKubectlInput(namespace string, action kubectlAction, data string, t in
 	timeout := time.Duration(t) * time.Minute
 	e2elog.Logf("waiting for kubectl (%s) to finish", action)
 	start := time.Now()
+
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		_, err := framework.RunKubectlInput(namespace, data, string(action), "-f", "-")
 		if err != nil {
@@ -1221,8 +1242,10 @@ func retryKubectlInput(namespace string, action kubectlAction, data string, t in
 				"will run kubectl (%s) again (%d seconds elapsed)",
 				action,
 				int(time.Since(start).Seconds()))
+
 			return false, fmt.Errorf("failed to run kubectl: %w", err)
 		}
+
 		return true, nil
 	})
 }
@@ -1234,6 +1257,7 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 	timeout := time.Duration(t) * time.Minute
 	e2elog.Logf("waiting for kubectl (%s -f %q) to finish", action, filename)
 	start := time.Now()
+
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		_, err := framework.RunKubectl(namespace, string(action), "-f", filename)
 		if err != nil {
@@ -1245,8 +1269,10 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 				action,
 				filename,
 				int(time.Since(start).Seconds()))
+
 			return false, fmt.Errorf("failed to run kubectl: %w", err)
 		}
+
 		return true, nil
 	})
 }

--- a/internal/cephfs/cephfs_util.go
+++ b/internal/cephfs/cephfs_util.go
@@ -27,12 +27,14 @@ func (vo *volumeOptions) getFscID(ctx context.Context) (int64, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem ID for %s:", vo.FsName, err)
+
 		return 0, err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
 		util.ErrorLog(ctx, "could not list volumes, can not fetch filesystem ID for %s:", vo.FsName, err)
+
 		return 0, err
 	}
 
@@ -43,6 +45,7 @@ func (vo *volumeOptions) getFscID(ctx context.Context) (int64, error) {
 	}
 
 	util.ErrorLog(ctx, "failed to list volume %s", vo.FsName)
+
 	return 0, ErrVolumeNotFound
 }
 
@@ -50,12 +53,14 @@ func (vo *volumeOptions) getMetadataPool(ctx context.Context) (string, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s:", vo.FsName, err)
+
 		return "", err
 	}
 
 	fsPoolInfos, err := fsa.ListFileSystems()
 	if err != nil {
 		util.ErrorLog(ctx, "could not list filesystems, can not fetch metadata pool for %s:", vo.FsName, err)
+
 		return "", err
 	}
 
@@ -72,12 +77,14 @@ func (vo *volumeOptions) getFsName(ctx context.Context) (string, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem name for ID %d:", vo.FscID, err)
+
 		return "", err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
 		util.ErrorLog(ctx, "could not list volumes, can not fetch filesystem name for ID %d:", vo.FscID, err)
+
 		return "", err
 	}
 

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -97,8 +97,10 @@ func checkVolExists(ctx context.Context,
 				}
 				err = j.UndoReservation(ctx, volOptions.MetadataPool,
 					volOptions.MetadataPool, vid.FsSubvolName, volOptions.RequestName)
+
 				return nil, err
 			}
+
 			return nil, err
 		}
 		if cloneState == cephFSCloneInprogress {
@@ -111,6 +113,7 @@ func checkVolExists(ctx context.Context,
 			err = volOptions.purgeVolume(ctx, volumeID(vid.FsSubvolName), true)
 			if err != nil {
 				util.ErrorLog(ctx, "failed to delete volume %s: %v", vid.FsSubvolName, err)
+
 				return nil, err
 			}
 			if pvID != nil {
@@ -124,6 +127,7 @@ func checkVolExists(ctx context.Context,
 			}
 			err = j.UndoReservation(ctx, volOptions.MetadataPool,
 				volOptions.MetadataPool, vid.FsSubvolName, volOptions.RequestName)
+
 			return nil, err
 		}
 		if cloneState != cephFSCloneComplete {
@@ -147,8 +151,10 @@ func checkVolExists(ctx context.Context,
 			}
 			err = j.UndoReservation(ctx, volOptions.MetadataPool,
 				volOptions.MetadataPool, vid.FsSubvolName, volOptions.RequestName)
+
 			return nil, err
 		}
+
 		return nil, err
 	}
 
@@ -327,6 +333,7 @@ func undoSnapReservation(
 
 	err = j.UndoReservation(ctx, volOptions.MetadataPool,
 		volOptions.MetadataPool, vid.FsSnapshotName, snapName)
+
 	return err
 }
 
@@ -374,8 +381,10 @@ func checkSnapExists(
 		if errors.Is(err, ErrSnapNotFound) {
 			err = j.UndoReservation(ctx, volOptions.MetadataPool,
 				volOptions.MetadataPool, snapID, snap.RequestName)
+
 			return nil, nil, err
 		}
+
 		return nil, nil, err
 	}
 
@@ -384,6 +393,7 @@ func checkSnapExists(
 			err = volOptions.deleteSnapshot(ctx, volumeID(snapID), volumeID(parentSubVolName))
 			if err != nil {
 				util.ErrorLog(ctx, "failed to delete snapshot %s: %v", snapID, err)
+
 				return
 			}
 			err = j.UndoReservation(ctx, volOptions.MetadataPool,

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -52,6 +52,7 @@ func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volum
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+
 		return err
 	}
 
@@ -59,8 +60,10 @@ func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volum
 	if err != nil {
 		util.ErrorLog(ctx, "failed to create subvolume snapshot %s %s in fs %s: %s",
 			string(snapID), string(volID), vo.FsName, err)
+
 		return err
 	}
+
 	return nil
 }
 
@@ -68,6 +71,7 @@ func (vo *volumeOptions) deleteSnapshot(ctx context.Context, snapID, volID volum
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+
 		return err
 	}
 
@@ -75,8 +79,10 @@ func (vo *volumeOptions) deleteSnapshot(ctx context.Context, snapID, volID volum
 	if err != nil {
 		util.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s in fs %s: %s",
 			string(snapID), string(volID), vo.FsName, err)
+
 		return err
 	}
+
 	return nil
 }
 
@@ -92,6 +98,7 @@ func (vo *volumeOptions) getSnapshotInfo(ctx context.Context, snapID, volID volu
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+
 		return snap, err
 	}
 
@@ -107,11 +114,13 @@ func (vo *volumeOptions) getSnapshotInfo(ctx context.Context, snapID, volID volu
 			string(snapID),
 			vo.FsName,
 			err)
+
 		return snap, err
 	}
 	snap.CreatedAt = info.CreatedAt.Time
 	snap.HasPendingClones = info.HasPendingClones
 	snap.Protected = info.Protected
+
 	return snap, nil
 }
 
@@ -124,6 +133,7 @@ func (vo *volumeOptions) protectSnapshot(ctx context.Context, snapID, volID volu
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+
 		return err
 	}
 
@@ -140,8 +150,10 @@ func (vo *volumeOptions) protectSnapshot(ctx context.Context, snapID, volID volu
 			string(snapID),
 			vo.FsName,
 			err)
+
 		return err
 	}
+
 	return nil
 }
 
@@ -154,6 +166,7 @@ func (vo *volumeOptions) unprotectSnapshot(ctx context.Context, snapID, volID vo
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+
 		return err
 	}
 
@@ -172,8 +185,10 @@ func (vo *volumeOptions) unprotectSnapshot(ctx context.Context, snapID, volID vo
 			string(snapID),
 			vo.FsName,
 			err)
+
 		return err
 	}
+
 	return nil
 }
 
@@ -185,6 +200,7 @@ func (vo *volumeOptions) cloneSnapshot(
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+
 		return err
 	}
 	co := &admin.CloneOptions{
@@ -207,7 +223,9 @@ func (vo *volumeOptions) cloneSnapshot(
 		if errors.Is(err, rados.ErrNotFound) {
 			return ErrVolumeNotFound
 		}
+
 		return err
 	}
+
 	return nil
 }

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -34,6 +34,7 @@ type volumeID string
 
 func execCommandErr(ctx context.Context, program string, args ...string) error {
 	_, _, err := util.ExecCommand(ctx, program, args...)
+
 	return err
 }
 
@@ -91,6 +92,7 @@ func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeReq
 			return status.Error(codes.InvalidArgument, "unsupported volume data source")
 		}
 	}
+
 	return nil
 }
 
@@ -129,11 +131,13 @@ func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (sn
 	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
 	if err != nil {
 		util.ErrorLog(ctx, "failed getting mons (%s)", err)
+
 		return nil, err
 	}
 	if namePrefix, ok := snapOptions["snapshotNamePrefix"]; ok {
 		cephfsSnap.NamePrefix = namePrefix
 	}
+
 	return cephfsSnap, nil
 }
 
@@ -141,7 +145,9 @@ func parseTime(ctx context.Context, createTime time.Time) (*timestamp.Timestamp,
 	tm, err := ptypes.TimestampProto(createTime)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to convert time %s %v", createTime, err)
+
 		return tm, err
 	}
+
 	return tm, nil
 }

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -60,6 +60,7 @@ func (vo *volumeOptions) getVolumeRootPathCeph(ctx context.Context, volID volume
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin err %s", err)
+
 		return "", err
 	}
 	svPath, err := fsa.SubVolumePath(vo.FsName, vo.SubvolumeGroup, string(volID))
@@ -68,8 +69,10 @@ func (vo *volumeOptions) getVolumeRootPathCeph(ctx context.Context, volID volume
 		if errors.Is(err, rados.ErrNotFound) {
 			return "", util.JoinErrors(ErrVolumeNotFound, err)
 		}
+
 		return "", err
 	}
+
 	return svPath, nil
 }
 
@@ -77,6 +80,7 @@ func (vo *volumeOptions) getSubVolumeInfo(ctx context.Context, volID volumeID) (
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s:", vo.FsName, err)
+
 		return nil, err
 	}
 
@@ -147,6 +151,7 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, volID volumeID
 	ca, err := volOptions.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin, can not create subvolume %s: %s", string(volID), err)
+
 		return err
 	}
 
@@ -161,6 +166,7 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, volID volumeID
 				volOptions.SubvolumeGroup,
 				string(volID),
 				err)
+
 			return err
 		}
 		util.DebugLog(ctx, "cephfs: created subvolume group %s", volOptions.SubvolumeGroup)
@@ -179,6 +185,7 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, volID volumeID
 	err = ca.CreateSubVolume(volOptions.FsName, volOptions.SubvolumeGroup, string(volID), &opts)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to create subvolume %s in fs %s: %s", string(volID), volOptions.FsName, err)
+
 		return err
 	}
 
@@ -203,21 +210,25 @@ func (vo *volumeOptions) resizeVolume(ctx context.Context, volID volumeID, bytes
 		fsa, err := vo.conn.GetFSAdmin()
 		if err != nil {
 			util.ErrorLog(ctx, "could not get FSAdmin, can not resize volume %s:", vo.FsName, err)
+
 			return err
 		}
 		_, err = fsa.ResizeSubVolume(vo.FsName, vo.SubvolumeGroup, string(volID), fsAdmin.ByteCount(bytesQuota), true)
 		if err == nil {
 			clusterAdditionalInfo[vo.ClusterID].resizeState = supported
+
 			return nil
 		}
 		var invalid fsAdmin.NotImplementedError
 		// In case the error is other than invalid command return error to the caller.
 		if !errors.As(err, &invalid) {
 			util.ErrorLog(ctx, "failed to resize subvolume %s in fs %s: %s", string(volID), vo.FsName, err)
+
 			return err
 		}
 	}
 	clusterAdditionalInfo[vo.ClusterID].resizeState = unsupported
+
 	return createVolume(ctx, vo, volID, bytesQuota)
 }
 
@@ -225,6 +236,7 @@ func (vo *volumeOptions) purgeVolume(ctx context.Context, volID volumeID, force 
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin %s:", err)
+
 		return err
 	}
 
@@ -244,6 +256,7 @@ func (vo *volumeOptions) purgeVolume(ctx context.Context, volID volumeID, force 
 		if errors.Is(err, rados.ErrNotFound) {
 			return util.JoinErrors(ErrVolumeNotFound, err)
 		}
+
 		return err
 	}
 
@@ -260,5 +273,6 @@ func checkSubvolumeHasFeature(feature string, subVolFeatures []string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -123,6 +123,7 @@ func newMounter(volOptions *volumeOptions) (volumeMounter, error) {
 	for _, availMounter := range availableMounters {
 		if availMounter == wantMounter {
 			chosenMounter = wantMounter
+
 			break
 		}
 	}
@@ -235,6 +236,7 @@ func mountKernel(ctx context.Context, mountPoint string, cr *util.Credentials, v
 	if err != nil {
 		return fmt.Errorf("%w stderr: %s", err, stderr)
 	}
+
 	return err
 }
 
@@ -275,6 +277,7 @@ func unmountVolume(ctx context.Context, mountPoint string) error {
 			strings.Contains(err.Error(), "No such file or directory") {
 			return nil
 		}
+
 		return err
 	}
 

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -67,6 +67,7 @@ func (vo *volumeOptions) Connect(cr *util.Credentials) error {
 	}
 
 	vo.conn = conn
+
 	return nil
 }
 
@@ -98,6 +99,7 @@ func extractOptionalOption(dest *string, optionLabel string, options map[string]
 	}
 
 	*dest = opt
+
 	return nil
 }
 
@@ -112,6 +114,7 @@ func extractOption(dest *string, optionLabel string, options map[string]string) 
 	}
 
 	*dest = opt
+
 	return nil
 }
 
@@ -144,6 +147,7 @@ func getClusterInformation(options map[string]string) (*util.ClusterInfo, error)
 	clusterID, ok := options["clusterID"]
 	if !ok {
 		err := fmt.Errorf("clusterID must be set")
+
 		return nil, err
 	}
 
@@ -154,12 +158,14 @@ func getClusterInformation(options map[string]string) (*util.ClusterInfo, error)
 	monitors, err := util.Mons(util.CsiConfigFile, clusterID)
 	if err != nil {
 		err = fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", clusterID, err)
+
 		return nil, err
 	}
 
 	subvolumeGroup, err := util.CephFSSubvolumeGroup(util.CsiConfigFile, clusterID)
 	if err != nil {
 		err = fmt.Errorf("failed to fetch subvolumegroup using clusterID (%s): %w", clusterID, err)
+
 		return nil, err
 	}
 	clusterData := &util.ClusterInfo{
@@ -167,6 +173,7 @@ func getClusterInformation(options map[string]string) (*util.ClusterInfo, error)
 		Monitors:  strings.Split(monitors, ","),
 	}
 	clusterData.CephFS.SubvolumeGroup = subvolumeGroup
+
 	return clusterData, nil
 }
 
@@ -265,6 +272,7 @@ func newVolumeOptionsFromVolID(
 	err := vi.DecomposeCSIID(volID)
 	if err != nil {
 		err = fmt.Errorf("error decoding volume ID (%s): %w", volID, err)
+
 		return nil, nil, util.JoinErrors(ErrInvalidVolID, err)
 	}
 	volOptions.ClusterID = vi.ClusterID

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -49,6 +49,7 @@ func addToManager(mgr manager.Manager, config Config) error {
 			return fmt.Errorf("failed to add: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -65,16 +66,19 @@ func Start(config Config) error {
 	mgr, err := manager.New(clientConfig.GetConfigOrDie(), opts)
 	if err != nil {
 		util.ErrorLogMsg("failed to create manager %s", err)
+
 		return err
 	}
 	err = addToManager(mgr, config)
 	if err != nil {
 		util.ErrorLogMsg("failed to add manager %s", err)
+
 		return err
 	}
 	err = mgr.Start(signals.SetupSignalHandler())
 	if err != nil {
 		util.ErrorLogMsg("failed to start manager %s", err)
 	}
+
 	return err
 }

--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -75,6 +75,7 @@ func (cs *DefaultControllerServer) ControllerGetCapabilities(
 	if cs.Driver == nil {
 		return nil, status.Error(codes.Unimplemented, "Controller server is not enabled")
 	}
+
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: cs.Driver.capabilities,
 	}, nil

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -44,16 +44,19 @@ type CSIDriver struct {
 func NewCSIDriver(name, v, nodeID string) *CSIDriver {
 	if name == "" {
 		klog.Errorf("Driver name missing")
+
 		return nil
 	}
 
 	if nodeID == "" {
 		klog.Errorf("NodeID missing")
+
 		return nil
 	}
 	// TODO version format and validation
 	if v == "" {
 		klog.Errorf("Version argument missing")
+
 		return nil
 	}
 
@@ -78,6 +81,7 @@ func (d *CSIDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapa
 			return nil
 		}
 	}
+
 	return status.Error(codes.InvalidArgument, fmt.Sprintf("%s", c)) //nolint
 }
 
@@ -103,6 +107,7 @@ func (d *CSIDriver) AddVolumeCapabilityAccessModes(
 		vca = append(vca, NewVolumeCapabilityAccessMode(c))
 	}
 	d.vc = vca
+
 	return vca
 }
 

--- a/internal/csi-common/identityserver-default.go
+++ b/internal/csi-common/identityserver-default.go
@@ -61,6 +61,7 @@ func (ids *DefaultIdentityServer) GetPluginCapabilities(
 	ctx context.Context,
 	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	util.TraceLog(ctx, "Using default capabilities")
+
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -104,6 +104,7 @@ func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) 
 					return true
 				}
 			}
+
 			return false
 		}
 		for _, f := range m.MountFlags {
@@ -112,6 +113,7 @@ func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) 
 			}
 		}
 	}
+
 	return mountOptions
 }
 
@@ -122,5 +124,6 @@ func MountOptionContains(mountOptions []string, opt string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -44,6 +44,7 @@ func parseEndpoint(ep string) (string, string, error) {
 			return s[0], s[1], nil
 		}
 	}
+
 	return "", "", fmt.Errorf("invalid endpoint: %v", ep)
 }
 
@@ -55,6 +56,7 @@ func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *c
 // NewDefaultNodeServer initializes default node server.
 func NewDefaultNodeServer(d *CSIDriver, t string, topology map[string]string) *DefaultNodeServer {
 	d.topology = topology
+
 	return &DefaultNodeServer{
 		Driver: d,
 		Type:   t,
@@ -98,6 +100,7 @@ func isReplicationRequest(req interface{}) bool {
 	default:
 		isReplicationRequest = false
 	}
+
 	return isReplicationRequest
 }
 
@@ -145,6 +148,7 @@ func getReqID(req interface{}) string {
 	case *replication.ResyncVolumeRequest:
 		reqID = r.VolumeId
 	}
+
 	return reqID
 }
 
@@ -160,6 +164,7 @@ func contextIDInjector(
 	if reqID := getReqID(req); reqID != "" {
 		ctx = context.WithValue(ctx, util.ReqID, reqID)
 	}
+
 	return handler(ctx, req)
 }
 
@@ -181,6 +186,7 @@ func logGRPC(
 	} else {
 		util.TraceLog(ctx, "GRPC response: %s", protosanitizer.StripSecrets(resp))
 	}
+
 	return resp, err
 }
 
@@ -196,6 +202,7 @@ func panicHandler(
 			err = status.Errorf(codes.Internal, "panic %v", r)
 		}
 	}()
+
 	return handler(ctx, req)
 }
 
@@ -209,6 +216,7 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 		if os.IsNotExist(err) {
 			return nil, status.Errorf(codes.InvalidArgument, "targetpath %s does not exist", targetPath)
 		}
+
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if !isMnt {
@@ -228,6 +236,7 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 	capacity, ok := (*(volMetrics.Capacity)).AsInt64()
 	if !ok {
 		util.ErrorLog(ctx, "failed to fetch capacity bytes")
+
 		return nil, status.Error(codes.Unknown, "failed to fetch capacity bytes")
 	}
 	used, ok := (*(volMetrics.Used)).AsInt64()
@@ -237,6 +246,7 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 	inodes, ok := (*(volMetrics.Inodes)).AsInt64()
 	if !ok {
 		util.ErrorLog(ctx, "failed to fetch available inodes")
+
 		return nil, status.Error(codes.Unknown, "failed to fetch available inodes")
 	}
 	inodesFree, ok := (*(volMetrics.InodesFree)).AsInt64()
@@ -248,6 +258,7 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 	if !ok {
 		util.ErrorLog(ctx, "failed to fetch used inodes")
 	}
+
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
 			{

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -76,13 +76,16 @@ func getOMapValues(
 		if errors.Is(err, rados.ErrNotFound) {
 			util.ErrorLog(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v",
 				poolName, namespace, oid, err)
+
 			return nil, util.JoinErrors(util.ErrKeyNotFound, err)
 		}
+
 		return nil, err
 	}
 
 	util.DebugLog(ctx, "got omap values: (pool=%q, namespace=%q, name=%q): %+v",
 		poolName, namespace, oid, results)
+
 	return results, nil
 }
 
@@ -112,11 +115,13 @@ func removeMapKeys(
 		} else {
 			util.ErrorLog(ctx, "failed removing omap keys (pool=%q, namespace=%q, name=%q): %v",
 				poolName, namespace, oid, err)
+
 			return err
 		}
 	}
 	util.DebugLog(ctx, "removed omap keys (pool=%q, namespace=%q, name=%q): %+v",
 		poolName, namespace, oid, keys)
+
 	return nil
 }
 
@@ -143,10 +148,12 @@ func setOMapKeys(
 	if err != nil {
 		util.ErrorLog(ctx, "failed setting omap keys (pool=%q, namespace=%q, name=%q, pairs=%+v): %v",
 			poolName, namespace, oid, pairs, err)
+
 		return err
 	}
 	util.DebugLog(ctx, "set omap keys (pool=%q, namespace=%q, name=%q): %+v)",
 		poolName, namespace, oid, pairs)
+
 	return nil
 }
 
@@ -154,5 +161,6 @@ func omapPoolError(err error) error {
 	if errors.Is(err, rados.ErrNotFound) {
 		return util.JoinErrors(util.ErrPoolNotFound, err)
 	}
+
 	return err
 }

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -196,6 +196,7 @@ func NewCSISnapshotJournal(suffix string) *Config {
 func NewCSIVolumeJournalWithNamespace(suffix, ns string) *Config {
 	j := NewCSIVolumeJournal(suffix)
 	j.namespace = ns
+
 	return j
 }
 
@@ -204,6 +205,7 @@ func NewCSIVolumeJournalWithNamespace(suffix, ns string) *Config {
 func NewCSISnapshotJournalWithNamespace(suffix, ns string) *Config {
 	j := NewCSISnapshotJournal(suffix)
 	j.namespace = ns
+
 	return j
 }
 
@@ -216,6 +218,7 @@ func (cj *Config) GetNameForUUID(prefix, uid string, isSnapshot bool) string {
 			prefix = defaultVolumeNamingPrefix
 		}
 	}
+
 	return prefix + uid
 }
 
@@ -251,6 +254,7 @@ func (cj *Config) Connect(monitors, namespace string, cr *util.Credentials) (*Co
 		cr:       cr,
 		conn:     cc,
 	}
+
 	return conn, nil
 }
 
@@ -282,6 +286,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 	if parentName != "" {
 		if cj.cephSnapSourceKey == "" {
 			err := errors.New("invalid request, cephSnapSourceKey is nil")
+
 			return nil, err
 		}
 		snapSource = true
@@ -300,6 +305,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 			// stop processing but without an error for no reservation exists
 			return nil, nil
 		}
+
 		return nil, err
 	}
 	objUUIDAndPool, found := values[cj.csiNameKeyPrefix+reqName]
@@ -330,6 +336,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 			if errors.Is(err, util.ErrPoolNotFound) {
 				err = conn.UndoReservation(ctx, journalPool, "", "", reqName)
 			}
+
 			return nil, err
 		}
 	}
@@ -343,6 +350,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 			err = conn.UndoReservation(ctx, journalPool, savedImagePool,
 				cj.GetNameForUUID(namePrefix, objUUID, snapSource), reqName)
 		}
+
 		return nil, err
 	}
 
@@ -375,6 +383,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 			err = fmt.Errorf("%w: snapname points to different volume, request name (%s)"+
 				" source name (%s) saved source name (%s)", util.ErrSnapNameConflict,
 				reqName, parentName, savedImageAttributes.SourceName)
+
 			return nil, err
 		}
 	}
@@ -429,6 +438,7 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 		if err != nil {
 			if !errors.Is(err, util.ErrObjectNotFound) {
 				util.ErrorLog(ctx, "failed removing oMap %s (%s)", cj.cephUUIDDirectoryPrefix+imageUUID, err)
+
 				return err
 			}
 		}
@@ -439,6 +449,7 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 		[]string{cj.csiNameKeyPrefix + reqName})
 	if err != nil {
 		util.ErrorLog(ctx, "failed removing oMap key %s (%s)", cj.csiNameKeyPrefix+reqName, err)
+
 		return err
 	}
 
@@ -477,6 +488,7 @@ func reserveOMapName(
 				// try again with a different uuid, for maxAttempts tries
 				util.DebugLog(ctx, "uuid (%s) conflict detected, retrying (attempt %d of %d)",
 					iterUUID, attempt, maxAttempts)
+
 				continue
 			}
 
@@ -534,6 +546,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	if parentName != "" {
 		if cj.cephSnapSourceKey == "" {
 			err = errors.New("invalid request, cephSnapSourceKey is nil")
+
 			return "", "", err
 		}
 		snapSource = true
@@ -623,6 +636,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	if err != nil {
 		return "", "", err
 	}
+
 	return volUUID, imageName, nil
 }
 
@@ -650,6 +664,7 @@ func (conn *Connection) GetImageAttributes(
 
 	if snapSource && cj.cephSnapSourceKey == "" {
 		err = errors.New("invalid request, cephSnapSourceKey is nil")
+
 		return nil, err
 	}
 
@@ -720,6 +735,7 @@ func (conn *Connection) StoreImageID(ctx context.Context, pool, reservedUUID, im
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -749,8 +765,10 @@ func (conn *Connection) CheckNewUUIDMapping(ctx context.Context,
 			// stop processing but without an error for no reservation exists
 			return "", nil
 		}
+
 		return "", err
 	}
+
 	return values[cj.csiNameKeyPrefix+volumeHandle], nil
 }
 
@@ -767,5 +785,6 @@ func (conn *Connection) ReserveNewUUIDMapping(ctx context.Context,
 	setKeys := map[string]string{
 		cj.csiNameKeyPrefix + oldVolumeHandle: newVolumeHandle,
 	}
+
 	return setOMapKeys(ctx, conn, journalPool, cj.namespace, cj.csiDirectory, setKeys)
 }

--- a/internal/liveness/liveness.go
+++ b/internal/liveness/liveness.go
@@ -44,12 +44,14 @@ func getLiveness(timeout time.Duration, csiConn *grpc.ClientConn) {
 	if err != nil {
 		liveness.Set(0)
 		util.ErrorLogMsg("health check failed: %v", err)
+
 		return
 	}
 
 	if !ready {
 		liveness.Set(0)
 		util.ErrorLogMsg("driver responded but is not ready")
+
 		return
 	}
 	liveness.Set(1)

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -61,12 +61,14 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 			if errors.Is(err, ErrSnapNotFound) {
 				return true, nil
 			}
+
 			return false, err
 		}
 		err = tempClone.deleteSnapshot(ctx, snap)
 		if err == nil {
 			return true, nil
 		}
+
 		return false, err
 	}
 	if !errors.Is(err, ErrImageNotFound) {
@@ -90,6 +92,7 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 			if err != nil {
 				return false, err
 			}
+
 			return true, nil
 		case !errors.Is(err, ErrImageNotFound):
 			// any error other than image not found return error
@@ -104,13 +107,16 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 		if err != nil {
 			util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
 			err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", rv.RbdImageName, snap.RbdSnapName, err)
+
 			return false, err
 		}
 		err = tempClone.deleteSnapshot(ctx, snap)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to delete snapshot: %v", err)
+
 			return false, err
 		}
+
 		return true, nil
 	}
 	// as the temp clone does not exist,check snapshot exists on parent volume
@@ -125,6 +131,7 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 	if errors.Is(err, ErrSnapNotFound) {
 		return false, nil
 	}
+
 	return false, err
 }
 
@@ -142,6 +149,7 @@ func (rv *rbdVolume) generateTempClone() *rbdVolume {
 	// this name will be always unique, as cephcsi never creates an image with
 	// this format for new rbd images
 	tempClone.RbdImageName = rv.RbdImageName + "-temp"
+
 	return &tempClone
 }
 
@@ -160,6 +168,7 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 	err = rv.getImageID()
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get volume id %s: %v", rv, err)
+
 		return err
 	}
 
@@ -180,8 +189,10 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to store volume %s: %v", rv, err)
+
 		return err
 	}
+
 	return nil
 }
 
@@ -248,6 +259,7 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 		if errClone != nil {
 			// set errFlatten error to cleanup temporary snapshot and temporary clone
 			errFlatten = errors.New("failed to create user requested cloned image")
+
 			return errClone
 		}
 	}
@@ -285,5 +297,6 @@ func (rv *rbdVolume) flattenCloneImage(ctx context.Context) error {
 	if !errors.Is(err, ErrImageNotFound) {
 		return err
 	}
+
 	return rv.flattenRbdImage(ctx, rv.conn.Creds, false, hardLimit, softLimit)
 }

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -91,6 +91,7 @@ func NewReplicationServer(c *ControllerServer) *ReplicationServer {
 // NewNodeServer initialize a node server for rbd CSI driver.
 func NewNodeServer(d *csicommon.CSIDriver, t string, topology map[string]string) (*NodeServer, error) {
 	mounter := mount.New("")
+
 	return &NodeServer{
 		DefaultNodeServer: csicommon.NewDefaultNodeServer(d, t, topology),
 		mounter:           mounter,

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -65,14 +65,17 @@ func (ri *rbdImage) checkRbdImageEncrypted(ctx context.Context) (rbdEncryptionSt
 	value, err := ri.GetMetadata(encryptionMetaKey)
 	if errors.Is(err, librbd.ErrNotFound) {
 		util.DebugLog(ctx, "image %s encrypted state not set", ri)
+
 		return rbdImageEncryptionUnknown, nil
 	} else if err != nil {
 		util.ErrorLog(ctx, "checking image %s encrypted state metadata failed: %s", ri, err)
+
 		return rbdImageEncryptionUnknown, err
 	}
 
 	encrypted := rbdEncryptionState(strings.TrimSpace(value))
 	util.DebugLog(ctx, "image %s encrypted state metadata reports %q", ri, encrypted)
+
 	return encrypted, nil
 }
 
@@ -98,6 +101,7 @@ func (ri *rbdImage) setupEncryption(ctx context.Context) error {
 	if err != nil {
 		util.ErrorLog(ctx, "failed to save encryption passphrase for "+
 			"image %s: %s", ri, err)
+
 		return err
 	}
 
@@ -105,6 +109,7 @@ func (ri *rbdImage) setupEncryption(ctx context.Context) error {
 	if err != nil {
 		util.ErrorLog(ctx, "failed to save encryption status, deleting "+
 			"image %s: %s", ri, err)
+
 		return err
 	}
 
@@ -181,18 +186,21 @@ func (ri *rbdImage) encryptDevice(ctx context.Context, devicePath string) error 
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get crypto passphrase for %s: %v",
 			ri, err)
+
 		return err
 	}
 
 	if err = util.EncryptVolume(ctx, devicePath, passphrase); err != nil {
 		err = fmt.Errorf("failed to encrypt volume %s: %w", ri, err)
 		util.ErrorLog(ctx, err.Error())
+
 		return err
 	}
 
 	err = ri.ensureEncryptionMetadataSet(rbdImageEncrypted)
 	if err != nil {
 		util.ErrorLog(ctx, err.Error())
+
 		return err
 	}
 
@@ -204,6 +212,7 @@ func (rv *rbdVolume) openEncryptedDevice(ctx context.Context, devicePath string)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get passphrase for encrypted device %s: %v",
 			rv, err)
+
 		return "", err
 	}
 
@@ -212,6 +221,7 @@ func (rv *rbdVolume) openEncryptedDevice(ctx context.Context, devicePath string)
 	isOpen, err := util.IsDeviceOpen(ctx, mapperFilePath)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to check device %s encryption status: %s", devicePath, err)
+
 		return devicePath, err
 	}
 	if isOpen {
@@ -221,6 +231,7 @@ func (rv *rbdVolume) openEncryptedDevice(ctx context.Context, devicePath string)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to open device %s: %v",
 				rv, err)
+
 			return devicePath, err
 		}
 	}

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -38,6 +38,7 @@ func (ri *rbdImage) enableImageMirroring(mode librbd.ImageMirrorMode) error {
 	if err != nil {
 		return fmt.Errorf("failed to enable mirroring on %q with error: %w", ri, err)
 	}
+
 	return nil
 }
 
@@ -53,6 +54,7 @@ func (ri *rbdImage) disableImageMirroring(force bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to disable mirroring on %q with error: %w", ri, err)
 	}
+
 	return nil
 }
 
@@ -68,6 +70,7 @@ func (ri *rbdImage) getImageMirroringInfo() (*librbd.MirrorImageInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mirroring info of %q with error: %w", ri, err)
 	}
+
 	return info, nil
 }
 
@@ -82,6 +85,7 @@ func (ri *rbdImage) promoteImage(force bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to promote image %q with error: %w", ri, err)
 	}
+
 	return nil
 }
 
@@ -96,6 +100,7 @@ func (ri *rbdImage) demoteImage() error {
 	if err != nil {
 		return fmt.Errorf("failed to demote image %q with error: %w", ri, err)
 	}
+
 	return nil
 }
 
@@ -110,6 +115,7 @@ func (ri *rbdImage) resyncImage() error {
 	if err != nil {
 		return fmt.Errorf("failed to resync image %q with error: %w", ri, err)
 	}
+
 	return nil
 }
 
@@ -148,6 +154,7 @@ func (ri *rbdImage) getImageMirroringStatus() (*imageMirrorStatus, error) {
 			": (2) No such file or directory") {
 			return nil, util.JoinErrors(ErrImageNotFound, err)
 		}
+
 		return nil, err
 	}
 
@@ -157,5 +164,6 @@ func (ri *rbdImage) getImageMirroringStatus() (*imageMirrorStatus, error) {
 			return nil, fmt.Errorf("unmarshal failed (%w), raw buffer response: %s", err, stdout)
 		}
 	}
+
 	return &imgStatus, nil
 }

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -140,6 +140,7 @@ func findDeviceMappingImage(ctx context.Context, pool, namespace, image string, 
 	rbdDeviceList, err := rbdGetDeviceList(ctx, accessType)
 	if err != nil {
 		util.WarningLog(ctx, "failed to determine if image (%s) is mapped to a device (%v)", imageSpec, err)
+
 		return "", false
 	}
 
@@ -177,14 +178,17 @@ func checkRbdNbdTools() bool {
 		_, _, err = util.ExecCommand(context.TODO(), "modprobe", moduleNbd)
 		if err != nil {
 			util.ExtendedLogMsg("rbd-nbd: nbd modprobe failed with error %v", err)
+
 			return false
 		}
 	}
 	if _, _, err := util.ExecCommand(context.TODO(), rbdTonbd, "--version"); err != nil {
 		util.ExtendedLogMsg("rbd-nbd: running rbd-nbd --version failed with error %v", err)
+
 		return false
 	}
 	util.ExtendedLogMsg("rbd-nbd tools were found.")
+
 	return true
 }
 
@@ -325,6 +329,7 @@ func createPath(ctx context.Context, volOpt *rbdVolume, device string, cr *util.
 				util.WarningLog(ctx, "rbd: %s unmap error %v", imagePath, detErr)
 			}
 		}
+
 		return "", fmt.Errorf("rbd: map failed with error %w, rbd error output: %s", err, stderr)
 	}
 	devicePath := strings.TrimSuffix(stdout, "\n")
@@ -342,8 +347,10 @@ func waitForrbdImage(ctx context.Context, backoff wait.Backoff, volOptions *rbdV
 		}
 		if (volOptions.DisableInUseChecks) && (used) {
 			util.UsefulLog(ctx, "valid multi-node attach requested, ignoring watcher in-use result")
+
 			return used, nil
 		}
+
 		return !used, nil
 	})
 	// return error if rbd image has not become available for the specified timeout
@@ -376,6 +383,7 @@ func detachRBDImageOrDeviceSpec(
 		if err != nil {
 			util.ErrorLog(ctx, "error determining LUKS device on %s, %s: %s",
 				mapperPath, imageOrDeviceSpec, err)
+
 			return err
 		}
 		if len(mapper) > 0 {
@@ -384,6 +392,7 @@ func detachRBDImageOrDeviceSpec(
 			if err != nil {
 				util.ErrorLog(ctx, "error closing LUKS device on %s, %s: %s",
 					mapperPath, imageOrDeviceSpec, err)
+
 				return err
 			}
 			imageOrDeviceSpec = mappedDevice
@@ -402,8 +411,10 @@ func detachRBDImageOrDeviceSpec(
 				strings.Contains(stderr, fmt.Sprintf(rbdUnmapCmdNbdMissingMap, imageOrDeviceSpec))) {
 			// Devices found not to be mapped are treated as a successful detach
 			util.TraceLog(ctx, "image or device spec (%s) not mapped", imageOrDeviceSpec)
+
 			return nil
 		}
+
 		return fmt.Errorf("rbd: unmap for spec (%s) failed (%w): (%s)", imageOrDeviceSpec, err, stderr)
 	}
 

--- a/internal/rbd/rbd_healer.go
+++ b/internal/rbd/rbd_healer.go
@@ -44,6 +44,7 @@ func accessModeStrToInt(mode v1.PersistentVolumeAccessMode) csi.VolumeCapability
 	case v1.ReadWriteMany:
 		return csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
 	}
+
 	return csi.VolumeCapability_AccessMode_UNKNOWN
 }
 
@@ -54,6 +55,7 @@ func getSecret(c *k8s.Clientset, ns, name string) (map[string]string, error) {
 	secret, err := c.CoreV1().Secrets(ns).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		util.ErrorLogMsg("get secret failed, err: %v", err)
+
 		return nil, err
 	}
 
@@ -78,6 +80,7 @@ func callNodeStageVolume(ns *NodeServer, c *k8s.Clientset, pv *v1.PersistentVolu
 		pv.Spec.PersistentVolumeSource.CSI.NodeStageSecretRef.Name)
 	if err != nil {
 		util.ErrorLogMsg("getSecret failed for volID: %s, err: %v", volID, err)
+
 		return err
 	}
 
@@ -113,6 +116,7 @@ func callNodeStageVolume(ns *NodeServer, c *k8s.Clientset, pv *v1.PersistentVolu
 	if err != nil {
 		util.ErrorLogMsg("nodeStageVolume request failed, volID: %s, stagingPath: %s, err: %v",
 			volID, stagingParentPath, err)
+
 		return err
 	}
 
@@ -125,6 +129,7 @@ func runVolumeHealer(ns *NodeServer, conf *util.Config) error {
 	val, err := c.StorageV1().VolumeAttachments().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		util.ErrorLogMsg("list volumeAttachments failed, err: %v", err)
+
 		return err
 	}
 
@@ -142,6 +147,7 @@ func runVolumeHealer(ns *NodeServer, conf *util.Config) error {
 			if !apierrors.IsNotFound(err) {
 				util.ErrorLogMsg("get persistentVolumes failed for pv: %s, err: %v", pvName, err)
 			}
+
 			continue
 		}
 		// TODO: check with pv delete annotations, for eg: what happens when the pv is marked for delete
@@ -162,6 +168,7 @@ func runVolumeHealer(ns *NodeServer, conf *util.Config) error {
 				util.ErrorLogMsg("get volumeAttachments failed for volumeAttachment: %s, volID: %s, err: %v",
 					val.Items[i].Name, pv.Spec.PersistentVolumeSource.CSI.VolumeHandle, err)
 			}
+
 			continue
 		}
 		if !va.Status.Attached {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -168,11 +168,13 @@ func checkSnapCloneExists(
 			if err != nil {
 				if !errors.Is(err, ErrSnapNotFound) {
 					util.ErrorLog(ctx, "failed to delete snapshot %s: %v", rbdSnap, err)
+
 					return false, err
 				}
 			}
 			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 		}
+
 		return false, err
 	}
 
@@ -198,6 +200,7 @@ func checkSnapCloneExists(
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, sErr)
 			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
+
 			return false, err
 		}
 	}
@@ -210,18 +213,21 @@ func checkSnapCloneExists(
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to get image id %s: %v", vol, sErr)
 			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
+
 			return false, err
 		}
 		sErr = j.StoreImageID(ctx, vol.JournalPool, vol.ReservedID, vol.ImageID)
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to store volume id %s: %v", vol, sErr)
 			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
+
 			return false, err
 		}
 	}
 
 	util.DebugLog(ctx, "found existing image (%s) with name (%s) for request (%s)",
 		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
+
 	return true, nil
 }
 
@@ -299,8 +305,10 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 			}
 			err = j.UndoReservation(ctx, rv.JournalPool, rv.Pool,
 				rv.RbdImageName, rv.RequestName)
+
 			return false, err
 		}
+
 		return false, err
 	}
 
@@ -327,6 +335,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 		err = parentVol.copyEncryptionConfig(&rv.rbdImage)
 		if err != nil {
 			util.ErrorLog(ctx, err.Error())
+
 			return false, err
 		}
 	}
@@ -348,11 +357,13 @@ func (rv *rbdVolume) repairImageID(ctx context.Context, j *journal.Connection) e
 	err := rv.getImageID()
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
+
 		return err
 	}
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
+
 		return err
 	}
 
@@ -544,6 +555,7 @@ func RegenerateJournal(
 	rbdVol.Monitors, _, err = util.GetMonsAndClusterID(options)
 	if err != nil {
 		util.ErrorLog(ctx, "failed getting mons (%s)", err)
+
 		return "", err
 	}
 
@@ -593,6 +605,7 @@ func RegenerateJournal(
 		if err != nil {
 			return "", err
 		}
+
 		return rbdVol.VolID, nil
 	}
 
@@ -635,12 +648,15 @@ func (rv *rbdVolume) storeImageID(ctx context.Context, j *journal.Connection) er
 	err := rv.getImageID()
 	if err != nil {
 		util.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
+
 		return err
 	}
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
+
 		return err
 	}
+
 	return nil
 }

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -131,6 +131,7 @@ func TestValidateImageFeatures(t *testing.T) {
 		err := test.rbdVol.validateImageFeatures(test.imageFeatures)
 		if test.isErr {
 			assert.EqualError(t, err, test.errMsg)
+
 			continue
 		}
 		assert.Nil(t, err)

--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -69,6 +69,7 @@ func TestValidateSchedulingInterval(t *testing.T) {
 			got, err := validateSchedulingInterval(tt.interval)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateSchedulingInterval() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
@@ -145,6 +146,7 @@ func TestGetSchedulingDetails(t *testing.T) {
 			interval, startTime, err := getSchedulingDetails(tt.parameters)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getSchedulingDetails() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if !reflect.DeepEqual(interval, tt.wantInterval) {

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -32,6 +32,7 @@ func createRBDClone(
 	err := parentVol.createSnapshot(ctx, snap)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to create snapshot %s: %v", snap, err)
+
 		return err
 	}
 
@@ -58,6 +59,7 @@ func createRBDClone(
 		if delErr != nil {
 			util.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", cloneRbdVol, delErr)
 		}
+
 		return err
 	}
 
@@ -68,6 +70,7 @@ func createRBDClone(
 		if delErr != nil {
 			util.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", cloneRbdVol, delErr)
 		}
+
 		return err
 	}
 
@@ -86,6 +89,7 @@ func cleanUpSnapshot(
 	if err != nil {
 		if !errors.Is(err, ErrSnapNotFound) {
 			util.ErrorLog(ctx, "failed to delete snapshot %q: %v", rbdSnap, err)
+
 			return err
 		}
 	}
@@ -95,6 +99,7 @@ func cleanUpSnapshot(
 		if err != nil {
 			if !errors.Is(err, ErrImageNotFound) {
 				util.ErrorLog(ctx, "failed to delete rbd image %q with error: %v", rbdVol, err)
+
 				return err
 			}
 		}
@@ -117,6 +122,7 @@ func generateVolFromSnap(rbdSnap *rbdSnapshot) *rbdVolume {
 	// snapshot will have the same volumeID which cases the panic in
 	// copyEncryptionConfig function.
 	vol.encryption = rbdSnap.encryption
+
 	return vol
 }
 
@@ -129,8 +135,10 @@ func undoSnapshotCloning(
 	err := cleanUpSnapshot(ctx, parentVol, rbdSnap, cloneVol, cr)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to clean up  %s or %s: %v", cloneVol, rbdSnap, err)
+
 		return err
 	}
 	err = undoSnapReservation(ctx, rbdSnap, cr)
+
 	return err
 }

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -52,6 +52,7 @@ func ExecCommand(ctx context.Context, program string, args ...string) (string, s
 		if ctx != context.TODO() {
 			UsefulLog(ctx, "%s", err)
 		}
+
 		return stdout, stderr, err
 	}
 
@@ -98,6 +99,7 @@ func GetPoolName(monitors string, cr *Credentials, poolID int64) (string, error)
 	} else if err != nil {
 		return "", fmt.Errorf("failed to get pool ID %d: %w", poolID, err)
 	}
+
 	return name, nil
 }
 
@@ -136,6 +138,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 		if errors.Is(err, ErrPoolNotFound) {
 			err = JoinErrors(ErrObjectNotFound, err)
 		}
+
 		return err
 	}
 	defer ioctx.Destroy()
@@ -149,6 +152,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 		return JoinErrors(ErrObjectExists, err)
 	} else if err != nil {
 		ErrorLog(ctx, "failed creating omap (%s) in pool (%s): (%v)", objectName, poolName, err)
+
 		return err
 	}
 
@@ -170,6 +174,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 		if errors.Is(err, ErrPoolNotFound) {
 			err = JoinErrors(ErrObjectNotFound, err)
 		}
+
 		return err
 	}
 	defer ioctx.Destroy()
@@ -183,6 +188,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 		return JoinErrors(ErrObjectNotFound, err)
 	} else if err != nil {
 		ErrorLog(ctx, "failed removing omap (%s) in pool (%s): (%v)", oMapName, poolName, err)
+
 		return err
 	}
 

--- a/internal/util/cephconf.go
+++ b/internal/util/cephconf.go
@@ -72,5 +72,6 @@ if any ceph commands fails it will log below error message
 // createKeyRingFile creates the keyring files to fix above error message logging.
 func createKeyRingFile() error {
 	_, err := os.Create(keyRing)
+
 	return err
 }

--- a/internal/util/conn_pool.go
+++ b/internal/util/conn_pool.go
@@ -111,8 +111,10 @@ func (cp *ConnPool) getConn(unique string) *rados.Conn {
 	ce, exists := cp.conns[unique]
 	if exists {
 		ce.get()
+
 		return ce.conn
 	}
+
 	return nil
 }
 
@@ -159,6 +161,7 @@ func (cp *ConnPool) Get(monitors, user, keyfile string) (*rados.Conn, error) {
 	if oldConn := cp.getConn(unique); oldConn != nil {
 		// there was a race, oldConn already exists
 		ce.destroy()
+
 		return oldConn, nil
 	}
 	// this really is a new connection, add it to the map
@@ -176,6 +179,7 @@ func (cp *ConnPool) Copy(conn *rados.Conn) *rados.Conn {
 	for _, ce := range cp.conns {
 		if ce.conn == conn {
 			ce.get()
+
 			return ce.conn
 		}
 	}
@@ -192,6 +196,7 @@ func (cp *ConnPool) Put(conn *rados.Conn) {
 	for _, ce := range cp.conns {
 		if ce.conn == conn {
 			ce.put()
+
 			return
 		}
 	}

--- a/internal/util/conn_pool_test.go
+++ b/internal/util/conn_pool_test.go
@@ -65,6 +65,7 @@ func (cp *ConnPool) fakeGet(monitors, user, keyfile string) (*rados.Conn, string
 	if oldConn := cp.getConn(unique); oldConn != nil {
 		// there was a race, oldConn already exists
 		ce.destroy()
+
 		return oldConn, unique, nil
 	}
 	// this really is a new connection, add it to the map
@@ -83,6 +84,7 @@ func TestConnPool(t *testing.T) {
 	err := ioutil.WriteFile(keyfile, []byte("the-key"), 0o600)
 	if err != nil {
 		t.Errorf("failed to create keyfile: %v", err)
+
 		return
 	}
 	defer os.Remove(keyfile)

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -98,6 +98,7 @@ func (cc *ClusterConnection) GetIoctx(pool string) (*rados.IOContext, error) {
 		} else {
 			err = fmt.Errorf("failed to open IOContext for pool %s: %w", pool, err)
 		}
+
 		return nil, err
 	}
 
@@ -137,5 +138,6 @@ func (cc *ClusterConnection) DisableDiscardOnZeroedWriteSame() error {
 	}
 
 	cc.discardOnZeroedWriteSameDisabled = true
+
 	return nil
 }

--- a/internal/util/credentials.go
+++ b/internal/util/credentials.go
@@ -58,6 +58,7 @@ func storeKey(key string) (string, error) {
 	keyFile := tmpfile.Name()
 	if keyFile == "" {
 		err = fmt.Errorf("error reading temporary filename for key: %w", err)
+
 		return "", err
 	}
 
@@ -115,5 +116,6 @@ func GetMonValFromSecret(secrets map[string]string) (string, error) {
 	if mons, ok := secrets[credMonitors]; ok {
 		return mons, nil
 	}
+
 	return "", fmt.Errorf("missing %q", credMonitors)
 }

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -87,6 +87,7 @@ func NewVolumeEncryption(id string, kms EncryptionKMS) (*VolumeEncryption, error
 		}
 
 		ve.dekStore = dekStore
+
 		return ve, nil
 	}
 
@@ -196,6 +197,7 @@ func (ve *VolumeEncryption) StoreCryptoPassphrase(volumeID, passphrase string) e
 	if err != nil {
 		return fmt.Errorf("failed to save the passphrase for %s: %w", volumeID, err)
 	}
+
 	return nil
 }
 
@@ -226,6 +228,7 @@ func generateNewEncryptionPassphrase() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return base64.URLEncoding.EncodeToString(bytesPassphrase), nil
 }
 
@@ -233,6 +236,7 @@ func generateNewEncryptionPassphrase() (string, error) {
 func VolumeMapper(volumeID string) (mapperFile, mapperFilePath string) {
 	mapperFile = mapperFilePrefix + volumeID
 	mapperFilePath = path.Join(mapperFilePathPrefix, mapperFile)
+
 	return mapperFile, mapperFilePath
 }
 
@@ -242,6 +246,7 @@ func EncryptVolume(ctx context.Context, devicePath, passphrase string) error {
 	if _, _, err := LuksFormat(devicePath, passphrase); err != nil {
 		return fmt.Errorf("failed to encrypt device %s with LUKS: %w", devicePath, err)
 	}
+
 	return nil
 }
 
@@ -252,6 +257,7 @@ func OpenEncryptedVolume(ctx context.Context, devicePath, mapperFile, passphrase
 	if err != nil {
 		WarningLog(ctx, "failed to open LUKS device %q: %s", devicePath, stderr)
 	}
+
 	return err
 }
 
@@ -259,12 +265,14 @@ func OpenEncryptedVolume(ctx context.Context, devicePath, mapperFile, passphrase
 func CloseEncryptedVolume(ctx context.Context, mapperFile string) error {
 	DebugLog(ctx, "Closing LUKS device %s", mapperFile)
 	_, _, err := LuksClose(mapperFile)
+
 	return err
 }
 
 // IsDeviceOpen determines if encrypted device is already open.
 func IsDeviceOpen(ctx context.Context, device string) (bool, error) {
 	_, mappedFile, err := DeviceEncryptionStatus(ctx, device)
+
 	return (mappedFile != ""), err
 }
 
@@ -279,6 +287,7 @@ func DeviceEncryptionStatus(ctx context.Context, devicePath string) (mappedDevic
 	stdout, _, err := LuksStatus(mapPath)
 	if err != nil {
 		DebugLog(ctx, "device %s is not an active LUKS device: %v", devicePath, err)
+
 		return devicePath, "", nil
 	}
 	lines := strings.Split(string(stdout), "\n")

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -72,6 +72,7 @@ func readClusterInfo(pathToConfig, clusterID string) (*ClusterInfo, error) {
 	content, err := ioutil.ReadFile(pathToConfig)
 	if err != nil {
 		err = fmt.Errorf("error fetching configuration for cluster ID %q: %w", clusterID, err)
+
 		return nil, err
 	}
 
@@ -100,6 +101,7 @@ func Mons(pathToConfig, clusterID string) (string, error) {
 	if len(cluster.Monitors) == 0 {
 		return "", fmt.Errorf("empty monitor list for cluster ID (%s) in config", clusterID)
 	}
+
 	return strings.Join(cluster.Monitors, ","), nil
 }
 
@@ -109,6 +111,7 @@ func RadosNamespace(pathToConfig, clusterID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return cluster.RadosNamespace, nil
 }
 
@@ -122,6 +125,7 @@ func CephFSSubvolumeGroup(pathToConfig, clusterID string) (string, error) {
 	if cluster.CephFS.SubvolumeGroup == "" {
 		return defaultCsiSubvolumeGroup, nil
 	}
+
 	return cluster.CephFS.SubvolumeGroup, nil
 }
 

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -14,6 +14,7 @@ import (
 // ValidateURL validates the url.
 func ValidateURL(c *Config) error {
 	_, err := url.Parse(c.MetricsPath)
+
 	return err
 }
 

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -51,6 +51,7 @@ func (vl *VolumeLocks) TryAcquire(volumeID string) bool {
 		return false
 	}
 	vl.locks.Insert(volumeID)
+
 	return true
 }
 
@@ -96,6 +97,7 @@ func NewOperationLock() *OperationLock {
 	lock[cloneOpt] = make(map[string]int)
 	lock[restoreOp] = make(map[string]int)
 	lock[expandOp] = make(map[string]int)
+
 	return &OperationLock{
 		locks: lock,
 	}
@@ -176,6 +178,7 @@ func (ol *OperationLock) tryAcquire(op operation, volumeID string) error {
 	default:
 		return fmt.Errorf("%v operation not supported", op)
 	}
+
 	return nil
 }
 

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -44,5 +44,6 @@ func NewK8sClient() *k8s.Clientset {
 	if err != nil {
 		FatalLogMsg("Failed to create client with error: %v\n", err)
 	}
+
 	return client
 }

--- a/internal/util/kms.go
+++ b/internal/util/kms.go
@@ -181,6 +181,7 @@ func getKMSProvider(config map[string]interface{}) (string, error) {
 			return "", fmt.Errorf("could not convert KMS provider"+
 				"type (%v) to string", providerName)
 		}
+
 		return name, nil
 	}
 
@@ -191,6 +192,7 @@ func getKMSProvider(config map[string]interface{}) (string, error) {
 			return "", fmt.Errorf("could not convert KMS provider"+
 				"type (%v) to string", providerName)
 		}
+
 		return name, nil
 	}
 

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -49,6 +49,7 @@ func Log(ctx context.Context, format string) string {
 		return a + format
 	}
 	a += fmt.Sprintf("Req-ID: %v ", reqID)
+
 	return a + format
 }
 

--- a/internal/util/pidlimit.go
+++ b/internal/util/pidlimit.go
@@ -53,6 +53,7 @@ func getCgroupPidsFile() (string, error) {
 		}
 		if parts[1] == "pids" {
 			slice = parts[2]
+
 			break
 		}
 	}
@@ -61,6 +62,7 @@ func getCgroupPidsFile() (string, error) {
 	}
 
 	pidsMax := fmt.Sprintf(sysPidsMaxFmt, slice)
+
 	return pidsMax, nil
 }
 
@@ -91,6 +93,7 @@ func GetPIDLimit() (int, error) {
 			return 0, err
 		}
 	}
+
 	return maxPids, nil
 }
 
@@ -115,6 +118,7 @@ func SetPIDLimit(limit int) error {
 	_, err = f.WriteString(limitStr)
 	if err != nil {
 		f.Close() // #nosec: a write error will be more useful to return
+
 		return err
 	}
 

--- a/internal/util/secretskms.go
+++ b/internal/util/secretskms.go
@@ -64,6 +64,7 @@ func initSecretsKMS(secrets map[string]string) (EncryptionKMS, error) {
 	if !ok {
 		return nil, errors.New("missing encryption passphrase in secrets")
 	}
+
 	return SecretsKMS{passphrase: passphraseValue}, nil
 }
 
@@ -267,6 +268,7 @@ func generateCipher(passphrase, salt string) (cipher.AEAD, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return aead, nil
 }
 

--- a/internal/util/stripsecrets.go
+++ b/internal/util/stripsecrets.go
@@ -48,11 +48,13 @@ func stripKey(out []string) bool {
 	for i := range out {
 		if strings.HasPrefix(out[i], keyArg) {
 			out[i] = strippedKey
+
 			return true
 		}
 
 		if strings.HasPrefix(out[i], keyFileArg) {
 			out[i] = strippedKeyFile
+
 			return true
 		}
 	}

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -102,6 +102,7 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 				missingLabels = append(missingLabels, key)
 			}
 		}
+
 		return nil, fmt.Errorf("missing domain labels %v on node %q", missingLabels, nodeName)
 	}
 
@@ -173,6 +174,7 @@ func MatchTopologyForPool(topologyPools *[]TopologyConstrainedPool,
 	for _, value := range *topologyPools {
 		if value.PoolName == poolName {
 			topologyPool = append(topologyPool, value)
+
 			break
 		}
 	}
@@ -230,6 +232,7 @@ func matchPoolToTopology(topologyPools *[]TopologyConstrainedPool, topology *csi
 		for _, segment := range topologyPool.DomainSegments {
 			if domainValue, ok := domainMap[segment.DomainLabel]; !ok || domainValue != segment.DomainValue {
 				mismatch = true
+
 				break
 			}
 		}

--- a/internal/util/topology_test.go
+++ b/internal/util/topology_test.go
@@ -235,6 +235,7 @@ func TestFindPoolAndTopology(t *testing.T) {
 				topologyPrefix+"/"+label1+l1Value1, topologyPrefix+"/"+label2+l2Value1,
 				poolName, topoSegment)
 		}
+
 		return nil
 	}
 	// Test nil values

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -52,6 +52,7 @@ func RoundOffBytes(bytes int64) int64 {
 		num = int64(math.Ceil(floatBytes / helpers.GiB))
 		num *= helpers.GiB
 	}
+
 	return num
 }
 
@@ -131,10 +132,12 @@ func ValidateDriverName(driverName string) error {
 	for _, msg := range validation.IsDNS1123Subdomain(strings.ToLower(driverName)) {
 		if err == nil {
 			err = errors.New(msg)
+
 			continue
 		}
 		err = fmt.Errorf("%s: %w", msg, err)
 	}
+
 	return err
 }
 
@@ -145,6 +148,7 @@ func GetKernelVersion() (string, error) {
 	if err := unix.Uname(&utsname); err != nil {
 		return "", err
 	}
+
 	return strings.TrimRight(string(utsname.Release[:]), "\x00"), nil
 }
 
@@ -213,6 +217,7 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 	version, patchlevel, sublevel, extraversion, err := parseKernelRelease(release)
 	if err != nil {
 		ErrorLogMsg("%v", err)
+
 		return false
 	}
 
@@ -238,6 +243,7 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 		}
 	}
 	ErrorLogMsg("kernel %s does not support required features", release)
+
 	return false
 }
 
@@ -282,6 +288,7 @@ func checkDirExists(p string) bool {
 	if _, err := os.Stat(p); os.IsNotExist(err) {
 		return false
 	}
+
 	return true
 }
 
@@ -299,6 +306,7 @@ func IsMountPoint(p string) (bool, error) {
 // Mount mounts the source to target path.
 func Mount(source, target, fstype string, options []string) error {
 	dummyMount := mount.New("")
+
 	return dummyMount.Mount(source, target, fstype, options)
 }
 
@@ -354,5 +362,6 @@ func getKeys(m map[string]interface{}) []string {
 func CallStack() string {
 	stack := make([]byte, 2048)
 	_ = runtime.Stack(stack, false)
+
 	return string(stack)
 }

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -32,6 +32,7 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 			"staging path %s does not exist on node",
 			req.GetStagingTargetPath())
 	}
+
 	return nil
 }
 
@@ -93,5 +94,6 @@ func CheckReadOnlyManyIsSupported(req *csi.CreateVolumeRequest) error {
 			}
 		}
 	}
+
 	return nil
 }

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -105,6 +105,7 @@ func setConfigString(option *string, config map[string]interface{}, key string) 
 	}
 
 	*option = s
+
 	return nil
 }
 
@@ -389,6 +390,7 @@ func detectAuthMountPath(path string) (string, error) {
 	for _, part := range parts {
 		if part == "auth" {
 			match = true
+
 			continue
 		}
 		if part == "login" {

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -134,6 +134,7 @@ func transformConfig(svMap map[string]interface{}) (map[string]interface{}, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to Unmarshal the CSI vault configuration: %w", err)
 	}
+
 	return jsonMap, nil
 }
 
@@ -577,5 +578,6 @@ func fetchTenantConfig(config map[string]interface{}, tenant string) (map[string
 	if !ok {
 		return nil, false
 	}
+
 	return tenantConfig, true
 }

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -138,6 +138,7 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 	err := json.Unmarshal([]byte(vaultConfigMap), sv)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
+
 		return
 	}
 


### PR DESCRIPTION
`nlreturn` linter requires a new line before return and branch statements except when the return is alone
inside a statement group (such as an if statement) to increase code clarity. This commit addresses such issues.

Updates: #1586

Signed-off-by: Rakshith R <rar@redhat.com>
<details>
<summary>

Expand to see `nlreturn` errors fixed by this pr</summary>

```bash

internal/journal/omap.go:86:2: return with no blank line before (nlreturn)
	return results, nil
	^
internal/journal/omap.go:81:3: return with no blank line before (nlreturn)
		return nil, err
		^
internal/journal/omap.go:79:4: return with no blank line before (nlreturn)
			return nil, util.JoinErrors(util.ErrKeyNotFound, err)
			^
internal/journal/voljournal.go:470:5: continue with no blank line before (nlreturn)
				continue
				^
internal/cephfs/volumemounter.go:126:4: break with no blank line before (nlreturn)
			break
			^
e2e/cephfs.go:327:7: break with no blank line before (nlreturn)
						break
						^
e2e/rbd.go:743:7: break with no blank line before (nlreturn)
						break
						^
internal/rbd/rbd_util.go:606:4: continue with no blank line before (nlreturn)
			continue
			^
internal/rbd/rbd_util_test.go:126:4: continue with no blank line before (nlreturn)
			continue
```
</details>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
