### PR TITLE
ci: run jobs with Kubernetes 1.21 by default

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -6,6 +6,8 @@
           only_run_on_request: true
       - '1.21':
           only_run_on_request: false
+      - '1.22':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -3,9 +3,9 @@
     name: k8s-e2e-external-storage
     k8s_version:
       - '1.20':
-          only_run_on_request: false
-      - '1.21':
           only_run_on_request: true
+      - '1.21':
+          only_run_on_request: false
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -7,7 +7,7 @@
       - '1.20':
           only_run_on_request: false
       - '1.21':
-          only_run_on_request: true
+          only_run_on_request: false
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -8,6 +8,8 @@
           only_run_on_request: false
       - '1.21':
           only_run_on_request: false
+      - '1.22':
+          only_run_on_request: true
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.20'
+    k8s_version: '1.21'
     test_type:
       - 'cephfs'
       - 'rbd'


### PR DESCRIPTION
The jobs with Kubernetes 1.21 seem to be as stable as the with older versions.

Kubernetes 1.21 is the latest stable release, and Ceph-CSI should be
tested with that. Currently 1.19 is still supported too, so we will need
to run the CI jobs with 1.19, 1.20 and 1.21.

Kubernetes 1.22 is in the release process and can be used for testing
already. The CI jobs will be available and can be triggered by leaving a
comment in the PRs like

    /test ci/centos/mini-e2e-helm/k8s-1.22

See-also: https://kubernetes.io/releases/
See-also: https://github.com/kubernetes/sig-release/tree/master/releases/release-1.22
Updates: #1963

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
