### PR TITLE
rbd: check free size during thick volume creation

### DIFF
--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -26,6 +26,9 @@ const (
 
 	// SnapshotOperationAlreadyExistsFmt string format to return for concurrent operation
 	SnapshotOperationAlreadyExistsFmt = "an operation with the given Snapshot ID %s already exists"
+
+	// PoolOperationAlreadyExistsFmt string format to return for concurrent operation
+	PoolOperationAlreadyExistsFmt = "checking pool %s available size to provision another thick volume"
 )
 
 // VolumeLocks implements a map with atomic operations. It stores a set of all volume IDs


### PR DESCRIPTION
Added check to validate the request PVC size against 80% of the free size of a pool. This will help us to ensure that we don't try to create a volume that is greater than the available size to an extend.

Note:- when the ceph cluster is  85% full the cluster will become read-only. 80% is chosen as a random value to avoid overcommitting.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

