### PR TITLE
rbd: deprecate .rbd.csi.ceph.com/thick-provisioned metadata key

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -170,13 +170,7 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 		}
 	}
 
-	// TODO: copy thick provision config
-	thick, err := parentVol.isThickProvisioned()
-	if err != nil {
-		return fmt.Errorf("failed checking thick-provisioning of %q: %w", parentVol, err)
-	}
-
-	if thick {
+	if rv.ThickProvision {
 		err = rv.setThickProvisioned()
 		if err != nil {
 			return fmt.Errorf("failed mark %q thick-provisioned: %w", rv, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1524,10 +1524,10 @@ func (ri *rbdImage) SetMetadata(key, value string) error {
 
 // setThickProvisioned records in the image metadata that it has been
 // thick-provisioned.
-func (rv *rbdVolume) setThickProvisioned() error {
-	err := rv.SetMetadata(thickProvisionMetaKey, "true")
+func (ri *rbdImage) setThickProvisioned() error {
+	err := ri.SetMetadata(thickProvisionMetaKey, "true")
 	if err != nil {
-		return fmt.Errorf("failed to set metadata %q for %q: %w", thickProvisionMetaKey, rv, err)
+		return fmt.Errorf("failed to set metadata %q for %q: %w", thickProvisionMetaKey, ri, err)
 	}
 
 	return nil


### PR DESCRIPTION
As image metadata key starting with '.rbd' will not be copied when we do clone or mirroring, deprecating the old key for the same reason use 'csi.ceph.com/thick-provisioned' to set image metadata. set thickProvisionMetaKey only if the parent volume is having a deprecated metadata key set.

updates #2219 
closes:  #2121

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

## Test scenarios

### Backward compatibility

* Create Thick PVC from cephcsi 3.3.0
* Upgrade cephcsi from  3.3.0 to latest(custom build from this PR)
* Create Snapshot from Thick PVC-> Verify metadata with the new key is  present on rbd image created during CreateSnapshot operation)
* Restore Snapshot to a thick PVC -> Verify the metadata with new key
* Create PVC-PVC clone from Thick PVC created during 3.3.0 -> Verify  the metadata with a new key on the clone image

### Mirroring

Able to mount/resize the rbd image after the failover to another cluster.
