### PR TITLE
rbd: use DeepCopy() to create thick-provisioned volumes from a snapshot

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1047,7 +1047,6 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 	// parent volume of the clone to check thick provision during CreateVolume
 	// from snapshot operation because the parent volume can be deleted anytime
 	// after snapshot is created.
-	// TODO: copy thick provision config
 	thick, err := parentVol.isThickProvisioned()
 	if err != nil {
 		return ready, nil, status.Errorf(codes.Internal, "failed checking thick-provisioning of %q: %s", parentVol, err)
@@ -1058,14 +1057,14 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 		if err != nil {
 			return ready, nil, status.Errorf(codes.Internal, "failed mark %q thick-provisioned: %s", cloneRbd, err)
 		}
-	}
-
-	err = cloneRbd.createSnapshot(ctx, rbdSnap)
-	if err != nil {
-		// update rbd image name for logging
-		rbdSnap.RbdImageName = cloneRbd.RbdImageName
-		util.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, err)
-		return ready, cloneRbd, err
+	} else {
+		err = cloneRbd.createSnapshot(ctx, rbdSnap)
+		if err != nil {
+			// update rbd image name for logging
+			rbdSnap.RbdImageName = cloneRbd.RbdImageName
+			util.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, err)
+			return ready, cloneRbd, err
+		}
 	}
 
 	err = cloneRbd.getImageID()

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -379,22 +379,22 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 		// When cloning into a thick-provisioned volume was happening,
 		// the image should be marked as thick-provisioned, unless it
 		// was aborted in flight. In order to restart the
-		// thick-cloning, delete the volume and let the caller retry
-		// from the start.
+		// thick-cloning, delete the volume and undo the reservation in
+		// the journal to let the caller retry from the start.
 		if isThickProvisionRequest(req.GetParameters()) {
 			thick, err := rbdVol.isThickProvisioned()
 			if err != nil {
-				return nil, status.Errorf(codes.Aborted, "failed to verify thick-provisioned volume %q: %s", rbdVol, err)
+				return nil, status.Errorf(codes.Internal, "failed to verify thick-provisioned volume %q: %s", rbdVol, err)
 			} else if !thick {
 				err = cleanUpSnapshot(ctx, parentVol, rbdSnap, rbdVol, cr)
 				if err != nil {
-					return nil, status.Errorf(codes.Aborted, "failed to remove partially cloned volume %q: %s", rbdVol, err)
+					return nil, status.Errorf(codes.Internal, "failed to remove partially cloned volume %q: %s", rbdVol, err)
 				}
 				err = undoVolReservation(ctx, rbdVol, cr)
 				if err != nil {
-					return nil, status.Errorf(codes.Aborted, "failed to remove volume %q from journal: %s", rbdVol, err)
+					return nil, status.Errorf(codes.Internal, "failed to remove volume %q from journal: %s", rbdVol, err)
 				}
-				return nil, status.Errorf(codes.Aborted, "cloning thick-provisioned volume %q has been interrupted, please retry", rbdVol)
+				return nil, status.Errorf(codes.Internal, "cloning thick-provisioned volume %q has been interrupted, please retry", rbdVol)
 			}
 		}
 	}
@@ -503,11 +503,22 @@ func (cs *ControllerServer) createVolumeFromSnapshot(ctx context.Context, cr *ut
 	// as we are operating on single cluster reuse the connection
 	parentVol.conn = rbdVol.conn.Copy()
 
-	// create clone image and delete snapshot
-	err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap, parentVol)
-	if err != nil {
-		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rbdVol, rbdSnap, err)
-		return err
+	if rbdVol.ThickProvision {
+		err = parentVol.DeepCopy(rbdVol)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to deep copy %q into %q: %v", parentVol, rbdVol, err)
+		}
+		err = rbdVol.setThickProvisioned()
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to mark %q thick-provisioned: %s", rbdVol, err)
+		}
+	} else {
+		// create clone image and delete snapshot
+		err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap, parentVol)
+		if err != nil {
+			util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rbdVol, rbdSnap, err)
+			return err
+		}
 	}
 
 	util.DebugLog(ctx, "create volume %s from snapshot %s", rbdVol.RequestName, rbdSnap.RbdSnapName)


### PR DESCRIPTION
# Describe what this PR does #

While restoring a volume from a snapshot, the new volume should be thick-provisioned in case the parent volume was thick-provisioned too. This was not the case, as cloning from snapshots always makes volumes thin-provisioned.

## Is there anything that requires special attention ##

Writing an e2e test case for this is not trivial. The existing validation functions used for the snapshot test cases are not small/modular enough. Hopefully #2178 can bring improvements there.

## Related issues ##

Fixes: #2181
~Depends-on: #2134 (**[DNM]** until this is merged)~

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
