### PR TITLE
Get rid of locking at node {publish,unpublish} operations

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -267,16 +267,9 @@ func (ns *NodeServer) NodeUnpublishVolume(
 	if err = util.ValidateNodeUnpublishVolumeRequest(req); err != nil {
 		return nil, err
 	}
-
-	volID := req.GetVolumeId()
+	// considering kubelet make sure node operations like unpublish/unstage...etc can not be called
+	// at same time, an explicit locking at time of nodeunpublish is not required.
 	targetPath := req.GetTargetPath()
-
-	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
-		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
-	}
-	defer ns.VolumeLocks.Release(volID)
-
 	isMnt, err := util.IsMountPoint(targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -217,11 +217,8 @@ func (ns *NodeServer) NodePublishVolume(
 	targetPath := req.GetTargetPath()
 	volID := req.GetVolumeId()
 
-	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
-		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
-	}
-	defer ns.VolumeLocks.Release(volID)
+	// Considering kubelet make sure the stage and publish operations
+	// are serialized, we dont need any extra locking in nodePublish
 
 	if err := util.CreateMountPoint(targetPath); err != nil {
 		util.ErrorLog(ctx, "failed to create mount point at %s: %v", targetPath, err)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -611,14 +611,8 @@ func (ns *NodeServer) NodeUnpublishVolume(
 	}
 
 	targetPath := req.GetTargetPath()
-	volID := req.GetVolumeId()
-
-	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
-		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
-	}
-	defer ns.VolumeLocks.Release(volID)
-
+	// considering kubelet make sure node operations like unpublish/unstage...etc can not be called
+	// at same time, an explicit locking at time of nodeunpublish is not required.
 	notMnt, err := mount.IsNotMountPoint(ns.mounter, targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -439,11 +439,8 @@ func (ns *NodeServer) NodePublishVolume(
 	volID := req.GetVolumeId()
 	stagingPath += "/" + volID
 
-	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
-		util.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
-	}
-	defer ns.VolumeLocks.Release(volID)
+	// Considering kubelet make sure the stage and publish operations
+	// are serialized, we dont need any extra locking in nodePublish
 
 	// Check if that target path exists properly
 	notMnt, err := ns.createTargetMountPath(ctx, targetPath, isBlock)


### PR DESCRIPTION
Considering kubelet make sure node operations like unpublish/nodeunpublish
..etc can **not** be called at same time, we dont require extra locking
in nodePublish and nodeUnpublish operation from driver side. Till this commit, we were
operating at NodePublish/NodeUnpublish with a lock and it is now removed.

**RBD**:

- [x] Lock removed from nodePublish
- [x] Lock removed from nodeUnpublish


**CephFS**

- [x] Lock removed from nodePublish
- [x] Lock removed from nodeUnpublish


Fixes: #https://github.com/ceph/ceph-csi/issues/2123
Updates: https://github.com/ceph/ceph-csi/issues/2197

Thanks to @mape90 for reporting and analyzing this issue

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>