### PR TITLE
e2e: minor changes to allow running e2e on OpenShift

### DIFF
--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -50,20 +50,7 @@ func deleteVault() {
 }
 
 func createORDeleteVault(action string) {
-	data, err := replaceNamespaceInTemplate(vaultExamplePath + vaultServicePath)
-	if err != nil {
-		e2elog.Failf("failed to read content from %s %v", vaultExamplePath+vaultServicePath, err)
-	}
-
-	data = strings.ReplaceAll(data, "vault.default", "vault."+cephCSINamespace)
-
-	data = strings.ReplaceAll(data, "value: default", "value: "+cephCSINamespace)
-	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
-	if err != nil {
-		e2elog.Failf("failed to %s vault statefulset %v", action, err)
-	}
-
-	data, err = replaceNamespaceInTemplate(vaultExamplePath + vaultRBACPath)
+	data, err := replaceNamespaceInTemplate(vaultExamplePath + vaultRBACPath)
 	if err != nil {
 		e2elog.Failf("failed to read content from %s %v", vaultExamplePath+vaultRBACPath, err)
 	}
@@ -89,5 +76,18 @@ func createORDeleteVault(action string) {
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
 	if err != nil {
 		e2elog.Failf("failed to %s vault psp %v", action, err)
+	}
+
+	data, err = replaceNamespaceInTemplate(vaultExamplePath + vaultServicePath)
+	if err != nil {
+		e2elog.Failf("failed to read content from %s %v", vaultExamplePath+vaultServicePath, err)
+	}
+
+	data = strings.ReplaceAll(data, "vault.default", "vault."+cephCSINamespace)
+
+	data = strings.ReplaceAll(data, "value: default", "value: "+cephCSINamespace)
+	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
+	if err != nil {
+		e2elog.Failf("failed to %s vault statefulset %v", action, err)
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -27,6 +27,7 @@ func init() {
 	flag.StringVar(&upgradeVersion, "upgrade-version", "v3.3.1", "target version for upgrade testing")
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
+	flag.StringVar(&defaultFSID, "fsid", noFSID, "Ceph cluster ID")
 	setDefaultKubeconfig()
 
 	// Register framework flags, then handle flags

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -28,6 +28,7 @@ func init() {
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
 	flag.StringVar(&defaultFSID, "fsid", noFSID, "Ceph cluster ID")
+	flag.BoolVar(&testMetricsForPVC, "test-metrics", true, "test Kubelet metrics for PVC")
 	setDefaultKubeconfig()
 
 	// Register framework flags, then handle flags

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -96,18 +96,8 @@ func createORDeleteRbdResources(action string) {
 			e2elog.Failf("failed to %s CSIDriver object with error %v", action, err)
 		}
 	}
-	data, err := replaceNamespaceInTemplate(rbdDirPath + rbdProvisioner)
-	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisioner, err)
-	}
-	data = oneReplicaDeployYaml(data)
-	data = enableTopologyInTemplate(data)
-	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
-	if err != nil {
-		e2elog.Failf("failed to %s rbd provisioner with error %v", action, err)
-	}
 
-	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdProvisionerRBAC)
+	data, err := replaceNamespaceInTemplate(rbdDirPath + rbdProvisionerRBAC)
 	if err != nil {
 		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisionerRBAC, err)
 	}
@@ -123,18 +113,6 @@ func createORDeleteRbdResources(action string) {
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, "-f", "-")
 	if err != nil {
 		e2elog.Failf("failed to %s provisioner psp with error %v", action, err)
-	}
-
-	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdNodePlugin)
-	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdNodePlugin, err)
-	}
-
-	domainLabel := nodeRegionLabel + "," + nodeZoneLabel
-	data = addTopologyDomainsToDSYaml(data, domainLabel)
-	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
-	if err != nil {
-		e2elog.Failf("failed to %s nodeplugin with error %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdNodePluginRBAC)
@@ -153,6 +131,29 @@ func createORDeleteRbdResources(action string) {
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
 	if err != nil {
 		e2elog.Failf("failed to %s nodeplugin psp with error %v", action, err)
+	}
+
+	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdProvisioner)
+	if err != nil {
+		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisioner, err)
+	}
+	data = oneReplicaDeployYaml(data)
+	data = enableTopologyInTemplate(data)
+
+	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
+	if err != nil {
+		e2elog.Failf("failed to %s rbd provisioner with error %v", action, err)
+	}
+	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdNodePlugin)
+	if err != nil {
+		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdNodePlugin, err)
+	}
+
+	domainLabel := nodeRegionLabel + "," + nodeZoneLabel
+	data = addTopologyDomainsToDSYaml(data, domainLabel)
+	_, err = framework.RunKubectlInput(cephCSINamespace, data, action, ns, "-f", "-")
+	if err != nil {
+		e2elog.Failf("failed to %s nodeplugin with error %v", action, err)
 	}
 }
 

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -59,15 +59,19 @@ func createRBDStorageClass(
 	sc.Parameters["csi.storage.k8s.io/node-stage-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/node-stage-secret-name"] = rbdNodePluginSecretName
 
-	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
-	if err != nil {
-		return err
+	fsID := defaultFSID
+	if fsID == noFSID {
+		var stdErr string
+		fsID, stdErr, err = execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
+		if err != nil {
+			return err
+		}
+		if stdErr != "" {
+			return fmt.Errorf("error getting fsid %v", stdErr)
+		}
+		// remove new line present in fsID
+		fsID = strings.Trim(fsID, "\n")
 	}
-	if stdErr != "" {
-		return fmt.Errorf("error getting fsid %v", stdErr)
-	}
-	// remove new line present in fsID
-	fsID = strings.Trim(fsID, "\n")
 
 	sc.Parameters["clusterID"] = fsID
 	for k, v := range parameters {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -48,7 +48,8 @@ const (
 	vaultTokens = "vaulttokens"
 	noError     = ""
 
-	noKms = ""
+	noKms  = ""
+	noFSID = ""
 )
 
 var (
@@ -67,6 +68,9 @@ var (
 	ns               string
 	vaultAddr        string
 	poll             = 2 * time.Second
+
+	// defaultFSID should be set to noFSID for auto detection
+	defaultFSID = noFSID
 )
 
 func initResources() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -71,6 +71,10 @@ var (
 
 	// defaultFSID should be set to noFSID for auto detection
 	defaultFSID = noFSID
+
+	// testMetricsForPVC can be used to disable verification of the PVC
+	// metrics provided by Kubelet
+	testMetricsForPVC = true
 )
 
 func initResources() {
@@ -328,7 +332,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 	if pvc.Spec.VolumeMode != nil {
 		isBlockMode = (*pvc.Spec.VolumeMode == v1.PersistentVolumeBlock)
 	}
-	if !isBlockMode || k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
+	if testMetricsForPVC && !isBlockMode || k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
 		err = getMetricsForPVC(f, pvc, deployTimeout)
 		if err != nil {
 			return err

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -41,13 +41,13 @@ spec:
         - name: vault
           image: docker.io/library/vault:latest
           imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsUser: 100
           env:
             - name: VAULT_DEV_ROOT_TOKEN_ID
               value: sample_root_token_id
             - name: SKIP_SETCAP
               value: any
+            - name: HOME
+              value: /tmp
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
Most of my manual testing I do on OpenShift. It is useful to run the e2e suite for
validation. However, running on OpenShift fails with different issues. This PR
addresses the problems, and adds arguments that make it possible to run the
tests on an OpenShift deployment with a Ceph cluster configured through Red
Hats OpenShift Container Storage.

This isn't making everything work out of the box though. Some changes to the
files in the `examples/` directory are still needed (like different drivername and
ServiceAccount). But things are getting much closer already.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
