### PR TITLE
cleanup: correct initResources() function name typo

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -54,5 +54,5 @@ func handleFlags() {
 	framework.RegisterClusterFlags(flag.CommandLine)
 	testing.Init()
 	flag.Parse()
-	initResouces()
+	initResources()
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -65,7 +65,7 @@ var (
 	poll             = 2 * time.Second
 )
 
-func initResouces() {
+func initResources() {
 	ns = fmt.Sprintf("--namespace=%v", cephCSINamespace)
 	vaultAddr = fmt.Sprintf("http://vault.%s.svc.cluster.local:8200", cephCSINamespace)
 }


### PR DESCRIPTION
 This function was wrongly declared with name initResouces() in e2e
  utils package and this patch address the typo in the name

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

