### PR TITLE
ci: configure `lll` linter to its default value ie 120 chars

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -66,26 +66,58 @@ func init() {
 	flag.IntVar(&conf.PidLimit, "pidlimit", 0, "the PID limit to configure through cgroups")
 	flag.BoolVar(&conf.IsControllerServer, "controllerserver", false, "start cephcsi controller server")
 	flag.BoolVar(&conf.IsNodeServer, "nodeserver", false, "start cephcsi node server")
-	flag.StringVar(&conf.DomainLabels, "domainlabels", "", "list of kubernetes node labels, that determines the topology"+
-		" domain the node belongs to, separated by ','")
+	flag.StringVar(
+		&conf.DomainLabels,
+		"domainlabels",
+		"",
+		"list of kubernetes node labels, that determines the topology"+
+			" domain the node belongs to, separated by ','")
 
 	// cephfs related flags
-	flag.BoolVar(&conf.ForceKernelCephFS, "forcecephkernelclient", false, "enable Ceph Kernel clients on kernel < 4.17 which support quotas")
+	flag.BoolVar(
+		&conf.ForceKernelCephFS,
+		"forcecephkernelclient",
+		false,
+		"enable Ceph Kernel clients on kernel < 4.17 which support quotas")
 
 	// liveness/grpc metrics related flags
 	flag.IntVar(&conf.MetricsPort, "metricsport", 8080, "TCP port for liveness/grpc metrics requests")
-	flag.StringVar(&conf.MetricsPath, "metricspath", "/metrics", "path of prometheus endpoint where metrics will be available")
+	flag.StringVar(
+		&conf.MetricsPath,
+		"metricspath",
+		"/metrics",
+		"path of prometheus endpoint where metrics will be available")
 	flag.DurationVar(&conf.PollTime, "polltime", time.Second*pollTime, "time interval in seconds between each poll")
 	flag.DurationVar(&conf.PoolTimeout, "timeout", time.Second*probeTimeout, "probe timeout in seconds")
 
 	flag.BoolVar(&conf.EnableGRPCMetrics, "enablegrpcmetrics", false, "[DEPRECATED] enable grpc metrics")
-	flag.StringVar(&conf.HistogramOption, "histogramoption", "0.5,2,6",
-		"[DEPRECATED] Histogram option for grpc metrics, should be comma separated value, ex:= 0.5,2,6 where start=0.5 factor=2, count=6")
+	flag.StringVar(
+		&conf.HistogramOption,
+		"histogramoption",
+		"0.5,2,6",
+		"[DEPRECATED] Histogram option for grpc metrics, should be comma separated value, "+
+			"ex:= 0.5,2,6 where start=0.5 factor=2, count=6")
 
-	flag.UintVar(&conf.RbdHardMaxCloneDepth, "rbdhardmaxclonedepth", 8, "Hard limit for maximum number of nested volume clones that are taken before a flatten occurs")
-	flag.UintVar(&conf.RbdSoftMaxCloneDepth, "rbdsoftmaxclonedepth", 4, "Soft limit for maximum number of nested volume clones that are taken before a flatten occurs")
-	flag.UintVar(&conf.MaxSnapshotsOnImage, "maxsnapshotsonimage", 450, "Maximum number of snapshots allowed on rbd image without flattening")
-	flag.UintVar(&conf.MinSnapshotsOnImage, "minsnapshotsonimage", 250, "Minimum number of snapshots required on rbd image to start flattening")
+	flag.UintVar(
+		&conf.RbdHardMaxCloneDepth,
+		"rbdhardmaxclonedepth",
+		8,
+		"Hard limit for maximum number of nested volume clones that are taken before a flatten occurs")
+	flag.UintVar(
+		&conf.RbdSoftMaxCloneDepth,
+		"rbdsoftmaxclonedepth",
+		4,
+		"Soft limit for maximum number of nested volume clones that are taken before a flatten occurs")
+	flag.UintVar(
+		&conf.MaxSnapshotsOnImage,
+		"maxsnapshotsonimage",
+		450,
+		"Maximum number of snapshots allowed on rbd image without flattening")
+	flag.UintVar(
+		&conf.MinSnapshotsOnImage,
+		"minsnapshotsonimage",
+		250,
+		"Minimum number of snapshots required on rbd image to start flattening")
 	flag.BoolVar(&conf.SkipForceFlatten, "skipforceflatten", false,
 		"skip image flattening if kernel support mapping of rbd images which has the deep-flatten feature")
 

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -69,6 +69,33 @@ import (
 * Use log level `ERROR` when something occurs which is fatal to the operation,
   but not to the service or application.
 
+### Wrap long lines
+
+At present, we restrict the number of chars in a line to `120` which is the
+default value for the `lll` linter check we have in CI. If your source code line
+or comment goes beyond this limit please try to organize it in such a way it
+is within the line length limit and help on code reading.
+
+Example:
+
+```
+_, err := framework.RunKubectl(cephCSINamespace, "delete", "cm", "ceph-csi-encryption-kms-config", "--namespace", cephCSINamespace, "--ignore-not-found=true")
+```
+
+Instead of above long function signature, we can organize it to something like below
+which is clear and help on easy code reading.
+
+```
+_, err := framework.RunKubectl(
+            cephCSINamespace,
+            "delete",
+            "cm",
+            "ceph-csi-encryption-kms-config",
+            "--namespace",
+            cephCSINamespace,
+            "--ignore-not-found=true")
+```
+
 ### Mark Down Rules
 
 * MD014 - Dollar signs used before commands without showing output

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -160,7 +160,10 @@ func validateSubvolumePath(f *framework.Framework, pvcName, pvcNamespace, fileSy
 		return err
 	}
 	if subVolumePath != subVolumePathInPV {
-		return fmt.Errorf("subvolumePath %s is not matching the subvolumePath %s in PV", subVolumePath, subVolumePathInPV)
+		return fmt.Errorf(
+			"subvolumePath %s is not matching the subvolumePath %s in PV",
+			subVolumePath,
+			subVolumePathInPV)
 	}
 	return nil
 }
@@ -226,11 +229,15 @@ var _ = Describe("cephfs", func() {
 		if err != nil {
 			e2elog.Failf("failed to delete configmap with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), cephFSProvisionerSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), cephFSProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete provisioner secret with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), cephFSNodePluginSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), cephFSNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete node secret with error %v", err)
 		}
@@ -298,7 +305,11 @@ var _ = Describe("cephfs", func() {
 
 			By("create PVC in storageClass with volumeNamePrefix", func() {
 				volumeNamePrefix := "foo-bar-"
-				err := createCephfsStorageClass(f.ClientSet, f, false, map[string]string{"volumeNamePrefix": volumeNamePrefix})
+				err := createCephfsStorageClass(
+					f.ClientSet,
+					f,
+					false,
+					map[string]string{"volumeNamePrefix": volumeNamePrefix})
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -591,7 +602,11 @@ var _ = Describe("cephfs", func() {
 				}
 
 				filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
-				_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo 'Hello World' > %s", filePath), app.Namespace, &opt)
+				_, stdErr := execCommandInPodAndAllowFail(
+					f,
+					fmt.Sprintf("echo 'Hello World' > %s", filePath),
+					app.Namespace,
+					&opt)
 				readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
 				if !strings.Contains(stdErr, readOnlyErr) {
 					e2elog.Failf(stdErr)
@@ -1110,7 +1125,11 @@ var _ = Describe("cephfs", func() {
 				}
 
 				filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
-				_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo 'Hello World' > %s", filePath), app.Namespace, &opt)
+				_, stdErr := execCommandInPodAndAllowFail(
+					f,
+					fmt.Sprintf("echo 'Hello World' > %s", filePath),
+					app.Namespace,
+					&opt)
 				readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
 				if !strings.Contains(stdErr, readOnlyErr) {
 					e2elog.Failf(stdErr)

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -22,7 +22,14 @@ var (
 func deployVault(c kubernetes.Interface, deployTimeout int) {
 	// hack to make helm E2E pass as helm charts creates this configmap as part
 	// of cephcsi deployment
-	_, err := framework.RunKubectl(cephCSINamespace, "delete", "cm", "ceph-csi-encryption-kms-config", "--namespace", cephCSINamespace, "--ignore-not-found=true")
+	_, err := framework.RunKubectl(
+		cephCSINamespace,
+		"delete",
+		"cm",
+		"ceph-csi-encryption-kms-config",
+		"--namespace",
+		cephCSINamespace,
+		"--ignore-not-found=true")
 	Expect(err).Should(BeNil())
 
 	createORDeleteVault("create")

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -54,7 +54,13 @@ func waitForDaemonSets(name, ns string, c kubernetes.Interface, t int) error {
 		}
 		dNum := ds.Status.DesiredNumberScheduled
 		ready := ds.Status.NumberReady
-		e2elog.Logf("%d / %d pods ready in namespace '%s' in daemonset '%s' (%d seconds elapsed)", ready, dNum, ns, ds.ObjectMeta.Name, int(time.Since(start).Seconds()))
+		e2elog.Logf(
+			"%d / %d pods ready in namespace '%s' in daemonset '%s' (%d seconds elapsed)",
+			ready,
+			dNum,
+			ns,
+			ds.ObjectMeta.Name,
+			int(time.Since(start).Seconds()))
 		if ready != dNum {
 			return false, nil
 		}
@@ -91,7 +97,10 @@ func waitForDeploymentComplete(name, ns string, c kubernetes.Interface, t int) e
 		if deployment.Status.Replicas == deployment.Status.ReadyReplicas {
 			return true, nil
 		}
-		e2elog.Logf("deployment status: expected replica count %d running replica count %d", deployment.Status.Replicas, deployment.Status.ReadyReplicas)
+		e2elog.Logf(
+			"deployment status: expected replica count %d running replica count %d",
+			deployment.Status.Replicas,
+			deployment.Status.ReadyReplicas)
 		reason = fmt.Sprintf("deployment status: %#v", deployment.Status.String())
 		return false, nil
 	})
@@ -128,7 +137,10 @@ func findPodAndContainerName(f *framework.Framework, ns, cn string, opt *metav1.
 	return podList.Items[0].Name, podList.Items[0].Spec.Containers[0].Name, nil
 }
 
-func getCommandInPodOpts(f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions) (framework.ExecOptions, error) {
+func getCommandInPodOpts(
+	f *framework.Framework,
+	c, ns, cn string,
+	opt *metav1.ListOptions) (framework.ExecOptions, error) {
 	cmd := []string{"/bin/sh", "-c", c}
 	pName, cName, err := findPodAndContainerName(f, ns, cn, opt)
 	if err != nil {
@@ -147,7 +159,9 @@ func getCommandInPodOpts(f *framework.Framework, c, ns, cn string, opt *metav1.L
 }
 
 // execCommandInDaemonsetPod executes commands inside given container of a daemonset pod on a particular node.
-func execCommandInDaemonsetPod(f *framework.Framework, c, daemonsetName, nodeName, containerName, ns string) (string, string, error) {
+func execCommandInDaemonsetPod(
+	f *framework.Framework,
+	c, daemonsetName, nodeName, containerName, ns string) (string, string, error) {
 	selector, err := getDaemonSetLabelSelector(f, ns, daemonsetName)
 	if err != nil {
 		return "", "", err
@@ -204,7 +218,9 @@ func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOpti
 	return stdOut, stdErr, err
 }
 
-func execCommandInContainer(f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions) (string, string, error) { //nolint:unparam,lll // cn can be used with different inputs later
+//nolint:unparam // cn can be used with different inputs later
+func execCommandInContainer(
+	f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions) (string, string, error) {
 	podOpt, err := getCommandInPodOpts(f, c, ns, cn, opt)
 	if err != nil {
 		return "", "", err
@@ -298,7 +314,11 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, ex
 				}
 			}
 		}
-		e2elog.Logf("%s app  is in %s phase expected to be in Running  state (%d seconds elapsed)", name, pod.Status.Phase, int(time.Since(start).Seconds()))
+		e2elog.Logf(
+			"%s app  is in %s phase expected to be in Running  state (%d seconds elapsed)",
+			name,
+			pod.Status.Phase,
+			int(time.Since(start).Seconds()))
 		return false, nil
 	})
 }
@@ -325,7 +345,8 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 	})
 }
 
-func deletePodWithLabel(label, ns string, skipNotFound bool) error { //nolint:unparam // skipNotFound can be used with different inputs later
+//nolint:unparam // skipNotFound arg can be used with different inputs later
+func deletePodWithLabel(label, ns string, skipNotFound bool) error {
 	_, err := framework.RunKubectl(ns, "delete", "po", "-l", label, fmt.Sprintf("--ignore-not-found=%t", skipNotFound))
 	if err != nil {
 		e2elog.Logf("failed to delete pod %v", err)

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -102,8 +102,14 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 	pvcToDelete := pvc
 	err = wait.PollImmediate(poll, timeout, func() (bool, error) {
 		// Check that the PVC is deleted.
-		e2elog.Logf("waiting for PVC %s in state %s to be deleted (%d seconds elapsed)", pvcToDelete.Name, pvcToDelete.Status.String(), int(time.Since(start).Seconds()))
-		pvcToDelete, err = c.CoreV1().PersistentVolumeClaims(pvcToDelete.Namespace).Get(context.TODO(), pvcToDelete.Name, metav1.GetOptions{})
+		e2elog.Logf(
+			"waiting for PVC %s in state %s to be deleted (%d seconds elapsed)",
+			pvcToDelete.Name,
+			pvcToDelete.Status.String(),
+			int(time.Since(start).Seconds()))
+		pvcToDelete, err = c.CoreV1().
+			PersistentVolumeClaims(pvcToDelete.Namespace).
+			Get(context.TODO(), pvcToDelete.Name, metav1.GetOptions{})
 		if err == nil {
 			if pvcToDelete.Status.Phase == "" {
 				// this is unexpected, an empty Phase is not defined
@@ -113,7 +119,10 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 			return false, nil
 		}
 		if !apierrs.IsNotFound(err) {
-			return false, fmt.Errorf("get on deleted PVC %v failed with error other than \"not found\": %w", pvc.Name, err)
+			return false, fmt.Errorf(
+				"get on deleted PVC %v failed with error other than \"not found\": %w",
+				pvc.Name,
+				err)
 		}
 
 		return true, nil
@@ -126,7 +135,11 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 	pvToDelete := pv
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		// Check that the PV is deleted.
-		e2elog.Logf("waiting for PV %s in state %s to be deleted (%d seconds elapsed)", pvToDelete.Name, pvToDelete.Status.String(), int(time.Since(start).Seconds()))
+		e2elog.Logf(
+			"waiting for PV %s in state %s to be deleted (%d seconds elapsed)",
+			pvToDelete.Name,
+			pvToDelete.Status.String(),
+			int(time.Since(start).Seconds()))
 
 		pvToDelete, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pvToDelete.Name, metav1.GetOptions{})
 		if err == nil {
@@ -141,7 +154,9 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 	})
 }
 
-func getPVCAndPV(c kubernetes.Interface, pvcName, pvcNamespace string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+func getPVCAndPV(
+	c kubernetes.Interface,
+	pvcName, pvcNamespace string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
 	pvc, err := c.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get PVC with error %v", err)
@@ -176,7 +191,11 @@ func deletePVCAndValidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 	start := time.Now()
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		// Check that the PVC is really deleted.
-		e2elog.Logf("waiting for PVC %s in state %s to be deleted (%d seconds elapsed)", name, pvc.Status.String(), int(time.Since(start).Seconds()))
+		e2elog.Logf(
+			"waiting for PVC %s in state %s to be deleted (%d seconds elapsed)",
+			name,
+			pvc.Status.String(),
+			int(time.Since(start).Seconds()))
 		pvc, err = c.CoreV1().PersistentVolumeClaims(nameSpace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err == nil {
 			return false, nil
@@ -202,7 +221,9 @@ func deletePVCAndValidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 // getBoundPV returns a PV details.
 func getBoundPV(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
 	// Get new copy of the claim
-	claim, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+	claim, err := client.CoreV1().
+		PersistentVolumeClaims(pvc.Namespace).
+		Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pvc: %w", err)
 	}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -162,7 +162,10 @@ func validateRBDImageCount(f *framework.Framework, count int, pool string) {
 		e2elog.Failf("failed to list rbd images with error %v", err)
 	}
 	if len(imageList) != count {
-		e2elog.Failf("backend images not matching kubernetes resource count,image count %d kubernetes resource count %d", len(imageList), count)
+		e2elog.Failf(
+			"backend images not matching kubernetes resource count,image count %d kubernetes resource count %d",
+			len(imageList),
+			count)
 	}
 }
 
@@ -241,11 +244,15 @@ var _ = Describe("RBD", func() {
 		if err != nil {
 			e2elog.Failf("failed to delete configmap with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), rbdProvisionerSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), rbdProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete provisioner secret with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), rbdNodePluginSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), rbdNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete node secret with error %v", err)
 		}
@@ -331,7 +338,13 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"csi.storage.k8s.io/fstype": "ext4"}, deletePolicy)
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{"csi.storage.k8s.io/fstype": "ext4"},
+					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -356,7 +369,13 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"mounter": "rbd-nbd"}, deletePolicy)
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{"mounter": "rbd-nbd"},
+					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -382,7 +401,13 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
 				// Storage class with rbd-nbd mounter
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"mounter": "rbd-nbd"}, deletePolicy)
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{"mounter": "rbd-nbd"},
+					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -438,7 +463,11 @@ var _ = Describe("RBD", func() {
 				// For now to prove this isn't working, write something to
 				// mountpoint and expect a failure as the processes are terminated.
 				filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
-				_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo 'Hello World' > %s", filePath), app.Namespace, &opt)
+				_, stdErr := execCommandInPodAndAllowFail(
+					f,
+					fmt.Sprintf("echo 'Hello World' > %s", filePath),
+					app.Namespace,
+					&opt)
 				IOErr := fmt.Sprintf("cannot create %s: Input/output error", filePath)
 				if !strings.Contains(stdErr, IOErr) {
 					e2elog.Failf(stdErr)
@@ -514,7 +543,12 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to run uname cmd : %v, stdErr: %v ", err, stdErr)
 				}
 				e2elog.Logf("uname -a: %v", uname)
-				rpmv, stdErr, err := execCommandInContainer(f, "rpm -qa | grep rbd-nbd", cephCSINamespace, "csi-rbdplugin", &opt)
+				rpmv, stdErr, err := execCommandInContainer(
+					f,
+					"rpm -qa | grep rbd-nbd",
+					cephCSINamespace,
+					"csi-rbdplugin",
+					&opt)
 				if err != nil || stdErr != "" {
 					e2elog.Failf("failed to run rpm -qa cmd : %v, stdErr: %v ", err, stdErr)
 				}
@@ -522,14 +556,23 @@ var _ = Describe("RBD", func() {
 
 				// Get details of rbd-nbd process
 				// # ps -eo 'cmd' | grep [r]bd-nbd
-				// /usr/bin/rbd-nbd --id cephcsi-rbd-node -m svc-name:6789 --keyfile=/tmp/csi/keys/keyfile attach --device /dev/nbd0 pool-name/image-name --try-netlink --reattach-timeout=180
-				mapCmd, stdErr, err := execCommandInContainer(f, "ps -eo 'cmd' | grep [r]bd-nbd", cephCSINamespace, "csi-rbdplugin", &opt)
+				// /usr/bin/rbd-nbd --id cephcsi-rbd-node -m svc-name:6789 --keyfile=/tmp/csi/keys/keyfile attach \
+				// --device /dev/nbd0 pool-name/image-name --try-netlink --reattach-timeout=180
+				mapCmd, stdErr, err := execCommandInContainer(
+					f,
+					"ps -eo 'cmd' | grep [r]bd-nbd",
+					cephCSINamespace,
+					"csi-rbdplugin",
+					&opt)
 				if err != nil || stdErr != "" {
 					e2elog.Failf("failed to run ps cmd : %v, stdErr: %v ", err, stdErr)
 				}
 				e2elog.Logf("map command running before restart, mapCmd: %v", mapCmd)
 
-				rbdNodeKey, stdErr, err := execCommandInToolBoxPod(f, "ceph auth get-key client.cephcsi-rbd-node", rookNamespace)
+				rbdNodeKey, stdErr, err := execCommandInToolBoxPod(
+					f,
+					"ceph auth get-key client.cephcsi-rbd-node",
+					rookNamespace)
 				if err != nil || stdErr != "" {
 					e2elog.Failf("error getting cephcsi-rbd-node key, err: %v, stdErr: %v ", err, stdErr)
 				}
@@ -553,7 +596,12 @@ var _ = Describe("RBD", func() {
 				e2elog.Logf("attach command to run after restart, attachCmd: %v", attachCmd)
 
 				// create the keyfile
-				_, stdErr, err = execCommandInContainer(f, fmt.Sprintf("echo %s > /tmp/csi/keys/keyfile-test", rbdNodeKey), cephCSINamespace, "csi-rbdplugin", &opt)
+				_, stdErr, err = execCommandInContainer(
+					f,
+					fmt.Sprintf("echo %s > /tmp/csi/keys/keyfile-test", rbdNodeKey),
+					cephCSINamespace,
+					"csi-rbdplugin",
+					&opt)
 				if err != nil || stdErr != "" {
 					e2elog.Failf("failed to write key to a file,  err: %v, stdErr: %v ", err, stdErr)
 				}
@@ -563,7 +611,12 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to run attach cmd err: %v, stdErr: %v ", err, stdErr)
 				}
 
-				runningAttachCmd, stdErr, err := execCommandInContainer(f, "ps -eo 'cmd' | grep [r]bd-nbd", cephCSINamespace, "csi-rbdplugin", &opt)
+				runningAttachCmd, stdErr, err := execCommandInContainer(
+					f,
+					"ps -eo 'cmd' | grep [r]bd-nbd",
+					cephCSINamespace,
+					"csi-rbdplugin",
+					&opt)
 				if err != nil || stdErr != "" {
 					e2elog.Failf("failed to run ps cmd : %v, stdErr: %v ", err, stdErr)
 				}
@@ -574,7 +627,11 @@ var _ = Describe("RBD", func() {
 				}
 				// Write something to mountpoint and expect it to happen
 				filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
-				_, stdErr, err = execCommandInPod(f, fmt.Sprintf("echo 'Hello World' > %s", filePath), app.Namespace, &appOpt)
+				_, stdErr, err = execCommandInPod(
+					f,
+					fmt.Sprintf("echo 'Hello World' > %s", filePath),
+					app.Namespace,
+					&appOpt)
 				if err != nil || stdErr != "" {
 					e2elog.Failf("failed to write IO, err: %v, stdErr: %v ", err, stdErr)
 				}
@@ -600,7 +657,13 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"encrypted": "true"}, deletePolicy)
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{"encrypted": "true"},
+					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -728,40 +791,64 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
-			By("create a PVC and Bind it to an app with journaling/exclusive-lock image-features and rbd-nbd mounter", func() {
-				err := deleteResource(rbdExamplePath + "storageclass.yaml")
-				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
-				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"}, deletePolicy)
-				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
-				}
-				err = validatePVCAndAppBinding(pvcPath, appPath, f)
-				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
-				}
-				err = deleteResource(rbdExamplePath + "storageclass.yaml")
-				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
-				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
-				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
-				}
-			})
+			By(
+				"create a PVC and Bind it to an app with journaling/exclusive-lock image-features and rbd-nbd mounter",
+				func() {
+					err := deleteResource(rbdExamplePath + "storageclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete storageclass with error %v", err)
+					}
+					err = createRBDStorageClass(
+						f.ClientSet,
+						f,
+						defaultSCName,
+						nil,
+						map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"},
+						deletePolicy)
+					if err != nil {
+						e2elog.Failf("failed to create storageclass with error %v", err)
+					}
+					err = validatePVCAndAppBinding(pvcPath, appPath, f)
+					if err != nil {
+						e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					}
+					err = deleteResource(rbdExamplePath + "storageclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete storageclass with error %v", err)
+					}
+					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+					if err != nil {
+						e2elog.Failf("failed to create storageclass with error %v", err)
+					}
+				},
+			)
 
 			By("create a PVC clone and bind it to an app", func() {
 				// snapshot beta is only supported from v1.17+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
-					validatePVCSnapshot(defaultCloneCount, pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, "", f)
+					validatePVCSnapshot(
+						defaultCloneCount,
+						pvcPath,
+						appPath,
+						snapshotPath,
+						pvcClonePath,
+						appClonePath,
+						"",
+						f)
 				}
 			})
 
 			By("create a PVC-PVC clone and bind it to an app", func() {
 				// pvc clone is only supported from v1.16+
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
-					validatePVCClone(defaultCloneCount, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, noPVCValidation, f)
+					validatePVCClone(
+						defaultCloneCount,
+						pvcPath,
+						appPath,
+						pvcSmartClonePath,
+						appSmartClonePath,
+						noPVCValidation,
+						f)
 				}
 			})
 
@@ -866,7 +953,14 @@ var _ = Describe("RBD", func() {
 				}
 				// pvc clone is only supported from v1.16+
 				if v.Major > "1" || (v.Major == "1" && v.Minor >= "16") {
-					validatePVCClone(defaultCloneCount, rawPvcPath, rawAppPath, pvcBlockSmartClonePath, appBlockSmartClonePath, noPVCValidation, f)
+					validatePVCClone(
+						defaultCloneCount,
+						rawPvcPath,
+						rawAppPath,
+						pvcBlockSmartClonePath,
+						appBlockSmartClonePath,
+						noPVCValidation,
+						f)
 				}
 			})
 			By("create/delete multiple PVCs and Apps", func() {
@@ -928,7 +1022,13 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("failed to delete storageclass with error %v", err)
 					}
-					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"csi.storage.k8s.io/fstype": "xfs"}, deletePolicy)
+					err = createRBDStorageClass(
+						f.ClientSet,
+						f,
+						defaultSCName,
+						nil,
+						map[string]string{"csi.storage.k8s.io/fstype": "xfs"},
+						deletePolicy)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
 					}
@@ -998,7 +1098,13 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{"volumeNamePrefix": volumeNamePrefix}, deletePolicy)
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{"volumeNamePrefix": volumeNamePrefix},
+					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1205,7 +1311,13 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, map[string]string{rbdMountOptions: "debug,invalidOption"}, nil, deletePolicy)
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					map[string]string{rbdMountOptions: "debug,invalidOption"},
+					nil,
+					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -1401,7 +1513,11 @@ var _ = Describe("RBD", func() {
 						}
 
 						filePath := appClone.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
-						_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo 'Hello World' > %s", filePath), appClone.Namespace, &opt)
+						_, stdErr := execCommandInPodAndAllowFail(
+							f,
+							fmt.Sprintf("echo 'Hello World' > %s", filePath),
+							appClone.Namespace,
+							&opt)
 						readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
 						if !strings.Contains(stdErr, readOnlyErr) {
 							e2elog.Failf(stdErr)
@@ -1577,7 +1693,11 @@ var _ = Describe("RBD", func() {
 
 				updateConfigMap("e2e-ns")
 				// create rbd provisioner secret
-				key, err := createCephUser(f, keyringRBDNamespaceProvisionerUsername, rbdProvisionerCaps(defaultRBDPool, radosNamespace))
+				key, err := createCephUser(
+					f,
+					keyringRBDNamespaceProvisionerUsername,
+					rbdProvisionerCaps(defaultRBDPool, radosNamespace),
+				)
 				if err != nil {
 					e2elog.Failf("failed to create user %s with error %v", keyringRBDNamespaceProvisionerUsername, err)
 				}
@@ -1586,7 +1706,10 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create provisioner secret with error %v", err)
 				}
 				// create rbd plugin secret
-				key, err = createCephUser(f, keyringRBDNamespaceNodePluginUsername, rbdNodePluginCaps(defaultRBDPool, radosNamespace))
+				key, err = createCephUser(
+					f,
+					keyringRBDNamespaceNodePluginUsername,
+					rbdNodePluginCaps(defaultRBDPool, radosNamespace))
 				if err != nil {
 					e2elog.Failf("failed to create user %s with error %v", keyringRBDNamespaceNodePluginUsername, err)
 				}
@@ -1704,7 +1827,9 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete user %s with error %v", keyringRBDNamespaceProvisionerUsername, err)
 				}
-				err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), rbdNamespaceProvisionerSecretName, metav1.DeleteOptions{})
+				err = c.CoreV1().
+					Secrets(cephCSINamespace).
+					Delete(context.TODO(), rbdNamespaceProvisionerSecretName, metav1.DeleteOptions{})
 				if err != nil {
 					e2elog.Failf("failed to delete provisioner secret with error %v", err)
 				}
@@ -1713,7 +1838,9 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to delete user %s with error %v", keyringRBDNamespaceNodePluginUsername, err)
 				}
-				err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), rbdNamespaceNodePluginSecretName, metav1.DeleteOptions{})
+				err = c.CoreV1().
+					Secrets(cephCSINamespace).
+					Delete(context.TODO(), rbdNamespaceNodePluginSecretName, metav1.DeleteOptions{})
 				if err != nil {
 					e2elog.Failf("failed to delete node secret with error %v", err)
 				}
@@ -1761,7 +1888,11 @@ var _ = Describe("RBD", func() {
 				}
 
 				filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
-				_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo 'Hello World' > %s", filePath), app.Namespace, &opt)
+				_, stdErr := execCommandInPodAndAllowFail(
+					f,
+					fmt.Sprintf("echo 'Hello World' > %s", filePath),
+					app.Namespace,
+					&opt)
 				readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
 				if !strings.Contains(stdErr, readOnlyErr) {
 					e2elog.Failf(stdErr)

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -35,7 +35,12 @@ func rbdOptions(pool string) string {
 	return "--pool=" + pool
 }
 
-func createRBDStorageClass(c kubernetes.Interface, f *framework.Framework, name string, scOptions, parameters map[string]string, policy v1.PersistentVolumeReclaimPolicy) error {
+func createRBDStorageClass(
+	c kubernetes.Interface,
+	f *framework.Framework,
+	name string,
+	scOptions, parameters map[string]string,
+	policy v1.PersistentVolumeReclaimPolicy) error {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc, err := getStorageClass(scPath)
 	if err != nil {
@@ -211,8 +216,14 @@ func validateImageOwner(pvcPath string, f *framework.Framework) error {
 		return err
 	}
 
-	stdOut, stdErr, err := execCommandInToolBoxPod(f,
-		fmt.Sprintf("rados %s getomapval csi.volume.%s %s", rbdOptions(defaultRBDPool), imageData.imageID, ownerKey), rookNamespace)
+	stdOut, stdErr, err := execCommandInToolBoxPod(
+		f,
+		fmt.Sprintf(
+			"rados %s getomapval csi.volume.%s %s",
+			rbdOptions(defaultRBDPool),
+			imageData.imageID,
+			ownerKey),
+		rookNamespace)
 	if err != nil {
 		return err
 	}
@@ -221,7 +232,11 @@ func validateImageOwner(pvcPath string, f *framework.Framework) error {
 	}
 
 	if radosNamespace != "" {
-		e2elog.Logf("found image journal %s in pool %s namespace %s", "csi.volume."+imageData.imageID, defaultRBDPool, radosNamespace)
+		e2elog.Logf(
+			"found image journal %s in pool %s namespace %s",
+			"csi.volume."+imageData.imageID,
+			defaultRBDPool,
+			radosNamespace)
 	} else {
 		e2elog.Logf("found image journal %s in pool %s", "csi.volume."+imageData.imageID, defaultRBDPool)
 	}
@@ -628,7 +643,10 @@ func checkPVCImageInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, 
 	return err
 }
 
-func checkPVCDataPoolForImageInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, pool, dataPool string) error {
+func checkPVCDataPoolForImageInPool(
+	f *framework.Framework,
+	pvc *v1.PersistentVolumeClaim,
+	pool, dataPool string) error {
 	stdOut, err := getPVCImageInfoInPool(f, pvc, pool)
 	if err != nil {
 		return err
@@ -657,7 +675,11 @@ func checkPVCImageJournalInPool(f *framework.Framework, pvc *v1.PersistentVolume
 	}
 
 	if radosNamespace != "" {
-		e2elog.Logf("found image journal %s in pool %s namespace %s", "csi.volume."+imageData.imageID, pool, radosNamespace)
+		e2elog.Logf(
+			"found image journal %s in pool %s namespace %s",
+			"csi.volume."+imageData.imageID,
+			pool,
+			radosNamespace)
 	} else {
 		e2elog.Logf("found image journal %s in pool %s", "csi.volume."+imageData.imageID, pool)
 	}
@@ -671,8 +693,15 @@ func checkPVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeCl
 		return err
 	}
 
-	_, stdErr, err := execCommandInToolBoxPod(f,
-		fmt.Sprintf("rados getomapval %s csi.volumes.default csi.volume.%s", rbdOptions(pool), imageData.pvName), rookNamespace)
+	_, stdErr, err := execCommandInToolBoxPod(
+		f,
+		fmt.Sprintf(
+			"rados getomapval %s csi.volumes.default csi.volume.%s",
+			rbdOptions(pool),
+			imageData.pvName,
+		),
+		rookNamespace,
+	)
 	if err != nil {
 		return err
 	}
@@ -681,7 +710,11 @@ func checkPVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeCl
 	}
 
 	if radosNamespace != "" {
-		e2elog.Logf("found CSI journal entry %s in pool %s namespace %s", "csi.volume."+imageData.pvName, pool, radosNamespace)
+		e2elog.Logf(
+			"found CSI journal entry %s in pool %s namespace %s",
+			"csi.volume."+imageData.pvName,
+			pool,
+			radosNamespace)
 	} else {
 		e2elog.Logf("found CSI journal entry %s in pool %s", "csi.volume."+imageData.pvName, pool)
 	}
@@ -701,7 +734,11 @@ func deletePVCImageJournalInPool(f *framework.Framework, pvc *v1.PersistentVolum
 		return err
 	}
 	if stdErr != "" {
-		return fmt.Errorf("failed to remove omap %s csi.volume.%s with error %v", rbdOptions(pool), imageData.imageID, stdErr)
+		return fmt.Errorf(
+			"failed to remove omap %s csi.volume.%s with error %v",
+			rbdOptions(pool),
+			imageData.imageID,
+			stdErr)
 	}
 
 	return nil
@@ -713,13 +750,22 @@ func deletePVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeC
 		return err
 	}
 
-	_, stdErr, err := execCommandInToolBoxPod(f,
-		fmt.Sprintf("rados rmomapkey %s csi.volumes.default csi.volume.%s", rbdOptions(pool), imageData.pvName), rookNamespace)
+	_, stdErr, err := execCommandInToolBoxPod(
+		f,
+		fmt.Sprintf(
+			"rados rmomapkey %s csi.volumes.default csi.volume.%s",
+			rbdOptions(pool),
+			imageData.pvName),
+		rookNamespace)
 	if err != nil {
 		return err
 	}
 	if stdErr != "" {
-		return fmt.Errorf("failed to remove %s csi.volumes.default csi.volume.%s with error %v", rbdOptions(pool), imageData.imageID, stdErr)
+		return fmt.Errorf(
+			"failed to remove %s csi.volumes.default csi.volume.%s with error %v",
+			rbdOptions(pool),
+			imageData.imageID,
+			stdErr)
 	}
 
 	return nil

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -47,7 +47,10 @@ func createSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 	if err != nil {
 		return err
 	}
-	_, err = sclient.VolumeSnapshots(snap.Namespace).Create(context.TODO(), snap, metav1.CreateOptions{})
+
+	_, err = sclient.
+		VolumeSnapshots(snap.Namespace).
+		Create(context.TODO(), snap, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create volumesnapshot: %w", err)
 	}
@@ -60,7 +63,9 @@ func createSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		e2elog.Logf("waiting for snapshot %s (%d seconds elapsed)", snap.Name, int(time.Since(start).Seconds()))
-		snaps, err := sclient.VolumeSnapshots(snap.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		snaps, err := sclient.
+			VolumeSnapshots(snap.Namespace).
+			Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			e2elog.Logf("Error getting snapshot in namespace: '%s': %v", snap.Namespace, err)
 			if isRetryableAPIError(err) {
@@ -87,7 +92,10 @@ func deleteSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 	if err != nil {
 		return err
 	}
-	err = sclient.VolumeSnapshots(snap.Namespace).Delete(context.TODO(), snap.Name, metav1.DeleteOptions{})
+
+	err = sclient.
+		VolumeSnapshots(snap.Namespace).
+		Delete(context.TODO(), snap.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete volumesnapshot: %w", err)
 	}
@@ -99,13 +107,18 @@ func deleteSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		e2elog.Logf("deleting snapshot %s (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
-		_, err := sclient.VolumeSnapshots(snap.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		_, err := sclient.
+			VolumeSnapshots(snap.Namespace).
+			Get(context.TODO(), name, metav1.GetOptions{})
 		if err == nil {
 			return false, nil
 		}
 
 		if !apierrs.IsNotFound(err) {
-			return false, fmt.Errorf("get on deleted snapshot %v failed with error other than \"not found\": %v", name, err)
+			return false, fmt.Errorf(
+				"get on deleted snapshot %v failed with error other than \"not found\": %v",
+				name,
+				err)
 		}
 
 		return true, nil
@@ -177,12 +190,17 @@ func getVolumeSnapshotContent(namespace, snapshotName string) (*snapapi.VolumeSn
 	if err != nil {
 		return nil, err
 	}
-	snapshot, err := sclient.VolumeSnapshots(namespace).Get(context.TODO(), snapshotName, metav1.GetOptions{})
+
+	snapshot, err := sclient.
+		VolumeSnapshots(namespace).
+		Get(context.TODO(), snapshotName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get volumesnapshot: %w", err)
 	}
 
-	volumeSnapshotContent, err := sclient.VolumeSnapshotContents().Get(context.TODO(), *snapshot.Status.BoundVolumeSnapshotContentName, metav1.GetOptions{})
+	volumeSnapshotContent, err := sclient.
+		VolumeSnapshotContents().
+		Get(context.TODO(), *snapshot.Status.BoundVolumeSnapshotContentName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get volumesnapshotcontent: %w", err)
 	}

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -11,7 +11,10 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-func getStaticPV(name, volName, size, secretName, secretNS, sc, driverName string, blockPV bool, options map[string]string) *v1.PersistentVolume {
+func getStaticPV(
+	name, volName, size, secretName, secretNS, sc, driverName string,
+	blockPV bool,
+	options map[string]string) *v1.PersistentVolume {
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -102,7 +105,11 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 	fsID = strings.Trim(fsID, "\n")
 	size := "4Gi"
 	// create rbd image
-	cmd := fmt.Sprintf("rbd create %s --size=%d --image-feature=layering %s", rbdImageName, 4096, rbdOptions(defaultRBDPool))
+	cmd := fmt.Sprintf(
+		"rbd create %s --size=%d --image-feature=layering %s",
+		rbdImageName,
+		4096,
+		rbdOptions(defaultRBDPool))
 
 	_, e, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
 	if err != nil {
@@ -121,7 +128,16 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 		opt["radosNamespace"] = radosNamespace
 	}
 
-	pv := getStaticPV(pvName, rbdImageName, size, rbdNodePluginSecretName, cephCSINamespace, sc, "rbd.csi.ceph.com", isBlock, opt)
+	pv := getStaticPV(
+		pvName,
+		rbdImageName,
+		size,
+		rbdNodePluginSecretName,
+		cephCSINamespace,
+		sc,
+		"rbd.csi.ceph.com",
+		isBlock,
+		opt)
 
 	_, err = c.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
 	if err != nil {

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -112,11 +112,15 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to delete configmap with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), cephFSProvisionerSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), cephFSProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete provisioner secret with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), cephFSNodePluginSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), cephFSNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete node secret with error %v", err)
 		}
@@ -191,7 +195,11 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				filePath := filepath.Join(mountPath, "testClone")
 
 				// create a test file at the mountPath.
-				_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo %s > %s", data, filePath), app.Namespace, &opt)
+				_, stdErr := execCommandInPodAndAllowFail(
+					f,
+					fmt.Sprintf("echo %s > %s", data, filePath),
+					app.Namespace,
+					&opt)
 				if stdErr != "" {
 					e2elog.Failf("failed to write data to a file %s", stdErr)
 				}
@@ -289,7 +297,10 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					}
 
 					if strings.Compare(newCheckSum, checkSum) != 0 {
-						e2elog.Failf("The checksum of files did not match, expected %s received %s  ", checkSum, newCheckSum)
+						e2elog.Failf(
+							"The checksum of files did not match, expected %s received %s  ",
+							checkSum,
+							newCheckSum)
 					}
 					e2elog.Logf("The checksum of files matched")
 
@@ -350,7 +361,10 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					}
 
 					if strings.Compare(newCheckSum, checkSum) != 0 {
-						e2elog.Failf("The checksum of files did not match, expected %s received %s", checkSum, newCheckSum)
+						e2elog.Failf(
+							"The checksum of files did not match, expected %s received %s",
+							checkSum,
+							newCheckSum)
 					}
 					e2elog.Logf("The checksum of files matched")
 
@@ -373,7 +387,9 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					opt := metav1.ListOptions{
 						LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
 					}
-					pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+					pvc, err = f.ClientSet.CoreV1().
+						PersistentVolumeClaims(pvc.Namespace).
+						Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 					if err != nil {
 						e2elog.Failf("failed to get pvc with error %v", err)
 					}

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -119,11 +119,15 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to delete configmap with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), rbdProvisionerSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), rbdProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete provisioner secret with error %v", err)
 		}
-		err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), rbdNodePluginSecretName, metav1.DeleteOptions{})
+		err = c.CoreV1().
+			Secrets(cephCSINamespace).
+			Delete(context.TODO(), rbdNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
 			e2elog.Failf("failed to delete node secret with error %v", err)
 		}
@@ -206,7 +210,11 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				filePath := filepath.Join(mountPath, "testClone")
 
 				// create a test file at the mountPath.
-				_, stdErr := execCommandInPodAndAllowFail(f, fmt.Sprintf("echo %s > %s", data, filePath), app.Namespace, &opt)
+				_, stdErr := execCommandInPodAndAllowFail(
+					f,
+					fmt.Sprintf("echo %s > %s", data, filePath),
+					app.Namespace,
+					&opt)
 				if stdErr != "" {
 					e2elog.Failf("failed to write data to a file %s", stdErr)
 				}
@@ -307,7 +315,10 @@ var _ = Describe("RBD Upgrade Testing", func() {
 						e2elog.Failf("failed to calculate checksum with error %v", err)
 					}
 					if strings.Compare(newCheckSum, checkSum) != 0 {
-						e2elog.Failf("The checksum of files did not match, expected %s received %s  ", checkSum, newCheckSum)
+						e2elog.Failf(
+							"The checksum of files did not match, expected %s received %s",
+							checkSum,
+							newCheckSum)
 					}
 					e2elog.Logf("The checksum of files matched")
 
@@ -356,7 +367,10 @@ var _ = Describe("RBD Upgrade Testing", func() {
 						e2elog.Failf("failed to calculate checksum with error %v", err)
 					}
 					if strings.Compare(newCheckSum, checkSum) != 0 {
-						e2elog.Failf("The checksum of files did not match, expected %s received %s  ", checkSum, newCheckSum)
+						e2elog.Failf(
+							"The checksum of files did not match, expected %s received %s",
+							checkSum,
+							newCheckSum)
 					}
 					e2elog.Logf("The checksum of files matched")
 
@@ -380,7 +394,9 @@ var _ = Describe("RBD Upgrade Testing", func() {
 						LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
 					}
 					var err error
-					pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+					pvc, err = f.ClientSet.CoreV1().
+						PersistentVolumeClaims(pvc.Namespace).
+						Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 					if err != nil {
 						e2elog.Failf("failed to get pvc with error %v", err)
 					}

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -134,7 +134,10 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 	return nil
 }
 
-func cleanupCloneFromSubvolumeSnapshot(ctx context.Context, volID, cloneID volumeID, parentVolOpt *volumeOptions) error {
+func cleanupCloneFromSubvolumeSnapshot(
+	ctx context.Context,
+	volID, cloneID volumeID,
+	parentVolOpt *volumeOptions) error {
 	// snapshot name is same as clone name as we need a name which can be
 	// identified during PVC-PVC cloning.
 	snapShotID := cloneID
@@ -167,7 +170,11 @@ func isCloneRetryError(err error) bool {
 	return errors.Is(err, ErrCloneInProgress) || errors.Is(err, ErrClonePending)
 }
 
-func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volumeOptions, vID *volumeIdentifier, sID *snapshotIdentifier) error {
+func createCloneFromSnapshot(
+	ctx context.Context,
+	parentVolOpt, volOptions *volumeOptions,
+	vID *volumeIdentifier,
+	sID *snapshotIdentifier) error {
 	snapID := volumeID(sID.FsSnapshotName)
 	err := parentVolOpt.cloneSnapshot(ctx, volumeID(sID.FsSubvolName), snapID, volumeID(vID.FsSubvolName), volOptions)
 	if err != nil {
@@ -211,7 +218,12 @@ func createCloneFromSnapshot(ctx context.Context, parentVolOpt, volOptions *volu
 func (vo *volumeOptions) getCloneState(ctx context.Context, volID volumeID) (cephFSCloneState, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin, can get clone status for volume %s with ID %s: %v", vo.FsName, string(volID), err)
+		util.ErrorLog(
+			ctx,
+			"could not get FSAdmin, can get clone status for volume %s with ID %s: %v",
+			vo.FsName,
+			string(volID),
+			err)
 		return cephFSCloneError, err
 	}
 

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -136,7 +136,11 @@ func checkVolExists(ctx context.Context,
 			// If the subvolume is not present, cleanup the stale snapshot
 			// created for clone.
 			if parentVolOpt != nil && pvID != nil {
-				err = cleanupCloneFromSubvolumeSnapshot(ctx, volumeID(pvID.FsSubvolName), volumeID(vid.FsSubvolName), parentVolOpt)
+				err = cleanupCloneFromSubvolumeSnapshot(
+					ctx,
+					volumeID(pvID.FsSubvolName),
+					volumeID(vid.FsSubvolName),
+					parentVolOpt)
 				if err != nil {
 					return nil, err
 				}
@@ -165,7 +169,11 @@ func checkVolExists(ctx context.Context,
 		vid.VolumeID, vid.FsSubvolName, volOptions.RequestName)
 
 	if parentVolOpt != nil && pvID != nil {
-		err = cleanupCloneFromSubvolumeSnapshot(ctx, volumeID(pvID.FsSubvolName), volumeID(vid.FsSubvolName), parentVolOpt)
+		err = cleanupCloneFromSubvolumeSnapshot(
+			ctx,
+			volumeID(pvID.FsSubvolName),
+			volumeID(vid.FsSubvolName),
+			parentVolOpt)
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +183,11 @@ func checkVolExists(ctx context.Context,
 }
 
 // undoVolReservation is a helper routine to undo a name reservation for a CSI VolumeName.
-func undoVolReservation(ctx context.Context, volOptions *volumeOptions, vid volumeIdentifier, secret map[string]string) error {
+func undoVolReservation(
+	ctx context.Context,
+	volOptions *volumeOptions,
+	vid volumeIdentifier,
+	secret map[string]string) error {
 	cr, err := util.NewAdminCredentials(secret)
 	if err != nil {
 		return err
@@ -259,7 +271,12 @@ func reserveVol(ctx context.Context, volOptions *volumeOptions, secret map[strin
 
 // reserveSnap is a helper routine to request a UUID reservation for the CSI SnapName and,
 // to generate the snapshot identifier for the reserved UUID.
-func reserveSnap(ctx context.Context, volOptions *volumeOptions, parentSubVolName string, snap *cephfsSnapshot, cr *util.Credentials) (*snapshotIdentifier, error) {
+func reserveSnap(
+	ctx context.Context,
+	volOptions *volumeOptions,
+	parentSubVolName string,
+	snap *cephfsSnapshot,
+	cr *util.Credentials) (*snapshotIdentifier, error) {
 	var (
 		vid       snapshotIdentifier
 		imageUUID string
@@ -295,7 +312,12 @@ func reserveSnap(ctx context.Context, volOptions *volumeOptions, parentSubVolNam
 }
 
 // undoSnapReservation is a helper routine to undo a name reservation for a CSI SnapshotName.
-func undoSnapReservation(ctx context.Context, volOptions *volumeOptions, vid snapshotIdentifier, snapName string, cr *util.Credentials) error {
+func undoSnapReservation(
+	ctx context.Context,
+	volOptions *volumeOptions,
+	vid snapshotIdentifier,
+	snapName string,
+	cr *util.Credentials) error {
 	// Connect to cephfs' default radosNamespace (csi)
 	j, err := snapJournal.Connect(volOptions.Monitors, radosNamespace, cr)
 	if err != nil {

--- a/internal/cephfs/identityserver.go
+++ b/internal/cephfs/identityserver.go
@@ -31,7 +31,9 @@ type IdentityServer struct {
 }
 
 // GetPluginCapabilities returns available capabilities of the ceph driver.
-func (is *IdentityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+func (is *IdentityServer) GetPluginCapabilities(
+	ctx context.Context,
+	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -67,7 +67,9 @@ func getCredentialsForVolume(volOptions *volumeOptions, req *csi.NodeStageVolume
 }
 
 // NodeStageVolume mounts the volume to a staging path on the node.
-func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (ns *NodeServer) NodeStageVolume(
+	ctx context.Context,
+	req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	var (
 		volOptions *volumeOptions
 	)
@@ -179,14 +181,25 @@ func (*NodeServer) mount(ctx context.Context, volOptions *volumeOptions, req *cs
 			err)
 		return status.Error(codes.Internal, err.Error())
 	}
-	if !csicommon.MountOptionContains(kernelMountOptions, readOnly) && !csicommon.MountOptionContains(fuseMountOptions, readOnly) {
+	if !csicommon.MountOptionContains(kernelMountOptions, readOnly) &&
+		!csicommon.MountOptionContains(fuseMountOptions, readOnly) {
 		// #nosec - allow anyone to write inside the stagingtarget path
 		err = os.Chmod(stagingTargetPath, 0777)
 		if err != nil {
-			util.ErrorLog(ctx, "failed to change stagingtarget path %s permission for volume %s: %v", stagingTargetPath, volID, err)
+			util.ErrorLog(
+				ctx,
+				"failed to change stagingtarget path %s permission for volume %s: %v",
+				stagingTargetPath,
+				volID,
+				err)
 			uErr := unmountVolume(ctx, stagingTargetPath)
 			if uErr != nil {
-				util.ErrorLog(ctx, "failed to umount stagingtarget path %s for volume %s: %v", stagingTargetPath, volID, uErr)
+				util.ErrorLog(
+					ctx,
+					"failed to umount stagingtarget path %s for volume %s: %v",
+					stagingTargetPath,
+					volID,
+					uErr)
 			}
 			return status.Error(codes.Internal, err.Error())
 		}
@@ -196,7 +209,9 @@ func (*NodeServer) mount(ctx context.Context, volOptions *volumeOptions, req *cs
 
 // NodePublishVolume mounts the volume mounted to the staging path to the target
 // path.
-func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (ns *NodeServer) NodePublishVolume(
+	ctx context.Context,
+	req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	mountOptions := []string{"bind", "_netdev"}
 	if err := util.ValidateNodePublishVolumeRequest(req); err != nil {
 		return nil, err
@@ -249,7 +264,9 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 }
 
 // NodeUnpublishVolume unmounts the volume from the target path.
-func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (ns *NodeServer) NodeUnpublishVolume(
+	ctx context.Context,
+	req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	var err error
 	if err = util.ValidateNodeUnpublishVolumeRequest(req); err != nil {
 		return nil, err
@@ -296,7 +313,9 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 }
 
 // NodeUnstageVolume unstages the volume from the staging path.
-func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (ns *NodeServer) NodeUnstageVolume(
+	ctx context.Context,
+	req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	var err error
 	if err = util.ValidateNodeUnstageVolumeRequest(req); err != nil {
 		return nil, err
@@ -334,7 +353,9 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 }
 
 // NodeGetCapabilities returns the supported capabilities of the node server.
-func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+func (ns *NodeServer) NodeGetCapabilities(
+	ctx context.Context,
+	req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{
 			{
@@ -356,7 +377,9 @@ func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 }
 
 // NodeGetVolumeStats returns volume stats.
-func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+func (ns *NodeServer) NodeGetVolumeStats(
+	ctx context.Context,
+	req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
 	var err error
 	targetPath := req.GetVolumePath()
 	if targetPath == "" {

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -100,7 +100,13 @@ func (vo *volumeOptions) getSnapshotInfo(ctx context.Context, snapID, volID volu
 		if errors.Is(err, rados.ErrNotFound) {
 			return snap, ErrSnapNotFound
 		}
-		util.ErrorLog(ctx, "failed to get subvolume snapshot info %s %s in fs %s with error %s", string(volID), string(snapID), vo.FsName, err)
+		util.ErrorLog(
+			ctx,
+			"failed to get subvolume snapshot info %s %s in fs %s with error %s",
+			string(volID),
+			string(snapID),
+			vo.FsName,
+			err)
 		return snap, err
 	}
 	snap.CreatedAt = info.CreatedAt.Time
@@ -127,7 +133,13 @@ func (vo *volumeOptions) protectSnapshot(ctx context.Context, snapID, volID volu
 		if errors.Is(err, rados.ErrObjectExists) {
 			return nil
 		}
-		util.ErrorLog(ctx, "failed to protect subvolume snapshot %s %s in fs %s with error: %s", string(volID), string(snapID), vo.FsName, err)
+		util.ErrorLog(
+			ctx,
+			"failed to protect subvolume snapshot %s %s in fs %s with error: %s",
+			string(volID),
+			string(snapID),
+			vo.FsName,
+			err)
 		return err
 	}
 	return nil
@@ -153,13 +165,23 @@ func (vo *volumeOptions) unprotectSnapshot(ctx context.Context, snapID, volID vo
 		if errors.Is(err, rados.ErrObjectExists) {
 			return nil
 		}
-		util.ErrorLog(ctx, "failed to unprotect subvolume snapshot %s %s in fs %s with error: %s", string(volID), string(snapID), vo.FsName, err)
+		util.ErrorLog(
+			ctx,
+			"failed to unprotect subvolume snapshot %s %s in fs %s with error: %s",
+			string(volID),
+			string(snapID),
+			vo.FsName,
+			err)
 		return err
 	}
 	return nil
 }
 
-func (vo *volumeOptions) cloneSnapshot(ctx context.Context, volID, snapID, cloneID volumeID, cloneVolOptions *volumeOptions) error {
+func (vo *volumeOptions) cloneSnapshot(
+	ctx context.Context,
+	volID, snapID, cloneID volumeID,
+	cloneVolOptions *volumeOptions,
+) error {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
 		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
@@ -174,7 +196,14 @@ func (vo *volumeOptions) cloneSnapshot(ctx context.Context, volID, snapID, clone
 
 	err = fsa.CloneSubVolumeSnapshot(vo.FsName, vo.SubvolumeGroup, string(volID), string(snapID), string(cloneID), co)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to clone subvolume snapshot %s %s in fs %s with error: %s", string(volID), string(snapID), string(cloneID), vo.FsName, err)
+		util.ErrorLog(
+			ctx,
+			"failed to clone subvolume snapshot %s %s in fs %s with error: %s",
+			string(volID),
+			string(snapID),
+			string(cloneID),
+			vo.FsName,
+			err)
 		if errors.Is(err, rados.ErrNotFound) {
 			return ErrVolumeNotFound
 		}

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -39,7 +39,8 @@ func execCommandErr(ctx context.Context, program string, args ...string) error {
 
 // Controller service request validation.
 func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
-	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		return fmt.Errorf("invalid CreateVolumeRequest: %w", err)
 	}
 
@@ -94,7 +95,8 @@ func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeReq
 }
 
 func (cs *ControllerServer) validateDeleteVolumeRequest() error {
-	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		return fmt.Errorf("invalid DeleteVolumeRequest: %w", err)
 	}
 

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -157,7 +157,12 @@ func createVolume(ctx context.Context, volOptions *volumeOptions, volID volumeID
 		opts := fsAdmin.SubVolumeGroupOptions{}
 		err = ca.CreateSubVolumeGroup(volOptions.FsName, volOptions.SubvolumeGroup, &opts)
 		if err != nil {
-			util.ErrorLog(ctx, "failed to create subvolume group %s, for the vol %s: %s", volOptions.SubvolumeGroup, string(volID), err)
+			util.ErrorLog(
+				ctx,
+				"failed to create subvolume group %s, for the vol %s: %s",
+				volOptions.SubvolumeGroup,
+				string(volID),
+				err)
 			return err
 		}
 		util.DebugLog(ctx, "cephfs: created subvolume group %s", volOptions.SubvolumeGroup)

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -195,7 +195,11 @@ func mountFuse(ctx context.Context, mountPoint string, cr *util.Credentials, vol
 	return nil
 }
 
-func (m *fuseMounter) mount(ctx context.Context, mountPoint string, cr *util.Credentials, volOptions *volumeOptions) error {
+func (m *fuseMounter) mount(
+	ctx context.Context,
+	mountPoint string,
+	cr *util.Credentials,
+	volOptions *volumeOptions) error {
 	if err := util.CreateMountPoint(mountPoint); err != nil {
 		return err
 	}
@@ -234,7 +238,11 @@ func mountKernel(ctx context.Context, mountPoint string, cr *util.Credentials, v
 	return err
 }
 
-func (m *kernelMounter) mount(ctx context.Context, mountPoint string, cr *util.Credentials, volOptions *volumeOptions) error {
+func (m *kernelMounter) mount(
+	ctx context.Context,
+	mountPoint string,
+	cr *util.Credentials,
+	volOptions *volumeOptions) error {
 	if err := util.CreateMountPoint(mountPoint); err != nil {
 		return err
 	}

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -251,7 +251,10 @@ func newVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVo
 
 // newVolumeOptionsFromVolID generates a new instance of volumeOptions and volumeIdentifier
 // from the provided CSI VolumeID.
-func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secrets map[string]string) (*volumeOptions, *volumeIdentifier, error) {
+func newVolumeOptionsFromVolID(
+	ctx context.Context,
+	volID string,
+	volOpt, secrets map[string]string) (*volumeOptions, *volumeIdentifier, error) {
 	var (
 		vi         util.CSIIdentifier
 		volOptions volumeOptions
@@ -359,7 +362,9 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 
 // newVolumeOptionsFromMonitorList generates a new instance of volumeOptions and
 // volumeIdentifier from the provided CSI volume context.
-func newVolumeOptionsFromMonitorList(volID string, options, secrets map[string]string) (*volumeOptions, *volumeIdentifier, error) {
+func newVolumeOptionsFromMonitorList(
+	volID string,
+	options, secrets map[string]string) (*volumeOptions, *volumeIdentifier, error) {
 	var (
 		opts                volumeOptions
 		vid                 volumeIdentifier
@@ -412,7 +417,9 @@ func newVolumeOptionsFromMonitorList(volID string, options, secrets map[string]s
 // newVolumeOptionsFromStaticVolume generates a new instance of volumeOptions and
 // volumeIdentifier from the provided CSI volume context, if the provided context is
 // detected to be a statically provisioned volume.
-func newVolumeOptionsFromStaticVolume(volID string, options map[string]string) (*volumeOptions, *volumeIdentifier, error) {
+func newVolumeOptionsFromStaticVolume(
+	volID string,
+	options map[string]string) (*volumeOptions, *volumeIdentifier, error) {
 	var (
 		opts      volumeOptions
 		vid       volumeIdentifier
@@ -479,7 +486,10 @@ func newVolumeOptionsFromStaticVolume(volID string, options map[string]string) (
 
 // newSnapshotOptionsFromID generates a new instance of volumeOptions and snapshotIdentifier
 // from the provided CSI VolumeID.
-func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Credentials) (*volumeOptions, *snapshotInfo, *snapshotIdentifier, error) {
+func newSnapshotOptionsFromID(
+	ctx context.Context,
+	snapID string,
+	cr *util.Credentials) (*volumeOptions, *snapshotInfo, *snapshotIdentifier, error) {
 	var (
 		vi         util.CSIIdentifier
 		volOptions volumeOptions
@@ -495,11 +505,17 @@ func newSnapshotOptionsFromID(ctx context.Context, snapID string, cr *util.Crede
 	volOptions.FscID = vi.LocationID
 
 	if volOptions.Monitors, err = util.Mons(util.CsiConfigFile, vi.ClusterID); err != nil {
-		return &volOptions, nil, &sid, fmt.Errorf("failed to fetch monitor list using clusterID (%s): %w", vi.ClusterID, err)
+		return &volOptions, nil, &sid, fmt.Errorf(
+			"failed to fetch monitor list using clusterID (%s): %w",
+			vi.ClusterID,
+			err)
 	}
 
 	if volOptions.SubvolumeGroup, err = util.CephFSSubvolumeGroup(util.CsiConfigFile, vi.ClusterID); err != nil {
-		return &volOptions, nil, &sid, fmt.Errorf("failed to fetch subvolumegroup list using clusterID (%s): %w", vi.ClusterID, err)
+		return &volOptions, nil, &sid, fmt.Errorf(
+			"failed to fetch subvolumegroup list using clusterID (%s): %w",
+			vi.ClusterID,
+			err)
 	}
 
 	err = volOptions.Connect(cr)

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -70,7 +70,10 @@ func newPVReconciler(mgr manager.Manager, config ctrl.Config) reconcile.Reconcil
 
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("persistentvolume-controller", mgr, controller.Options{MaxConcurrentReconciles: 1, Reconciler: r})
+	c, err := controller.New(
+		"persistentvolume-controller",
+		mgr,
+		controller.Options{MaxConcurrentReconciles: 1, Reconciler: r})
 	if err != nil {
 		return err
 	}

--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -32,33 +32,45 @@ type DefaultControllerServer struct {
 }
 
 // ControllerPublishVolume publish volume on node.
-func (cs *DefaultControllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+func (cs *DefaultControllerServer) ControllerPublishVolume(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ControllerUnpublishVolume unpublish on node.
-func (cs *DefaultControllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+func (cs *DefaultControllerServer) ControllerUnpublishVolume(
+	ctx context.Context,
+	req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ControllerExpandVolume expand volume.
-func (cs *DefaultControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+func (cs *DefaultControllerServer) ControllerExpandVolume(
+	ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ListVolumes lists volumes.
-func (cs *DefaultControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+func (cs *DefaultControllerServer) ListVolumes(
+	ctx context.Context,
+	req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // GetCapacity get volume capacity.
-func (cs *DefaultControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+func (cs *DefaultControllerServer) GetCapacity(
+	ctx context.Context,
+	req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ControllerGetCapabilities implements the default GRPC callout.
 // Default supports all capabilities.
-func (cs *DefaultControllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+func (cs *DefaultControllerServer) ControllerGetCapabilities(
+	ctx context.Context,
+	req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 	util.TraceLog(ctx, "Using default ControllerGetCapabilities")
 	if cs.Driver == nil {
 		return nil, status.Error(codes.Unimplemented, "Controller server is not enabled")
@@ -69,21 +81,29 @@ func (cs *DefaultControllerServer) ControllerGetCapabilities(ctx context.Context
 }
 
 // CreateSnapshot creates snapshot.
-func (cs *DefaultControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+func (cs *DefaultControllerServer) CreateSnapshot(
+	ctx context.Context,
+	req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // DeleteSnapshot deletes snapshot.
-func (cs *DefaultControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+func (cs *DefaultControllerServer) DeleteSnapshot(
+	ctx context.Context,
+	req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ListSnapshots lists snapshots.
-func (cs *DefaultControllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+func (cs *DefaultControllerServer) ListSnapshots(
+	ctx context.Context,
+	req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ControllerGetVolume fetch volume information.
-func (cs *DefaultControllerServer) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
+func (cs *DefaultControllerServer) ControllerGetVolume(
+	ctx context.Context,
+	req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -95,7 +95,8 @@ func (d *CSIDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceC
 }
 
 // AddVolumeCapabilityAccessModes stores volume access modes.
-func (d *CSIDriver) AddVolumeCapabilityAccessModes(vc []csi.VolumeCapability_AccessMode_Mode) []*csi.VolumeCapability_AccessMode {
+func (d *CSIDriver) AddVolumeCapabilityAccessModes(
+	vc []csi.VolumeCapability_AccessMode_Mode) []*csi.VolumeCapability_AccessMode {
 	var vca []*csi.VolumeCapability_AccessMode
 	for _, c := range vc {
 		util.DefaultLog("Enabling volume access mode: %v", c.String())

--- a/internal/csi-common/identityserver-default.go
+++ b/internal/csi-common/identityserver-default.go
@@ -32,7 +32,9 @@ type DefaultIdentityServer struct {
 }
 
 // GetPluginInfo returns plugin information.
-func (ids *DefaultIdentityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+func (ids *DefaultIdentityServer) GetPluginInfo(
+	ctx context.Context,
+	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	util.TraceLog(ctx, "Using default GetPluginInfo")
 
 	if ids.Driver.name == "" {
@@ -55,7 +57,9 @@ func (ids *DefaultIdentityServer) Probe(ctx context.Context, req *csi.ProbeReque
 }
 
 // GetPluginCapabilities returns plugin capabilities.
-func (ids *DefaultIdentityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+func (ids *DefaultIdentityServer) GetPluginCapabilities(
+	ctx context.Context,
+	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	util.TraceLog(ctx, "Using default capabilities")
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -33,22 +33,30 @@ type DefaultNodeServer struct {
 }
 
 // NodeStageVolume returns unimplemented response.
-func (ns *DefaultNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (ns *DefaultNodeServer) NodeStageVolume(
+	ctx context.Context,
+	req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // NodeUnstageVolume returns unimplemented response.
-func (ns *DefaultNodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (ns *DefaultNodeServer) NodeUnstageVolume(
+	ctx context.Context,
+	req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // NodeExpandVolume returns unimplemented response.
-func (ns *DefaultNodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+func (ns *DefaultNodeServer) NodeExpandVolume(
+	ctx context.Context,
+	req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // NodeGetInfo returns node ID.
-func (ns *DefaultNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+func (ns *DefaultNodeServer) NodeGetInfo(
+	ctx context.Context,
+	req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	util.TraceLog(ctx, "Using default NodeGetInfo")
 
 	csiTopology := &csi.Topology{
@@ -62,7 +70,9 @@ func (ns *DefaultNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetIn
 }
 
 // NodeGetCapabilities returns RPC unknown capability.
-func (ns *DefaultNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+func (ns *DefaultNodeServer) NodeGetCapabilities(
+	ctx context.Context,
+	req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	util.TraceLog(ctx, "Using default NodeGetCapabilities")
 
 	return &csi.NodeGetCapabilitiesResponse{
@@ -79,7 +89,9 @@ func (ns *DefaultNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.N
 }
 
 // NodeGetVolumeStats returns volume stats.
-func (ns *DefaultNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+func (ns *DefaultNodeServer) NodeGetVolumeStats(
+	ctx context.Context,
+	req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -150,7 +150,11 @@ func getReqID(req interface{}) string {
 
 var id uint64
 
-func contextIDInjector(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+func contextIDInjector(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (resp interface{}, err error) {
 	atomic.AddUint64(&id, 1)
 	ctx = context.WithValue(ctx, util.CtxKey, id)
 	if reqID := getReqID(req); reqID != "" {
@@ -159,7 +163,11 @@ func contextIDInjector(ctx context.Context, req interface{}, info *grpc.UnarySer
 	return handler(ctx, req)
 }
 
-func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func logGRPC(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (interface{}, error) {
 	util.ExtendedLog(ctx, "GRPC call: %s", info.FullMethod)
 	if isReplicationRequest(req) {
 		util.TraceLog(ctx, "GRPC request: %s", rp.StripReplicationSecrets(req))
@@ -176,7 +184,11 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	return resp, err
 }
 
-func panicHandler(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+func panicHandler(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (resp interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.Errorf("panic occurred: %v", r)

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -419,7 +419,13 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 			return fmt.Errorf("failed parsing UUID in %s", volName)
 		}
 
-		err := util.RemoveObject(ctx, conn.monitors, conn.cr, volJournalPool, cj.namespace, cj.cephUUIDDirectoryPrefix+imageUUID)
+		err := util.RemoveObject(
+			ctx,
+			conn.monitors,
+			conn.cr,
+			volJournalPool,
+			cj.namespace,
+			cj.cephUUIDDirectoryPrefix+imageUUID)
 		if err != nil {
 			if !errors.Is(err, util.ErrObjectNotFound) {
 				util.ErrorLog(ctx, "failed removing oMap %s (%s)", cj.cephUUIDDirectoryPrefix+imageUUID, err)
@@ -445,7 +451,11 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 // already exists.if the passed volUUID is empty It ensures generated omap name
 // does not already exist and if conflicts are detected, a set number of
 // retires with newer uuids are attempted before returning an error.
-func reserveOMapName(ctx context.Context, monitors string, cr *util.Credentials, pool, namespace, oMapNamePrefix, volUUID string) (string, error) {
+func reserveOMapName(
+	ctx context.Context,
+	monitors string,
+	cr *util.Credentials,
+	pool, namespace, oMapNamePrefix, volUUID string) (string, error) {
 	var iterUUID string
 
 	maxAttempts := 5
@@ -470,7 +480,10 @@ func reserveOMapName(ctx context.Context, monitors string, cr *util.Credentials,
 				continue
 			}
 
-			return "", fmt.Errorf("failed to create omap object for oMapNamePrefix+iterUUID=%s: %w", oMapNamePrefix+iterUUID, err)
+			return "", fmt.Errorf(
+				"failed to create omap object for oMapNamePrefix+iterUUID=%s: %w",
+				oMapNamePrefix+iterUUID,
+				err)
 		}
 
 		return iterUUID, nil
@@ -530,7 +543,14 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	// NOTE: If any service loss occurs post creation of the UUID directory, and before
 	// setting the request name key (csiNameKey) to point back to the UUID directory, the
 	// UUID directory key will be leaked
-	volUUID, err = reserveOMapName(ctx, conn.monitors, conn.cr, imagePool, cj.namespace, cj.cephUUIDDirectoryPrefix, volUUID)
+	volUUID, err = reserveOMapName(
+		ctx,
+		conn.monitors,
+		conn.cr,
+		imagePool,
+		cj.namespace,
+		cj.cephUUIDDirectoryPrefix,
+		volUUID)
 	if err != nil {
 		return "", "", err
 	}
@@ -618,7 +638,10 @@ type ImageAttributes struct {
 }
 
 // GetImageAttributes fetches all keys and their values, from a UUID directory, returning ImageAttributes structure.
-func (conn *Connection) GetImageAttributes(ctx context.Context, pool, objectUUID string, snapSource bool) (*ImageAttributes, error) {
+func (conn *Connection) GetImageAttributes(
+	ctx context.Context,
+	pool, objectUUID string,
+	snapSource bool) (*ImageAttributes, error) {
 	var (
 		err             error
 		imageAttributes *ImageAttributes = &ImageAttributes{}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -53,7 +53,8 @@ type ControllerServer struct {
 }
 
 func (cs *ControllerServer) validateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest) error {
-	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		util.ErrorLog(ctx, "invalid create volume req: %v", protosanitizer.StripSecrets(req))
 		return err
 	}
@@ -91,7 +92,9 @@ func (cs *ControllerServer) validateVolumeReq(ctx context.Context, req *csi.Crea
 	return nil
 }
 
-func (cs *ControllerServer) parseVolCreateRequest(ctx context.Context, req *csi.CreateVolumeRequest) (*rbdVolume, error) {
+func (cs *ControllerServer) parseVolCreateRequest(
+	ctx context.Context,
+	req *csi.CreateVolumeRequest) (*rbdVolume, error) {
 	// TODO (sbezverk) Last check for not exceeding total storage capacity
 
 	isMultiNode := false
@@ -108,7 +111,9 @@ func (cs *ControllerServer) parseVolCreateRequest(ctx context.Context, req *csi.
 
 	// We want to fail early if the user is trying to create a RWX on a non-block type device
 	if isMultiNode && !isBlock {
-		return nil, status.Error(codes.InvalidArgument, "multi node access modes are only supported on rbd `block` type volumes")
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"multi node access modes are only supported on rbd `block` type volumes")
 	}
 
 	if imageFeatures, ok := req.GetParameters()["imageFeatures"]; checkImageFeatures(imageFeatures, ok, true) {
@@ -203,12 +208,20 @@ func validateRequestedVolumeSize(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSnaps
 			return status.Error(codes.Internal, err.Error())
 		}
 		if rbdVol.VolSize != vol.VolSize {
-			return status.Errorf(codes.InvalidArgument, "size mismatches, requested volume size %d and source snapshot size %d", rbdVol.VolSize, vol.VolSize)
+			return status.Errorf(
+				codes.InvalidArgument,
+				"size mismatches, requested volume size %d and source snapshot size %d",
+				rbdVol.VolSize,
+				vol.VolSize)
 		}
 	}
 	if parentVol != nil {
 		if rbdVol.VolSize != parentVol.VolSize {
-			return status.Errorf(codes.InvalidArgument, "size mismatches, requested volume size %d and source volume size %d", rbdVol.VolSize, parentVol.VolSize)
+			return status.Errorf(
+				codes.InvalidArgument,
+				"size mismatches, requested volume size %d and source volume size %d",
+				rbdVol.VolSize,
+				parentVol.VolSize)
 		}
 	}
 	return nil
@@ -246,7 +259,9 @@ func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSna
 }
 
 // CreateVolume creates the volume in backend.
-func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+func (cs *ControllerServer) CreateVolume(
+	ctx context.Context,
+	req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	if err := cs.validateVolumeReq(ctx, req); err != nil {
 		return nil, err
 	}
@@ -374,7 +389,11 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 		if isThickProvisionRequest(req.GetParameters()) {
 			thick, err := rbdVol.isThickProvisioned()
 			if err != nil {
-				return nil, status.Errorf(codes.Aborted, "failed to verify thick-provisioned volume %q: %s", rbdVol, err)
+				return nil, status.Errorf(
+					codes.Aborted,
+					"failed to verify thick-provisioned volume %q: %s",
+					rbdVol,
+					err)
 			} else if !thick {
 				err = deleteImage(ctx, rbdVol, cr)
 				if err != nil {
@@ -384,7 +403,9 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 				if err != nil {
 					return nil, status.Errorf(codes.Aborted, "failed to remove volume %q from journal: %s", rbdVol, err)
 				}
-				return nil, status.Errorf(codes.Aborted, "restoring thick-provisioned volume %q has been interrupted, please retry", rbdVol)
+				return nil, status.Errorf(
+					codes.Aborted,
+					"restoring thick-provisioned volume %q has been interrupted, please retry", rbdVol)
 			}
 		}
 		// restore from snapshot imploes rbdSnap != nil
@@ -409,7 +430,11 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 		if isThickProvisionRequest(req.GetParameters()) {
 			thick, err := rbdVol.isThickProvisioned()
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to verify thick-provisioned volume %q: %s", rbdVol, err)
+				return nil, status.Errorf(
+					codes.Internal,
+					"failed to verify thick-provisioned volume %q: %s",
+					rbdVol,
+					err)
 			} else if !thick {
 				err = cleanUpSnapshot(ctx, parentVol, rbdSnap, rbdVol, cr)
 				if err != nil {
@@ -419,7 +444,9 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 				if err != nil {
 					return nil, status.Errorf(codes.Internal, "failed to remove volume %q from journal: %s", rbdVol, err)
 				}
-				return nil, status.Errorf(codes.Internal, "cloning thick-provisioned volume %q has been interrupted, please retry", rbdVol)
+				return nil, status.Errorf(
+					codes.Internal,
+					"cloning thick-provisioned volume %q has been interrupted, please retry", rbdVol)
 			}
 		}
 	}
@@ -448,7 +475,12 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 	}
 
 	if len(snaps) > int(maxSnapshotsOnImage) {
-		util.DebugLog(ctx, "snapshots count %d on image: %s reached configured hard limit %d", len(snaps), rbdVol, maxSnapshotsOnImage)
+		util.DebugLog(
+			ctx,
+			"snapshots count %d on image: %s reached configured hard limit %d",
+			len(snaps),
+			rbdVol,
+			maxSnapshotsOnImage)
 		err = flattenClonedRbdImages(
 			ctx,
 			snaps,
@@ -463,7 +495,12 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 	}
 
 	if len(snaps) > int(minSnapshotsOnImageToStartFlatten) {
-		util.DebugLog(ctx, "snapshots count %d on image: %s reached configured soft limit %d", len(snaps), rbdVol, minSnapshotsOnImageToStartFlatten)
+		util.DebugLog(
+			ctx,
+			"snapshots count %d on image: %s reached configured soft limit %d",
+			len(snaps),
+			rbdVol,
+			minSnapshotsOnImageToStartFlatten)
 		// If we start flattening all the snapshots at one shot the volume
 		// creation time will be affected,so we will flatten only the extra
 		// snapshots.
@@ -505,7 +542,12 @@ func checkFlatten(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials) 
 	return nil
 }
 
-func (cs *ControllerServer) createVolumeFromSnapshot(ctx context.Context, cr *util.Credentials, secrets map[string]string, rbdVol *rbdVolume, snapshotID string) error {
+func (cs *ControllerServer) createVolumeFromSnapshot(
+	ctx context.Context,
+	cr *util.Credentials,
+	secrets map[string]string,
+	rbdVol *rbdVolume,
+	snapshotID string) error {
 	rbdSnap := &rbdSnapshot{}
 	if acquired := cs.SnapshotLocks.TryAcquire(snapshotID); !acquired {
 		util.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, snapshotID)
@@ -550,7 +592,12 @@ func (cs *ControllerServer) createVolumeFromSnapshot(ctx context.Context, cr *ut
 	return nil
 }
 
-func (cs *ControllerServer) createBackingImage(ctx context.Context, cr *util.Credentials, secrets map[string]string, rbdVol, parentVol *rbdVolume, rbdSnap *rbdSnapshot) error {
+func (cs *ControllerServer) createBackingImage(
+	ctx context.Context,
+	cr *util.Credentials,
+	secrets map[string]string,
+	rbdVol, parentVol *rbdVolume,
+	rbdSnap *rbdSnapshot) error {
 	var err error
 
 	var j = &journal.Connection{}
@@ -614,7 +661,10 @@ func (cs *ControllerServer) createBackingImage(ctx context.Context, cr *util.Cre
 	return nil
 }
 
-func checkContentSource(ctx context.Context, req *csi.CreateVolumeRequest, cr *util.Credentials) (*rbdVolume, *rbdSnapshot, error) {
+func checkContentSource(
+	ctx context.Context,
+	req *csi.CreateVolumeRequest,
+	cr *util.Credentials) (*rbdVolume, *rbdSnapshot, error) {
 	if req.VolumeContentSource == nil {
 		return nil, nil, nil
 	}
@@ -663,8 +713,11 @@ func checkContentSource(ctx context.Context, req *csi.CreateVolumeRequest, cr *u
 // DeleteVolume deletes the volume in backend and removes the volume metadata
 // from store
 // TODO: make this function less complex.
-func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
-	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
+func (cs *ControllerServer) DeleteVolume(
+	ctx context.Context,
+	req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		util.ErrorLog(ctx, "invalid delete volume req: %v", protosanitizer.StripSecrets(req))
 		return nil, err
 	}
@@ -781,7 +834,9 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 
 // ValidateVolumeCapabilities checks whether the volume capabilities requested
 // are supported.
-func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+func (cs *ControllerServer) ValidateVolumeCapabilities(
+	ctx context.Context,
+	req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
 	}
@@ -803,7 +858,9 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 }
 
 // CreateSnapshot creates the snapshot in backend and stores metadata in store.
-func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+func (cs *ControllerServer) CreateSnapshot(
+	ctx context.Context,
+	req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	if err := cs.validateSnapshotReq(ctx, req); err != nil {
 		return nil, err
 	}
@@ -833,7 +890,10 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 
 	// Check if source volume was created with required image features for snaps
 	if !rbdVol.hasSnapshotFeature() {
-		return nil, status.Errorf(codes.InvalidArgument, "volume(%s) has not snapshot feature(layering)", req.GetSourceVolumeId())
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"volume(%s) has not snapshot feature(layering)",
+			req.GetSourceVolumeId())
 	}
 
 	rbdSnap, err := genSnapFromOptions(ctx, rbdVol, req.GetParameters())
@@ -910,7 +970,11 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 
 // cloneFromSnapshot is a helper for CreateSnapshot that continues creating an
 // RBD image from an RBD snapshot if the process was interrupted at one point.
-func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnapshot, cr *util.Credentials) (*csi.CreateSnapshotResponse, error) {
+func cloneFromSnapshot(
+	ctx context.Context,
+	rbdVol *rbdVolume,
+	rbdSnap *rbdSnapshot,
+	cr *util.Credentials) (*csi.CreateSnapshotResponse, error) {
 	vol := generateVolFromSnap(rbdSnap)
 	err := vol.Connect(cr)
 	if err != nil {
@@ -981,7 +1045,8 @@ func cloneFromSnapshot(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnaps
 }
 
 func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.CreateSnapshotRequest) error {
-	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
 		util.ErrorLog(ctx, "invalid create snapshot req: %v", protosanitizer.StripSecrets(req))
 		return err
 	}
@@ -1004,7 +1069,11 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 	return nil
 }
 
-func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdVolume, rbdSnap *rbdSnapshot, cr *util.Credentials) (bool, *rbdVolume, error) {
+func (cs *ControllerServer) doSnapshotClone(
+	ctx context.Context,
+	parentVol *rbdVolume,
+	rbdSnap *rbdSnapshot,
+	cr *util.Credentials) (bool, *rbdVolume, error) {
 	// generate cloned volume details from snapshot
 	cloneRbd := generateVolFromSnap(rbdSnap)
 	defer cloneRbd.Destroy()
@@ -1104,8 +1173,11 @@ func (cs *ControllerServer) doSnapshotClone(ctx context.Context, parentVol *rbdV
 
 // DeleteSnapshot deletes the snapshot in backend and removes the
 // snapshot metadata from store.
-func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
-	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
+func (cs *ControllerServer) DeleteSnapshot(
+	ctx context.Context,
+	req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
 		util.ErrorLog(ctx, "invalid delete snapshot req: %v", protosanitizer.StripSecrets(req))
 		return nil, err
 	}
@@ -1199,7 +1271,9 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 }
 
 // ControllerExpandVolume expand RBD Volumes on demand based on resizer request.
-func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+func (cs *ControllerServer) ControllerExpandVolume(
+	ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_EXPAND_VOLUME); err != nil {
 		util.ErrorLog(ctx, "invalid expand volume req: %v", protosanitizer.StripSecrets(req))
 		return nil, err

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -50,10 +50,12 @@ var (
 	// VolumeName to backing RBD images
 	volJournal  *journal.Config
 	snapJournal *journal.Config
-	// rbdHardMaxCloneDepth is the hard limit for maximum number of nested volume clones that are taken before a flatten occurs
+	// rbdHardMaxCloneDepth is the hard limit for maximum number of nested volume clones that are taken before a flatten
+	// occurs
 	rbdHardMaxCloneDepth uint
 
-	// rbdSoftMaxCloneDepth is the soft limit for maximum number of nested volume clones that are taken before a flatten occurs
+	// rbdSoftMaxCloneDepth is the soft limit for maximum number of nested volume clones that are taken before a flatten
+	// occurs
 	rbdSoftMaxCloneDepth              uint
 	maxSnapshotsOnImage               uint
 	minSnapshotsOnImageToStartFlatten uint
@@ -134,7 +136,8 @@ func (r *Driver) Run(conf *util.Config) {
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		})
-		// We only support the multi-writer option when using block, but it's a supported capability for the plugin in general
+		// We only support the multi-writer option when using block, but it's a supported capability for the plugin in
+		// general
 		// In addition, we want to add the remaining modes like MULTI_NODE_READER_ONLY,
 		// MULTI_NODE_SINGLE_WRITER etc, but need to do some verification of RO modes first
 		// will work those as follow up features

--- a/internal/rbd/identityserver.go
+++ b/internal/rbd/identityserver.go
@@ -31,7 +31,9 @@ type IdentityServer struct {
 }
 
 // GetPluginCapabilities returns available capabilities of the rbd driver.
-func (is *IdentityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+func (is *IdentityServer) GetPluginCapabilities(
+	ctx context.Context,
+	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -111,7 +111,9 @@ var (
 //   - Create the staging file/directory under staging path
 //   - Stage the device (mount the device mapped for image)
 // TODO: make this function less complex.
-func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (ns *NodeServer) NodeStageVolume(
+	ctx context.Context,
+	req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	if err := util.ValidateNodeStageVolumeRequest(req); err != nil {
 		return nil, err
 	}
@@ -121,8 +123,16 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	// MULTI_NODE_MULTI_WRITER is supported by default for Block access type volumes
 	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
 		if !isBlock {
-			util.WarningLog(ctx, "MULTI_NODE_MULTI_WRITER currently only supported with volumes of access type `block`, invalid AccessMode for volume: %v", req.GetVolumeId())
-			return nil, status.Error(codes.InvalidArgument, "rbd: RWX access mode request is only valid for volumes with access type `block`")
+			util.WarningLog(
+				ctx,
+				"MULTI_NODE_MULTI_WRITER currently only supported with volumes of access type `block`,"+
+					"invalid AccessMode for volume: %v",
+				req.GetVolumeId(),
+			)
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"rbd: RWX access mode request is only valid for volumes with access type `block`",
+			)
 		}
 
 		disableInUseChecks = true
@@ -231,12 +241,20 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	util.DebugLog(ctx, "rbd: successfully mounted volume %s to stagingTargetPath %s", req.GetVolumeId(), stagingTargetPath)
+	util.DebugLog(
+		ctx,
+		"rbd: successfully mounted volume %s to stagingTargetPath %s",
+		req.GetVolumeId(),
+		stagingTargetPath)
 
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, volOptions *rbdVolume, staticVol bool) (stageTransaction, error) {
+func (ns *NodeServer) stageTransaction(
+	ctx context.Context,
+	req *csi.NodeStageVolumeRequest,
+	volOptions *rbdVolume,
+	staticVol bool) (stageTransaction, error) {
 	transaction := stageTransaction{}
 
 	var err error
@@ -330,7 +348,11 @@ func (ns *NodeServer) stageTransaction(ctx context.Context, req *csi.NodeStageVo
 	return transaction, err
 }
 
-func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeStageVolumeRequest, transaction stageTransaction, volOptions *rbdVolume) {
+func (ns *NodeServer) undoStagingTransaction(
+	ctx context.Context,
+	req *csi.NodeStageVolumeRequest,
+	transaction stageTransaction,
+	volOptions *rbdVolume) {
 	var err error
 
 	stagingTargetPath := getStagingTargetPath(req)
@@ -347,7 +369,8 @@ func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeS
 		err = os.Remove(stagingTargetPath)
 		if err != nil {
 			util.ErrorLog(ctx, "failed to remove stagingtargetPath: %s with error: %v", stagingTargetPath, err)
-			// continue on failure to unmap the image, as leaving stale images causes more issues than a stale file/directory
+			// continue on failure to unmap the image, as leaving stale images causes more issues than a stale
+			// file/directory
 		}
 	}
 
@@ -357,8 +380,14 @@ func (ns *NodeServer) undoStagingTransaction(ctx context.Context, req *csi.NodeS
 	if transaction.devicePath != "" {
 		err = detachRBDDevice(ctx, transaction.devicePath, volID, volOptions.UnmapOptions, transaction.isEncrypted)
 		if err != nil {
-			util.ErrorLog(ctx, "failed to unmap rbd device: %s for volume %s with error: %v", transaction.devicePath, volID, err)
-			// continue on failure to delete the stash file, as kubernetes will fail to delete the staging path otherwise
+			util.ErrorLog(
+				ctx,
+				"failed to unmap rbd device: %s for volume %s with error: %v",
+				transaction.devicePath,
+				volID,
+				err)
+			// continue on failure to delete the stash file, as kubernetes will fail to delete the staging path
+			// otherwise
 		}
 	}
 
@@ -398,7 +427,9 @@ func (ns *NodeServer) createStageMountPoint(ctx context.Context, mountPath strin
 
 // NodePublishVolume mounts the volume mounted to the device path to the target
 // path.
-func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (ns *NodeServer) NodePublishVolume(
+	ctx context.Context,
+	req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	err := util.ValidateNodePublishVolumeRequest(req)
 	if err != nil {
 		return nil, err
@@ -435,7 +466,11 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (ns *NodeServer) mountVolumeToStagePath(ctx context.Context, req *csi.NodeStageVolumeRequest, staticVol bool, stagingPath, devicePath string) (bool, error) {
+func (ns *NodeServer) mountVolumeToStagePath(
+	ctx context.Context,
+	req *csi.NodeStageVolumeRequest,
+	staticVol bool,
+	stagingPath, devicePath string) (bool, error) {
 	readOnly := false
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
 	diskMounter := &mount.SafeFormatAndMount{Interface: ns.mounter, Exec: utilexec.New()}
@@ -568,7 +603,9 @@ func (ns *NodeServer) createTargetMountPath(ctx context.Context, mountPath strin
 }
 
 // NodeUnpublishVolume unmounts the volume from the target path.
-func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (ns *NodeServer) NodeUnpublishVolume(
+	ctx context.Context,
+	req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	err := util.ValidateNodeUnpublishVolumeRequest(req)
 	if err != nil {
 		return nil, err
@@ -626,7 +663,9 @@ func getStagingTargetPath(req interface{}) string {
 }
 
 // NodeUnstageVolume unstages the volume from the staging path.
-func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (ns *NodeServer) NodeUnstageVolume(
+	ctx context.Context,
+	req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	var err error
 	if err = util.ValidateNodeUnstageVolumeRequest(req); err != nil {
 		return nil, err
@@ -693,8 +732,19 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 	// Unmapping rbd device
 	imageSpec := imgInfo.String()
-	if err = detachRBDImageOrDeviceSpec(ctx, imageSpec, true, imgInfo.NbdAccess, imgInfo.Encrypted, req.GetVolumeId(), imgInfo.UnmapOptions); err != nil {
-		util.ErrorLog(ctx, "error unmapping volume (%s) from staging path (%s): (%v)", req.GetVolumeId(), stagingTargetPath, err)
+	if err = detachRBDImageOrDeviceSpec(
+		ctx, imageSpec,
+		true,
+		imgInfo.NbdAccess,
+		imgInfo.Encrypted,
+		req.GetVolumeId(),
+		imgInfo.UnmapOptions); err != nil {
+		util.ErrorLog(
+			ctx,
+			"error unmapping volume (%s) from staging path (%s): (%v)",
+			req.GetVolumeId(),
+			stagingTargetPath,
+			err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -709,7 +759,9 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 }
 
 // NodeExpandVolume resizes rbd volumes.
-func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+func (ns *NodeServer) NodeExpandVolume(
+	ctx context.Context,
+	req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume ID must be provided")
@@ -755,7 +807,12 @@ func getDevicePath(ctx context.Context, volumePath string) (string, error) {
 	if err != nil {
 		util.ErrorLog(ctx, "failed to find image metadata: %v", err)
 	}
-	device, found := findDeviceMappingImage(ctx, imgInfo.Pool, imgInfo.RadosNamespace, imgInfo.ImageName, imgInfo.NbdAccess)
+	device, found := findDeviceMappingImage(
+		ctx,
+		imgInfo.Pool,
+		imgInfo.RadosNamespace,
+		imgInfo.ImageName,
+		imgInfo.NbdAccess)
 	if found {
 		return device, nil
 	}
@@ -763,7 +820,9 @@ func getDevicePath(ctx context.Context, volumePath string) (string, error) {
 }
 
 // NodeGetCapabilities returns the supported capabilities of the node server.
-func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+func (ns *NodeServer) NodeGetCapabilities(
+	ctx context.Context,
+	req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{
 			{
@@ -791,7 +850,10 @@ func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 	}, nil
 }
 
-func (ns *NodeServer) processEncryptedDevice(ctx context.Context, volOptions *rbdVolume, devicePath string) (string, error) {
+func (ns *NodeServer) processEncryptedDevice(
+	ctx context.Context,
+	volOptions *rbdVolume,
+	devicePath string) (string, error) {
 	imageSpec := volOptions.String()
 	encrypted, err := volOptions.checkRbdImageEncrypted(ctx)
 	if err != nil {
@@ -881,7 +943,9 @@ func (ns *NodeServer) xfsSupportsReflink() bool {
 }
 
 // NodeGetVolumeStats returns volume stats.
-func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+func (ns *NodeServer) NodeGetVolumeStats(
+	ctx context.Context,
+	req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
 	var err error
 	targetPath := req.GetVolumePath()
 	if targetPath == "" {

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -96,7 +96,10 @@ func rbdGetDeviceList(ctx context.Context, accessType string) ([]rbdDeviceInfo, 
 		err = json.Unmarshal([]byte(stdout), &nbdDeviceList)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error to parse JSON output of device list for devices of type (%s): %w", accessType, err)
+		return nil, fmt.Errorf(
+			"error to parse JSON output of device list for devices of type (%s): %w",
+			accessType,
+			err)
 	}
 
 	// convert output to a rbdDeviceInfo list for consumers
@@ -270,7 +273,14 @@ func createPath(ctx context.Context, volOpt *rbdVolume, cr *util.Credentials) (s
 		util.WarningLog(ctx, "rbd: map error %v, rbd output: %s", err, stderr)
 		// unmap rbd image if connection timeout
 		if strings.Contains(err.Error(), rbdMapConnectionTimeout) {
-			detErr := detachRBDImageOrDeviceSpec(ctx, imagePath, true, isNbd, volOpt.isEncrypted(), volOpt.VolID, volOpt.UnmapOptions)
+			detErr := detachRBDImageOrDeviceSpec(
+				ctx,
+				imagePath,
+				true,
+				isNbd,
+				volOpt.isEncrypted(),
+				volOpt.VolID,
+				volOpt.UnmapOptions)
 			if detErr != nil {
 				util.WarningLog(ctx, "rbd: %s unmap error %v", imagePath, detErr)
 			}
@@ -315,7 +325,11 @@ func detachRBDDevice(ctx context.Context, devicePath, volumeID, unmapOptions str
 
 // detachRBDImageOrDeviceSpec detaches an rbd imageSpec or devicePath, with additional checking
 // when imageSpec is used to decide if image is already unmapped.
-func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, isImageSpec, isNbd, encrypted bool, volumeID, unmapOptions string) error {
+func detachRBDImageOrDeviceSpec(
+	ctx context.Context,
+	imageOrDeviceSpec string,
+	isImageSpec, isNbd, encrypted bool,
+	volumeID, unmapOptions string) error {
 	if encrypted {
 		mapperFile, mapperPath := util.VolumeMapper(volumeID)
 		mappedDevice, mapper, err := util.DeviceEncryptionStatus(ctx, mapperPath)

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -119,7 +119,11 @@ deletion are inverse of each other, and protected by the request name lock, and
 hence any stale omaps are leftovers from incomplete transactions and are hence
 safe to garbage collect.
 */
-func checkSnapCloneExists(ctx context.Context, parentVol *rbdVolume, rbdSnap *rbdSnapshot, cr *util.Credentials) (bool, error) {
+func checkSnapCloneExists(
+	ctx context.Context,
+	parentVol *rbdVolume,
+	rbdSnap *rbdSnapshot,
+	cr *util.Credentials) (bool, error) {
 	err := validateRbdSnap(rbdSnap)
 	if err != nil {
 		return false, err
@@ -517,7 +521,9 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 // Generate new volume Handler
 // The volume handler won't remain same as its contains poolID,clusterID etc
 // which are not same across clusters.
-func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName string, cr *util.Credentials) (string, error) {
+func RegenerateJournal(
+	imageName, volumeID, pool, journalPool, requestName string,
+	cr *util.Credentials) (string, error) {
 	ctx := context.Background()
 	var (
 		options map[string]string

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -472,7 +472,13 @@ func isNotMountPoint(mounter mount.Interface, stagingTargetPath string) (bool, e
 func addRbdManagerTask(ctx context.Context, pOpts *rbdVolume, arg []string) (bool, error) {
 	args := []string{"rbd", "task", "add"}
 	args = append(args, arg...)
-	util.DebugLog(ctx, "executing %v for image (%s) using mon %s, pool %s", args, pOpts.RbdImageName, pOpts.Monitors, pOpts.Pool)
+	util.DebugLog(
+		ctx,
+		"executing %v for image (%s) using mon %s, pool %s",
+		args,
+		pOpts.RbdImageName,
+		pOpts.Monitors,
+		pOpts.Pool)
 	supported := true
 	_, stderr, err := util.ExecCommand(ctx, "ceph", args...)
 
@@ -480,7 +486,11 @@ func addRbdManagerTask(ctx context.Context, pOpts *rbdVolume, arg []string) (boo
 		switch {
 		case strings.Contains(stderr, rbdTaskRemoveCmdInvalidString1) &&
 			strings.Contains(stderr, rbdTaskRemoveCmdInvalidString2):
-			util.WarningLog(ctx, "cluster with cluster ID (%s) does not support Ceph manager based rbd commands (minimum ceph version required is v14.2.3)", pOpts.ClusterID)
+			util.WarningLog(
+				ctx,
+				"cluster with cluster ID (%s) does not support Ceph manager based rbd commands"+
+					"(minimum ceph version required is v14.2.3)",
+				pOpts.ClusterID)
 			supported = false
 		case strings.HasPrefix(stderr, rbdTaskRemoveCmdAccessDeniedMessage):
 			util.WarningLog(ctx, "access denied to Ceph MGR-based rbd commands on cluster ID (%s)", pOpts.ClusterID)
@@ -595,7 +605,11 @@ type trashSnapInfo struct {
 	origSnapName string
 }
 
-func flattenClonedRbdImages(ctx context.Context, snaps []librbd.SnapInfo, pool, monitors, rbdImageName string, cr *util.Credentials) error {
+func flattenClonedRbdImages(
+	ctx context.Context,
+	snaps []librbd.SnapInfo,
+	pool, monitors, rbdImageName string,
+	cr *util.Credentials) error {
 	rv := &rbdVolume{}
 	rv.Monitors = monitors
 	rv.Pool = pool
@@ -636,7 +650,11 @@ func flattenClonedRbdImages(ctx context.Context, snaps []librbd.SnapInfo, pool, 
 	return nil
 }
 
-func (rv *rbdVolume) flattenRbdImage(ctx context.Context, cr *util.Credentials, forceFlatten bool, hardlimit, softlimit uint) error {
+func (rv *rbdVolume) flattenRbdImage(
+	ctx context.Context,
+	cr *util.Credentials,
+	forceFlatten bool,
+	hardlimit, softlimit uint) error {
 	var depth uint
 	var err error
 
@@ -646,7 +664,13 @@ func (rv *rbdVolume) flattenRbdImage(ctx context.Context, cr *util.Credentials, 
 		if err != nil {
 			return err
 		}
-		util.ExtendedLog(ctx, "clone depth is (%d), configured softlimit (%d) and hardlimit (%d) for %s", depth, softlimit, hardlimit, rv)
+		util.ExtendedLog(
+			ctx,
+			"clone depth is (%d), configured softlimit (%d) and hardlimit (%d) for %s",
+			depth,
+			softlimit,
+			hardlimit,
+			rv)
 	}
 
 	if !forceFlatten && (depth < hardlimit) && (depth < softlimit) {
@@ -669,7 +693,10 @@ func (rv *rbdVolume) flattenRbdImage(ctx context.Context, cr *util.Credentials, 
 		}
 	}
 	if !supported {
-		util.ErrorLog(ctx, "task manager does not support flatten,image will be flattened once hardlimit is reached: %v", err)
+		util.ErrorLog(
+			ctx,
+			"task manager does not support flatten,image will be flattened once hardlimit is reached: %v",
+			err)
 		if forceFlatten || depth >= hardlimit {
 			err = rv.Connect(cr)
 			if err != nil {
@@ -769,7 +796,12 @@ func (rv *rbdVolume) checkImageChainHasFeature(ctx context.Context, feature uint
 
 // genSnapFromSnapID generates a rbdSnapshot structure from the provided identifier, updating
 // the structure with elements from on-disk snapshot metadata as well.
-func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID string, cr *util.Credentials, secrets map[string]string) error {
+func genSnapFromSnapID(
+	ctx context.Context,
+	rbdSnap *rbdSnapshot,
+	snapshotID string,
+	cr *util.Credentials,
+	secrets map[string]string) error {
 	var (
 		options map[string]string
 		vi      util.CSIIdentifier
@@ -853,7 +885,11 @@ func genSnapFromSnapID(ctx context.Context, rbdSnap *rbdSnapshot, snapshotID str
 }
 
 // generateVolumeFromVolumeID generates a rbdVolume structure from the provided identifier.
-func generateVolumeFromVolumeID(ctx context.Context, volumeID string, cr *util.Credentials, secrets map[string]string) (*rbdVolume, error) {
+func generateVolumeFromVolumeID(
+	ctx context.Context,
+	volumeID string,
+	cr *util.Credentials,
+	secrets map[string]string) (*rbdVolume, error) {
 	var (
 		options map[string]string
 		vi      util.CSIIdentifier
@@ -944,9 +980,14 @@ func generateVolumeFromVolumeID(ctx context.Context, volumeID string, cr *util.C
 
 // genVolFromVolID generates a rbdVolume structure from the provided identifier, updating
 // the structure with elements from on-disk image metadata as well.
-func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials, secrets map[string]string) (*rbdVolume, error) {
+func genVolFromVolID(
+	ctx context.Context,
+	volumeID string,
+	cr *util.Credentials,
+	secrets map[string]string) (*rbdVolume, error) {
 	vol, err := generateVolumeFromVolumeID(ctx, volumeID, cr, secrets)
-	if !errors.Is(err, util.ErrKeyNotFound) && !errors.Is(err, util.ErrPoolNotFound) && !errors.Is(err, ErrImageNotFound) {
+	if !errors.Is(err, util.ErrKeyNotFound) && !errors.Is(err, util.ErrPoolNotFound) &&
+		!errors.Is(err, ErrImageNotFound) {
 		return vol, err
 	}
 
@@ -974,7 +1015,10 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 	return vol, err
 }
 
-func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[string]string, disableInUseChecks bool) (*rbdVolume, error) {
+func genVolFromVolumeOptions(
+	ctx context.Context,
+	volOptions, credentials map[string]string,
+	disableInUseChecks bool) (*rbdVolume, error) {
 	var (
 		ok         bool
 		err        error
@@ -1012,7 +1056,12 @@ func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[st
 		return nil, err
 	}
 
-	util.ExtendedLog(ctx, "setting disableInUseChecks: %t image features: %v mounter: %s", disableInUseChecks, rbdVol.imageFeatureSet.Names(), rbdVol.Mounter)
+	util.ExtendedLog(
+		ctx,
+		"setting disableInUseChecks: %t image features: %v mounter: %s",
+		disableInUseChecks,
+		rbdVol.imageFeatureSet.Names(),
+		rbdVol.Mounter)
 	rbdVol.DisableInUseChecks = disableInUseChecks
 
 	err = rbdVol.initKMS(ctx, volOptions, credentials)
@@ -1110,7 +1159,10 @@ func (rv *rbdVolume) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) err
 	return err
 }
 
-func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *rbdSnapshot, parentVol *rbdVolume) error {
+func (rv *rbdVolume) cloneRbdImageFromSnapshot(
+	ctx context.Context,
+	pSnapOpts *rbdSnapshot,
+	parentVol *rbdVolume) error {
 	var err error
 	logMsg := "rbd: clone %s %s (features: %s) using mon %s"
 
@@ -1155,7 +1207,13 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(ctx context.Context, pSnapOpts *r
 		return fmt.Errorf("failed to get IOContext: %w", err)
 	}
 
-	err = librbd.CloneImage(parentVol.ioctx, pSnapOpts.RbdImageName, pSnapOpts.RbdSnapName, rv.ioctx, rv.RbdImageName, options)
+	err = librbd.CloneImage(
+		parentVol.ioctx,
+		pSnapOpts.RbdImageName,
+		pSnapOpts.RbdSnapName,
+		rv.ioctx,
+		rv.RbdImageName,
+		options)
 	if err != nil {
 		return fmt.Errorf("failed to create rbd clone: %w", err)
 	}

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -90,7 +90,11 @@ func getForceOption(ctx context.Context, parameters map[string]string) (bool, er
 func getMirroringMode(ctx context.Context, parameters map[string]string) (librbd.ImageMirrorMode, error) {
 	val, ok := parameters[imageMirroringKey]
 	if !ok {
-		util.WarningLog(ctx, "%s is not set in parameters, setting to mirroringMode to default (%s)", imageMirroringKey, imageMirrorModeSnapshot)
+		util.WarningLog(
+			ctx,
+			"%s is not set in parameters, setting to mirroringMode to default (%s)",
+			imageMirroringKey,
+			imageMirrorModeSnapshot)
 		return librbd.ImageMirrorModeSnapshot, nil
 	}
 
@@ -286,7 +290,11 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	}
 
 	if mirroringInfo.State != librbd.MirrorImageEnabled {
-		return nil, status.Errorf(codes.InvalidArgument, "mirroring is not enabled on %s, image is in %d Mode", rbdVol.VolID, mirroringInfo.State)
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"mirroring is not enabled on %s, image is in %d Mode",
+			rbdVol.VolID,
+			mirroringInfo.State)
 	}
 
 	// promote secondary to primary
@@ -353,7 +361,11 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	}
 
 	if mirroringInfo.State != librbd.MirrorImageEnabled {
-		return nil, status.Errorf(codes.InvalidArgument, "mirroring is not enabled on %s, image is in %d Mode", rbdVol.VolID, mirroringInfo.State)
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"mirroring is not enabled on %s, image is in %d Mode",
+			rbdVol.VolID,
+			mirroringInfo.State)
 	}
 
 	// demote image to secondary
@@ -449,7 +461,13 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		ready = true
 		for _, s := range mirrorStatus.PeerSites {
 			if imageMirroringState(s.State) != upAndUnknown {
-				util.UsefulLog(ctx, "peer site name=%s, mirroring state=%s, description=%s and lastUpdate=%s", s.SiteName, s.State, s.Description, s.LastUpdate)
+				util.UsefulLog(
+					ctx,
+					"peer site name=%s, mirroring state=%s, description=%s and lastUpdate=%s",
+					s.SiteName,
+					s.State,
+					s.Description,
+					s.LastUpdate)
 				ready = false
 			}
 		}
@@ -464,7 +482,12 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		}
 	}
 
-	util.UsefulLog(ctx, "image mirroring state=%s, description=%s and lastUpdate=%s", mirrorStatus.State, mirrorStatus.Description, mirrorStatus.LastUpdate)
+	util.UsefulLog(
+		ctx,
+		"image mirroring state=%s, description=%s and lastUpdate=%s",
+		mirrorStatus.State,
+		mirrorStatus.Description,
+		mirrorStatus.LastUpdate)
 	resp := &replication.ResyncVolumeResponse{
 		Ready: ready,
 	}

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -23,7 +23,11 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 )
 
-func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap *rbdSnapshot, cr *util.Credentials) error {
+func createRBDClone(
+	ctx context.Context,
+	parentVol, cloneRbdVol *rbdVolume,
+	snap *rbdSnapshot,
+	cr *util.Credentials) error {
 	// create snapshot
 	err := parentVol.createSnapshot(ctx, snap)
 	if err != nil {
@@ -35,8 +39,17 @@ func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap
 	// create clone image and delete snapshot
 	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
-		err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", cloneRbdVol.RbdImageName, snap.RbdSnapName, err)
+		util.ErrorLog(
+			ctx,
+			"failed to clone rbd image %s from snapshot %s: %v",
+			cloneRbdVol.RbdImageName,
+			snap.RbdSnapName,
+			err)
+		err = fmt.Errorf(
+			"failed to clone rbd image %s from snapshot %s: %w",
+			cloneRbdVol.RbdImageName,
+			snap.RbdSnapName,
+			err)
 	}
 	errSnap := parentVol.deleteSnapshot(ctx, snap)
 	if errSnap != nil {
@@ -63,14 +76,17 @@ func createRBDClone(ctx context.Context, parentVol, cloneRbdVol *rbdVolume, snap
 
 // cleanUpSnapshot removes the RBD-snapshot (rbdSnap) from the RBD-image
 // (parentVol) and deletes the RBD-image rbdVol.
-func cleanUpSnapshot(ctx context.Context, parentVol *rbdVolume, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, cr *util.Credentials) error {
-	if parentVol != nil && rbdSnap != nil {
-		err := parentVol.deleteSnapshot(ctx, rbdSnap)
-		if err != nil {
-			if !errors.Is(err, ErrSnapNotFound) {
-				util.ErrorLog(ctx, "failed to delete snapshot %q: %v", rbdSnap, err)
-				return err
-			}
+func cleanUpSnapshot(
+	ctx context.Context,
+	parentVol *rbdVolume,
+	rbdSnap *rbdSnapshot,
+	rbdVol *rbdVolume,
+	cr *util.Credentials) error {
+	err := parentVol.deleteSnapshot(ctx, rbdSnap)
+	if err != nil {
+		if !errors.Is(err, ErrSnapNotFound) {
+			util.ErrorLog(ctx, "failed to delete snapshot %q: %v", rbdSnap, err)
+			return err
 		}
 	}
 
@@ -104,7 +120,12 @@ func generateVolFromSnap(rbdSnap *rbdSnapshot) *rbdVolume {
 	return vol
 }
 
-func undoSnapshotCloning(ctx context.Context, parentVol *rbdVolume, rbdSnap *rbdSnapshot, cloneVol *rbdVolume, cr *util.Credentials) error {
+func undoSnapshotCloning(
+	ctx context.Context,
+	parentVol *rbdVolume,
+	rbdSnap *rbdSnapshot,
+	cloneVol *rbdVolume,
+	cr *util.Credentials) error {
 	err := cleanUpSnapshot(ctx, parentVol, rbdSnap, cloneVol, cr)
 	if err != nil {
 		util.ErrorLog(ctx, "failed to clean up  %s or %s: %v", cloneVol, rbdSnap, err)

--- a/internal/util/cryptsetup.go
+++ b/internal/util/cryptsetup.go
@@ -25,7 +25,17 @@ import (
 
 // LuksFormat sets up volume as an encrypted LUKS partition.
 func LuksFormat(devicePath, passphrase string) (stdout, stderr []byte, err error) {
-	return execCryptsetupCommand(&passphrase, "-q", "luksFormat", "--type", "luks2", "--hash", "sha256", devicePath, "-d", "/dev/stdin")
+	return execCryptsetupCommand(
+		&passphrase,
+		"-q",
+		"luksFormat",
+		"--type",
+		"luks2",
+		"--hash",
+		"sha256",
+		devicePath,
+		"-d",
+		"/dev/stdin")
 }
 
 // LuksOpen opens LUKS encrypted partition and sets up a mapping.

--- a/internal/util/kms.go
+++ b/internal/util/kms.go
@@ -252,7 +252,10 @@ func RegisterKMSProvider(provider KMSProvider) bool {
 // buildKMS creates a new KMSProvider instance, based on the configuration that
 // was passed. This uses getKMSProvider() internally to identify the
 // KMSProvider to instantiate.
-func (kf *kmsProviderList) buildKMS(tenant string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
+func (kf *kmsProviderList) buildKMS(
+	tenant string,
+	config map[string]interface{},
+	secrets map[string]string) (EncryptionKMS, error) {
 	providerName, err := getKMSProvider(config)
 	if err != nil {
 		return nil, err

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -131,7 +131,8 @@ type TopologyConstrainedPool struct {
 
 // GetTopologyFromRequest extracts TopologyConstrainedPools and passed in accessibility constraints
 // from a CSI CreateVolume request.
-func GetTopologyFromRequest(req *csi.CreateVolumeRequest) (*[]TopologyConstrainedPool, *csi.TopologyRequirement, error) {
+func GetTopologyFromRequest(
+	req *csi.CreateVolumeRequest) (*[]TopologyConstrainedPool, *csi.TopologyRequirement, error) {
 	var (
 		topologyPools []TopologyConstrainedPool
 	)
@@ -151,7 +152,10 @@ func GetTopologyFromRequest(req *csi.CreateVolumeRequest) (*[]TopologyConstraine
 	// extract topology based pools configuration
 	err := json.Unmarshal([]byte(strings.Replace(topologyPoolsStr, "\n", " ", -1)), &topologyPools)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse JSON encoded topology constrained pools parameter (%s): %v", topologyPoolsStr, err)
+		return nil, nil, fmt.Errorf(
+			"failed to parse JSON encoded topology constrained pools parameter (%s): %v",
+			topologyPoolsStr,
+			err)
 	}
 
 	return &topologyPools, accessibilityRequirements, nil

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -76,8 +76,9 @@ type Config struct {
 	DomainLabels    string // list of domain labels to read from the node
 
 	// metrics related flags
-	MetricsPath       string        // path of prometheus endpoint where metrics will be available
-	HistogramOption   string        // Histogram option for grpc metrics, should be comma separated value, ex:= "0.5,2,6" where start=0.5 factor=2, count=6
+	MetricsPath     string // path of prometheus endpoint where metrics will be available
+	HistogramOption string // Histogram option for grpc metrics, should be comma separated value,
+	// ex:= "0.5,2,6" where start=0.5 factor=2, count=6
 	MetricsIP         string        // TCP port for liveness/ metrics requests
 	PidLimit          int           // PID limit to configure through cgroups")
 	MetricsPort       int           // TCP port for liveness/grpc metrics requests
@@ -97,10 +98,12 @@ type Config struct {
 	// cephfs related flags
 	ForceKernelCephFS bool // force to use the ceph kernel client even if the kernel is < 4.17
 
-	// RbdHardMaxCloneDepth is the hard limit for maximum number of nested volume clones that are taken before a flatten occurs
+	// RbdHardMaxCloneDepth is the hard limit for maximum number of nested volume clones that are taken before a flatten
+	// occurs
 	RbdHardMaxCloneDepth uint
 
-	// RbdSoftMaxCloneDepth is the soft limit for maximum number of nested volume clones that are taken before a flatten occurs
+	// RbdSoftMaxCloneDepth is the soft limit for maximum number of nested volume clones that are taken before a flatten
+	// occurs
 	RbdSoftMaxCloneDepth uint
 
 	// MaxSnapshotsOnImage represents the maximum number of snapshots allowed
@@ -233,7 +236,13 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 
 // GenerateVolID generates a volume ID based on passed in parameters and version, to be returned
 // to the CO system.
-func GenerateVolID(ctx context.Context, monitors string, cr *Credentials, locationID int64, pool, clusterID, objUUID string, volIDVersion uint16) (string, error) {
+func GenerateVolID(
+	ctx context.Context,
+	monitors string,
+	cr *Credentials,
+	locationID int64,
+	pool, clusterID, objUUID string,
+	volIDVersion uint16) (string, error) {
 	var err error
 
 	if locationID == InvalidPoolID {

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -27,7 +27,10 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 	// validate stagingpath exists
 	ok := checkDirExists(req.GetStagingTargetPath())
 	if !ok {
-		return status.Errorf(codes.InvalidArgument, "staging path %s does not exist on node", req.GetStagingTargetPath())
+		return status.Errorf(
+			codes.InvalidArgument,
+			"staging path %s does not exist on node",
+			req.GetStagingTargetPath())
 	}
 	return nil
 }
@@ -83,7 +86,8 @@ func ValidateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) err
 // volume is from source as empty ReadOnlyMany is not supported.
 func CheckReadOnlyManyIsSupported(req *csi.CreateVolumeRequest) error {
 	for _, capability := range req.GetVolumeCapabilities() {
-		if m := capability.GetAccessMode().Mode; m == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY || m == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
+		if m := capability.GetAccessMode().Mode; m == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY ||
+			m == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
 			if req.GetVolumeContentSource() == nil {
 				return status.Error(codes.InvalidArgument, "readOnly accessMode is supported only with content source")
 			}

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -340,7 +340,10 @@ func (kms *VaultTokensKMS) initCertificates(config map[string]interface{}) error
 	if vaultClientCertKeyFromSecret != "" {
 		certKey, err := getCertificate(kms.Tenant, vaultClientCertKeyFromSecret, "key")
 		if err != nil && !apierrs.IsNotFound(err) {
-			return fmt.Errorf("failed to get client certificate key from secret %s: %w", vaultClientCertKeyFromSecret, err)
+			return fmt.Errorf(
+				"failed to get client certificate key from secret %s: %w",
+				vaultClientCertKeyFromSecret,
+				err)
 		}
 		// if the certificate is not present in tenant namespace get it from
 		// cephcsi pod namespace

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -109,8 +109,7 @@ linters-settings:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the
     # tab-width option
-    # TODO make line length to 120 char
-    line-length: 180
+    line-length: 120
     # tab width in spaces. Default to 1.
     tab-width: 1
   gocritic:


### PR DESCRIPTION
 `lll` linter configuration was made for 180 chars till now due to
long source code signatures/comments we had in the project. This
address it and enabling linter with 120 chars check.
    
 Signed-off-by: Humble Chirammal <hchiramm@redhat.com>