### PR TITLE
e2e: correct configmap name and typos in external-storage test

### DIFF
--- a/scripts/k8s-storage/README.md
+++ b/scripts/k8s-storage/README.md
@@ -8,7 +8,7 @@ driver configuration refers to a StorageClass that is used while testing.
 The StorageClasses are created with the `create-storageclass.sh` script and the
 `sc-*.yaml.in` templates.
 
-The Ceph-CSI Configuration from the `ceph-csiconfig` ConfigMap is created with
+The Ceph-CSI Configuration from the `ceph-csi-config` ConfigMap is created with
 `create-configmap.sh` after the deployment is finished. The ConfigMap is
 referenced in the StorageClasses and contains the connection details for the
 Ceph cluster.

--- a/scripts/k8s-storage/driver-cephfs.yaml
+++ b/scripts/k8s-storage/driver-cephfs.yaml
@@ -26,11 +26,11 @@ DriverInfo:
     rw: {}
 
   # Optional list of access modes required for provisioning. Default is RWO
-  # RequiredAcccessModes:
+  # RequiredAccessModes:
 
   # Map that represents the capabilities the driver supports
   Capabilities:
-    # Data is persistest across pod restarts
+    # Data is persisted across pod restarts
     persistence: true
 
     # Volume ownership via fsGroup
@@ -51,7 +51,7 @@ DriverInfo:
     # Support for volume expansion in nodes
     nodeExpansion: false
 
-    # Support volume that an run on single node only (like hostpath)
+    # Support volume that can run on single node only (like hostpath)
     singleNodeVolume: false
 
     # Support ReadWriteMany access modes

--- a/scripts/k8s-storage/driver-rbd-rwo.yaml
+++ b/scripts/k8s-storage/driver-rbd-rwo.yaml
@@ -31,11 +31,11 @@ DriverInfo:
     rw: {}
 
   # Optional list of access modes required for provisioning. Default is RWO
-  # RequiredAcccessModes:
+  # RequiredAccessModes:
 
   # Map that represents the capabilities the driver supports
   Capabilities:
-    # Data is persistest across pod restarts
+    # Data is persisted across pod restarts
     persistence: true
 
     # Volume ownership via fsGroup
@@ -56,7 +56,7 @@ DriverInfo:
     # Support for volume expansion in nodes
     nodeExpansion: true
 
-    # Support volume that an run on single node only (like hostpath)
+    # Support volume that can run on single node only (like hostpath)
     singleNodeVolume: false
 
     # Support ReadWriteMany access modes


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>