### PR TITLE
cleanup: addresses paralleltest linter

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -45,6 +45,7 @@ func setDefaultKubeconfig() {
 }
 
 func TestE2E(t *testing.T) {
+	t.Parallel()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2e Suite")
 }

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -25,6 +25,7 @@ import (
 var fakeID = "fake-id"
 
 func TestGetReqID(t *testing.T) {
+	t.Parallel()
 	req := []interface{}{
 		&csi.CreateVolumeRequest{
 			Name: fakeID,

--- a/internal/rbd/nodeserver_test.go
+++ b/internal/rbd/nodeserver_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGetStagingPath(t *testing.T) {
+	t.Parallel()
 	var stagingPath string
 	// test with nodestagevolumerequest
 	nsvr := &csi.NodeStageVolumeRequest{

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestHasSnapshotFeature(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		features   string
 		hasFeature bool
@@ -45,6 +46,7 @@ func TestHasSnapshotFeature(t *testing.T) {
 }
 
 func TestValidateImageFeatures(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		imageFeatures string
 		rbdVol        *rbdVolume

--- a/internal/util/aws_metadata_test.go
+++ b/internal/util/aws_metadata_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAWSMetadataKMSRegistered(t *testing.T) {
+	t.Parallel()
 	_, ok := kmsManager.providers[kmsTypeAWSMetadata]
 	assert.True(t, ok)
 }

--- a/internal/util/conn_pool_test.go
+++ b/internal/util/conn_pool_test.go
@@ -74,6 +74,7 @@ func (cp *ConnPool) fakeGet(monitors, user, keyfile string) (*rados.Conn, string
 }
 
 func TestConnPool(t *testing.T) {
+	t.Parallel()
 	cp := NewConnPool(interval, expiry)
 	defer cp.Destroy()
 

--- a/internal/util/crypto_test.go
+++ b/internal/util/crypto_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestInitSecretsKMS(t *testing.T) {
+	t.Parallel()
 	secrets := map[string]string{}
 
 	// no passphrase in the secrets, should fail
@@ -40,6 +41,7 @@ func TestInitSecretsKMS(t *testing.T) {
 }
 
 func TestGenerateNewEncryptionPassphrase(t *testing.T) {
+	t.Parallel()
 	b64Passphrase, err := generateNewEncryptionPassphrase()
 	require.NoError(t, err)
 
@@ -51,6 +53,7 @@ func TestGenerateNewEncryptionPassphrase(t *testing.T) {
 }
 
 func TestKMSWorkflow(t *testing.T) {
+	t.Parallel()
 	secrets := map[string]string{
 		encryptionPassphraseKey: "workflow test",
 	}

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -34,6 +34,7 @@ func cleanupTestData() {
 
 // TODO: make this function less complex.
 func TestCSIConfig(t *testing.T) {
+	t.Parallel()
 	var err error
 	var data string
 	var content string

--- a/internal/util/errors_test.go
+++ b/internal/util/errors_test.go
@@ -32,6 +32,7 @@ func wrapError(e error) error {
 }
 
 func TestJoinErrors(t *testing.T) {
+	t.Parallel()
 	assertErrorIs := func(e1, e2 error, ok bool) {
 		if errors.Is(e1, e2) != ok {
 			t.Errorf("errors.Is(e1, e2) != %v - e1: %#v - e2: %#v", ok, e1, e2)

--- a/internal/util/idlocker_test.go
+++ b/internal/util/idlocker_test.go
@@ -22,6 +22,7 @@ import (
 
 // very basic tests for the moment.
 func TestIDLocker(t *testing.T) {
+	t.Parallel()
 	fakeID := "fake-id"
 	locks := NewVolumeLocks()
 	// acquire lock for fake-id
@@ -52,6 +53,7 @@ func TestIDLocker(t *testing.T) {
 }
 
 func TestOperationLocks(t *testing.T) {
+	t.Parallel()
 	volumeID := "test-vol"
 	lock := NewOperationLock()
 	err := lock.GetCloneLock(volumeID)

--- a/internal/util/kms_test.go
+++ b/internal/util/kms_test.go
@@ -27,6 +27,7 @@ func noinitKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 }
 
 func TestRegisterKMSProvider(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		provider KMSProvider
 		panics   bool

--- a/internal/util/pidlimit_test.go
+++ b/internal/util/pidlimit_test.go
@@ -24,6 +24,7 @@ import (
 // minimal test to check if GetPIDLimit() returns an int
 // changing the limit require root permissions, not tested.
 func TestGetPIDLimit(t *testing.T) {
+	t.Parallel()
 	runTest := os.Getenv("CEPH_CSI_RUN_ALL_TESTS")
 	if runTest == "" {
 		t.Skip("not running test that requires root permissions and cgroup support")

--- a/internal/util/secretskms_test.go
+++ b/internal/util/secretskms_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestGenerateNonce(t *testing.T) {
+	t.Parallel()
 	size := 64
 	nonce, err := generateNonce(size)
 	assert.Equal(t, size, len(nonce))
@@ -31,6 +32,7 @@ func TestGenerateNonce(t *testing.T) {
 }
 
 func TestGenerateCipher(t *testing.T) {
+	t.Parallel()
 	// nolint:gosec // this passphrase is intentionally hardcoded
 	passphrase := "my-cool-luks-passphrase"
 	salt := "unique-id-for-the-volume"
@@ -41,6 +43,7 @@ func TestGenerateCipher(t *testing.T) {
 }
 
 func TestInitSecretsMetadataKMS(t *testing.T) {
+	t.Parallel()
 	args := KMSInitializerArgs{
 		Tenant:  "tenant",
 		Config:  nil,
@@ -62,6 +65,7 @@ func TestInitSecretsMetadataKMS(t *testing.T) {
 }
 
 func TestWorkflowSecretsMetadataKMS(t *testing.T) {
+	t.Parallel()
 	secrets := map[string]string{
 		encryptionPassphraseKey: "my-passphrase-from-kubernetes",
 	}
@@ -100,6 +104,7 @@ func TestWorkflowSecretsMetadataKMS(t *testing.T) {
 }
 
 func TestSecretsMetadataKMSRegistered(t *testing.T) {
+	t.Parallel()
 	_, ok := kmsManager.providers[kmsTypeSecretsMetadata]
 	assert.True(t, ok)
 }

--- a/internal/util/topology_test.go
+++ b/internal/util/topology_test.go
@@ -37,6 +37,7 @@ func checkAndReportError(t *testing.T, msg string, err error) {
 
 // TestFindPoolAndTopology also tests MatchTopologyForPool.
 func TestFindPoolAndTopology(t *testing.T) {
+	t.Parallel()
 	var err error
 	var label1 = "region"
 	var label2 = "zone"

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestRoundOffBytes(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		bytes int64
 	}
@@ -75,6 +76,7 @@ func TestRoundOffBytes(t *testing.T) {
 	for _, tt := range tests {
 		ts := tt
 		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
 			if got := RoundOffBytes(ts.args.bytes); got != ts.want {
 				t.Errorf("RoundOffBytes() = %v, want %v", got, ts.want)
 			}
@@ -83,6 +85,7 @@ func TestRoundOffBytes(t *testing.T) {
 }
 
 func TestRoundOffVolSize(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		size int64
 	}
@@ -137,6 +140,7 @@ func TestRoundOffVolSize(t *testing.T) {
 	for _, tt := range tests {
 		ts := tt
 		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
 			if got := RoundOffVolSize(ts.args.size); got != ts.want {
 				t.Errorf("RoundOffVolSize() = %v, want %v", got, ts.want)
 			}
@@ -145,6 +149,7 @@ func TestRoundOffVolSize(t *testing.T) {
 }
 
 func TestGetKernelVersion(t *testing.T) {
+	t.Parallel()
 	version, err := GetKernelVersion()
 	if err != nil {
 		t.Errorf("failed to get kernel version: %s", err)
@@ -158,6 +163,7 @@ func TestGetKernelVersion(t *testing.T) {
 }
 
 func TestMountOptionsAdd(t *testing.T) {
+	t.Parallel()
 	moaTests := []struct {
 		name         string
 		mountOptions string
@@ -228,7 +234,9 @@ func TestMountOptionsAdd(t *testing.T) {
 
 	for _, moaTest := range moaTests {
 		mt := moaTest
+		moaTest := moaTest
 		t.Run(moaTest.name, func(t *testing.T) {
+			t.Parallel()
 			result := MountOptionsAdd(mt.mountOptions, mt.option...)
 			if result != mt.result {
 				t.Errorf("MountOptionsAdd(): %v, want %v", result, mt.result)
@@ -237,6 +245,7 @@ func TestMountOptionsAdd(t *testing.T) {
 	}
 }
 func TestCheckKernelSupport(t *testing.T) {
+	t.Parallel()
 	supportsQuota := []string{
 		"4.17.0",
 		"5.0.0",

--- a/internal/util/vault_test.go
+++ b/internal/util/vault_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestDetectAuthMountPath(t *testing.T) {
+	t.Parallel()
 	authMountPath, err := detectAuthMountPath(vaultDefaultAuthPath)
 	if err != nil {
 		t.Errorf("detectAuthMountPath() failed: %s", err)
@@ -43,6 +44,7 @@ func TestDetectAuthMountPath(t *testing.T) {
 }
 
 func TestCreateTempFile(t *testing.T) {
+	t.Parallel()
 	data := []byte("Hello World!")
 	tmpfile, err := createTempFile("my-file", data)
 	if err != nil {
@@ -59,6 +61,7 @@ func TestCreateTempFile(t *testing.T) {
 }
 
 func TestSetConfigString(t *testing.T) {
+	t.Parallel()
 	const defaultValue = "default-value"
 	options := make(map[string]interface{})
 
@@ -99,6 +102,7 @@ func TestSetConfigString(t *testing.T) {
 }
 
 func TestVaultKMSRegistered(t *testing.T) {
+	t.Parallel()
 	_, ok := kmsManager.providers[kmsTypeVault]
 	assert.True(t, ok)
 }

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
+	t.Parallel()
 	kms := VaultTokensKMS{}
 
 	config := make(map[string]interface{})
@@ -71,6 +72,7 @@ func TestParseConfig(t *testing.T) {
 // When vault.New() is called at the end of initVaultTokensKMS(), errors will
 // mention the missing VAULT_TOKEN, and that is expected.
 func TestInitVaultTokensKMS(t *testing.T) {
+	t.Parallel()
 	if true {
 		// FIXME: testing only works when KUBE_CONFIG is set to a
 		// cluster that has a working Vault deployment
@@ -122,6 +124,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 // TestStdVaultToCSIConfig converts a JSON document with standard VAULT_*
 // environment variables to a vaultTokenConf structure.
 func TestStdVaultToCSIConfig(t *testing.T) {
+	t.Parallel()
 	vaultConfigMap := `{
 		"KMS_PROVIDER":"vaulttokens",
 		"VAULT_ADDR":"https://vault.example.com",
@@ -167,6 +170,7 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 }
 
 func TestTransformConfig(t *testing.T) {
+	t.Parallel()
 	cm := make(map[string]interface{})
 	cm["KMS_PROVIDER"] = "vaulttokens"
 	cm["VAULT_ADDR"] = "https://vault.example.com"
@@ -192,6 +196,7 @@ func TestTransformConfig(t *testing.T) {
 }
 
 func TestVaultTokensKMSRegistered(t *testing.T) {
+	t.Parallel()
 	_, ok := kmsManager.providers[kmsTypeVaultTokens]
 	assert.True(t, ok)
 }

--- a/internal/util/volid_test.go
+++ b/internal/util/volid_test.go
@@ -47,6 +47,7 @@ var testData = []testTuple{
 }
 
 func TestComposeDecomposeID(t *testing.T) {
+	t.Parallel()
 	var (
 		err           error
 		viDecompose   CSIIdentifier


### PR DESCRIPTION
The Go linter paralleltest checks that the t.Parallel
gets called for the test method and for the range of
test cases within the test.

Updates: #2025

Signed-off-by: Yati Padia <ypadia@redhat.com>