### PR TITLE
ci: disable push artifacts on forked repo

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -13,6 +13,7 @@ jobs:
   push:
     name: Publish artifacts
     runs-on: ubuntu-latest
+    if: github.repository == 'ceph/ceph-csi'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
disabling push artifacts GitHub action on the fork repos as it doesn't make sense to run push actions on the forked repo.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

