### PR TITLE
cleanup: gocyclo being unused for linter

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -591,8 +591,7 @@ func checkContentSource(ctx context.Context, req *csi.CreateVolumeRequest, cr *u
 
 // DeleteVolume deletes the volume in backend and removes the volume metadata
 // from store
-// TODO: make this function less complex
-// nolint:gocyclo // golangci-lint did not catch this earlier, needs to get fixed later
+// TODO: make this function less complex.
 func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		util.ErrorLog(ctx, "invalid delete volume req: %v", protosanitizer.StripSecrets(req))

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -110,8 +110,7 @@ var (
 //   - Map the image (creates a device)
 //   - Create the staging file/directory under staging path
 //   - Stage the device (mount the device mapped for image)
-// TODO: make this function less complex
-// nolint:gocyclo // complexity needs to be reduced.
+// TODO: make this function less complex.
 func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	if err := util.ValidateNodeStageVolumeRequest(req); err != nil {
 		return nil, err

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -370,7 +370,6 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 // ResyncVolume extracts the RBD volume information from the volumeID, If the
 // image is present, mirroring is enabled and the image is in demoted state.
 // If yes it will resync the image to correct the split-brain.
-// nolint:gocyclo // reduce complexity
 // FIXME: reduce complexity.
 func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	req *replication.ResyncVolumeRequest,

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -32,8 +32,7 @@ func cleanupTestData() {
 	os.RemoveAll(basePath)
 }
 
-// TODO: make this function less complex
-// nolint:gocyclo // complexity needs to be reduced.
+// TODO: make this function less complex.
 func TestCSIConfig(t *testing.T) {
 	var err error
 	var data string


### PR DESCRIPTION
This commit addresses the following issue:
'nolint:gocyclo // complexity needs to be reduced.'
is unused for linter "gocyclo" (nolintlint)

Updates:#1586

Signed-off-by: Yati Padia <ypadia@redhat.com>
