### PR TITLE
ci: disable exhaustivestruct linter

### DIFF
--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -167,5 +167,6 @@ linters:
     - wsl
     - funlen
     - testpackage
+    - exhaustivestruct
     # TODO: enable goerr113, see: https://github.com/ceph/ceph-csi/issues/1227
     - goerr113


### PR DESCRIPTION
This commit disables the exhaustivestruct linter
as it is meant to be used only for special cases.

Fixes: #2224

Signed-off-by: Yati Padia <ypadia@redhat.com>
