### PR TITLE
build: use cephcsi bot token to push helm charts

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -32,4 +32,4 @@ jobs:
         # https://github.com/containers/buildah/issues/1407
         # use docker to build images
         # yamllint disable-line rule:line-length
-        run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} CONTAINER_CMD=docker ./deploy.sh
+        run: GITHUB_TOKEN=${{ secrets.CEPH_CSI_BOT_TOKEN }} CONTAINER_CMD=docker ./deploy.sh


### PR DESCRIPTION
GITHUB_TOKEN is auto-generated for the cephcsi repo and it cannot be used to push helm charts to a different repo. added new secret CEPH_CSI_BOT_TOKEN to push helm charts.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

