### PR TITLE
cleanup: spell check getImageMirroingStatus

### DIFF
--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -127,8 +127,8 @@ type imageMirrorStatus struct {
 }
 
 // FIXME: once https://github.com/ceph/go-ceph/issues/460 is fixed use go-ceph.
-// getImageMirroingStatus get the mirroring status of an image.
-func (ri *rbdImage) getImageMirroingStatus() (*imageMirrorStatus, error) {
+// getImageMirroringStatus get the mirroring status of an image.
+func (ri *rbdImage) getImageMirroringStatus() (*imageMirrorStatus, error) {
 	// rbd mirror image status --format=json info [image-spec | snap-spec]
 	var imgStatus imageMirrorStatus
 	stdout, stderr, err := util.ExecCommand(

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -515,7 +515,7 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		return nil, status.Error(codes.InvalidArgument, "image is in primary state")
 	}
 
-	mirrorStatus, err := rbdVol.getImageMirroingStatus()
+	mirrorStatus, err := rbdVol.getImageMirroringStatus()
 	if err != nil {
 		// the image gets recreated after issuing resync in that case return
 		// volume as not ready.


### PR DESCRIPTION
This commit corrects the spelling for
getImageMirroingStatus() -> getImageMirroringStatus

Signed-off-by: Yati Padia <ypadia@redhat.com>
