### PR TITLE
build: git config before commit

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -27,9 +27,14 @@ jobs:
         if: github.ref == 'refs/heads/devel'
         run: echo "BRANCH_NAME=devel" >> $GITHUB_ENV
 
+      - name: Set build environment variables
+        run: |
+          echo "GITHUB_USER=${{ secrets.CEPH_CSI_BOT_NAME }}" >> $GITHUB_ENV
+          echo "GITHUB_EMAIL=${{ secrets.CEPH_CSI_BOT_EMAIL }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.CEPH_CSI_BOT_TOKEN }}" >> $GITHUB_ENV
+
       - name: publish artifacts
         # podman cannot pull images with both tag and digest
         # https://github.com/containers/buildah/issues/1407
         # use docker to build images
-        # yamllint disable-line rule:line-length
-        run: GITHUB_TOKEN=${{ secrets.CEPH_CSI_BOT_TOKEN }} CONTAINER_CMD=docker ./deploy.sh
+        run: CONTAINER_CMD=docker ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,8 @@ source "$(dirname "${0}")/build.env"
 
 BRANCH_NAME=${BRANCH_NAME:-""}
 GITHUB_TOKEN=${GITHUB_TOKEN:-""}
+GITHUB_USER=${GITHUB_USER:-"autobuild-bot"}
+GITHUB_EMAIL=${GITHUB_EMAIL:-"ceph-csi-bot@users.noreply.github.com"}
 
 # Build and push images. Steps as below:
 # 1. get base image from ./build.env (BASE_IMAGE=ceph/ceph:v14.2)
@@ -82,6 +84,8 @@ push_helm_charts() {
 
 	pushd "${CHARTDIR}/csi-charts/docs" >/dev/null
 	helm repo index .
+	git config user.name "${GITHUB_USER}"
+	git config user.email "${GITHUB_EMAIL}"
 	git add --all :/ && git commit -m "Update for helm charts ${PACKAGE}-${VERSION}"
 	git push https://"${GITHUB_TOKEN}"@github.com/ceph/csi-charts
 	popd >/dev/null


### PR DESCRIPTION
currently, git commit of the helm charts to csi-chart repo is failing with the below error

```
Author identity unknown

*** Please tell me who you are.

Run

git config --global user.email "you@example.com"
git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.
```
https://github.com/ceph/ceph-csi/runs/2791603305?check_suite_focus=true

this commit adds git config for a bot user.

Note:- used `ceph.io` for the bot user and it's not a valid email id and am also looking for a suggestion if anyone as.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

