### PR TITLE
rbd: add validation for thick restore/clone

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -222,8 +222,18 @@ func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSna
 		if err != nil {
 			return status.Errorf(codes.InvalidArgument, "cannot restore from snapshot %s: %s", rbdSnap, err.Error())
 		}
+
+		err = rbdSnap.isCompatibleThickProvision(rbdVol)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "cannot restore from snapshot %s: %s", rbdSnap, err.Error())
+		}
 	case parentVol != nil:
 		err = parentVol.isCompatibleEncryption(&rbdVol.rbdImage)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "cannot clone from volume %s: %s", parentVol, err.Error())
+		}
+
+		err = parentVol.isCompatibleThickProvision(rbdVol)
 		if err != nil {
 			return status.Errorf(codes.InvalidArgument, "cannot clone from volume %s: %s", parentVol, err.Error())
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -895,6 +895,30 @@ func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnaps
 		}
 	}
 
+	// The clone image created during CreateSnapshot has to be marked as thick.
+	// As snapshot and volume both are independent we cannot depend on the
+	// parent volume of the clone to check thick provision during CreateVolume
+	// from snapshot operation because the parent volume can be deleted anytime
+	// after snapshot is created.
+	// TODO: copy thick provision config
+	thick, err := rbdVol.isThickProvisioned()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed checking thick-provisioning of %q: %s", rbdVol, err)
+	}
+
+	if thick {
+		// check the thick metadata is already set on the clone image.
+		thick, err = vol.isThickProvisioned()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed checking thick-provisioning of %q: %s", vol, err)
+		}
+		if !thick {
+			err = vol.setThickProvisioned()
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failed mark %q thick-provisioned: %s", vol, err)
+			}
+		}
+	}
 	// if flattening is not needed, the snapshot is ready for use
 	readyToUse := true
 
@@ -983,6 +1007,24 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 				"config for %q: %v", cloneRbd, cryptErr)
 			return ready, nil, status.Errorf(codes.Internal,
 				err.Error())
+		}
+	}
+
+	// The clone image created during CreateSnapshot has to be marked as thick.
+	// As snapshot and volume both are independent we cannot depend on the
+	// parent volume of the clone to check thick provision during CreateVolume
+	// from snapshot operation because the parent volume can be deleted anytime
+	// after snapshot is created.
+	// TODO: copy thick provision config
+	thick, err := parentVol.isThickProvisioned()
+	if err != nil {
+		return ready, nil, status.Errorf(codes.Internal, "failed checking thick-provisioning of %q: %s", parentVol, err)
+	}
+
+	if thick {
+		err = cloneRbd.setThickProvisioned()
+		if err != nil {
+			return ready, nil, status.Errorf(codes.Internal, "failed mark %q thick-provisioned: %s", cloneRbd, err)
 		}
 	}
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1613,3 +1613,19 @@ func (ri *rbdImage) isCompatibleEncryption(dst *rbdImage) error {
 
 	return nil
 }
+
+func (ri *rbdImage) isCompatibleThickProvision(dst *rbdVolume) error {
+	thick, err := ri.isThickProvisioned()
+	if err != nil {
+		return err
+	}
+	switch {
+	case thick && !dst.ThickProvision:
+		return fmt.Errorf("cannot create thin volume from thick volume %q", ri)
+
+	case !thick && dst.ThickProvision:
+		return fmt.Errorf("cannot create thick volume from thin volume %q", ri)
+	}
+
+	return nil
+}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1455,13 +1455,13 @@ func (rv *rbdVolume) setThickProvisioned() error {
 // isThickProvisioned checks in the image metadata if the image has been marked
 // as thick-provisioned. This can be used while expanding the image, so that
 // the expansion can be allocated too.
-func (rv *rbdVolume) isThickProvisioned() (bool, error) {
-	value, err := rv.GetMetadata(thickProvisionMetaKey)
+func (ri *rbdImage) isThickProvisioned() (bool, error) {
+	value, err := ri.GetMetadata(thickProvisionMetaKey)
 	if err != nil {
 		if err == librbd.ErrNotFound {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to get metadata %q for %q: %w", thickProvisionMetaKey, rv, err)
+		return false, fmt.Errorf("failed to get metadata %q for %q: %w", thickProvisionMetaKey, ri, err)
 	}
 
 	thick, err := strconv.ParseBool(value)


### PR DESCRIPTION
added validation to allow only Restore of Thick PVC snapshot to a thick clone and creation of a thick clone from thick PVC.
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>