### PR TITLE
cephfs: use IsMountPoint to check mountpoint in nodeplugin

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -271,7 +271,7 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 			util.DebugLog(ctx, "targetPath: %s has already been deleted", targetPath)
 			return &csi.NodeUnpublishVolumeResponse{}, nil
 		}
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if !isMnt {
 		if err = os.RemoveAll(targetPath); err != nil {
@@ -318,7 +318,7 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 			util.DebugLog(ctx, "targetPath: %s has already been deleted", stagingTargetPath)
 			return &csi.NodeUnstageVolumeResponse{}, nil
 		}
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if !isMnt {
 		return &csi.NodeUnstageVolumeResponse{}, nil

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -198,7 +198,7 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 		if os.IsNotExist(err) {
 			return nil, status.Errorf(codes.InvalidArgument, "targetpath %s does not exist", targetPath)
 		}
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if !isMnt {
 		return nil, status.Errorf(codes.InvalidArgument, "targetpath %s is not mounted", targetPath)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -28,8 +28,6 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cloud-provider/volume/helpers"
 	"k8s.io/utils/mount"
@@ -276,7 +274,7 @@ func IsMountPoint(p string) (bool, error) {
 	dummyMount := mount.New("")
 	notMnt, err := dummyMount.IsLikelyNotMountPoint(p)
 	if err != nil {
-		return false, status.Error(codes.Internal, err.Error())
+		return false, err
 	}
 
 	return !notMnt, nil


### PR DESCRIPTION
Currently, we are relying on the error output from the umount command we run on the nodes when mounting the volume but we are not checking for all the error messages to verify the volume is mounted or not. This commits uses the IsMountPoint function in util to check the mountpoint.

```text
125913:2021-05-26T09:34:00.09289623Z E0526 09:34:00.092827       1 utils.go:163] ID: 1283134 Req-ID: 0001-0011-openshift-storage-0000000000000001-85b343f7-8017-11eb-9363-0a580a80028b GRPC error: rpc error: code = Internal desc = an error (exit status 32) and stdError (umount: /var/lib/kubelet/pods/8a57e125-9c07-437c-8da9-3fa021dbc37e/volumes/kubernetes.io~csi/pvc-3a2355da-57c3-4c4a-8698-200fac97f4be/mount: no mount point specified
```

cc @gnufied