### PR TITLE
 e2e: remove bootstrapper BeforeEach and AfterEach  

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,14 +43,6 @@ func setDefaultKubeconfig() {
 	}
 }
 
-var _ = BeforeSuite(func() {
-
-})
-
-var _ = AfterSuite(func() {
-
-})
-
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2e Suite")


### PR DESCRIPTION
The e2e bootstrap does not make use of these or its declared
unwantedly in the same, removing it with this commit

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

