### PR TITLE
rbd: add support to expand encrypted volume

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -597,6 +597,48 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("Resize Encrypted Block PVC and check Device size", func() {
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{"encrypted": "true"},
+					deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+
+				// FileSystem PVC resize
+				err = resizePVCAndValidateSize(pvcPath, appPath, f)
+				if err != nil {
+					e2elog.Failf("failed to resize filesystem PVC with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				// Block PVC resize
+				err = resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
+				if err != nil {
+					e2elog.Failf("failed to resize block PVC with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+			})
+
 			By("create a PVC and bind it to an app with encrypted RBD volume with VaultKMS", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -294,7 +294,8 @@ func DeviceEncryptionStatus(ctx context.Context, devicePath string) (mappedDevic
 	if len(lines) < 1 {
 		return "", "", fmt.Errorf("device encryption status returned no stdout for %s", devicePath)
 	}
-	if !strings.HasSuffix(lines[0], " is active.") {
+	// The line will look like: "/dev/mapper/xxx is active and is in use."
+	if !strings.Contains(lines[0], " is active") {
 		// Implies this is not a LUKS device
 		return devicePath, "", nil
 	}

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -261,6 +261,17 @@ func OpenEncryptedVolume(ctx context.Context, devicePath, mapperFile, passphrase
 	return err
 }
 
+// ResizeEncryptedVolume resizes encrypted volume so that it can be used by the client.
+func ResizeEncryptedVolume(ctx context.Context, mapperFile string) error {
+	DebugLog(ctx, "Resizing LUKS device %s", mapperFile)
+	_, stderr, err := LuksResize(mapperFile)
+	if err != nil {
+		ErrorLog(ctx, "failed to resize LUKS device %s: %s", mapperFile, stderr)
+	}
+
+	return err
+}
+
 // CloseEncryptedVolume closes encrypted volume so it can be detached.
 func CloseEncryptedVolume(ctx context.Context, mapperFile string) error {
 	DebugLog(ctx, "Closing LUKS device %s", mapperFile)

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -255,7 +255,7 @@ func OpenEncryptedVolume(ctx context.Context, devicePath, mapperFile, passphrase
 	DebugLog(ctx, "Opening device %s with LUKS on %s", devicePath, mapperFile)
 	_, stderr, err := LuksOpen(devicePath, mapperFile, passphrase)
 	if err != nil {
-		WarningLog(ctx, "failed to open LUKS device %q: %s", devicePath, stderr)
+		ErrorLog(ctx, "failed to open LUKS device %q: %s", devicePath, stderr)
 	}
 
 	return err

--- a/internal/util/cryptsetup.go
+++ b/internal/util/cryptsetup.go
@@ -40,7 +40,9 @@ func LuksFormat(devicePath, passphrase string) (stdout, stderr []byte, err error
 
 // LuksOpen opens LUKS encrypted partition and sets up a mapping.
 func LuksOpen(devicePath, mapperFile, passphrase string) (stdout, stderr []byte, err error) {
-	return execCryptsetupCommand(&passphrase, "luksOpen", devicePath, mapperFile, "-d", "/dev/stdin")
+	// cryptsetup option --disable-keyring (introduced with cryptsetup v2.0.0)
+	// will be ignored with luks1
+	return execCryptsetupCommand(&passphrase, "luksOpen", devicePath, mapperFile, "--disable-keyring", "-d", "/dev/stdin")
 }
 
 // LuksResize resizes LUKS encrypted partition.

--- a/internal/util/cryptsetup.go
+++ b/internal/util/cryptsetup.go
@@ -43,6 +43,11 @@ func LuksOpen(devicePath, mapperFile, passphrase string) (stdout, stderr []byte,
 	return execCryptsetupCommand(&passphrase, "luksOpen", devicePath, mapperFile, "-d", "/dev/stdin")
 }
 
+// LuksResize resizes LUKS encrypted partition.
+func LuksResize(mapperFile string) (stdout, stderr []byte, err error) {
+	return execCryptsetupCommand(nil, "resize", mapperFile)
+}
+
 // LuksClose removes existing mapping.
 func LuksClose(mapperFile string) (stdout, stderr []byte, err error) {
 	return execCryptsetupCommand(nil, "luksClose", mapperFile)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Previously in ControllerExpandVolume() we had a check for encrypted volumes and we use to fail for all expand requests on an encrypted volume. Also for Block VolumeMode PVCs NodeExpandVolume used to be ignored/skipped.                                                            
                                                                            
With these changes, we add support for the expansion of encrypted volumes. Also for raw Block VolumeMode PVCs with Encryption, we call NodeExpandVolume.
                                                                            
That said,                                                                  
With LUKS1, cryptsetup utility doesn't prompt for a passphrase on resizing the crypto mapper device. This is because LUKS1 devices don't use kernel keyring for volume keys.

Whereas, LUKS2 devices use kernel keyring for volume key by default, i.e. cryptsetup utility asks for a passphrase if it detects volume key was previously passed to dm-crypt via kernel keyring service, we are overriding the default by `--disable-keyring` option during cryptsetup open command. So that at the time of crypto mapper device resize we will not be prompted for any passphrase.

Fixes: #1469

### Other notable changes:

* fix bug in DeviceEncryptionStatus() which could lead to failures with unmap in the NodeUnstageVolume path for the encrypted volumes.
* Added testcases
