### PR TITLE
e2e: various corrections in e2e code

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -55,17 +55,17 @@ func deployCephfsPlugin() {
 		e2elog.Failf("failed to delete nodeplugin rbac %s with error %v", cephfsDirPath+cephfsNodePluginRBAC, err)
 	}
 
-	createORDeleteCephfsResouces("create")
+	createORDeleteCephfsResources("create")
 }
 
 func deleteCephfsPlugin() {
-	createORDeleteCephfsResouces("delete")
+	createORDeleteCephfsResources("delete")
 }
 
-func createORDeleteCephfsResouces(action string) {
+func createORDeleteCephfsResources(action string) {
 	csiDriver, err := ioutil.ReadFile(cephfsDirPath + csiDriverObject)
 	if err != nil {
-		// createORDeleteRbdResouces is used for upgrade testing as csidriverObject is
+		// createORDeleteRbdResources is used for upgrade testing as csidriverObject is
 		// newly added, discarding file not found error.
 		if !os.IsNotExist(err) {
 			e2elog.Failf("failed to read content from %s with error %v", cephfsDirPath+csiDriverObject, err)
@@ -214,7 +214,7 @@ var _ = Describe("cephfs", func() {
 		if CurrentGinkgoTestDescription().Failed {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-cephfs", c)
-			// log provisoner
+			// log provisioner
 			logsCSIPods("app=csi-cephfsplugin-provisioner", c)
 			// log node plugin
 			logsCSIPods("app=csi-cephfsplugin", c)
@@ -512,7 +512,7 @@ var _ = Describe("cephfs", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				// verify subvolumegroup creation.
+				// verify subvolume group creation.
 				err = validateSubvolumegroup(f, "subvolgrp1")
 				if err != nil {
 					e2elog.Failf("failed to validate subvolume group with error %v", err)
@@ -876,7 +876,7 @@ var _ = Describe("cephfs", func() {
 
 					parentPVCCount := totalSubvolumes - totalCount
 					validateSubvolumeCount(f, parentPVCCount, fileSystemName, subvolumegroup)
-					// create clones from different snapshosts and bind it to an
+					// create clones from different snapshots and bind it to an
 					// app
 					wg.Add(totalCount)
 					for i := 0; i < totalCount; i++ {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -911,7 +911,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, map[string]string{rbdmountOptions: "debug,invalidOption"}, nil, deletePolicy)
+				err = createRBDStorageClass(f.ClientSet, f, map[string]string{rbdMountOptions: "debug,invalidOption"}, nil, deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -60,17 +60,17 @@ func deployRBDPlugin() {
 		e2elog.Failf("failed to delete nodeplugin rbac %s with error %v", rbdDirPath+rbdNodePluginRBAC, err)
 	}
 
-	createORDeleteRbdResouces("create")
+	createORDeleteRbdResources("create")
 }
 
 func deleteRBDPlugin() {
-	createORDeleteRbdResouces("delete")
+	createORDeleteRbdResources("delete")
 }
 
-func createORDeleteRbdResouces(action string) {
+func createORDeleteRbdResources(action string) {
 	csiDriver, err := ioutil.ReadFile(rbdDirPath + csiDriverObject)
 	if err != nil {
-		// createORDeleteRbdResouces is used for upgrade testing as csidriverObject is
+		// createORDeleteRbdResources is used for upgrade testing as csidriverObject is
 		// newly added, discarding file not found error.
 		if !os.IsNotExist(err) {
 			e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+csiDriverObject, err)
@@ -213,7 +213,7 @@ var _ = Describe("RBD", func() {
 		if CurrentGinkgoTestDescription().Failed {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-rbd", c)
-			// log provisoner
+			// log provisioner
 			logsCSIPods("app=csi-rbdplugin-provisioner", c)
 			// log node plugin
 			logsCSIPods("app=csi-rbdplugin", c)

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -68,7 +68,7 @@ func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, scOpt
 	}
 
 	// comma separated mount options
-	if opt, ok := scOptions[rbdmountOptions]; ok {
+	if opt, ok := scOptions[rbdMountOptions]; ok {
 		mOpt := strings.Split(opt, ",")
 		sc.MountOptions = append(sc.MountOptions, mOpt...)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -35,7 +35,7 @@ const (
 	vaultPassphrasePath = "ceph-csi/"
 
 	rookToolBoxPodLabel = "app=rook-ceph-tools"
-	rbdmountOptions     = "mountOptions"
+	rbdMountOptions     = "mountOptions"
 
 	retainPolicy = v1.PersistentVolumeReclaimRetain
 	// deletePolicy is the default policy in E2E.

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -24,7 +24,7 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
-/* #nosec:G101, values not credententials, just a reference to the location.*/
+/* #nosec:G101, values not credentials, just a reference to the location.*/
 const (
 	defaultNs = "default"
 

--- a/internal/util/aws_metadata.go
+++ b/internal/util/aws_metadata.go
@@ -93,7 +93,7 @@ func initAWSMetadataKMS(args KMSInitializerArgs) (EncryptionKMS, error) {
 		return nil, err
 	}
 
-	// read the Kubenetes Secret with credentials
+	// read the Kubernetes Secret with credentials
 	secrets, err := kms.getSecrets()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secrets for %T: %w", kms,

--- a/scripts/travis-functest.sh
+++ b/scripts/travis-functest.sh
@@ -2,10 +2,10 @@
 set -e
 
 # This script will be used by travis to run functional test
-# against different kuberentes version
+# against different Kubernetes version
 export KUBE_VERSION=$1
 shift
-# parse the kubernetes version, return the digit passed as argument
+# parse the Kubernetes version, return the digit passed as argument
 # v1.17.0 -> kube_version 1 -> 1
 # v1.17.0 -> kube_version 2 -> 17
 kube_version() {

--- a/scripts/travis-helmtest.sh
+++ b/scripts/travis-helmtest.sh
@@ -2,10 +2,10 @@
 set -e
 
 # This script will be used by travis to run functional test
-# against different kuberentes version
+# against different Kubernetes version
 export KUBE_VERSION=$1
 shift
-# parse the kubernetes version, return the digit passed as argument
+# parse the Kubernetes version, return the digit passed as argument
 # v1.17.0 -> kube_version 1 -> 1
 # v1.17.0 -> kube_version 2 -> 17
 kube_version() {


### PR DESCRIPTION
This PR covers below items in e2e code and travis CI scripts

correct createORDeleteCephfsResources() function name for both cephfs and rbd
e2e: correct gosec marker for credentials rule
e2e: use proper variable name for rbdmountoptions
cleanup: fix codespell error in internal/utils package
cleanup: correct typo in travis scripts

Closes: #2167
Closes: #2168