### PR TITLE
cleanup: Modifies Wrapcheck linter

### DIFF
--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -24,7 +24,7 @@ func validateSubvolumegroup(f *framework.Framework, subvolgrp string) error {
 	cmd := fmt.Sprintf("ceph fs subvolumegroup getpath myfs %s", subvolgrp)
 	stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to exec command in toolbox: %w", err)
 	}
 	if stdErr != "" {
 		return fmt.Errorf("failed to getpath for subvolumegroup %s with error %v", subvolgrp, stdErr)
@@ -106,12 +106,12 @@ func unmountCephFSVolume(f *framework.Framework, appName, pvcName string) error 
 	pod, err := f.ClientSet.CoreV1().Pods(f.UniqueName).Get(context.TODO(), appName, metav1.GetOptions{})
 	if err != nil {
 		e2elog.Logf("Error occurred getting pod %s in namespace %s", appName, f.UniqueName)
-		return err
+		return fmt.Errorf("failed to get pod: %w", err)
 	}
 	pvc, err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.UniqueName).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	if err != nil {
 		e2elog.Logf("Error occurred getting PVC %s in namespace %s", pvcName, f.UniqueName)
-		return err
+		return fmt.Errorf("failed to get pvc: %w", err)
 	}
 	cmd := fmt.Sprintf("umount /var/lib/kubelet/pods/%s/volumes/kubernetes.io~csi/%s/mount", pod.UID, pvc.Spec.VolumeName)
 	_, stdErr, err := execCommandInDaemonsetPod(f, cmd, cephfsDeamonSetName, pod.Spec.NodeName, cephfsContainerName, cephCSINamespace)
@@ -179,11 +179,11 @@ func getSnapName(snapNamespace, snapName string) (string, error) {
 	}
 	snap, err := sclient.SnapshotV1beta1().VolumeSnapshots(snapNamespace).Get(context.TODO(), snapName, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get volumesnapshot: %w", err)
 	}
 	sc, err := sclient.SnapshotV1beta1().VolumeSnapshotContents().Get(context.TODO(), *snap.Status.BoundVolumeSnapshotContentName, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get volumesnapshotcontent: %w", err)
 	}
 	snapIDRegex := regexp.MustCompile(`(\w+\-?){5}$`)
 	snapID := snapIDRegex.FindString(*sc.Status.SnapshotHandle)

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -68,7 +68,7 @@ func createConfigMap(pluginPath string, c kubernetes.Interface, f *framework.Fra
 	if err == nil {
 		_, updateErr := c.CoreV1().ConfigMaps(cephCSINamespace).Update(context.TODO(), &cm, metav1.UpdateOptions{})
 		if updateErr != nil {
-			return updateErr
+			return fmt.Errorf("failed to update configmap: %w", updateErr)
 		}
 	}
 	if apierrs.IsNotFound(err) {
@@ -116,5 +116,8 @@ func createCustomConfigMap(c kubernetes.Interface, pluginPath string, subvolgrpI
 	cm.Namespace = cephCSINamespace
 	// since a configmap is already created, update the existing configmap
 	_, err = c.CoreV1().ConfigMaps(cephCSINamespace).Update(context.TODO(), &cm, metav1.UpdateOptions{})
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to update configmap: %w", err)
+	}
+	return nil
 }

--- a/e2e/namespace.go
+++ b/e2e/namespace.go
@@ -24,7 +24,7 @@ func createNamespace(c kubernetes.Interface, name string) error {
 	}
 	_, err := c.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 	if err != nil && !apierrs.IsAlreadyExists(err) {
-		return err
+		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
@@ -47,7 +47,7 @@ func deleteNamespace(c kubernetes.Interface, name string) error {
 	timeout := time.Duration(deployTimeout) * time.Minute
 	err := c.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil && !apierrs.IsNotFound(err) {
-		return err
+		return fmt.Errorf("failed to delete namespace: %w", err)
 	}
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		_, err = c.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})

--- a/e2e/node.go
+++ b/e2e/node.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,7 @@ func createNodeLabel(f *framework.Framework, labelKey, labelValue string) error 
 	//       the same label values, which is fine for the test
 	nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list node: %w", err)
 	}
 	for i := range nodes.Items {
 		framework.AddOrUpdateLabelOnNode(f.ClientSet, nodes.Items[i].Name, labelKey, labelValue)
@@ -26,7 +27,7 @@ func createNodeLabel(f *framework.Framework, labelKey, labelValue string) error 
 func deleteNodeLabel(c kubernetes.Interface, labelKey string) error {
 	nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list node: %w", err)
 	}
 	for i := range nodes.Items {
 		framework.RemoveLabelOffNode(c, nodes.Items[i].Name, labelKey)
@@ -37,7 +38,7 @@ func deleteNodeLabel(c kubernetes.Interface, labelKey string) error {
 func checkNodeHasLabel(c kubernetes.Interface, labelKey, labelValue string) error {
 	nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list node: %w", err)
 	}
 	for i := range nodes.Items {
 		framework.ExpectNodeHasLabel(c, nodes.Items[i].Name, labelKey, labelValue)
@@ -50,7 +51,7 @@ func checkNodeHasLabel(c kubernetes.Interface, labelKey, labelValue string) erro
 func getKubeletIP(c kubernetes.Interface) (string, error) {
 	nodes, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to list node: %w", err)
 	}
 
 	for _, address := range nodes.Items[0].Status.Addresses {

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -257,7 +257,7 @@ func loadApp(path string) (*v1.Pod, error) {
 func createApp(c kubernetes.Interface, app *v1.Pod, timeout int) error {
 	_, err := c.CoreV1().Pods(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create app: %w", err)
 	}
 	return waitForPodInRunningState(app.Name, app.Namespace, c, timeout)
 }
@@ -269,7 +269,7 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int) er
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("failed to get app: %w", err)
 		}
 		switch pod.Status.Phase {
 		case v1.PodRunning:
@@ -286,7 +286,7 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 	timeout := time.Duration(t) * time.Minute
 	err := c.CoreV1().Pods(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete app: %w", err)
 	}
 	start := time.Now()
 	e2elog.Logf("Waiting for pod %v to be deleted", name)
@@ -298,7 +298,7 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 		}
 		e2elog.Logf("%s app  to be deleted (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("failed to get app: %w", err)
 		}
 		return false, nil
 	})

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -157,12 +157,12 @@ func getImageInfoFromPVC(pvcNamespace, pvcName string, f *framework.Framework) (
 	c := f.ClientSet.CoreV1()
 	pvc, err := c.PersistentVolumeClaims(pvcNamespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	if err != nil {
-		return imageData, err
+		return imageData, fmt.Errorf("failed to get pvc: %w", err)
 	}
 
 	pv, err := c.PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 	if err != nil {
-		return imageData, err
+		return imageData, fmt.Errorf("failed to get pv: %w", err)
 	}
 
 	imageIDRegex := regexp.MustCompile(`(\w+\-?){5}$`)

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -40,7 +40,7 @@ func expandPVCSize(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, size s
 			if isRetryableAPIError(err) {
 				return false, nil
 			}
-			return false, err
+			return false, fmt.Errorf("failed to get pvc: %w", err)
 		}
 		pvcConditions := updatedPVC.Status.Conditions
 		if len(pvcConditions) > 0 {
@@ -92,7 +92,7 @@ func resizePVCAndValidateSize(pvcPath, appPath string, f *framework.Framework) e
 
 	pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get pvc: %w", err)
 	}
 	if *pvc.Spec.VolumeMode == v1.PersistentVolumeFilesystem {
 		err = checkDirSize(app, f, &opt, size)

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -49,7 +49,7 @@ func createSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 	}
 	_, err = sclient.SnapshotV1beta1().VolumeSnapshots(snap.Namespace).Create(context.TODO(), snap, metav1.CreateOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create volumesnapshot: %w", err)
 	}
 	e2elog.Logf("snapshot with name %v created in %v namespace", snap.Name, snap.Namespace)
 
@@ -69,7 +69,7 @@ func createSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 			if apierrs.IsNotFound(err) {
 				return false, nil
 			}
-			return false, err
+			return false, fmt.Errorf("failed to get volumesnapshot: %w", err)
 		}
 		if snaps.Status == nil || snaps.Status.ReadyToUse == nil {
 			return false, nil
@@ -89,7 +89,7 @@ func deleteSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 	}
 	err = sclient.SnapshotV1beta1().VolumeSnapshots(snap.Namespace).Delete(context.TODO(), snap.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete volumesnapshot: %w", err)
 	}
 
 	timeout := time.Duration(t) * time.Minute
@@ -166,6 +166,9 @@ func createCephFSSnapshotClass(f *framework.Framework) error {
 		return err
 	}
 	_, err = sclient.SnapshotV1beta1().VolumeSnapshotClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create volumesnapshotclass: %w", err)
+	}
 	return err
 }
 
@@ -176,12 +179,12 @@ func getVolumeSnapshotContent(namespace, snapshotName string) (*snapapi.VolumeSn
 	}
 	snapshot, err := sclient.SnapshotV1beta1().VolumeSnapshots(namespace).Get(context.TODO(), snapshotName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get volumesnapshot: %w", err)
 	}
 
 	volumeSnapshotContent, err := sclient.SnapshotV1beta1().VolumeSnapshotContents().Get(context.TODO(), *snapshot.Status.BoundVolumeSnapshotContentName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get volumesnapshotcontent: %w", err)
 	}
 	return volumeSnapshotContent, nil
 }

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -152,12 +152,12 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock bool) e
 
 	err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete pvc: %w", err)
 	}
 
 	err = c.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete pv: %w", err)
 	}
 
 	cmd = fmt.Sprintf("rbd rm %s %s", rbdImageName, rbdOptions(defaultRBDPool))
@@ -208,7 +208,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 		return err
 	}
 	if e != "" {
-		return fmt.Errorf("failed to create subvolumegroup %s", e)
+		return fmt.Errorf("failed to create subvolumegroup: %s", e)
 	}
 
 	// create subvolume
@@ -218,7 +218,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 		return err
 	}
 	if e != "" {
-		return fmt.Errorf("failed to create subvolume %s", e)
+		return fmt.Errorf("failed to create subvolume: %s", e)
 	}
 
 	// get rootpath
@@ -251,7 +251,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	secret.Namespace = cephCSINamespace
 	_, err = c.CoreV1().Secrets(cephCSINamespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to create secret, error %w", err)
+		return fmt.Errorf("failed to create secret: %w", err)
 	}
 
 	opt["clusterID"] = fsID
@@ -261,45 +261,45 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	pv := getStaticPV(pvName, pvName, "4Gi", secretName, cephCSINamespace, sc, "cephfs.csi.ceph.com", false, opt)
 	_, err = c.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to create PV, error %w", err)
+		return fmt.Errorf("failed to create PV: %w", err)
 	}
 
 	pvc := getStaticPVC(pvcName, pvName, size, namespace, sc, false)
 	_, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to create PVC, error %w", err)
+		return fmt.Errorf("failed to create PVC: %w", err)
 	}
 	// bind pvc to app
 	app, err := loadApp(appPath)
 	if err != nil {
-		return fmt.Errorf("failed to load app, error %w", err)
+		return fmt.Errorf("failed to load app: %w", err)
 	}
 
 	app.Namespace = namespace
 	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcName
 	err = createApp(f.ClientSet, app, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to create pod, error %w", err)
+		return fmt.Errorf("failed to create pod: %w", err)
 	}
 
 	err = deletePod(app.Name, namespace, f.ClientSet, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to delete pod, error %w", err)
+		return fmt.Errorf("failed to delete pod: %w", err)
 	}
 
 	err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete pvc: %w", err)
 	}
 
 	err = c.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete pv: %w", err)
 	}
 
 	err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to delete secret: %w", err)
 	}
 
 	// delete subvolume

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -78,7 +78,7 @@ func getMons(ns string, c kubernetes.Interface) ([]string, error) {
 
 	svcList, err := c.CoreV1().Services(ns).List(context.TODO(), opt)
 	if err != nil {
-		return services, err
+		return services, fmt.Errorf("failed to list services: %w", err)
 	}
 	for i := range svcList.Items {
 		s := fmt.Sprintf("%s.%s.svc.cluster.local:%d", svcList.Items[i].Name, svcList.Items[i].Namespace, svcList.Items[i].Spec.Ports[0].Port)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -16,6 +16,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	"github.com/ceph/ceph-csi/internal/util"
 
 	clientConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -44,7 +46,7 @@ func addToManager(mgr manager.Manager, config Config) error {
 	for _, c := range ControllerList {
 		err := c.Add(mgr, config)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to add: %w", err)
 		}
 	}
 	return nil

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -78,7 +78,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch for changes to PersistentVolumes
 	err = c.Watch(&source.Kind{Type: &corev1.PersistentVolume{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to watch the changes: %w", err)
 	}
 	return nil
 }

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -243,7 +243,7 @@ func (cj *Config) Connect(monitors, namespace string, cr *util.Credentials) (*Co
 	cj.namespace = namespace
 	cc := &util.ClusterConnection{}
 	if err := cc.Connect(monitors, cr); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to establish the connection: %w", err)
 	}
 	conn := &Connection{
 		config:   cj,
@@ -321,7 +321,7 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 
 		buf64, err = hex.DecodeString(savedImagePoolIDStr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to decode string: %w", err)
 		}
 		savedImagePoolID = int64(binary.BigEndian.Uint64(buf64))
 
@@ -470,7 +470,7 @@ func reserveOMapName(ctx context.Context, monitors string, cr *util.Credentials,
 				continue
 			}
 
-			return "", err
+			return "", fmt.Errorf("failed to create omap object for oMapNamePrefix+iterUUID=%s: %w", oMapNamePrefix+iterUUID, err)
 		}
 
 		return iterUUID, nil
@@ -674,7 +674,7 @@ func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID
 		var buf64 []byte
 		buf64, err = hex.DecodeString(journalPoolIDStr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to decode string: %w", err)
 		}
 		imageAttributes.JournalPoolID = int64(binary.BigEndian.Uint64(buf64))
 	}


### PR DESCRIPTION
Wrapcheck is a  simple Go linter to check that errors
from external packages are wrapped during return to
help identify the error source during debugging.
This commit addresses the wrapcheck error

Updates:#2025

Signed-off-by: Yati Padia <ypadia@redhat.com>