### PR TITLE
rbd: add check for imageFeatures parameter

### DIFF
--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -34,7 +34,7 @@ func deployVault(c kubernetes.Interface, deployTimeout int) {
 	Expect(err).Should(BeNil())
 	Expect(len(pods.Items)).Should(Equal(1))
 	name := pods.Items[0].Name
-	err = waitForPodInRunningState(name, cephCSINamespace, c, deployTimeout)
+	err = waitForPodInRunningState(name, cephCSINamespace, c, deployTimeout, noError)
 	Expect(err).Should(BeNil())
 }
 

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -259,10 +259,18 @@ func createApp(c kubernetes.Interface, app *v1.Pod, timeout int) error {
 	if err != nil {
 		return fmt.Errorf("failed to create app: %w", err)
 	}
-	return waitForPodInRunningState(app.Name, app.Namespace, c, timeout)
+	return waitForPodInRunningState(app.Name, app.Namespace, c, timeout, noError)
 }
 
-func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int) error {
+func createAppErr(c kubernetes.Interface, app *v1.Pod, timeout int, errString string) error {
+	_, err := c.CoreV1().Pods(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return waitForPodInRunningState(app.Name, app.Namespace, c, timeout, errString)
+}
+
+func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, expectedError string) error {
 	timeout := time.Duration(t) * time.Minute
 	start := time.Now()
 	e2elog.Logf("Waiting up to %v to be in Running state", name)
@@ -276,6 +284,19 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int) er
 			return true, nil
 		case v1.PodFailed, v1.PodSucceeded:
 			return false, conditions.ErrPodCompleted
+		case v1.PodPending:
+			if expectedError != "" {
+				events, err := c.CoreV1().Events(ns).List(context.TODO(), metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s", name),
+				})
+				if err != nil {
+					return false, err
+				}
+				if strings.Contains(events.String(), expectedError) {
+					e2elog.Logf("Expected Error %q found successfully", expectedError)
+					return true, err
+				}
+			}
 		}
 		e2elog.Logf("%s app  is in %s phase expected to be in Running  state (%d seconds elapsed)", name, pod.Status.Phase, int(time.Since(start).Seconds()))
 		return false, nil

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1051,7 +1051,7 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("validate RBD static FileSystem PVC", func() {
-				err := validateRBDStaticPV(f, appPath, false)
+				err := validateRBDStaticPV(f, appPath, false, false)
 				if err != nil {
 					e2elog.Failf("failed to validate rbd static pv with error %v", err)
 				}
@@ -1060,9 +1060,18 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("validate RBD static Block PVC", func() {
-				err := validateRBDStaticPV(f, rawAppPath, true)
+				err := validateRBDStaticPV(f, rawAppPath, true, false)
 				if err != nil {
 					e2elog.Failf("failed to validate rbd block pv with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+			})
+
+			By("validate failure of RBD static PVC without imageFeatures parameter", func() {
+				err := validateRBDStaticPV(f, rawAppPath, true, true)
+				if err != nil {
+					e2elog.Failf("Validation of static PVC without imageFeatures parameter failed with err %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -113,7 +113,7 @@ func resizePVCAndValidateSize(pvcPath, appPath string, f *framework.Framework) e
 		return err
 	}
 	// wait for application pod to come up after resize
-	err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout, noError)
 	if err != nil {
 		return err
 	}

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -384,7 +384,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 						e2elog.Failf("failed to expand pvc with error %v", err)
 					}
 					// wait for application pod to come up after resize
-					err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+					err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout, noError)
 					if err != nil {
 						e2elog.Failf("timeout waiting for pod to be in running state with error %v", err)
 					}

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -391,7 +391,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 						e2elog.Failf("failed to expand pvc with error %v", err)
 					}
 					// wait for application pod to come up after resize
-					err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+					err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout, noError)
 					if err != nil {
 						e2elog.Failf("timeout waiting for pod to be in running state with error %v", err)
 					}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -46,6 +46,7 @@ const (
 
 	// vaultTokens KMS type
 	vaultTokens = "vaulttokens"
+	noError     = ""
 )
 
 var (

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -111,6 +111,10 @@ func (cs *ControllerServer) parseVolCreateRequest(ctx context.Context, req *csi.
 		return nil, status.Error(codes.InvalidArgument, "multi node access modes are only supported on rbd `block` type volumes")
 	}
 
+	if imageFeatures, ok := req.GetParameters()["imageFeatures"]; checkImageFeatures(imageFeatures, ok, true) {
+		return nil, status.Error(codes.InvalidArgument, "missing required parameter imageFeatures")
+	}
+
 	// if it's NOT SINGLE_NODE_WRITER and it's BLOCK we'll set the parameter to ignore the in-use checks
 	rbdVol, err := genVolFromVolumeOptions(ctx, req.GetParameters(), req.GetSecrets(), (isMultiNode && isBlock))
 	if err != nil {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -154,14 +154,11 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	var isNotMnt bool
 	// check if stagingPath is already mounted
-	isNotMnt, err = mount.IsNotMountPoint(ns.mounter, stagingTargetPath)
-	if err != nil && !os.IsNotExist(err) {
+	isNotMnt, err := isNotMountPoint(ns.mounter, stagingTargetPath)
+	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	if !isNotMnt {
+	} else if !isNotMnt {
 		util.DebugLog(ctx, "rbd: volume %s is already mounted to %s, skipping", volID, stagingTargetPath)
 		return &csi.NodeStageVolumeResponse{}, nil
 	}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -166,6 +166,12 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
+	// throw error when imageFeatures parameter is missing or empty
+	// for backward compatibility, ignore error for non-static volumes from older cephcsi version
+	if imageFeatures, ok := req.GetVolumeContext()["imageFeatures"]; checkImageFeatures(imageFeatures, ok, staticVol) {
+		return nil, status.Error(codes.InvalidArgument, "missing required parameter imageFeatures")
+	}
+
 	volOptions, err := genVolFromVolumeOptions(ctx, req.GetVolumeContext(), req.GetSecrets(), disableInUseChecks)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1017,7 +1017,7 @@ func (rv *rbdVolume) validateImageFeatures(imageFeatures string) error {
 	// the Go split function would return a single item array with
 	// an empty string, causing a failure when trying to validate
 	// the features.
-	if strings.TrimSpace(imageFeatures) == "" {
+	if imageFeatures == "" {
 		return nil
 	}
 	arr := strings.Split(imageFeatures, ",")

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cloud-provider/volume/helpers"
+	mount "k8s.io/mount-utils"
 )
 
 const (
@@ -453,6 +454,16 @@ func (rv *rbdVolume) isInUse() (bool, error) {
 // for backward compatibility.
 func checkImageFeatures(imageFeatures string, ok, static bool) bool {
 	return static && (!ok || imageFeatures == "")
+}
+
+// isNotMountPoint checks whether MountPoint does not exists and
+// also discards error indicating mountPoint exists.
+func isNotMountPoint(mounter mount.Interface, stagingTargetPath string) (bool, error) {
+	isNotMnt, err := mount.IsNotMountPoint(mounter, stagingTargetPath)
+	if os.IsNotExist(err) {
+		err = nil
+	}
+	return isNotMnt, err
 }
 
 // addRbdManagerTask adds a ceph manager task to execute command

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -448,6 +448,13 @@ func (rv *rbdVolume) isInUse() (bool, error) {
 	return len(watchers) > defaultWatchers, nil
 }
 
+// checkImageFeatures check presence of imageFeatures parameter. It returns true when
+// there imageFeatures is missing or empty, skips missing parameter for non-static volumes
+// for backward compatibility.
+func checkImageFeatures(imageFeatures string, ok, static bool) bool {
+	return static && (!ok || imageFeatures == "")
+}
+
 // addRbdManagerTask adds a ceph manager task to execute command
 // asynchronously. If command is not found returns a bool set to false
 // example arg ["trash", "remove","pool/image"].


### PR DESCRIPTION
This commit adds checks for the missing `imageFeatures` parameter in createvolumerequest and nodestagerequest(only for static PVs). Missing `imageFeatures` parameter is ignored in the case of non-static PVs to ensure backward compatibility with older versions that did not have `imageFeatures` as a required parameter.

Signed-off-by: Rakshith R <rar@redhat.com>