### PR TITLE
ci: fix helm job failure

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -176,7 +176,7 @@ node('cico-workspace') {
 				}
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh up'
 				ssh "kubectl create namespace '${namespace}'"
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh install-cephcsi --namespace '${namespace}' '${deploy_param}'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh install-cephcsi --namespace '${namespace}' ${deploy_param}"
 			}
 		}
 		stage('run e2e') {


### PR DESCRIPTION
Due to the quotes, the job is accepting
both --deploy-sc and --deploy-secret as
as a single parameter.
Removing quotes to help it consider them
as different.

See: https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e-helm_k8s-1.20/detail/mini-e2e-helm_k8s-1.20/1419/pipeline
Updates: #1786 

Signed-off-by: Yug <yuggupta27@gmail.com>



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
