### PR TITLE
[WIP] e2e: async communication between test and callbacks

### DIFF
--- a/e2e/async.go
+++ b/e2e/async.go
@@ -1,0 +1,90 @@
+package e2e
+
+import (
+	"fmt"  //nolint:goimports
+	"sync" //nolint:goimports
+
+	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+)
+
+type configItem struct {
+	ID         int // Unique identification
+	f          *framework.Framework
+	obj        *objects // Objects which are set for callback
+	callbackFn string
+	retErr     chan error // error channel to receive errors
+}
+
+type objects struct {
+	snap *snapapi.VolumeSnapshot
+	pvc  *v1.PersistentVolumeClaim
+	app  *v1.Pod
+}
+
+func executeOperations(ch <-chan configItem) {
+	for proc := range ch {
+		switch proc.callbackFn {
+		case "createsnap":
+			mySnap := *(proc.obj.snap)
+			mySnap.Name = fmt.Sprintf("%s%d", proc.f.UniqueName, proc.ID)
+			err := createSnapshot(&mySnap, deployTimeout)
+			proc.retErr <- err
+		case "deletepvcandapp":
+			name := fmt.Sprintf("%s%d", proc.f.UniqueName, proc.ID)
+			if proc.obj != nil && proc.obj.pvc != nil {
+				proc.obj.pvc.Spec.DataSource.Name = name
+			}
+			err := deletePVCAndApp(name, proc.f, proc.obj.pvc, proc.obj.app)
+			proc.retErr <- err
+		default:
+			proc.retErr <- fmt.Errorf("unknown callback function")
+		}
+	}
+}
+
+func dispatch(
+	fwk *framework.Framework, passedObj *objects, callbackFunc string, sendCh chan configItem, tc int) []configItem {
+	configs := make([]configItem, tc)
+	for i := 0; i < tc; i++ {
+		proc := configItem{ID: i, f: fwk, obj: passedObj, callbackFn: callbackFunc, retErr: make(chan error)}
+		configs[i] = proc
+		sendCh <- proc
+	}
+	// todo: discard
+	return configs
+}
+
+func getRoutines(c int) chan configItem {
+	procCh := make(chan configItem, c)
+	for i := 0; i < c; i++ {
+		go executeOperations(procCh)
+	}
+	return procCh
+}
+
+func waitForAll(totalCount int, processes []configItem, cfunc string) (int, error) {
+	var newWg sync.WaitGroup
+	failed := 0
+	for i := 0; i < totalCount; i++ {
+		newWg.Add(1)
+		job := i
+		go func(ch <-chan error) {
+			defer newWg.Done()
+			result := <-ch
+			if result != nil {
+				e2elog.Logf("%v failed with error: %v on process: %d ", cfunc, result, job)
+				failed++
+			} else {
+				e2elog.Logf("successfully executed job for process: %d", job)
+			}
+		}(processes[i].retErr)
+	}
+	newWg.Wait()
+	if failed != 0 {
+		return failed, fmt.Errorf("creating snapshots failed, %d errors were logged", failed)
+	}
+	return 0, nil
+}

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -80,6 +80,7 @@ func createSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 			return false, nil
 		}
 		if *snaps.Status.ReadyToUse {
+			e2elog.Logf("snap details: %#v", *snap)
 			return true, nil
 		}
 		e2elog.Logf("snapshot %s in %v state", snap.Name, *snaps.Status.ReadyToUse)


### PR DESCRIPTION
The intention here is to add a framework  which looks similar to the  design in below doc:

https://hackmd.io/oIgJlaC3SaOG4xEaLV2K4w

Additional thoughts or validation of above is invited before taking this PR to next step.  

Cc @nixpanic @Madhu-1 @Yuggupta27 @yati1998  @Rakshith-R 

Just to give some example change in the caller ( once the implementation is done)  createsnapshot for 10 copies after changing the name and namespace becomes:

```
rc := RunConfig{{ {Name: createSnapshot, Args: *snaptemplate, 2}, Copies: 5, WforAll: true, PrepFuncs: [
      {{ SetName, SetNamespace}, arg {*snaptemplate}},....},
        
```

Then rc.Run() has been called, which internally spawn 10 routines to take care of the job and wait for all to finish and return the error or success back to the test case.



Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


