### PR TITLE
rbd: fail fast in create volume for missmatch encryption

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1528,3 +1528,15 @@ func (rv *rbdVolume) getOrigSnapName(snapID uint64) (string, error) {
 
 	return origSnapName, nil
 }
+
+func (ri *rbdImage) isCompatibleEncryption(dst *rbdImage) error {
+	switch {
+	case ri.isEncrypted() && !dst.isEncrypted():
+		return fmt.Errorf("encrypted volume %q does not match unencrypted volume %q", ri, dst)
+
+	case !ri.isEncrypted() && dst.isEncrypted():
+		return fmt.Errorf("unencrypted volume %q does not match encrypted volume %q", ri, dst)
+	}
+
+	return nil
+}


### PR DESCRIPTION
CreateVolume will fail in the below cases
    
### create volume from the snapshot
* If the snapshot is encrypted and the requested volume  is not encrypted
* If the snapshot is not encrypted and the requested volume is encrypted
    
### create volume from volume
* If the parent volume is encrypted and requested volume is not encrypted
* If the parent volume is not encrypted and the requested volume is encrypted
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
