### PR TITLE
rbd: use DeepCopy to create a thick-provisioned clone

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -761,7 +761,35 @@ var _ = Describe("RBD", func() {
 			By("create a PVC-PVC clone and bind it to an app", func() {
 				// pvc clone is only supported from v1.16+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
-					validatePVCClone(defaultCloneCount, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, false, f)
+					validatePVCClone(defaultCloneCount, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, noPVCValidation, f)
+				}
+			})
+
+			By("create a thick-provisioned PVC-PVC clone and bind it to an app", func() {
+				// pvc clone is only supported from v1.16+
+				if !k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
+					Skip("pvc clone is only supported from v1.16+")
+				}
+
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
+					"thickProvision": "true"}, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+
+				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, isThickPVC, f)
+
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 			})
 
@@ -813,7 +841,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, true, f)
+				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, isEncryptedPVC, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -838,7 +866,7 @@ var _ = Describe("RBD", func() {
 				}
 				// pvc clone is only supported from v1.16+
 				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
-					validatePVCClone(defaultCloneCount, rawPvcPath, rawAppPath, pvcBlockSmartClonePath, appBlockSmartClonePath, false, f)
+					validatePVCClone(defaultCloneCount, rawPvcPath, rawAppPath, pvcBlockSmartClonePath, appBlockSmartClonePath, noPVCValidation, f)
 				}
 			})
 			By("create/delete multiple PVCs and Apps", func() {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -414,7 +414,13 @@ func validateEncryptedPVCAndAppBinding(pvcPath, appPath, kms string, f *framewor
 	return nil
 }
 
-func validateEncryptedPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.Pod) error {
+type validateFunc func(f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.Pod) error
+
+// noPVCValidation can be used to pass to validatePVCClone when no extra
+// validation of the PVC is needed.
+var noPVCValidation validateFunc = nil
+
+func isEncryptedPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.Pod) error {
 	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
 	if err != nil {
 		return err
@@ -422,6 +428,16 @@ func validateEncryptedPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim,
 	rbdImageSpec := imageSpec(defaultRBDPool, imageData.imageName)
 
 	return validateEncryptedImage(f, rbdImageSpec, app)
+}
+
+func isThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.Pod) error {
+	du, err := getRbdDu(f, pvc)
+	if err != nil {
+		return fmt.Errorf("failed to get allocations of RBD image: %w", err)
+	} else if du.UsedSize == 0 || du.UsedSize != du.ProvisionedSize {
+		return fmt.Errorf("backing RBD image is not thick-provisioned (%d/%d)", du.UsedSize, du.ProvisionedSize)
+	}
+	return nil
 }
 
 // validateEncryptedImage verifies that the RBD image is encrypted. The

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -522,7 +522,7 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 }
 
 // nolint:gocyclo,gocognit // reduce complexity
-func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath string, validateEncryption bool, f *framework.Framework) {
+func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath string, validatePVC validateFunc, f *framework.Framework) {
 	var wg sync.WaitGroup
 	wgErrs := make([]error, totalCount)
 	chErrs := make([]error, totalCount)
@@ -598,8 +598,8 @@ func validatePVCClone(totalCount int, sourcePvcPath, sourceAppPath, clonePvcPath
 					e2elog.Logf("checksum didn't match. checksum=%s and checksumclone=%s", checkSum, checkSumClone)
 				}
 			}
-			if wgErrs[n] == nil && validateEncryption {
-				wgErrs[n] = validateEncryptedPVC(f, &p, &a)
+			if wgErrs[n] == nil && validatePVC != nil {
+				wgErrs[n] = validatePVC(f, &p, &a)
 			}
 			w.Done()
 		}(&wg, i, *pvcClone, *appClone)
@@ -791,7 +791,7 @@ func validatePVCSnapshot(totalCount int, pvcPath, appPath, snapshotPath, pvcClon
 				}
 			}
 			if wgErrs[n] == nil && kms != "" {
-				wgErrs[n] = validateEncryptedPVC(f, &p, &a)
+				wgErrs[n] = isEncryptedPVC(f, &p, &a)
 			}
 			w.Done()
 		}(&wg, i, *pvcClone, *appClone)

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -152,8 +152,6 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 	}
 	defer j.Destroy()
 
-	// TODO: if rv exists, delete the image and start over?
-
 	err = rv.doSnapClone(ctx, parentVol)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -264,6 +264,11 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 }
 
 func (rv *rbdVolume) flattenCloneImage(ctx context.Context) error {
+	if rv.ThickProvision {
+		// thick-provisioned images do not need flattening
+		return nil
+	}
+
 	tempClone := rv.generateTempClone()
 	// reducing the limit for cloned images to make sure the limit is in range,
 	// If the intermediate clone reaches the depth we may need to return ABORT

--- a/internal/rbd/controllerserver_test.go
+++ b/internal/rbd/controllerserver_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestIsThickProvisionRequest(t *testing.T) {
-	cs := &ControllerServer{}
 	req := &csi.CreateVolumeRequest{
 		Name: "fake",
 		Parameters: map[string]string{
@@ -32,38 +31,38 @@ func TestIsThickProvisionRequest(t *testing.T) {
 	}
 
 	// pass disabled/invalid values for "thickProvision" option
-	if cs.isThickProvisionRequest(req) {
+	if isThickProvisionRequest(req.GetParameters()) {
 		t.Error("request is not for thick-provisioning")
 	}
 
 	req.Parameters["thickProvision"] = ""
-	if cs.isThickProvisionRequest(req) {
+	if isThickProvisionRequest(req.GetParameters()) {
 		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
 	}
 
 	req.Parameters["thickProvision"] = "false"
-	if cs.isThickProvisionRequest(req) {
+	if isThickProvisionRequest(req.GetParameters()) {
 		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
 	}
 
 	req.Parameters["thickProvision"] = "off"
-	if cs.isThickProvisionRequest(req) {
+	if isThickProvisionRequest(req.GetParameters()) {
 		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
 	}
 
 	req.Parameters["thickProvision"] = "no"
-	if cs.isThickProvisionRequest(req) {
+	if isThickProvisionRequest(req.GetParameters()) {
 		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
 	}
 
 	req.Parameters["thickProvision"] = "**true**"
-	if cs.isThickProvisionRequest(req) {
+	if isThickProvisionRequest(req.GetParameters()) {
 		t.Errorf("request is not for thick-provisioning: %s", req.Parameters["thickProvision"])
 	}
 
 	// only "true" should enable thick provisioning
 	req.Parameters["thickProvision"] = "true"
-	if !cs.isThickProvisionRequest(req) {
+	if !isThickProvisionRequest(req.GetParameters()) {
 		t.Errorf("request should be for thick-provisioning: %s", req.Parameters["thickProvision"])
 	}
 }

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -171,6 +171,8 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	volOptions.ThickProvision = isThickProvisionRequest(req.GetVolumeContext())
+
 	// get rbd image name from the volume journal
 	// for static volumes, the image name is actually the volume ID itself
 	switch {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1531,7 +1531,24 @@ func (rv *rbdVolume) DeepCopy(dest *rbdVolume) error {
 	}
 	defer image.Close()
 
-	return image.DeepCopy(dest.ioctx, dest.RbdImageName, opts)
+	err = image.DeepCopy(dest.ioctx, dest.RbdImageName, opts)
+	if err != nil {
+		return err
+	}
+
+	// deep-flatten is not supported by all clients, so disable it
+	return dest.DisableDeepFlatten()
+}
+
+// DisableDeepFlatten removed the deep-flatten feature from the image.
+func (rv *rbdVolume) DisableDeepFlatten() error {
+	image, err := rv.open()
+	if err != nil {
+		return err
+	}
+	defer image.Close()
+
+	return image.UpdateFeatures(librbd.FeatureDeepFlatten, false)
 }
 
 func (rv *rbdVolume) listSnapshots() ([]librbd.SnapInfo, error) {


### PR DESCRIPTION
To create a full-allocated RBD image from a snapshot/clone DeepCopy()
can be used. This is needed when the parent of the new volume is
thick-provisioner, so that the new volume is independent of the parent
and thick-provisioned as well.

Things that need to be done:

- [x] manually tested and confirmed allocations with `rbd du`
- [x] rebase on top of the next go-ceph release (v0.10.0 #2147)
- [x] add e2e verification test

Fixes: #2077

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
