### PR TITLE
rbd: [DNM] set SetPoolFullTry to allow write fail

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -293,7 +293,14 @@ func (ri *rbdImage) openIoctx() error {
 	ioctx.SetNamespace(ri.RadosNamespace)
 	ri.ioctx = ioctx
 
-	return nil
+	err = ri.ioctx.SetPoolFullTry()
+	if err != nil {
+		err = fmt.Errorf("failed to set  SetPoolFullTry IOContext for pool %s: %w", ri.Pool, err)
+	} else {
+		fmt.Println("successfully set the setpoolfulltry option")
+	}
+
+	return err
 }
 
 // getImageID queries rbd about the given image and stores its id, returns

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx_octopus.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx_octopus.go
@@ -1,0 +1,35 @@
+// +build !nautilus
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <errno.h>
+// #include <stdlib.h>
+// #include <rados/librados.h>
+import "C"
+
+// SetPoolFullTry makes sure to send requests to the cluster despite
+// the cluster or pool being marked full; ops will either succeed(e.g., delete)
+// or return EDQUOT or ENOSPC.
+//
+// Implements:
+//  void rados_set_pool_full_try(rados_ioctx_t io);
+func (ioctx *IOContext) SetPoolFullTry() error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+	C.rados_set_pool_full_try(ioctx.ioctx)
+	return nil
+}
+
+// UnsetPoolFullTry unsets the flag set by SetPoolFullTry()
+//
+// Implements:
+//  void rados_unset_pool_full_try(rados_ioctx_t io);
+func (ioctx *IOContext) UnsetPoolFullTry() error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+	C.rados_unset_pool_full_try(ioctx.ioctx)
+	return nil
+}


### PR DESCRIPTION
when the ceph cluster is full or getting filled when thick provisioning is in progress the write won't fail it will be stuck, with this patch the write will fail when the ceph cluster gets full we can delete the image when write fails.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

closes #2128

Note:- PR title and description need to be updated
