### PR TITLE
cephfs: pass extra volume attributes to static PV (Issue #2114)

### DIFF
--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -455,6 +455,18 @@ func newVolumeOptionsFromStaticVolume(volID string, options map[string]string) (
 		return nil, nil, err
 	}
 
+	if err = extractOptionalOption(&opts.KernelMountOptions, "kernelMountOptions", options); err != nil {
+		return nil, nil, err
+	}
+
+	if err = extractOptionalOption(&opts.FuseMountOptions, "fuseMountOptions", options); err != nil {
+		return nil, nil, err
+	}
+
+	if err = extractOptionalOption(&opts.SubvolumeGroup, "subvolumeGroup", options); err != nil {
+		return nil, nil, err
+	}
+
 	if err = extractMounter(&opts.Mounter, options); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Feature ##
when using pre-provisioned volumes, pass these parameters in spec.csi.volumeAttributes in PV declaration:
- kernelMountOptions
- fuseMountOptions
- subvolumeGroup

Fixes: #2114