### PR TITLE
cleanup: use %w to format errors

### DIFF
--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -159,11 +159,11 @@ func getPVCAndPV(
 	pvcName, pvcNamespace string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
 	pvc, err := c.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get PVC with error %v", err)
+		return nil, nil, fmt.Errorf("failed to get PVC: %w", err)
 	}
 	pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 	if err != nil {
-		return pvc, nil, fmt.Errorf("failed to get PV with error %v", err)
+		return pvc, nil, fmt.Errorf("failed to get PV: %w", err)
 	}
 	return pvc, pv, nil
 }

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -33,11 +33,11 @@ func getSnapshot(path string) snapapi.VolumeSnapshot {
 func newSnapshotClient() (*snapclient.SnapshotV1Client, error) {
 	config, err := framework.LoadConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error creating client: %v", err.Error())
+		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 	c, err := snapclient.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating snapshot client: %v", err.Error())
+		return nil, fmt.Errorf("error creating snapshot client: %w", err)
 	}
 	return c, err
 }


### PR DESCRIPTION
Use %w instead of %v to format errors.

Updates: #1586

Signed-off-by: Yati Padia <ypadia@redhat.com>

