### PR TITLE
ci: pass GITHUB_BASE_REF when running commitlint

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -11,5 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: commitlint
-        run: CONTAINER_CMD=docker make containerized-test TARGET=commitlint
+        # yamllint disable-line rule:line-length
+        run: make containerized-test CONTAINER_CMD=docker TARGET=commitlint GIT_SINCE="origin/${GITHUB_BASE_REF}"

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ commitlint: REBASE ?= 0
 commitlint:
 	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
 	@test $(REBASE) -eq 0 || git -c user.name=commitlint -c user.email=commitline@localhost rebase FETCH_HEAD
-	commitlint --from FETCH_HEAD
+	commitlint --verbose --from $(GIT_SINCE)
 
 .PHONY: cephcsi
 cephcsi: check-env


### PR DESCRIPTION
Make the `commitlint` job a little more verbose, show what commits are tested.

This also updates the GitHub workflow so that the `Makefile` does not need to get adjusted for each branch. Instead of changing the `Makefile:GIT_SINCE` variable, pass it is a variable on the `make` commandline.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
