### PR TITLE
rbd: add volume healer

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -25,4 +25,10 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["list", "get"]
 {{- end -}}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -66,6 +66,7 @@ spec:
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath={{ .Values.kubeletDir }}/plugins"
+            - "--stagingpath={{ .Values.kubeletDir }}/plugins/kubernetes.io/csi/pv/"
             - "--type=rbd"
             - "--nodeserver=true"
             - "--pidlimit=-1"

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -65,6 +65,7 @@ spec:
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           args:
             - "--nodeid=$(NODE_ID)"
+            - "--pluginpath={{ .Values.kubeletDir }}/plugins"
             - "--type=rbd"
             - "--nodeserver=true"
             - "--pidlimit=-1"

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -49,7 +49,8 @@ const (
 	// use default namespace if namespace is not set.
 	defaultNS = "default"
 
-	defaultPluginPath = "/var/lib/kubelet/plugins"
+	defaultPluginPath  = "/var/lib/kubelet/plugins"
+	defaultStagingPath = defaultPluginPath + "/kubernetes.io/csi/pv/"
 )
 
 var conf util.Config
@@ -62,6 +63,7 @@ func init() {
 	flag.StringVar(&conf.DriverNamespace, "drivernamespace", defaultNS, "namespace in which driver is deployed")
 	flag.StringVar(&conf.NodeID, "nodeid", "", "node id")
 	flag.StringVar(&conf.PluginPath, "pluginpath", defaultPluginPath, "plugin path")
+	flag.StringVar(&conf.StagingPath, "stagingpath", defaultStagingPath, "staging path")
 	flag.StringVar(&conf.InstanceID, "instanceid", "", "Unique ID distinguishing this instance of Ceph CSI among other"+
 		" instances, when sharing Ceph clusters across CSI instances for provisioning")
 	flag.IntVar(&conf.PidLimit, "pidlimit", 0, "the PID limit to configure through cgroups")

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -48,6 +48,8 @@ const (
 
 	// use default namespace if namespace is not set.
 	defaultNS = "default"
+
+	defaultPluginPath = "/var/lib/kubelet/plugins"
 )
 
 var conf util.Config
@@ -59,6 +61,7 @@ func init() {
 	flag.StringVar(&conf.DriverName, "drivername", "", "name of the driver")
 	flag.StringVar(&conf.DriverNamespace, "drivernamespace", defaultNS, "namespace in which driver is deployed")
 	flag.StringVar(&conf.NodeID, "nodeid", "", "node id")
+	flag.StringVar(&conf.PluginPath, "pluginpath", defaultPluginPath, "plugin path")
 	flag.StringVar(&conf.InstanceID, "instanceid", "", "Unique ID distinguishing this instance of Ceph CSI among other"+
 		" instances, when sharing Ceph clusters across CSI instances for provisioning")
 	flag.IntVar(&conf.PidLimit, "pidlimit", 0, "the PID limit to configure through cgroups")

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -22,6 +22,12 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["list", "get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -51,6 +51,7 @@ spec:
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--nodeid=$(NODE_ID)"
+            - "--pluginpath=/var/lib/kubelet/plugins"
             - "--type=rbd"
             - "--nodeserver=true"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -52,6 +52,7 @@ spec:
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
+            - "--stagingpath=/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
             - "--type=rbd"
             - "--nodeserver=true"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -216,7 +216,6 @@ func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOpti
 	return stdOut, stdErr, err
 }
 
-//nolint:unparam // cn can be used with different inputs later
 func execCommandInContainer(
 	f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions) (string, string, error) {
 	podOpt, err := getCommandInPodOpts(f, c, ns, cn, opt)
@@ -349,7 +348,6 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 	})
 }
 
-//nolint:unparam // skipNotFound arg can be used with different inputs later
 func deletePodWithLabel(label, ns string, skipNotFound bool) error {
 	_, err := framework.RunKubectl(ns, "delete", "po", "-l", label, fmt.Sprintf("--ignore-not-found=%t", skipNotFound))
 	if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -2,15 +2,17 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo" // nolint
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
@@ -425,7 +427,7 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
-			By("perform IO on rbd-nbd volume after nodeplugin restart and expect a failure", func() {
+			By("perform IO on rbd-nbd volume after nodeplugin restart", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
@@ -483,91 +485,8 @@ var _ = Describe("RBD", func() {
 				}
 
 				opt := metav1.ListOptions{
-					LabelSelector: fmt.Sprintf("app=%s", app.Name),
-				}
-
-				// FIXME: Fix this behavior, i.e. when the nodeplugin is
-				// restarted, the rbd-nbd processes should be back to life
-				// as rbd-nbd processes are responsible for IO
-
-				// For now to prove this isn't working, write something to
-				// mountpoint and expect a failure as the processes are terminated.
-				filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
-				_, stdErr := execCommandInPodAndAllowFail(
-					f,
-					fmt.Sprintf("echo 'Hello World' > %s", filePath),
-					app.Namespace,
-					&opt)
-				IOErr := fmt.Sprintf("cannot create %s: Input/output error", filePath)
-				if !strings.Contains(stdErr, IOErr) {
-					e2elog.Failf(stdErr)
-				} else {
-					e2elog.Logf("failed IO as expected: %v", stdErr)
-				}
-
-				err = deletePVCAndApp("", f, pvc, app)
-				if err != nil {
-					e2elog.Failf("failed to delete PVC and application with error %v", err)
-				}
-				// validate created backend rbd images
-				validateRBDImageCount(f, 0, defaultRBDPool)
-				err = deleteResource(rbdExamplePath + "storageclass.yaml")
-				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
-				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
-				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
-				}
-			})
-
-			By("restart rbd-nbd process on nodeplugin and continue IO after nodeplugin restart", func() {
-				err := deleteResource(rbdExamplePath + "storageclass.yaml")
-				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
-				}
-				// Tweak Storageclass to add netlink,reattach rbd-nbd mounter options
-				scOpts := map[string]string{
-					"mounter":    "rbd-nbd",
-					"mapOptions": "try-netlink,reattach-timeout=180",
-				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
-				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
-				}
-
-				pvc, err := loadPVC(pvcPath)
-				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
-				}
-				pvc.Namespace = f.UniqueName
-
-				app, err := loadApp(appPath)
-				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
-				}
-				app.Namespace = f.UniqueName
-				label := map[string]string{
-					"app": app.Name,
-				}
-				app.Labels = label
-				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
-				err = createPVCAndApp("", f, pvc, app, deployTimeout)
-				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
-				}
-				// validate created backend rbd images
-				validateRBDImageCount(f, 1, defaultRBDPool)
-
-				selector, err := getDaemonSetLabelSelector(f, cephCSINamespace, rbdDaemonsetName)
-				if err != nil {
-					e2elog.Failf("failed to get the labels with error %v", err)
-				}
-
-				opt := metav1.ListOptions{
 					LabelSelector: selector,
 				}
-
 				uname, stdErr, err := execCommandInContainer(f, "uname -a", cephCSINamespace, "csi-rbdplugin", &opt)
 				if err != nil || stdErr != "" {
 					e2elog.Failf("failed to run uname cmd : %v, stdErr: %v ", err, stdErr)
@@ -584,78 +503,41 @@ var _ = Describe("RBD", func() {
 				}
 				e2elog.Logf("rbd-nbd package version: %v", rpmv)
 
-				// Get details of rbd-nbd process
-				// # ps -eo 'cmd' | grep [r]bd-nbd
-				// /usr/bin/rbd-nbd --id cephcsi-rbd-node -m svc-name:6789 --keyfile=/tmp/csi/keys/keyfile attach \
-				// --device /dev/nbd0 pool-name/image-name --try-netlink --reattach-timeout=180
-				mapCmd, stdErr, err := execCommandInContainer(
-					f,
-					"ps -eo 'cmd' | grep [r]bd-nbd",
-					cephCSINamespace,
-					"csi-rbdplugin",
-					&opt)
-				if err != nil || stdErr != "" {
-					e2elog.Failf("failed to run ps cmd : %v, stdErr: %v ", err, stdErr)
-				}
-				e2elog.Logf("map command running before restart, mapCmd: %v", mapCmd)
+				timeout := time.Duration(deployTimeout) * time.Minute
+				var reason string
+				err = wait.PollImmediate(poll, timeout, func() (bool, error) {
+					var runningAttachCmd string
+					runningAttachCmd, stdErr, err = execCommandInContainer(
+						f,
+						"ps -eo 'cmd' | grep [r]bd-nbd",
+						cephCSINamespace,
+						"csi-rbdplugin",
+						&opt)
+					// if the rbd-nbd process is not running the ps | grep command
+					// will return with exit code 1
+					if err != nil {
+						if strings.Contains(err.Error(), "command terminated with exit code 1") {
+							reason = fmt.Sprintf("rbd-nbd process is not running yet: %v", err)
+						} else if stdErr != "" {
+							reason = fmt.Sprintf("failed to run ps cmd : %v, stdErr: %v", err, stdErr)
+						}
+						e2elog.Logf("%s", reason)
+						return false, nil
+					}
+					e2elog.Logf("attach command running after restart, runningAttachCmd: %v", runningAttachCmd)
+					return true, nil
+				})
 
-				rbdNodeKey, stdErr, err := execCommandInToolBoxPod(
-					f,
-					"ceph auth get-key client.cephcsi-rbd-node",
-					rookNamespace)
-				if err != nil || stdErr != "" {
-					e2elog.Failf("error getting cephcsi-rbd-node key, err: %v, stdErr: %v ", err, stdErr)
+				if errors.Is(err, wait.ErrWaitTimeout) {
+					e2elog.Failf("timed out waiting for the rbd-nbd process: %s", reason)
 				}
-
-				// restart the rbd node plugin
-				err = deletePodWithLabel(selector, cephCSINamespace, false)
 				if err != nil {
-					e2elog.Failf("fail to delete pod with error %v", err)
+					e2elog.Failf("failed to poll: %v", err)
 				}
-
-				// wait for nodeplugin pods to come up
-				err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
-				if err != nil {
-					e2elog.Failf("timeout waiting for daemonset pods with error %v", err)
-				}
-
-				// Prepare the rbd-nbd with command args
-				attachCmd := strings.ReplaceAll(mapCmd, "map", "attach --device /dev/nbd0")
-				m1 := regexp.MustCompile(`/keyfile-\d* `)
-				attachCmd = m1.ReplaceAllString(attachCmd, "/keyfile-test ")
-				e2elog.Logf("attach command to run after restart, attachCmd: %v", attachCmd)
-
-				// create the keyfile
-				_, stdErr, err = execCommandInContainer(
-					f,
-					fmt.Sprintf("echo %s > /tmp/csi/keys/keyfile-test", rbdNodeKey),
-					cephCSINamespace,
-					"csi-rbdplugin",
-					&opt)
-				if err != nil || stdErr != "" {
-					e2elog.Failf("failed to write key to a file,  err: %v, stdErr: %v ", err, stdErr)
-				}
-
-				_, stdErr, err = execCommandInContainer(f, attachCmd, cephCSINamespace, "csi-rbdplugin", &opt)
-				if err != nil || stdErr != "" {
-					e2elog.Failf("failed to run attach cmd err: %v, stdErr: %v ", err, stdErr)
-				}
-
-				runningAttachCmd, stdErr, err := execCommandInContainer(
-					f,
-					"ps -eo 'cmd' | grep [r]bd-nbd",
-					cephCSINamespace,
-					"csi-rbdplugin",
-					&opt)
-				if err != nil || stdErr != "" {
-					e2elog.Failf("failed to run ps cmd : %v, stdErr: %v ", err, stdErr)
-				}
-				e2elog.Logf("attach command running after restart, runningAttachCmd: %v", runningAttachCmd)
 
 				appOpt := metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("app=%s", app.Name),
 				}
-				// Write something to mountpoint and expect it to happen
 				filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
 				_, stdErr, err = execCommandInPod(
 					f,

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -199,5 +199,14 @@ func (r *Driver) Run(conf *util.Config) {
 		util.DebugLogMsg("Registering profiling handler")
 		go util.EnableProfiling()
 	}
+	if conf.IsNodeServer {
+		go func() {
+			// TODO: move the healer to csi-addons
+			err := runVolumeHealer(r.ns, conf)
+			if err != nil {
+				util.ErrorLogMsg("healer had failures, err %v\n", err)
+			}
+		}()
+	}
 	s.Wait()
 }

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1395,7 +1395,7 @@ func (ri *rbdImageMetadataStash) String() string {
 
 // stashRBDImageMetadata stashes required fields into the stashFileName at the passed in path, in
 // JSON format.
-func stashRBDImageMetadata(volOptions *rbdVolume, path string) error {
+func stashRBDImageMetadata(volOptions *rbdVolume, metaDataPath string) error {
 	imgMeta := rbdImageMetadataStash{
 		// there are no checks for this at present
 		Version:        3, // nolint:gomnd // number specifies version.
@@ -1416,7 +1416,7 @@ func stashRBDImageMetadata(volOptions *rbdVolume, path string) error {
 		return fmt.Errorf("failed to marshall JSON image metadata for image (%s): %w", volOptions, err)
 	}
 
-	fPath := filepath.Join(path, stashFileName)
+	fPath := filepath.Join(metaDataPath, stashFileName)
 	err = ioutil.WriteFile(fPath, encodedBytes, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to stash JSON image metadata for image (%s) at path (%s): %w", volOptions, fPath, err)
@@ -1426,10 +1426,10 @@ func stashRBDImageMetadata(volOptions *rbdVolume, path string) error {
 }
 
 // lookupRBDImageMetadataStash reads and returns stashed image metadata at passed in path.
-func lookupRBDImageMetadataStash(path string) (rbdImageMetadataStash, error) {
+func lookupRBDImageMetadataStash(metaDataPath string) (rbdImageMetadataStash, error) {
 	var imgMeta rbdImageMetadataStash
 
-	fPath := filepath.Join(path, stashFileName)
+	fPath := filepath.Join(metaDataPath, stashFileName)
 	encodedBytes, err := ioutil.ReadFile(fPath) // #nosec - intended reading from fPath
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -1448,8 +1448,8 @@ func lookupRBDImageMetadataStash(path string) (rbdImageMetadataStash, error) {
 }
 
 // cleanupRBDImageMetadataStash cleans up any stashed metadata at passed in path.
-func cleanupRBDImageMetadataStash(path string) error {
-	fPath := filepath.Join(path, stashFileName)
+func cleanupRBDImageMetadataStash(metaDataPath string) error {
+	fPath := filepath.Join(metaDataPath, stashFileName)
 	if err := os.Remove(fPath); err != nil {
 		return fmt.Errorf("failed to cleanup stashed JSON data (%s): %w", fPath, err)
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -72,6 +72,7 @@ type Config struct {
 	NodeID          string // node id
 	InstanceID      string // unique ID distinguishing this instance of Ceph CSI
 	PluginPath      string // location of cephcsi plugin
+	StagingPath     string // location of cephcsi staging path
 	DomainLabels    string // list of domain labels to read from the node
 
 	// metrics related flags


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Problem:
-------
For rbd nbd userspace mounter backends, after a restart of the nodeplugin all the mounts will start seeing IO errors. This is because, for rbd-nbd backends there will be a userspace mount daemon running per volume, post restart of the nodeplugin pod, there is no way to restore the daemons back to life.

Solution:
--------
The volume healer is a one-time activity that is triggered at the startup time of the rbd nodeplugin. It navigates through the list of volume attachments on the node and acts accordingly.

For now, it is limited to nbd type storage only, but it is flexible and can be extended in the future for other backend types as needed.

From a few feets above:
This solves a severe problem for nbd backed csi volumes. The healer while going through the list of volume attachments on the node, if finds the volume is in attached state and is of type nbd, then it will attempt to fix the rbd-nbd volumes by sending a NodeStageVolume request with the required volume attributes like secrets, device name, image attributes, and etc.. which will finally help start the required rbd-nbd daemons in the nodeplugin csi-rbdplugin container. This will allow reattaching the backend images with the right nbd device, thus allowing the applications to perform IO without any interruptions even after a nodeplugin restart.

### Some points to be noted

**Q**: What is the route for the upgrade path? 
**A**: For upgrade:
*  Make sure no volume attachments of type nbd exists, meaning all fresh NodeStageVolume requests should happen after these changes are available so that the device attribute is captured in metadata stash file on the immediate NodeStageVolume.
Or
* Maybe, before upgrading we need to add device attribute to metadata stash file of nbd type PVs, we could provide an automated script, or perform manual edits to the metadata stash very carefully.

**Q**: Should this patch use rbd integrated CLI instead of rbd-nbd CLI?
**A**: Maybe once a release is available including https://github.com/ceph/ceph/pull/41279, for now, attach/detach commands are not promoted at rbd CLI.

**Q**: What if the Lock is acquired by some other op for a given attachment?
**A**: Throw error for that attachment and continue for the next attachment on the node

**Q**: What is the rbd-nbd reattach timeout?
**A**: 5mins, this means the node plugin pod should come back and the healer should finish triggering NodeStageVolume requests for all attachments on that node in 300 seconds

**Q**: What version of rbd-nbd is needed on the node plugin pod?
**A**: rbd-nbd version should satisfy ceph pacific version (v16)

**Q**: What happens if attach command is absent?
**A**: You will see something like, 'NodeStageVolume failed, err: ... bla bla unknown option 'attach cephfs.a.data/csi-vol-6dd424b9-b971-11eb-af01-7a53e508ee3b' errors in the logs

**Q**: What happens when there is an rbd-nbd command failure?
**A**: Similar to above

**Q**: What kind of logs will we see at the nodeplugin on a successful healer run?
**A**: Here are some logs:
```
I0531 12:20:35.455288 3103257 server.go:131] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
I0531 12:20:35.540709 3103257 rbd_healer.go:91] sending nodeStageVolume for volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-80d14346-c1f9-11eb-898d-0a3d575e4f27, stagingPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-87b90909-cf74-4ae8-a27a-a87f39655f72/globalmount
I0531 12:20:35.549634 3103257 rbd_util.go:984] setting disableInUseChecks: false image features: [layering] mounter: rbd-nbd
I0531 12:20:35.550360 3103257 rbd_healer.go:91] sending nodeStageVolume for volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-80acce7a-c1f9-11eb-898d-0a3d575e4f27, stagingPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-98e4b639-4960-4091-ba10-80c3603da961/globalmount
I0531 12:20:35.557438 3103257 rbd_util.go:984] setting disableInUseChecks: false image features: [layering] mounter: rbd-nbd
I0531 12:20:35.561080 3103257 rbd_healer.go:91] sending nodeStageVolume for volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-8142bc1a-c1f9-11eb-898d-0a3d575e4f27, stagingPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-b8dcb0ae-74ca-422a-82a1-6331a0cf4b47/globalmount
I0531 12:20:35.567149 3103257 rbd_util.go:984] setting disableInUseChecks: false image features: [layering] mounter: rbd-nbd
I0531 12:20:35.572580 3103257 rbd_healer.go:91] sending nodeStageVolume for volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-80866a60-c1f9-11eb-898d-0a3d575e4f27, stagingPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-17c243b2-0e13-4880-95a5-5ff49b992509/globalmount
I0531 12:20:35.578949 3103257 rbd_util.go:984] setting disableInUseChecks: false image features: [layering] mounter: rbd-nbd
I0531 12:20:35.594686 3103257 rbd_healer.go:91] sending nodeStageVolume for volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-807853e6-c1f9-11eb-898d-0a3d575e4f27, stagingPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-0dce65fb-6f07-4627-9b99-eca888b46810/globalmount
I0531 12:20:35.607218 3103257 rbd_util.go:984] setting disableInUseChecks: false image features: [layering] mounter: rbd-nbd

[...]

I0531 12:20:37.102849 3103257 nodeserver.go:245] rbd volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-807853e6-c1f9-11eb-898d-0a3d575e4f27 was successfully attached to device: /dev/nbd2
I0531 12:20:37.105944 3103257 nodeserver.go:245] rbd volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-8142bc1a-c1f9-11eb-898d-0a3d575e4f27 was successfully attached to device: /dev/nbd0
I0531 12:20:37.106125 3103257 nodeserver.go:245] rbd volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-80866a60-c1f9-11eb-898d-0a3d575e4f27 was successfully attached to device: /dev/nbd3          
I0531 12:20:37.108396 3103257 nodeserver.go:245] rbd volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-80acce7a-c1f9-11eb-898d-0a3d575e4f27 was successfully attached to device: /dev/nbd4
I0531 12:20:37.157031 3103257 nodeserver.go:245] rbd volID: 0001-0024-35f25a92-fce8-4ab9-b80a-69b7b35e2ef3-0000000000000003-80d14346-c1f9-11eb-898d-0a3d575e4f27 was successfully attached to device: /dev/nbd1

```

Initial discussion summary:
-------

We have captured the initial discussion at, https://hackmd.io/mA8CtRUPS4SSV9oVcDFVeg. This PR has few changes from the design, mainly we don't start a new sidecar, rather trigger it inside csi-rbdplugin container itself.

Fixes: #667 #1929