### PR TITLE
Add KMS that supports Hashicorp Vault with a ServiceAccount per Tenant

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -22,4 +22,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
 {{- end -}}

--- a/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
@@ -51,6 +51,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
 {{- if .Values.provisioner.resizer.enabled }}
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -19,6 +19,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -55,6 +55,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/e2e/kms.go
+++ b/e2e/kms.go
@@ -56,6 +56,12 @@ var (
 		},
 		backendPath: defaultVaultBackendPath,
 	}
+	vaultTenantSAKMS = &vaultConfig{
+		simpleKMS: &simpleKMS{
+			provider: "vaulttenantsa",
+		},
+		backendPath: "tenant/",
+	}
 )
 
 func (sk *simpleKMS) String() string {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -792,6 +792,42 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("create a PVC and bind it to an app with encrypted RBD volume with VaultTenantSA KMS", func() {
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass: %v", err)
+				}
+				scOpts := map[string]string{
+					"encrypted":       "true",
+					"encryptionKMSID": "vault-tenant-sa-test",
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+
+				err = createTenantServiceAccount(f.ClientSet, f.UniqueName)
+				if err != nil {
+					e2elog.Failf("failed to create ServiceAccount: %v", err)
+				}
+				defer deleteTenantServiceAccount(f.UniqueName)
+
+				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, vaultTenantSAKMS, f)
+				if err != nil {
+					e2elog.Failf("failed to validate encrypted pvc: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass: %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+			})
+
 			By("create a PVC and bind it to an app with encrypted RBD volume with SecretsMetadataKMS", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {

--- a/examples/kms/vault/csi-kms-connection-details.yaml
+++ b/examples/kms/vault/csi-kms-connection-details.yaml
@@ -31,6 +31,13 @@ data:
       "VAULT_BACKEND_PATH": "secret",
       "VAULT_SKIP_VERIFY": "true"
     }
+  vault-tenant-sa-test: |-
+    {
+      "KMS_PROVIDER": "vaulttenantsa",
+      "VAULT_ADDR": "http://vault.default.svc.cluster.local:8200",
+      "VAULT_BACKEND_PATH": "shared-secrets",
+      "VAULT_SKIP_VERIFY": "true"
+    }
   secrets-metadata-test: |-
     {
       "encryptionKMSType": "metadata"

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -31,6 +31,24 @@ data:
               }
           }
       },
+      "vault-tenant-sa-test": {
+          "encryptionKMSType": "vaulttenantsa",
+          "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+          "vaultBackendPath": "shared-secrets",
+          "vaultTLSServerName": "vault.default.svc.cluster.local",
+          "vaultCAVerify": "false",
+          "tenantConfigName": "ceph-csi-kms-config",
+          "tenantSAName": "ceph-csi-vault-sa",
+          "tenants": {
+              "my-app": {
+                  "vaultAddress": "https://vault.example.com",
+                  "vaultCAVerify": "true"
+              },
+              "an-other-app": {
+                  "tenantSAName": "storage-encryption-sa"
+              }
+          }
+      },
       "secrets-metadata-test": {
           "encryptionKMSType": "metadata"
       },

--- a/examples/kms/vault/tenant-sa-admin.yaml
+++ b/examples/kms/vault/tenant-sa-admin.yaml
@@ -1,0 +1,97 @@
+---
+#
+# "vault-tenant-sa-script" is an example of the commands that are required to
+# create a secret key-value store for a tenant. The ServiceAccount
+# "ceph-csi-vault-sa" in the Namespace of the tenant is given access to the
+# created key-value store.
+#
+# The steps in "add-tenant-sa.sh" would normally be executed by the
+# administrator of the Hashicorp Vault service. The tenant is not expected to
+# have sufficient permissions for running commands like this in a production
+# environment.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-tenant-sa-script
+  namespace: default
+data:
+  add-tenant-sa.sh: |
+    # login into vault to add a configuration for the tenant
+    vault login ${VAULT_DEV_ROOT_TOKEN_ID}
+
+    # create a secret store for the tenant
+    vault secrets enable -path="tenant" kv
+
+    # create a policy for the tenant
+    vault policy write "${TENANT_NAMESPACE}" - << EOS
+    path "tenant/*" {
+      capabilities = ["create", "update", "delete", "read", "list"]
+    }
+
+    path "sys/mounts" {
+      capabilities = ["read"]
+    }
+    EOS
+
+    # allow access with the tenant ServiceAccount
+    vault write "auth/${CLUSTER_IDENTIFIER}/role/${PLUGIN_ROLE}" \
+        bound_service_account_names="${TENANT_SA_NAME}" \
+        bound_service_account_namespaces="${TENANT_NAMESPACE}" \
+        policies="${TENANT_NAMESPACE}"
+---
+#
+# The "add-tenant-sa.sh" script from the above ConfigMap needs to get executed
+# against the Hashicorp Vault service. Usually the administrator of the KMS
+# would configure that, but for this example and testing a Job is included
+# here.
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-tenant-sa
+  namespace: default
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: vault-tenant-sa
+    spec:
+      serviceAccountName: rbd-csi-vault-token-review
+      volumes:
+        - name: vault-tenant-sa-script
+          configMap:
+            name: vault-tenant-sa-script
+      containers:
+        - name: vault-tenant-sa-job
+          image: docker.io/library/vault:latest
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsUser: 100
+          volumeMounts:
+            - mountPath: /scripts
+              name: vault-tenant-sa-script
+          env:
+            - name: HOME
+              value: /tmp
+            - name: CLUSTER_IDENTIFIER
+              value: kubernetes
+            - name: SERVICE_ACCOUNT_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount
+            - name: K8S_HOST
+              value: https://kubernetes.default.svc.cluster.local
+            - name: PLUGIN_ROLE
+              value: csi-kubernetes
+            - name: TENANT_SA_NAME
+              value: ceph-csi-vault-sa
+            - name: TENANT_NAMESPACE
+              value: tenant
+            - name: VAULT_ADDR
+              value: http://vault.default.svc.cluster.local:8200/
+            - name: VAULT_DEV_ROOT_TOKEN_ID
+              value: sample_root_token_id
+          command:
+            - /bin/sh
+            - /scripts/add-tenant-sa.sh
+      restartPolicy: Never

--- a/examples/kms/vault/tenant-sa-admin.yaml
+++ b/examples/kms/vault/tenant-sa-admin.yaml
@@ -82,7 +82,7 @@ spec:
             - name: K8S_HOST
               value: https://kubernetes.default.svc.cluster.local
             - name: PLUGIN_ROLE
-              value: csi-kubernetes
+              value: ceph-csi-tenant
             - name: TENANT_SA_NAME
               value: ceph-csi-vault-sa
             - name: TENANT_NAMESPACE

--- a/examples/kms/vault/tenant-sa.yaml
+++ b/examples/kms/vault/tenant-sa.yaml
@@ -1,0 +1,22 @@
+---
+#
+# The ServiceAccount "ceph-csi-vault-sa" should be created in the Namespace of
+# the tenant that will be creating encrypted PVCs with a "vaulttenantsa" KMS
+# provider.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-vault-sa
+---
+#
+# Each tenant most likely has their own VAULT_BACKEND_PATH or other
+# configuration options. In this example, the tenant has its own key-value
+# store at "tenant".
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-kms-config
+data:
+  vaultBackendPath: tenant

--- a/examples/kms/vault/tenant-sa.yaml
+++ b/examples/kms/vault/tenant-sa.yaml
@@ -20,3 +20,4 @@ metadata:
   name: ceph-csi-kms-config
 data:
   vaultBackendPath: tenant
+  vaultRole: ceph-csi-tenant

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -128,6 +128,8 @@ spec:
       containers:
         - name: vault-init-job
           image: docker.io/library/vault:latest
+          securityContext:
+            runAsUser: 100
           volumeMounts:
             - mountPath: /init-scripts
               name: init-scripts-volume

--- a/internal/util/vault_sa.go
+++ b/internal/util/vault_sa.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/libopenstorage/secrets/vault"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kmsTypeVaultTenantSA = "vaulttenantsa"
+
+	// vaultTenantSAName is the default name of the ServiceAccount that
+	// should be available in the Tenants namespace. This ServiceAccount
+	// will be used to connect to Hashicorp Vault.
+	vaultTenantSAName = "ceph-csi-vault-sa"
+)
+
+/*
+VaultTenantSA represents a Hashicorp Vault KMS configuration that uses a
+ServiceAccount from the Tenant that owns the volume to store/retrieve the
+encryption passphrase of volumes.
+
+Example JSON structure in the KMS config is,
+{
+    "vault-tenant-sa": {
+        "encryptionKMSType": "vaulttenantsa",
+        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackendPath": "secret/",
+        "vaultTLSServerName": "vault.default.svc.cluster.local",
+        "vaultCAFromSecret": "vault-ca",
+        "vaultClientCertFromSecret": "vault-client-cert",
+        "vaultClientCertKeyFromSecret": "vault-client-cert-key",
+        "vaultCAVerify": "false",
+        "tenantConfigName": "ceph-csi-kms-config",
+        "tenantSAName": "ceph-csi-vault-sa",
+        "tenants": {
+            "my-app": {
+                "vaultAddress": "https://vault.example.com",
+                "vaultCAVerify": "true"
+            },
+            "an-other-app": {
+                "tenantSAName": "encryped-storage-sa"
+            }
+	},
+	...
+}.
+*/
+type VaultTenantSA struct {
+	vaultTenantConnection
+
+	// tenantSAName is the name of the ServiceAccount in the Tenants Kubernetes Namespace
+	tenantSAName string
+
+	// saTokenDir contains the directory that holds the token to connect to Vault.
+	saTokenDir string
+}
+
+var _ = RegisterKMSProvider(KMSProvider{
+	UniqueID:    kmsTypeVaultTenantSA,
+	Initializer: initVaultTenantSA,
+})
+
+// initVaultTenantSA returns an interface to HashiCorp Vault KMS where Tenants
+// use their ServiceAccount to access the service.
+func initVaultTenantSA(args KMSInitializerArgs) (EncryptionKMS, error) {
+	var err error
+
+	config := args.Config
+	if _, ok := config[kmsProviderKey]; ok {
+		// configuration comes from the ConfigMap, needs to be
+		// converted to vaultTokenConf type
+		config, err = transformConfig(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert configuration: %w", err)
+		}
+	}
+
+	kms := &VaultTenantSA{}
+	err = kms.initConnection(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
+	}
+
+	// set default values for optional config options
+	kms.ConfigName = vaultTokensDefaultConfigName
+	kms.tenantSAName = vaultTenantSAName
+
+	// TODO: should this be configurable per tenant?
+	vaultRole := vaultDefaultRole
+	err = setConfigString(&vaultRole, args.Config, "vaultRole")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return nil, err
+	}
+	kms.vaultConfig[vault.AuthKubernetesRole] = vaultRole
+
+	err = kms.parseConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch the configuration for the tenant
+	if args.Tenant != "" {
+		kms.Tenant = args.Tenant
+		tenantConfig, found := fetchTenantConfig(config, args.Tenant)
+		if found {
+			// override connection details from the tenant
+			err = kms.parseConfig(tenantConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err = kms.parseTenantConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse config for tenant: %w", err)
+		}
+
+		err = kms.setServiceAccountName(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set the ServiceAccount name from %s for tenant (%s): %w",
+				kms.ConfigName, kms.Tenant, err)
+		}
+	}
+
+	kms.vaultConfig[vault.AuthMethod] = vault.AuthMethodKubernetes
+	kms.vaultConfig[vault.AuthKubernetesTokenPath], err = kms.getTokenPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed setting up token for %s/%s: %w", kms.Tenant, kms.tenantSAName, err)
+	}
+
+	err = kms.initCertificates(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Vault certificates: %w", err)
+	}
+	// connect to the Vault service
+	err = kms.connectVault()
+	if err != nil {
+		return nil, err
+	}
+
+	return kms, nil
+}
+
+// Destroy removes the temporary stored token from the ServiceAccount and
+// destroys the vaultTenantConnection object.
+func (kms *VaultTenantSA) Destroy() {
+	if kms.saTokenDir != "" {
+		_ = os.RemoveAll(kms.saTokenDir)
+	}
+
+	kms.vaultTenantConnection.Destroy()
+}
+
+// setServiceAccountName stores the name of the ServiceAccount in the
+// configuration if it has been set in the options.
+func (kms *VaultTenantSA) setServiceAccountName(config map[string]interface{}) error {
+	err := setConfigString(&kms.tenantSAName, config, "tenantSAName")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+
+	return nil
+}
+
+// getServiceAccount returns the Tenants ServiceAccount with the name
+// configured in the VaultTenantSA.
+func (kms *VaultTenantSA) getServiceAccount() (*corev1.ServiceAccount, error) {
+	c := kms.getK8sClient()
+	sa, err := c.CoreV1().ServiceAccounts(kms.Tenant).Get(context.TODO(),
+		kms.tenantSAName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ServiceAccount %s/%s: %w", kms.Tenant, kms.tenantSAName, err)
+	}
+
+	return sa, nil
+}
+
+// getToken looks up the ServiceAccount and the Secrets linked from it. When it
+// finds the Secret that contains the `token` field, the contents is read and
+// returned.
+func (kms *VaultTenantSA) getToken() (string, error) {
+	sa, err := kms.getServiceAccount()
+	if err != nil {
+		return "", err
+	}
+
+	c := kms.getK8sClient()
+	for _, secretRef := range sa.Secrets {
+		secret, err := c.CoreV1().Secrets(kms.Tenant).Get(context.TODO(), secretRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("failed to get Secret %s/%s: %w", kms.Tenant, secretRef.Name, err)
+		}
+
+		token, ok := secret.Data["token"]
+		if ok {
+			return string(token), nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find token in ServiceAccount %s/%s", kms.Tenant, kms.tenantSAName)
+}
+
+// getTokenPath creates a temporary directory structure that contains the token
+// linked from the ServiceAccount. This path can then be used in place of the
+// standard `/var/run/secrets/kubernetes.io/serviceaccount/token` location.
+func (kms *VaultTenantSA) getTokenPath() (string, error) {
+	dir, err := ioutil.TempDir("", kms.tenantSAName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create directory for ServiceAccount %s/%s: %w", kms.tenantSAName, kms.Tenant, err)
+	}
+
+	token, err := kms.getToken()
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(dir+"/token", []byte(token), 0600)
+	if err != nil {
+		return "", fmt.Errorf("failed to write token for ServiceAccount %s/%s: %w", kms.tenantSAName, kms.Tenant, err)
+	}
+
+	return dir + "/token", nil
+}

--- a/internal/util/vault_sa_test.go
+++ b/internal/util/vault_sa_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVaultTenantSAKMSRegistered(t *testing.T) {
+	_, ok := kmsManager.providers[kmsTypeVaultTenantSA]
+	assert.True(t, ok)
+}

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -28,12 +28,12 @@ import (
 
 func TestParseConfig(t *testing.T) {
 	t.Parallel()
-	kms := VaultTokensKMS{}
+	vtc := vaultTenantConnection{}
 
 	config := make(map[string]interface{})
 
 	// empty config map
-	err := kms.parseConfig(config)
+	err := vtc.parseConfig(config)
 	if !errors.Is(err, errConfigOptionMissing) {
 		t.Errorf("unexpected error (%T): %s", err, err)
 	}
@@ -41,28 +41,25 @@ func TestParseConfig(t *testing.T) {
 	// fill default options (normally done in initVaultTokensKMS)
 	config["vaultAddress"] = "https://vault.default.cluster.svc"
 	config["tenantConfigName"] = vaultTokensDefaultConfigName
-	config["tenantTokenName"] = vaultTokensDefaultTokenName
 
 	// parsing with all required options
-	err = kms.parseConfig(config)
+	err = vtc.parseConfig(config)
 	switch {
 	case err != nil:
 		t.Errorf("unexpected error: %s", err)
-	case kms.ConfigName != vaultTokensDefaultConfigName:
-		t.Errorf("ConfigName contains unexpected value: %s", kms.ConfigName)
-	case kms.TokenName != vaultTokensDefaultTokenName:
-		t.Errorf("TokenName contains unexpected value: %s", kms.TokenName)
+	case vtc.ConfigName != vaultTokensDefaultConfigName:
+		t.Errorf("ConfigName contains unexpected value: %s", vtc.ConfigName)
 	}
 
 	// tenant "bob" uses a different kms.ConfigName
 	bob := make(map[string]interface{})
 	bob["tenantConfigName"] = "the-config-from-bob"
-	err = kms.parseConfig(bob)
+	err = vtc.parseConfig(bob)
 	switch {
 	case err != nil:
 		t.Errorf("unexpected error: %s", err)
-	case kms.ConfigName != "the-config-from-bob":
-		t.Errorf("ConfigName contains unexpected value: %s", kms.ConfigName)
+	case vtc.ConfigName != "the-config-from-bob":
+		t.Errorf("ConfigName contains unexpected value: %s", vtc.ConfigName)
 	}
 }
 


### PR DESCRIPTION
This new KMS uses a Kubernetes ServiceAccount from a Tenant (Namespace)
to connect to Hashicorp Vault. The provisioner and node-plugin will
check for the configured ServiceAccount and use the token that is
located in one of the linked Secrets. Subsequently the Vault connection
is configured to use the Kubernetes token from the Tenant.

This PR contains the following pieces:

- [x] refactoring of `VaultTokensKMS` to make `vaultTenantConnection` re-usable
- [x] implementation of `VaultTenantSA` KMS
- [x] example `.yaml` files
- [x] e2e tests

Updates: #2222

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
