### PR TITLE
ci: skip Ephemeral-volume kubernetes external-storage tests

### DIFF
--- a/run-k8s-external-storage-e2e.sh
+++ b/run-k8s-external-storage-e2e.sh
@@ -23,7 +23,7 @@ for driver in /opt/build/go/src/github.com/ceph/ceph-csi/scripts/k8s-storage/dri
 do
 	kubernetes/test/bin/ginkgo \
 		-focus="External.Storage.*.csi.ceph.com" \
-		-skip='\[Feature:|\[Disruptive\]' \
+		-skip='\[Feature:|\[Disruptive\]|Generic Ephemeral-volume' \
 		kubernetes/test/bin/e2e.test \
 		-- \
 		-storage.testdriver="${driver}"


### PR DESCRIPTION
Ceph-CSI does not suport (inline) Ephemeral-volumes. Testing this will
continue to fail. The driver configuration can not be used to disable
testing of this feature, so it is done by skipping the tests by pattern
matching.

Updates: #2017

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
