### PR TITLE
e2e: refactor RBD and CephFS template deployment model

### DIFF
--- a/e2e/deployer.go
+++ b/e2e/deployer.go
@@ -1,0 +1,44 @@
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// deployer interface modify the templates on demand and also help
+// to create or delete templates.
+type deployer interface {
+	replaceNamespaceInTemplate(string) (string, error)
+	runAction(string, string, string) error
+}
+
+type deploy struct{}
+
+func (d deploy) replaceNamespaceInTemplate(filePath string) (string, error) {
+	read, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ReplaceAll(string(read), "namespace: default", fmt.Sprintf("namespace: %s", cephCSINamespace)), nil
+}
+
+func (d deploy) runAction(template, action, ns string) error {
+	data, err := d.replaceNamespaceInTemplate(template)
+	if err != nil {
+		return fmt.Errorf("failed to read content from %s with error %w", template, err)
+	}
+	if action == "create" {
+		_, err = framework.RunKubectlInput(cephCSINamespace, data, ns, action, "-f", "-")
+	}
+	if action == "delete" {
+		_, err = framework.RunKubectlInput(cephCSINamespace, data, "--ignore-not-found=true", ns, action, "-f", "-")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to %s %q with error %w", action, template, err)
+	}
+	return err
+}


### PR DESCRIPTION
    e2e: refactor RBD and CephFS template deployment model
    
    At present the RBD and CephFS deployment is really clumsy and have
    code deplication and difficulty to follow. This patch try to group the
    tasks together in more modular fashion and make it flexible to
    extend the same model for both deployment.
    
    This introduces a new interface called deployer with below methods:

        type deployer interface {
            replaceNamespaceInTemplate(string) (string, error)
            runAction(string, string, string) error
    }
        
    
    These methods handle common tasks for the deployment process of RBD and
    CephFS.The individual deployers are free to override the methods or extend
    their own later.  For example:
                    changeTemplateAndRunAction(string, string) error

     is 'deployer' specific ( rbd, cephfs...etc) which handle deployer specific cases.

    Functions removed from both cephfs.go and rbd.go:
        createORDeleteRbdResources()

 
Updates:  https://github.com/ceph/ceph-csi/issues/2178

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

