### PR TITLE
e2e: check isRetryableAPIError during polling

### DIFF
--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -27,6 +27,7 @@ func isRetryableAPIError(err error) bool {
 		apierrors.IsTooManyRequests(err) || utilnet.IsProbableEOF(err) || utilnet.IsConnectionReset(err) {
 		return true
 	}
+
 	// If the error sends the Retry-After header, we respect it as an explicit confirmation we should retry.
 	if _, shouldRetry := apierrors.SuggestsClientDelay(err); shouldRetry {
 		return true

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -63,6 +63,9 @@ func createPVCAndvalidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 		if err != nil {
 			return false, fmt.Errorf("failed to get pv: %w", err)
 		}
+		if isRetryableAPIError(err) {
+			return false, nil
+		}
 		if apierrs.IsNotFound(err) {
 			return false, nil
 		}
@@ -118,6 +121,9 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 			}
 			return false, nil
 		}
+		if isRetryableAPIError(err) {
+			return false, nil
+		}
 		if !apierrs.IsNotFound(err) {
 			return false, fmt.Errorf(
 				"get on deleted PVC %v failed with error other than \"not found\": %w",
@@ -145,7 +151,9 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 		if err == nil {
 			return false, nil
 		}
-
+		if isRetryableAPIError(err) {
+			return false, nil
+		}
 		if !apierrs.IsNotFound(err) {
 			return false, fmt.Errorf("delete PV %v failed with error other than \"not found\": %w", pv.Name, err)
 		}
@@ -200,6 +208,9 @@ func deletePVCAndValidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 		if err == nil {
 			return false, nil
 		}
+		if isRetryableAPIError(err) {
+			return false, nil
+		}
 		if !apierrs.IsNotFound(err) {
 			return false, fmt.Errorf("get on deleted PVC %v failed with error other than \"not found\": %w", name, err)
 		}
@@ -209,7 +220,9 @@ func deletePVCAndValidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 		if err == nil {
 			return false, nil
 		}
-
+		if isRetryableAPIError(err) {
+			return false, nil
+		}
 		if !apierrs.IsNotFound(err) {
 			return false, fmt.Errorf("delete PV %v failed with error other than \"not found\": %w", pv.Name, err)
 		}

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -114,6 +114,9 @@ func deleteSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 			return false, nil
 		}
 
+		if isRetryableAPIError(err) {
+			return false, nil
+		}
 		if !apierrs.IsNotFound(err) {
 			return false, fmt.Errorf(
 				"get on deleted snapshot %v failed with error other than \"not found\": %v",


### PR DESCRIPTION
added check to retry if it's an etcd timeout error when the function is polling for the resource.

Note:- This will make things better in some cases where we are polling.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

