### PR TITLE
Fix regression when no image features are provided

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -993,6 +993,13 @@ func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[st
 }
 
 func (rv *rbdVolume) validateImageFeatures(imageFeatures string) error {
+	// It is possible for image features to be an empty string which
+	// the Go split function would return a single item array with
+	// an empty string, causing a failure when trying to validate
+	// the features.
+	if strings.TrimSpace(imageFeatures) == "" {
+		return nil
+	}
 	arr := strings.Split(imageFeatures, ",")
 	featureSet := sets.NewString(arr...)
 	for _, f := range arr {

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -52,6 +52,14 @@ func TestValidateImageFeatures(t *testing.T) {
 		errMsg        string
 	}{
 		{
+			"",
+			&rbdVolume{
+				Mounter: rbdDefaultMounter,
+			},
+			false,
+			"",
+		},
+		{
 			"layering",
 			&rbdVolume{
 				Mounter: rbdDefaultMounter,


### PR DESCRIPTION
# Describe what this PR does #
There is an issue that if the storage class was originally created with no image features (which worked fine), it would fail when upgrading the Ceph CSI.

The regression was introduced by this commit:

https://github.com/ceph/ceph-csi/commit/d8f7b38d3dac9718695ff6c33328f5f6cfce2c2f

Several users have filed issues about this, see listed in related issues below.

## Is there anything that requires special attention ##

This is a regression which really hurts when upgrading (and only noticed when remounting volumes).  It's incredibly hard to fix in production because PVs are read-only.  Users could potentially lose their data if they try and force a replace as the PV is recreated.

## Related issues ##

Fixes: #1937 
Fixes: #2049 

## Future concerns ##

None for now.