### PR TITLE
rbd: add user secret based metadata encryption

### DIFF
--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -239,6 +239,30 @@ to a different K8s secrets `csi.storage.k8s.io/node-stage-secret-name`
 and `csi.storage.k8s.io/provisioner-secret-name` which carry new passphrase value
 for `encryptionPassphrase` key in these secrets.
 
+### Encryption `metadata` configuration
+
+CephCSI can generate unique passphrase (DEK Data-Encryption-Key) for each volume
+to be used to encrypt/decrypt data. The passphrase (DEK) is encrypted by
+`encryptionPassphrase` (KEK Key-Encryption-Key) and stored in the image metadata
+of the volume.
+
+To encrypt rbd volumes with `metadata` encryption, users need to set
+`encrypted: "true"` and `encryptionKMSID` to a unique identifier in storageclass.
+This unique identifier should be similar to the
+[examples](../examples/kms/vault/csi-kms-connection-details.yaml).
+The configuration must include `"encryptionKMSType": "metadata"`. The
+`encryptionPassphrase` is fetched based on the following conditions:
+
+* if `"secretName"` key is specified, `encryptionPassphrase` is fetched from this
+  secret and `"secretNamespace"` value is used for namespace if specified else
+  Tenant/Kubernetes namespace (i.e., namespace where the PVC was created) is used.
+* if `"secretName"` key is not specified, `encryptionPassphrase` is fetched from
+  storageclass secrets `csi.storage.k8s.io/provisioner-secret-namespace` /
+  `csi.storage.k8s.io/provisioner-secret-name` and
+  `csi.storage.k8s.io/node-stage-secret-namespace` /
+  `csi.storage.k8s.io/node-stage-secret-name`
+  similar to the previous [Encryption Configuration](#encryption-configuration).
+
 ### Encryption KMS configuration
 
 To further improve security robustness it is possible to use unique passphrases

--- a/examples/kms/vault/csi-kms-connection-details.yaml
+++ b/examples/kms/vault/csi-kms-connection-details.yaml
@@ -35,6 +35,17 @@ data:
     {
       "encryptionKMSType": "metadata"
     }
+  user-ns-secrets-metadata-test: |-
+    {
+      "encryptionKMSType": "metadata",
+      "secretName": "storage-encryption-secret",
+      "secretNamespace": "default"
+    }
+  user-secrets-metadata-test: |-
+    {
+      "encryptionKMSType": "metadata",
+      "secretName": "storage-encryption-secret"
+    }
   aws-metadata-test: |-
     {
       "KMS_PROVIDER": "aws-metadata",

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -33,6 +33,15 @@ data:
       },
       "secrets-metadata-test": {
           "encryptionKMSType": "metadata"
+      },
+      "user-ns-secrets-metadata-test": {
+        "encryptionKMSType": "metadata",
+        "secretName": "storage-encryption-secret",
+        "secretNamespace": "default"
+      },
+      "user-secrets-metadata-test": {
+        "encryptionKMSType": "metadata",
+        "secretName": "storage-encryption-secret"
       }
     }
 metadata:

--- a/examples/kms/vault/user-secret.yaml
+++ b/examples/kms/vault/user-secret.yaml
@@ -1,0 +1,11 @@
+---
+# This is the user secret containing encryptionPasspharse that can be
+# created in a Kubernetes Namespace for encrypting PVCs with the
+# "user-ns-secrets-metadata-test" or "user-secrets-metadata-test"
+# encryptionKMSID.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-encryption-secret
+stringData:
+  encryptionPassphrase: test-encryption


### PR DESCRIPTION
This commit adds capability to `metadata` encryption to be able to fetch `encryptionPassphrase` from user
specified secret name and namespace(if not specified, will default to namespace where PVC was created).

This behavior is followed if `secretName` key is found in the encryption configuration else defaults to fetching
`encryptionPassphrase` from storageclass secrets.

Closes: #2107 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
