### PR TITLE
helm: add support to pass --namespace option

### DIFF
--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -42,7 +42,7 @@ usage() {
     echo " " >&2
 }
 
-function check_deployment_status() {
+check_deployment_status() {
     LABEL=$1
     NAMESPACE=$2
     echo "Checking Deployment status for label $LABEL in Namespace $NAMESPACE"
@@ -66,7 +66,7 @@ function check_deployment_status() {
     fi
 }
 
-function check_daemonset_status() {
+check_daemonset_status() {
     LABEL=$1
     NAMESPACE=$2
     echo "Checking Daemonset status for label $LABEL in Namespace $NAMESPACE"


### PR DESCRIPTION
# Describe what this PR does #

The current approach uses hard-coded command-line arguments which are not very robust as it just depends
on positional arguments;

We would like to allow the possibility to add some additional flags as arguments (deploy_sc and deploy_secret 
to deploy storageclass and secrets) 
See: #1786

The reason why we are switching from `./scripts/install-helm.sh install-ceph-csi ${PASSED_NAMESPACE} ` to `./scripts/install-helm.sh install-ceph-csi --namespace ${PASSED_NAMESPACE}`  is because, In order to parse the arguments and identify known options, it is very difficult to do if we have an unknown string in the arguments(namespace).

To maintain backward compatibility, the script will also keep working as the previous approach(`./scripts/install-helm.sh install-ceph-csi ${PASSED_NAMESPACE}` ) which can be deprecated in the coming future.

Updates: #1786 #2013 
Signed-off-by: Yug <yuggupta27@gmail.com>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
