### PR TITLE
rbd: correct return error for isCompatibleEncryption

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1562,10 +1562,10 @@ func (rv *rbdVolume) getOrigSnapName(snapID uint64) (string, error) {
 func (ri *rbdImage) isCompatibleEncryption(dst *rbdImage) error {
 	switch {
 	case ri.isEncrypted() && !dst.isEncrypted():
-		return fmt.Errorf("encrypted volume %q does not match unencrypted volume %q", ri, dst)
+		return fmt.Errorf("cannot create unencrypted volume from encrypted volume %q", ri)
 
 	case !ri.isEncrypted() && dst.isEncrypted():
-		return fmt.Errorf("unencrypted volume %q does not match encrypted volume %q", ri, dst)
+		return fmt.Errorf("cannot create encrypted volume from unencrypted volume %q", ri)
 	}
 
 	return nil


### PR DESCRIPTION
`isCompatibleEncryption` is used to validate the requested volume and the existing volume and the destination volume name won't be generated yet and logging the destination volume prints the empty image name with pool name.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

