### PR TITLE
e2e: provide an option if tests run on helm deployment

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -22,6 +22,7 @@ func init() {
 	flag.BoolVar(&deployRBD, "deploy-rbd", true, "deploy rbd csi driver")
 	flag.BoolVar(&testCephFS, "test-cephfs", true, "test cephfs csi driver")
 	flag.BoolVar(&testRBD, "test-rbd", true, "test rbd csi driver")
+	flag.BoolVar(&helmTest, "helm-test", false, "tests running on deployment via helm")
 	flag.BoolVar(&upgradeTesting, "upgrade-testing", false, "perform upgrade testing")
 	flag.StringVar(&upgradeVersion, "upgrade-version", "v3.3.1", "target version for upgrade testing")
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -55,6 +55,7 @@ var (
 	deployRBD        bool
 	testCephFS       bool
 	testRBD          bool
+	helmTest         bool
 	upgradeTesting   bool
 	upgradeVersion   string
 	cephCSINamespace string


### PR DESCRIPTION
add an e2eArg `helmTest` to specify if tests are running
on ceph-csi deployment via helm.
For testing in CI, Storageclass and secret deployment
is enabled on helm installation.

Updates: #1786
Signed-off-by: Yug <yuggupta27@gmail.com>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
