### PR TITLE
doc: adds note to replace canary with version tag

### DIFF
--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -175,6 +175,19 @@ kubectl create -f csi-cephfsplugin.yaml
 Deploys a daemon set with two containers: CSI node-driver-registrar and
 the CSI CephFS driver.
 
+**NOTE:**
+In case you want to use a different release version, replace canary with the
+release version in the
+[provisioner](../deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml)
+and [nodeplugin](../deploy/cephfs/kubernetes/csi-cephfsplugin.yaml) YAMLs.
+
+```yaml
+# for stable functionality replace canary with latest release version
+    image: quay.io/cephcsi/cephcsi:canary
+```
+
+Check the release version [here.](../README.md#ceph-csi-container-images-and-release-compatibility)
+
 ## Verifying the deployment in Kubernetes
 
 After successfully completing the steps above, you should see output similar to this:

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -144,6 +144,19 @@ kubectl create -f csi-rbdplugin.yaml
 Deploys a daemon set with two containers: CSI node-driver-registrar and the CSI
 RBD driver.
 
+**NOTE:**
+In case you want to use a different release version, replace canary with the
+release version in the
+[provisioner](../deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml)
+and [nodeplugin](../deploy/rbd/kubernetes/csi-rbdplugin.yaml) YAMLs.
+
+```yaml
+# for stable functionality replace canary with latest release version
+    image: quay.io/cephcsi/cephcsi:canary
+```
+
+Check the release version [here.](../README.md#ceph-csi-container-images-and-release-compatibility)
+
 ## Verifying the deployment in Kubernetes
 
 After successfully completing the steps above, you should see output similar to this:


### PR DESCRIPTION
This commit adds a note to replace canary with version
tag when deploying in production.

Fixes: #2156

Signed-off-by: Yati Padia <ypadia@redhat.com>

