### PR TITLE
rbd: set scheduling interval on snapshot mirrored image

### DIFF
--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ceph/go-ceph/rbd/admin"
+)
+
+func TestValidateSchedulingInterval(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		interval string
+		want     admin.Interval
+		wantErr  bool
+	}{
+		{
+			"valid interval in minutes",
+			"3m",
+			admin.Interval("3m"),
+			false,
+		},
+		{
+			"valid interval in hour",
+			"22h",
+			admin.Interval("22h"),
+			false,
+		},
+		{
+			"valid interval in days",
+			"13d",
+			admin.Interval("13d"),
+			false,
+		},
+		{
+			"invalid interval without number",
+			"d",
+			admin.Interval(""),
+			true,
+		},
+		{
+			"invalid interval without (m|h|d) suffix",
+			"12",
+			admin.Interval(""),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		st := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateSchedulingInterval(st.interval)
+			if (err != nil) != st.wantErr {
+				t.Errorf("validateSchedulingInterval() error = %v, wantErr %v", err, st.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, st.want) {
+				t.Errorf("validateSchedulingInterval() = %v, want %v", got, st.want)
+			}
+		})
+	}
+}
+
+func TestGetSchedulingDetails(t *testing.T) {
+	tests := []struct {
+		name          string
+		parameters    map[string]string
+		wantInterval  admin.Interval
+		wantStartTime admin.StartTime
+		wantErr       bool
+	}{
+		{
+			"valid parameters",
+			map[string]string{
+				imageMirroringKey:      string(imageMirrorModeSnapshot),
+				schedulingIntervalKey:  "1h",
+				schedulingStartTimeKey: "14:00:00-05:00",
+			},
+			admin.Interval("1h"),
+			admin.StartTime("14:00:00-05:00"),
+			false,
+		},
+		{
+			"valid parameters when optional startTime is missing",
+			map[string]string{
+				imageMirroringKey:     string(imageMirrorModeSnapshot),
+				schedulingIntervalKey: "1h",
+			},
+			admin.Interval("1h"),
+			admin.NoStartTime,
+			false,
+		},
+		{
+			"when mirroring mode is journal",
+			map[string]string{
+				imageMirroringKey:     "journal",
+				schedulingIntervalKey: "1h",
+			},
+			admin.NoInterval,
+			admin.NoStartTime,
+			true,
+		},
+		{
+			"when startTime is specified without interval",
+			map[string]string{
+				imageMirroringKey:      string(imageMirrorModeSnapshot),
+				schedulingStartTimeKey: "14:00:00-05:00",
+			},
+			admin.NoInterval,
+			admin.NoStartTime,
+			true,
+		},
+		{
+			"when no scheduling is specified",
+			map[string]string{
+				imageMirroringKey: string(imageMirrorModeSnapshot),
+			},
+			admin.NoInterval,
+			admin.NoStartTime,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		st := tt
+		t.Run(tt.name, func(t *testing.T) {
+			interval, startTime, err := getSchedulingDetails(st.parameters)
+			if (err != nil) != st.wantErr {
+				t.Errorf("getSchedulingDetails() error = %v, wantErr %v", err, st.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(interval, st.wantInterval) {
+				t.Errorf("getSchedulingDetails() interval = %v, want %v", interval, st.wantInterval)
+			}
+			if !reflect.DeepEqual(startTime, st.wantStartTime) {
+				t.Errorf("getSchedulingDetails() startTime = %v, want %v", startTime, st.wantStartTime)
+			}
+		})
+	}
+}

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -23,6 +23,7 @@ import (
 
 	ca "github.com/ceph/go-ceph/cephfs/admin"
 	"github.com/ceph/go-ceph/rados"
+	ra "github.com/ceph/go-ceph/rbd/admin"
 )
 
 type ClusterConnection struct {
@@ -109,6 +110,15 @@ func (cc *ClusterConnection) GetFSAdmin() (*ca.FSAdmin, error) {
 	}
 
 	return ca.NewFromConn(cc.conn), nil
+}
+
+// GetRBDAdmin get RBDAdmin to administrate rbd volumes.
+func (cc *ClusterConnection) GetRBDAdmin() (*ra.RBDAdmin, error) {
+	if cc.conn == nil {
+		return nil, errors.New("cluster is not connected yet")
+	}
+
+	return ra.NewFromConn(cc.conn), nil
 }
 
 // DisableDiscardOnZeroedWriteSame enables the

--- a/vendor/github.com/ceph/go-ceph/rbd/admin/admin.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/admin/admin.go
@@ -1,0 +1,51 @@
+// +build !nautilus
+
+package admin
+
+import (
+	"fmt"
+
+	ccom "github.com/ceph/go-ceph/common/commands"
+)
+
+// RBDAdmin is used to administrate rbd volumes and pools.
+type RBDAdmin struct {
+	conn ccom.RadosCommander
+}
+
+// NewFromConn creates an new management object from a preexisting
+// rados connection. The existing connection can be rados.Conn or any
+// type implementing the RadosCommander interface.
+func NewFromConn(conn ccom.RadosCommander) *RBDAdmin {
+	return &RBDAdmin{conn}
+}
+
+// LevelSpec values are used to identify RBD objects wherever Ceph APIs
+// require a levelspec to select an image, pool, or namespace.
+type LevelSpec struct {
+	spec string
+}
+
+// NewLevelSpec is used to construct a LevelSpec given a pool and
+// optional namespace and image names.
+func NewLevelSpec(pool, namespace, image string) LevelSpec {
+	var s string
+	if image != "" && namespace != "" {
+		s = fmt.Sprintf("%s/%s/%s", pool, namespace, image)
+	} else if image != "" {
+		s = fmt.Sprintf("%s/%s", pool, image)
+	} else if namespace != "" {
+		s = fmt.Sprintf("%s/%s/", pool, namespace)
+	} else {
+		s = fmt.Sprintf("%s/", pool)
+	}
+	return LevelSpec{s}
+}
+
+// NewRawLevelSpec returns a LevelSpec directly based on the spec string
+// argument without constructing it from component values. This should only be
+// used if NewLevelSpec can not create the levelspec value you want to pass to
+// ceph.
+func NewRawLevelSpec(spec string) LevelSpec {
+	return LevelSpec{spec}
+}

--- a/vendor/github.com/ceph/go-ceph/rbd/admin/doc.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/admin/doc.go
@@ -1,0 +1,10 @@
+/*
+Package admin is a convenience layer to support the administration of
+rbd volumes, snapshots, scheduling etc that is outside of the C api
+for librbd.
+
+Unlike the rbd package this API does not map to APIs provided by
+ceph libraries themselves. This API is not yet stable and is subject
+to change.
+*/
+package admin

--- a/vendor/github.com/ceph/go-ceph/rbd/admin/msschedule.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/admin/msschedule.go
@@ -1,0 +1,170 @@
+// +build !nautilus
+
+package admin
+
+import (
+	ccom "github.com/ceph/go-ceph/common/commands"
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+// Interval of time between scheduled snapshots. Typically in the form
+// <num><m,h,d>. Exact content supported is defined internally on the ceph mgr.
+type Interval string
+
+// StartTime is the time the snapshot schedule begins. Exact content supported
+// is defined internally on the ceph mgr.
+type StartTime string
+
+var (
+	// NoInterval indicates no specific interval.
+	NoInterval = Interval("")
+
+	// NoStartTime indicates no specific start time.
+	NoStartTime = StartTime("")
+)
+
+// MirrorSnashotScheduleAdmin encapsulates management functions for
+// ceph rbd mirror snapshot schedules.
+type MirrorSnashotScheduleAdmin struct {
+	conn ccom.MgrCommander
+}
+
+// MirrorSnashotSchedule returns a MirrorSnashotScheduleAdmin type for
+// managing ceph rbd mirror snapshot schedules.
+func (ra *RBDAdmin) MirrorSnashotSchedule() *MirrorSnashotScheduleAdmin {
+	return &MirrorSnashotScheduleAdmin{conn: ra.conn}
+}
+
+// Add a new snapshot schedule to the given pool/image based on the supplied
+// level spec.
+//
+// Similar To:
+//  rbd mirror snapshot schedule add <level_spec> <interval> <start_time>
+func (mss *MirrorSnashotScheduleAdmin) Add(l LevelSpec, i Interval, s StartTime) error {
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule add",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	if i != NoInterval {
+		m["interval"] = string(i)
+	}
+	if s != NoStartTime {
+		m["start_time"] = string(s)
+	}
+	return commands.MarshalMgrCommand(mss.conn, m).NoData().End()
+}
+
+// List the snapshot schedules based on the supplied level spec.
+//
+// Similar To:
+//  rbd mirror snapshot schedule list <level_spec>
+func (mss *MirrorSnashotScheduleAdmin) List(l LevelSpec) ([]SnapshotSchedule, error) {
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule list",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	return parseMirrorSnapshotScheduleList(
+		commands.MarshalMgrCommand(mss.conn, m))
+}
+
+type snapshotScheduleMap map[string]snapshotScheduleSubsection
+
+type snapshotScheduleSubsection struct {
+	Name     string         `json:"name"`
+	Schedule []ScheduleTerm `json:"schedule"`
+}
+
+// ScheduleTerm represents the interval and start time component of
+// a snapshot schedule.
+type ScheduleTerm struct {
+	Interval  Interval  `json:"interval"`
+	StartTime StartTime `json:"start_time"`
+}
+
+// SnapshotSchedule contains values representing an entire snapshot schedule
+// for an image or pool.
+type SnapshotSchedule struct {
+	Name        string
+	LevelSpecID string
+	Schedule    []ScheduleTerm
+}
+
+func parseMirrorSnapshotScheduleList(res commands.Response) (
+	[]SnapshotSchedule, error) {
+
+	var ss snapshotScheduleMap
+	if err := res.NoStatus().Unmarshal(&ss).End(); err != nil {
+		return nil, err
+	}
+
+	var sched []SnapshotSchedule
+	for k, v := range ss {
+		sched = append(sched, SnapshotSchedule{
+			Name:        v.Name,
+			LevelSpecID: k,
+			Schedule:    v.Schedule,
+		})
+	}
+	return sched, nil
+}
+
+// Remove a snapshot schedule matching the supplied arguments.
+//
+// Similar To:
+//  rbd mirror snapshot schedule remove <level_spec> <interval> <start_time>
+func (mss *MirrorSnashotScheduleAdmin) Remove(
+	l LevelSpec, i Interval, s StartTime) error {
+
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule remove",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	if i != NoInterval {
+		m["interval"] = string(i)
+	}
+	if s != NoStartTime {
+		m["start_time"] = string(s)
+	}
+	return commands.MarshalMgrCommand(mss.conn, m).NoData().End()
+}
+
+// Status returns the status of the snapshot (eg. when it will next take place)
+// matching the supplied level spec.
+//
+// Similar To:
+//  rbd mirror snapshot schedule status <level_spec>
+func (mss *MirrorSnashotScheduleAdmin) Status(l LevelSpec) ([]ScheduledImage, error) {
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule status",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	return parseMirrorSnapshotScheduleStatus(
+		commands.MarshalMgrCommand(mss.conn, m))
+}
+
+// ScheduleTime is the time a snapshot will occur.
+type ScheduleTime string
+
+// ScheduledImage contains the item scheduled and when it will next occur.
+type ScheduledImage struct {
+	Image        string       `json:"image"`
+	ScheduleTime ScheduleTime `json:"schedule_time"`
+}
+
+type scheduledImageWrapper struct {
+	ScheduledImages []ScheduledImage `json:"scheduled_images"`
+}
+
+func parseMirrorSnapshotScheduleStatus(res commands.Response) (
+	[]ScheduledImage, error) {
+
+	var siw scheduledImageWrapper
+	if err := res.NoStatus().Unmarshal(&siw).End(); err != nil {
+		return nil, err
+	}
+	return siw.ScheduledImages, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,6 +59,7 @@ github.com/ceph/go-ceph/internal/retry
 github.com/ceph/go-ceph/internal/timespec
 github.com/ceph/go-ceph/rados
 github.com/ceph/go-ceph/rbd
+github.com/ceph/go-ceph/rbd/admin
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/container-storage-interface/spec v1.5.0


### PR DESCRIPTION
Mirror-snapshots can also be automatically created on a periodic basis if mirror-snapshot schedules are defined. The mirror snapshot can be scheduled globally, per-pool, or per-image levels. Multiple mirror-snapshot schedules can be defined at any level.
    
To create a mirror-snapshot schedule with rbd, specify the mirror snapshot schedule add command along with an  optional pool or image name; interval; and optional start time:
 The interval can be specified in days, hours, or minutes using d, h, m suffix respectively. The optional start-time can be specified using the ISO 8601 time format. For example:
    
```
$ rbd --cluster site-a mirror snapshot schedule add --pool image-pool --image image1 24h 14:00:00-05:00
```

fixes: #2119


**Note:-**  Documentation will be covered in #2117

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>