### PR TITLE
rbd: add support to create clone in different pools

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -142,8 +142,8 @@ func createORDeleteRbdResouces(action string) {
 	}
 }
 
-func validateRBDImageCount(f *framework.Framework, count int) {
-	imageList, err := listRBDImages(f)
+func validateRBDImageCount(f *framework.Framework, count int, pool string) {
+	imageList, err := listRBDImages(f, pool)
 	if err != nil {
 		e2elog.Failf("failed to list rbd images with error %v", err)
 	}
@@ -304,7 +304,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate owner of pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app", func() {
@@ -313,7 +313,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app with normal user", func() {
@@ -322,7 +322,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate normal user pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a PVC and bind it to an app with ext4 as the FS ", func() {
@@ -339,7 +339,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -364,7 +364,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -408,7 +408,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				selector, err := getDaemonSetLabelSelector(f, cephCSINamespace, rbdDaemonsetName)
 				if err != nil {
@@ -450,7 +450,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -497,7 +497,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				selector, err := getDaemonSetLabelSelector(f, cephCSINamespace, rbdDaemonsetName)
 				if err != nil {
@@ -583,7 +583,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -608,7 +608,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -637,7 +637,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -680,7 +680,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				// delete the Secret of the Tenant
 				err = c.CoreV1().Secrets(tenant).Delete(context.TODO(), token.Name, metav1.DeleteOptions{})
@@ -716,7 +716,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -863,7 +863,7 @@ var _ = Describe("RBD", func() {
 
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, totalCount)
+				validateRBDImageCount(f, totalCount, defaultRBDPool)
 				// delete PVC and app
 				for i := 0; i < totalCount; i++ {
 					name := fmt.Sprintf("%s%d", f.UniqueName, i)
@@ -875,7 +875,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("check data persist after recreating pod", func() {
@@ -884,7 +884,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to check data persist with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("Resize Filesystem PVC and check application directory size", func() {
@@ -909,7 +909,7 @@ var _ = Describe("RBD", func() {
 
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -921,7 +921,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to resize block PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -943,7 +943,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 				// delete rbd nodeplugin pods
 				err = deletePodWithLabel("app=csi-rbdplugin", cephCSINamespace, false)
 				if err != nil {
@@ -960,7 +960,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create PVC in storageClass with volumeNamePrefix", func() {
@@ -985,10 +985,10 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 				// list RBD images and check if one of them has the same prefix
 				foundIt := false
-				images, err := listRBDImages(f)
+				images, err := listRBDImages(f, defaultRBDPool)
 				if err != nil {
 					e2elog.Failf("failed to list rbd images with error %v", err)
 				}
@@ -1006,7 +1006,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to  delete PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1027,7 +1027,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate rbd static pv with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("validate RBD static Block PVC", func() {
@@ -1036,7 +1036,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate rbd block pv with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("validate mount options in app pod", func() {
@@ -1046,7 +1046,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to check mount options with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("creating an app with a PVC, using a topology constrained StorageClass", func() {
@@ -1187,7 +1187,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				// create an app and wait for 1 min for it to go to running state
 				err = createApp(f.ClientSet, app, 1)
@@ -1200,7 +1200,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -1242,7 +1242,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create PVC and application with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 					// delete pod as we should not create snapshot for in-use pvc
 					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 					if err != nil {
@@ -1260,7 +1260,7 @@ var _ = Describe("RBD", func() {
 					// validate created backend rbd images
 					// parent PVC + snapshot
 					totalImages := 2
-					validateRBDImageCount(f, totalImages)
+					validateRBDImageCount(f, totalImages, defaultRBDPool)
 					pvcClone, err := loadPVC(pvcClonePath)
 					if err != nil {
 						e2elog.Failf("failed to load PVC with error %v", err)
@@ -1276,7 +1276,7 @@ var _ = Describe("RBD", func() {
 					// validate created backend rbd images
 					// parent pvc+ snapshot + clone
 					totalImages = 3
-					validateRBDImageCount(f, totalImages)
+					validateRBDImageCount(f, totalImages, defaultRBDPool)
 
 					appClone, err := loadApp(appClonePath)
 					if err != nil {
@@ -1340,7 +1340,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to delete PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 			})
 
@@ -1377,7 +1377,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				snap := getSnapshot(snapshotPath)
 				snap.Namespace = f.UniqueName
@@ -1390,7 +1390,7 @@ var _ = Describe("RBD", func() {
 				// validate created backend rbd images
 				// parent PVC + snapshot
 				totalImages := 2
-				validateRBDImageCount(f, totalImages)
+				validateRBDImageCount(f, totalImages, defaultRBDPool)
 				pvcClone, err := loadPVC(pvcClonePath)
 				if err != nil {
 					e2elog.Failf("failed to load PVC with error %v", err)
@@ -1402,7 +1402,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				// create clone PVC
 				pvcClone.Namespace = f.UniqueName
@@ -1412,7 +1412,7 @@ var _ = Describe("RBD", func() {
 				}
 				// validate created backend rbd images = snapshot + clone
 				totalImages = 2
-				validateRBDImageCount(f, totalImages)
+				validateRBDImageCount(f, totalImages, defaultRBDPool)
 
 				// delete snapshot
 				err = deleteSnapshot(&snap, deployTimeout)
@@ -1422,7 +1422,7 @@ var _ = Describe("RBD", func() {
 
 				// validate created backend rbd images = clone
 				totalImages = 1
-				validateRBDImageCount(f, totalImages)
+				validateRBDImageCount(f, totalImages, defaultRBDPool)
 
 				appClone, err := loadApp(appClonePath)
 				if err != nil {
@@ -1447,7 +1447,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("ensuring all operations will work within a rados namespace", func() {
@@ -1525,7 +1525,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate owner of pvc with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				// Create a PVC and bind it to an app within the namesapce
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
@@ -1577,7 +1577,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create PVC with error %v", err)
 					}
 					// validate created backend rbd images
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 
 					snap := getSnapshot(snapshotPath)
 					snap.Namespace = f.UniqueName
@@ -1586,7 +1586,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to create snapshot with error %v", err)
 					}
-					validateRBDImageCount(f, 2)
+					validateRBDImageCount(f, 2, defaultRBDPool)
 
 					err = validatePVCAndAppBinding(pvcClonePath, appClonePath, f)
 					if err != nil {
@@ -1597,13 +1597,13 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to delete snapshot with error %v", err)
 					}
 					// as snapshot is deleted the image count should be one
-					validateRBDImageCount(f, 1)
+					validateRBDImageCount(f, 1, defaultRBDPool)
 
 					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to delete PVC with error %v", err)
 					}
-					validateRBDImageCount(f, 0)
+					validateRBDImageCount(f, 0, defaultRBDPool)
 				}
 
 				// delete RBD provisioner secret
@@ -1661,7 +1661,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 1)
+				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				opt := metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("app=%s", app.Name),
@@ -1680,7 +1680,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete PVC and application with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
 			By("create a thick-provisioned PVC", func() {
@@ -1758,7 +1758,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to validate controller with error %v", err)
 				}
 				// validate created backend rbd images
-				validateRBDImageCount(f, 0)
+				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -39,6 +39,20 @@ var (
 	nodeCSIZoneLabel    = "topology.rbd.csi.ceph.com/zone"
 	rbdTopologyPool     = "newrbdpool"
 	rbdTopologyDataPool = "replicapool" // NOTE: should be different than rbdTopologyPool for test to be effective
+
+	// yaml files required for deployment
+	pvcPath                = rbdExamplePath + "pvc.yaml"
+	appPath                = rbdExamplePath + "pod.yaml"
+	rawPvcPath             = rbdExamplePath + "raw-block-pvc.yaml"
+	rawAppPath             = rbdExamplePath + "raw-block-pod.yaml"
+	pvcClonePath           = rbdExamplePath + "pvc-restore.yaml"
+	pvcSmartClonePath      = rbdExamplePath + "pvc-clone.yaml"
+	pvcBlockSmartClonePath = rbdExamplePath + "pvc-block-clone.yaml"
+	appClonePath           = rbdExamplePath + "pod-restore.yaml"
+	appSmartClonePath      = rbdExamplePath + "pod-clone.yaml"
+	appBlockSmartClonePath = rbdExamplePath + "block-pod-clone.yaml"
+	snapshotPath           = rbdExamplePath + "snapshot.yaml"
+	defaultCloneCount      = 10
 )
 
 func deployRBDPlugin() {
@@ -271,19 +285,6 @@ var _ = Describe("RBD", func() {
 
 	Context("Test RBD CSI", func() {
 		It("Test RBD CSI", func() {
-			pvcPath := rbdExamplePath + "pvc.yaml"
-			appPath := rbdExamplePath + "pod.yaml"
-			rawPvcPath := rbdExamplePath + "raw-block-pvc.yaml"
-			rawAppPath := rbdExamplePath + "raw-block-pod.yaml"
-			pvcClonePath := rbdExamplePath + "pvc-restore.yaml"
-			pvcSmartClonePath := rbdExamplePath + "pvc-clone.yaml"
-			pvcBlockSmartClonePath := rbdExamplePath + "pvc-block-clone.yaml"
-			appClonePath := rbdExamplePath + "pod-restore.yaml"
-			appSmartClonePath := rbdExamplePath + "pod-clone.yaml"
-			appBlockSmartClonePath := rbdExamplePath + "block-pod-clone.yaml"
-			snapshotPath := rbdExamplePath + "snapshot.yaml"
-			defaultCloneCount := 10
-
 			By("checking provisioner deployment is running", func() {
 				err := waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -182,7 +182,7 @@ var _ = Describe("RBD", func() {
 		if err != nil {
 			e2elog.Failf("failed to create configmap with error %v", err)
 		}
-		err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+		err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 		if err != nil {
 			e2elog.Failf("failed to create storageclass with error %v", err)
 		}
@@ -330,7 +330,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"csi.storage.k8s.io/fstype": "ext4"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"csi.storage.k8s.io/fstype": "ext4"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -344,7 +344,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -355,7 +355,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"mounter": "rbd-nbd"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"mounter": "rbd-nbd"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -369,7 +369,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -381,7 +381,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
 				// Storage class with rbd-nbd mounter
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"mounter": "rbd-nbd"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"mounter": "rbd-nbd"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -455,7 +455,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -471,7 +471,7 @@ var _ = Describe("RBD", func() {
 					"mounter":    "rbd-nbd",
 					"mapOptions": "try-netlink,reattach-timeout=180",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -588,7 +588,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -599,7 +599,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"encrypted": "true"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"encrypted": "true"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -613,7 +613,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -628,7 +628,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -642,7 +642,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -657,7 +657,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-tokens-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -692,7 +692,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -707,7 +707,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "secrets-metadata-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -721,7 +721,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -732,7 +732,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -744,7 +744,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -777,7 +777,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -788,7 +788,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -807,7 +807,7 @@ var _ = Describe("RBD", func() {
 					"encrypted":       "true",
 					"encryptionKMSID": "secrets-metadata-test",
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, scOpts, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -818,7 +818,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -899,7 +899,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to delete storageclass with error %v", err)
 					}
-					err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"csi.storage.k8s.io/fstype": "xfs"}, deletePolicy)
+					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"csi.storage.k8s.io/fstype": "xfs"}, deletePolicy)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}
@@ -969,7 +969,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{"volumeNamePrefix": volumeNamePrefix}, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"volumeNamePrefix": volumeNamePrefix}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1012,7 +1012,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1069,7 +1069,7 @@ var _ = Describe("RBD", func() {
 				topologyConstraint := "[{\"poolName\":\"" + rbdTopologyPool + "\",\"domainSegments\":" +
 					"[{\"domainLabel\":\"region\",\"value\":\"" + regionValue + "\"}," +
 					"{\"domainLabel\":\"zone\",\"value\":\"" + zoneValue + "\"}]}]"
-				err = createRBDStorageClass(f.ClientSet, f,
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName,
 					map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 					map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 				if err != nil {
@@ -1118,7 +1118,7 @@ var _ = Describe("RBD", func() {
 						"\",\"domainSegments\":" +
 						"[{\"domainLabel\":\"region\",\"value\":\"" + regionValue + "\"}," +
 						"{\"domainLabel\":\"zone\",\"value\":\"" + zoneValue + "\"}]}]"
-					err = createRBDStorageClass(f.ClientSet, f,
+					err = createRBDStorageClass(f.ClientSet, f, defaultSCName,
 						map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 						map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 					if err != nil {
@@ -1154,7 +1154,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1167,7 +1167,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, map[string]string{rbdmountOptions: "debug,invalidOption"}, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, map[string]string{rbdmountOptions: "debug,invalidOption"}, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1205,7 +1205,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1515,7 +1515,7 @@ var _ = Describe("RBD", func() {
 				param["csi.storage.k8s.io/node-stage-secret-namespace"] = cephCSINamespace
 				param["csi.storage.k8s.io/node-stage-secret-name"] = rbdNodePluginSecretName
 
-				err = createRBDStorageClass(f.ClientSet, f, nil, param, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, param, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1628,7 +1628,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1688,7 +1688,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
 					"thickProvision": "true"}, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
@@ -1717,7 +1717,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1728,7 +1728,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, map[string]string{
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
 					"mapOptions":   "lock_on_read,queue_depth=1024",
 					"unmapOptions": "force"}, deletePolicy)
 				if err != nil {
@@ -1742,7 +1742,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1759,7 +1759,7 @@ var _ = Describe("RBD", func() {
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
-				err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -30,11 +30,14 @@ func rbdOptions(pool string) string {
 	return "--pool=" + pool
 }
 
-func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, scOptions, parameters map[string]string, policy v1.PersistentVolumeReclaimPolicy) error {
+func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, name string, scOptions, parameters map[string]string, policy v1.PersistentVolumeReclaimPolicy) error {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc, err := getStorageClass(scPath)
 	if err != nil {
 		return nil
+	}
+	if name != "" {
+		sc.Name = name
 	}
 	sc.Parameters["pool"] = defaultRBDPool
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = cephCSINamespace

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -303,11 +303,11 @@ func validateEncryptedImage(f *framework.Framework, rbdImageSpec string, app *v1
 	return nil
 }
 
-func listRBDImages(f *framework.Framework) ([]string, error) {
+func listRBDImages(f *framework.Framework, pool string) ([]string, error) {
 	var imgInfos []string
 
 	stdout, stdErr, err := execCommandInToolBoxPod(f,
-		fmt.Sprintf("rbd ls --format=json %s", rbdOptions(defaultRBDPool)), rookNamespace)
+		fmt.Sprintf("rbd ls --format=json %s", rbdOptions(pool)), rookNamespace)
 	if err != nil {
 		return imgInfos, err
 	}
@@ -554,7 +554,7 @@ func validateThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, siz
 	if err != nil {
 		return fmt.Errorf("failed to create PVC with error %w", err)
 	}
-	validateRBDImageCount(f, 1)
+	validateRBDImageCount(f, 1, defaultRBDPool)
 
 	// nothing has been written, but the image should be allocated
 	du, err := getRbdDu(f, pvc)
@@ -598,7 +598,7 @@ func validateThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, siz
 	if err != nil {
 		return fmt.Errorf("failed to delete PVC with error: %w", err)
 	}
-	validateRBDImageCount(f, 0)
+	validateRBDImageCount(f, 0, defaultRBDPool)
 
 	return nil
 }

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -419,6 +419,23 @@ func deletePool(name string, cephfs bool, f *framework.Framework) error {
 	return nil
 }
 
+func createPool(f *framework.Framework, name string) error {
+	var (
+		pgCount = 128
+		size    = 1
+	)
+	// ceph osd pool create replicapool
+	cmd := fmt.Sprintf("ceph osd pool create %s %d", name, pgCount)
+	_, _, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+	if err != nil {
+		return err
+	}
+	// ceph osd pool set replicapool size 1
+	cmd = fmt.Sprintf("ceph osd pool set %s size %d --yes-i-really-mean-it", name, size)
+	_, _, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
+	return err
+}
+
 func getPVCImageInfoInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, pool string) (string, error) {
 	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
 	if err != nil {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -234,7 +234,18 @@ func kmsIsVault(kms string) bool {
 	return kms == "vault"
 }
 
-// nolint:gocyclo // reduce complexity
+func logErrors(f *framework.Framework, msg string, wgErrs []error) int {
+	failures := 0
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("%s (%s%d): %v", msg, f.UniqueName, i, err)
+			failures++
+		}
+	}
+	return failures
+}
+
 func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc, destImagePool string) error {
 	var wg sync.WaitGroup
 	totalCount := 10
@@ -264,15 +275,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	}
 	wg.Wait()
 
-	failed := 0
-	for i, err := range wgErrs {
-		if err != nil {
-			// not using Failf() as it aborts the test and does not log other errors
-			e2elog.Logf("failed to create snapshot (%s%d): %v", f.UniqueName, i, err)
-			failed++
-		}
-	}
-	if failed != 0 {
+	if failed := logErrors(f, "failed to create snapshot", wgErrs); failed != 0 {
 		return fmt.Errorf("creating snapshots failed, %d errors were logged", failed)
 	}
 
@@ -311,14 +314,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	}
 	wg.Wait()
 
-	for i, err := range wgErrs {
-		if err != nil {
-			// not using Failf() as it aborts the test and does not log other errors
-			e2elog.Logf("failed to create PVC and application (%s%d): %v", f.UniqueName, i, err)
-			failed++
-		}
-	}
-	if failed != 0 {
+	if failed := logErrors(f, "failed to create PVC and application", wgErrs); failed != 0 {
 		return fmt.Errorf("creating PVCs and applications failed, %d errors were logged", failed)
 	}
 
@@ -343,14 +339,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	}
 	wg.Wait()
 
-	for i, err := range wgErrs {
-		if err != nil {
-			// not using Failf() as it aborts the test and does not log other errors
-			e2elog.Logf("failed to delete PVC and application (%s%d): %v", f.UniqueName, i, err)
-			failed++
-		}
-	}
-	if failed != 0 {
+	if failed := logErrors(f, "failed to delete PVC and application", wgErrs); failed != 0 {
 		return fmt.Errorf("deleting PVCs and applications failed, %d errors were logged", failed)
 	}
 
@@ -373,14 +362,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	}
 	wg.Wait()
 
-	for i, err := range wgErrs {
-		if err != nil {
-			// not using Failf() as it aborts the test and does not log other errors
-			e2elog.Logf("failed to delete snapshot (%s%d): %v", f.UniqueName, i, err)
-			failed++
-		}
-	}
-	if failed != 0 {
+	if failed := logErrors(f, "failed to delete snapshot", wgErrs); failed != 0 {
 		return fmt.Errorf("deleting snapshots failed, %d errors were logged", failed)
 	}
 	// validate all pools are empty

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
+	"github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	scv1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -230,6 +232,162 @@ func validateImageOwner(pvcPath string, f *framework.Framework) error {
 
 func kmsIsVault(kms string) bool {
 	return kms == "vault"
+}
+
+// nolint:gocyclo // reduce complexity
+func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc, destImagePool string) error {
+	var wg sync.WaitGroup
+	totalCount := 10
+	wgErrs := make([]error, totalCount)
+	wg.Add(totalCount)
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC with error %v", err)
+	}
+
+	pvc.Namespace = f.UniqueName
+	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create PVC with error %v", err)
+	}
+	validateRBDImageCount(f, 1, defaultRBDPool)
+	snap := getSnapshot(snapshotPath)
+	snap.Namespace = f.UniqueName
+	snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+	// create snapshot
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, s v1beta1.VolumeSnapshot) {
+			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = createSnapshot(&s, deployTimeout)
+			w.Done()
+		}(&wg, i, snap)
+	}
+	wg.Wait()
+
+	failed := 0
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to create snapshot (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("creating snapshots failed, %d errors were logged", failed)
+	}
+
+	// delete parent pvc
+	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete PVC with error %v", err)
+	}
+
+	// validate the rbd images created for snapshots
+	validateRBDImageCount(f, totalCount, snapshotPool)
+
+	pvcClone, err := loadPVC(pvcClonePath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC with error %v", err)
+	}
+	appClone, err := loadApp(appClonePath)
+	if err != nil {
+		return fmt.Errorf("failed to load application with error %v", err)
+	}
+	pvcClone.Namespace = f.UniqueName
+	// if request is to create clone with different storage class
+	if cloneSc != "" {
+		pvcClone.Spec.StorageClassName = &cloneSc
+	}
+	appClone.Namespace = f.UniqueName
+	pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s%d", f.UniqueName, 0)
+	// create multiple PVCs from same snapshot
+	wg.Add(totalCount)
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to create PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("creating PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	// total images in pool is total snaps + total clones
+	if destImagePool == snapshotPool {
+		totalCloneCount := totalCount + totalCount
+		validateRBDImageCount(f, totalCloneCount, snapshotPool)
+	} else {
+		// if clones are created in different pool we will have only rbd images of
+		// count equal to totalCount
+		validateRBDImageCount(f, totalCount, destImagePool)
+	}
+	wg.Add(totalCount)
+	// delete clone and app
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, p v1.PersistentVolumeClaim, a v1.Pod) {
+			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			p.Spec.DataSource.Name = name
+			wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
+			w.Done()
+		}(&wg, i, *pvcClone, *appClone)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to delete PVC and application (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("deleting PVCs and applications failed, %d errors were logged", failed)
+	}
+
+	if destImagePool == snapshotPool {
+		// as we have deleted all clones total images in pool is total snaps
+		validateRBDImageCount(f, totalCount, snapshotPool)
+	} else {
+		// we have deleted all clones
+		validateRBDImageCount(f, 0, destImagePool)
+	}
+
+	wg.Add(totalCount)
+	// delete snapshot
+	for i := 0; i < totalCount; i++ {
+		go func(w *sync.WaitGroup, n int, s v1beta1.VolumeSnapshot) {
+			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			wgErrs[n] = deleteSnapshot(&s, deployTimeout)
+			w.Done()
+		}(&wg, i, snap)
+	}
+	wg.Wait()
+
+	for i, err := range wgErrs {
+		if err != nil {
+			// not using Failf() as it aborts the test and does not log other errors
+			e2elog.Logf("failed to delete snapshot (%s%d): %v", f.UniqueName, i, err)
+			failed++
+		}
+	}
+	if failed != 0 {
+		return fmt.Errorf("deleting snapshots failed, %d errors were logged", failed)
+	}
+	// validate all pools are empty
+	validateRBDImageCount(f, 0, snapshotPool)
+	validateRBDImageCount(f, 0, defaultRBDPool)
+	validateRBDImageCount(f, 0, destImagePool)
+	return nil
 }
 
 func validateEncryptedPVCAndAppBinding(pvcPath, appPath, kms string, f *framework.Framework) error {

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -63,7 +63,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to create configmap with error %v", err)
 		}
-		err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+		err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 		if err != nil {
 			e2elog.Failf("failed to create storageclass with error %v", err)
 		}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -26,8 +26,8 @@ import (
 
 /* #nosec:G101, values not credententials, just a reference to the location.*/
 const (
-	defaultNs = "default"
-
+	defaultNs     = "default"
+	defaultSCName = ""
 	// vaultBackendPath is the default VAULT_BACKEND_PATH for secrets
 	vaultBackendPath = "secret/"
 	// vaultPassphrasePath is an advanced configuration option, only
@@ -975,7 +975,7 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	expandSize := "10Gi"
 	var err error
 	// create storageclass with retain
-	err = createRBDStorageClass(f.ClientSet, f, nil, nil, retainPolicy)
+	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, retainPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass with error %v", err)
 	}
@@ -1007,7 +1007,7 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	if err != nil {
 		return fmt.Errorf("failed to delete storageclass with error %v", err)
 	}
-	err = createRBDStorageClass(f.ClientSet, f, nil, nil, deletePolicy)
+	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass with error %v", err)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -561,7 +561,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 		}
 	}
 	// validate created backend rbd images
-	validateRBDImageCount(f, 1)
+	validateRBDImageCount(f, 1, defaultRBDPool)
 	pvcClone, err := loadPVC(clonePvcPath)
 	if err != nil {
 		e2elog.Failf("failed to load PVC with error %v", err)
@@ -632,7 +632,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 	// total images in cluster is 1 parent rbd image+ total
 	// temporary clone+ total clones
 	totalCloneCount := totalCount + totalCount + 1
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
@@ -640,7 +640,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 	}
 
 	totalCloneCount = totalCount + totalCount
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
@@ -664,7 +664,7 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 		e2elog.Failf("deleting PVCs and applications failed, %d errors were logged", failed)
 	}
 
-	validateRBDImageCount(f, 0)
+	validateRBDImageCount(f, 0, defaultRBDPool)
 }
 
 // nolint:gocyclo,gocognit,nestif // reduce complexity
@@ -711,7 +711,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	if err != nil {
 		e2elog.Failf("failed to calculate checksum with error %v", err)
 	}
-	validateRBDImageCount(f, 1)
+	validateRBDImageCount(f, 1, defaultRBDPool)
 	snap := getSnapshot(snapshotPath)
 	snap.Namespace = f.UniqueName
 	snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
@@ -752,7 +752,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	}
 
 	// total images in cluster is 1 parent rbd image+ total snaps
-	validateRBDImageCount(f, totalCount+1)
+	validateRBDImageCount(f, totalCount+1, defaultRBDPool)
 	pvcClone, err := loadPVC(pvcClonePath)
 	if err != nil {
 		e2elog.Failf("failed to load PVC with error %v", err)
@@ -822,7 +822,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	// total images in cluster is 1 parent rbd image+ total
 	// snaps+ total clones
 	totalCloneCount := totalCount + totalCount + 1
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
@@ -848,7 +848,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 
 	// total images in cluster is 1 parent rbd image+ total
 	// snaps
-	validateRBDImageCount(f, totalCount+1)
+	validateRBDImageCount(f, totalCount+1, defaultRBDPool)
 	// create clones from different snapshots and bind it to an
 	// app
 	wg.Add(totalCount)
@@ -876,7 +876,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	// total images in cluster is 1 parent rbd image+ total
 	// snaps+ total clones
 	totalCloneCount = totalCount + totalCount + 1
-	validateRBDImageCount(f, totalCloneCount)
+	validateRBDImageCount(f, totalCloneCount, defaultRBDPool)
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
@@ -885,7 +885,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 
 	// total images in cluster is total snaps+ total clones
 	totalSnapCount := totalCount + totalCount
-	validateRBDImageCount(f, totalSnapCount)
+	validateRBDImageCount(f, totalSnapCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete snapshot
 	for i := 0; i < totalCount; i++ {
@@ -929,7 +929,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 		e2elog.Failf("deleting snapshots failed, %d errors were logged", failed)
 	}
 
-	validateRBDImageCount(f, totalCount)
+	validateRBDImageCount(f, totalCount, defaultRBDPool)
 	wg.Add(totalCount)
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
@@ -954,7 +954,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 	}
 
 	// validate created backend rbd images
-	validateRBDImageCount(f, 0)
+	validateRBDImageCount(f, 0, defaultRBDPool)
 }
 
 // validateController simulates the required operations to validate the

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -101,7 +101,7 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 		// need to check for flatten here.
 		// as the snap exists,create clone image and delete temporary snapshot
 		// and add task to flatten temporary cloned image
-		err = rv.cloneRbdImageFromSnapshot(ctx, snap)
+		err = rv.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
 			err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", rv.RbdImageName, snap.RbdSnapName, err)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -464,8 +464,12 @@ func (cs *ControllerServer) createVolumeFromSnapshot(ctx context.Context, cr *ut
 
 	// update parent name(rbd image name in snapshot)
 	rbdSnap.RbdImageName = rbdSnap.RbdSnapName
+	parentVol := generateVolFromSnap(rbdSnap)
+	// as we are operating on single cluster reuse the connection
+	parentVol.conn = rbdVol.conn.Copy()
+
 	// create clone image and delete snapshot
-	err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap)
+	err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap, parentVol)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rbdVol, rbdSnap, err)
 		return err

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -844,7 +844,7 @@ func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnaps
 	vol := generateVolFromSnap(rbdSnap)
 	err := vol.Connect(cr)
 	if err != nil {
-		uErr := undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+		uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 		if uErr != nil {
 			util.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.RequestName, uErr)
 		}
@@ -868,7 +868,7 @@ func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnaps
 	if errors.Is(err, ErrFlattenInProgress) {
 		readyToUse = false
 	} else if err != nil {
-		uErr := undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+		uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 		if uErr != nil {
 			util.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.RequestName, uErr)
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -904,7 +904,9 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 	if value, ok := options["snapshotNamePrefix"]; ok && value == "" {
 		return status.Error(codes.InvalidArgument, "empty snapshot name prefix to provision snapshot from")
 	}
-
+	if value, ok := options["pool"]; ok && value == "" {
+		return status.Error(codes.InvalidArgument, "empty pool name in which rbd image will be created")
+	}
 	return nil
 }
 

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -167,7 +167,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 					return false, err
 				}
 			}
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 		}
 		return false, err
 	}
@@ -193,7 +193,7 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		sErr := vol.createSnapshot(ctx, rbdSnap)
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 	}
@@ -205,13 +205,13 @@ func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rb
 		sErr := vol.getImageID()
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to get image id %s: %v", vol, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 		sErr = j.StoreImageID(ctx, vol.JournalPool, vol.ReservedID, vol.ImageID)
 		if sErr != nil {
 			util.ErrorLog(ctx, "failed to store volume id %s: %v", vol, sErr)
-			err = undoSnapshotCloning(ctx, vol, rbdSnap, vol, cr)
+			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 			return false, err
 		}
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -114,8 +114,10 @@ type rbdVolume struct {
 	Topology            map[string]string
 	// DataPool is where the data for images in `Pool` are stored, this is used as the `--data-pool`
 	// 	 argument when the pool is created, and is not used anywhere else
-	DataPool           string
-	ParentName         string
+	DataPool   string
+	ParentName string
+	// Parent Pool is the pool that contains the parent image.
+	ParentPool         string
 	imageFeatureSet    librbd.FeatureSet
 	AdminID            string `json:"adminId"`
 	UserID             string `json:"userId"`
@@ -1189,6 +1191,7 @@ func (rv *rbdVolume) getImageInfo() error {
 		}
 	} else {
 		rv.ParentName = parentInfo.Image.ImageName
+		rv.ParentPool = parentInfo.Image.PoolName
 	}
 	// Get image creation time
 	tm, err := image.GetCreateTimestamp()

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -566,6 +566,7 @@ func (rv *rbdVolume) getCloneDepth(ctx context.Context) (uint, error) {
 			depth++
 		}
 		vol.RbdImageName = vol.ParentName
+		vol.Pool = vol.ParentPool
 	}
 }
 
@@ -741,6 +742,7 @@ func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint
 			return true, nil
 		}
 		vol.RbdImageName = vol.ParentName
+		vol.Pool = vol.ParentPool
 	}
 }
 

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -33,7 +33,7 @@ func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap
 
 	snap.RbdImageName = parentVol.RbdImageName
 	// create clone image and delete snapshot
-	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap)
+	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
 		err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)


### PR DESCRIPTION
Add support to restore a pvc into a different pool.

Assuming there are 2 pools namely "replicapool" and "testpool"
Workflow:
1. Create a PVC in a replicapool.
2. For cloning, a snapshot gets created in replicapool.
3. PVC restore operation can be done in a new pool named testpool.

Co-authored-by: Madhu Rajanna <madhupr007@gmail.com>

Updates: #1838 