### PR TITLE
e2e: disable iss validation in Hashicorp Vault

### DIFF
--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -100,6 +100,13 @@ items:
             bound_service_account_names="${SERVICE_ACCOUNTS}" \
             bound_service_account_namespaces="${SERVICE_ACCOUNTS_NAMESPACE}" \
             policies="${CLUSTER_IDENTIFIER}"
+
+        # disable iss validation
+        # from: external-secrets/kubernetes-external-secrets#721
+        vault write auth/${CLUSTER_IDENTIFIER}/config \
+          token_reviewer_jwt=@${SERVICE_ACCOUNT_TOKEN_PATH}/token \
+          kubernetes_host="${K8S_HOST}" \
+          disable_iss_validation=true
     kind: ConfigMap
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
Testing encrypted PVCs does not work anymore since Kubernetes v1.21. It
seems that disabling the iss validation in Hashicorp Vault is a
relatively simple workaround that we can use instead of the more complex
securing of the environment like should be done in production
deployments.

Updates: #1963
See-also: external-secrets/kubernetes-external-secrets#721

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
