### PR TITLE
rbd: fix vol.VolID in cloneFromSnapshot()

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -165,9 +165,11 @@ func validateRBDImageCount(f *framework.Framework, count int, pool string) {
 	}
 	if len(imageList) != count {
 		e2elog.Failf(
-			"backend images not matching kubernetes resource count,image count %d kubernetes resource count %d",
+			"backend images not matching kubernetes resource count,image count %d kubernetes resource count %d"+
+				"\nbackend image Info:\n %v",
 			len(imageList),
-			count)
+			count,
+			imageList)
 	}
 }
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1942,6 +1942,106 @@ var _ = Describe("RBD", func() {
 					validateRBDImageCount(f, 0, defaultRBDPool)
 				})
 
+			By("validate PVC Clone chained with depth 2", func() {
+				// snapshot beta is only supported from v1.17+
+				if !k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
+					Skip("pvc restore is only supported from v1.17+")
+				}
+				cloneChainDepth := 2
+
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass with error %v", err)
+				}
+
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{
+						"encrypted":       "true",
+						"encryptionKMSID": "vault-test",
+					},
+					deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
+				}
+				defer func() {
+					err = deleteResource(rbdExamplePath + "storageclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete storageclass with error %v", err)
+					}
+					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+					if err != nil {
+						e2elog.Failf("failed to create storageclass with error %v", err)
+					}
+				}()
+
+				// create PVC and bind it to an app
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					e2elog.Failf("failed to load PVC with error %v", err)
+				}
+
+				pvc.Namespace = f.UniqueName
+				app, err := loadApp(appPath)
+				if err != nil {
+					e2elog.Failf("failed to load application with error %v", err)
+				}
+				app.Namespace = f.UniqueName
+				err = createPVCAndApp("", f, pvc, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create PVC and application with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				for i := 0; i < cloneChainDepth; i++ {
+					var pvcClone *v1.PersistentVolumeClaim
+					pvcClone, err = loadPVC(pvcSmartClonePath)
+					if err != nil {
+						e2elog.Failf("failed to load PVC with error %v", err)
+					}
+
+					// create clone PVC
+					pvcClone.Name = fmt.Sprintf("%s-%d", pvcClone.Name, i)
+					pvcClone.Namespace = f.UniqueName
+					pvcClone.Spec.DataSource.Name = pvc.Name
+					err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to create PVC with error %v", err)
+					}
+
+					// delete parent PVC
+					err = deletePVCAndApp("", f, pvc, app)
+					if err != nil {
+						e2elog.Failf("failed to delete PVC and application with error %v", err)
+					}
+
+					app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
+					// create application
+					err = createApp(f.ClientSet, app, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to create application with error %v", err)
+					}
+
+					pvc = pvcClone
+				}
+
+				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete application with error %v", err)
+				}
+				// delete PVC clone
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete PVC with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+			})
+
 			By("ensuring all operations will work within a rados namespace", func() {
 				updateConfigMap := func(radosNS string) {
 					radosNamespace = radosNS

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1803,6 +1803,145 @@ var _ = Describe("RBD", func() {
 				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
+			By(
+				"validate PVC mounting if snapshot and parent PVC are deleted chained with depth 2",
+				func() {
+					// snapshot beta is only supported from v1.17+
+					if !k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
+						Skip("pvc restore is only supported from v1.17+")
+					}
+					snapChainDepth := 2
+
+					err := deleteResource(rbdExamplePath + "storageclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete storageclass with error %v", err)
+					}
+
+					err = createRBDStorageClass(
+						f.ClientSet,
+						f,
+						defaultSCName,
+						nil,
+						map[string]string{
+							"encrypted":       "true",
+							"encryptionKMSID": "vault-test",
+						},
+						deletePolicy)
+					if err != nil {
+						e2elog.Failf("failed to create storageclass with error %v", err)
+					}
+
+					err = createRBDSnapshotClass(f)
+					if err != nil {
+						e2elog.Failf("failed to create storageclass with error %v", err)
+					}
+
+					defer func() {
+						err = deleteRBDSnapshotClass()
+						if err != nil {
+							e2elog.Failf("failed to delete VolumeSnapshotClass: %v", err)
+						}
+						err = deleteResource(rbdExamplePath + "storageclass.yaml")
+						if err != nil {
+							e2elog.Failf("failed to delete storageclass with error %v", err)
+						}
+						err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+						if err != nil {
+							e2elog.Failf("failed to create storageclass with error %v", err)
+						}
+					}()
+
+					// create PVC and bind it to an app
+					pvc, err := loadPVC(pvcPath)
+					if err != nil {
+						e2elog.Failf("failed to load PVC with error %v", err)
+					}
+
+					pvc.Namespace = f.UniqueName
+					app, err := loadApp(appPath)
+					if err != nil {
+						e2elog.Failf("failed to load application with error %v", err)
+					}
+					app.Namespace = f.UniqueName
+					err = createPVCAndApp("", f, pvc, app, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to create PVC and application with error %v", err)
+					}
+					// validate created backend rbd images
+					validateRBDImageCount(f, 1, defaultRBDPool)
+					for i := 0; i < snapChainDepth; i++ {
+						var pvcClone *v1.PersistentVolumeClaim
+						snap := getSnapshot(snapshotPath)
+						snap.Name = fmt.Sprintf("%s-%d", snap.Name, i)
+						snap.Namespace = f.UniqueName
+						snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+
+						err = createSnapshot(&snap, deployTimeout)
+						if err != nil {
+							e2elog.Failf("failed to create snapshot with error %v", err)
+						}
+						// validate created backend rbd images
+						// parent PVC + snapshot
+						totalImages := 2
+						validateRBDImageCount(f, totalImages, defaultRBDPool)
+						pvcClone, err = loadPVC(pvcClonePath)
+						if err != nil {
+							e2elog.Failf("failed to load PVC with error %v", err)
+						}
+
+						// delete parent PVC
+						err = deletePVCAndApp("", f, pvc, app)
+						if err != nil {
+							e2elog.Failf("failed to delete PVC and application with error %v", err)
+						}
+						// validate created backend rbd images
+						validateRBDImageCount(f, 1, defaultRBDPool)
+
+						// create clone PVC
+						pvcClone.Name = fmt.Sprintf("%s-%d", pvcClone.Name, i)
+						pvcClone.Namespace = f.UniqueName
+						pvcClone.Spec.DataSource.Name = snap.Name
+						err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
+						if err != nil {
+							e2elog.Failf("failed to create PVC with error %v", err)
+						}
+						// validate created backend rbd images = snapshot + clone
+						totalImages = 2
+						validateRBDImageCount(f, totalImages, defaultRBDPool)
+
+						// delete snapshot
+						err = deleteSnapshot(&snap, deployTimeout)
+						if err != nil {
+							e2elog.Failf("failed to delete snapshot with error %v", err)
+						}
+
+						// validate created backend rbd images = clone
+						totalImages = 1
+						validateRBDImageCount(f, totalImages, defaultRBDPool)
+
+						app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
+						// create application
+						err = createApp(f.ClientSet, app, deployTimeout)
+						if err != nil {
+							e2elog.Failf("failed to create application with error %v", err)
+						}
+
+						pvc = pvcClone
+					}
+
+					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to delete application with error %v", err)
+					}
+					// delete PVC clone
+					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to delete PVC with error %v", err)
+					}
+					// validate created backend rbd images
+					validateRBDImageCount(f, 0, defaultRBDPool)
+				})
+
 			By("ensuring all operations will work within a rados namespace", func() {
 				updateConfigMap := func(radosNS string) {
 					radosNamespace = radosNS

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1034,8 +1034,6 @@ func cloneFromSnapshot(
 	defer vol.Destroy()
 
 	if rbdVol.isEncrypted() {
-		// FIXME: vol.VolID should be different from rbdVol.VolID
-		vol.VolID = rbdVol.VolID
 		err = rbdVol.copyEncryptionConfig(&vol.rbdImage)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -311,6 +311,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 
 		return false, err
 	}
+	// TODO: check image needs flattening and completed?
 
 	err = rv.repairImageID(ctx, j)
 	if err != nil {

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -81,6 +81,7 @@ func (cc *ClusterConnection) Copy() *ClusterConnection {
 	c := ClusterConnection{}
 	c.discardOnZeroedWriteSameDisabled = cc.discardOnZeroedWriteSameDisabled
 	c.conn = connPool.Copy(cc.conn)
+	c.Creds = cc.Creds
 
 	return &c
 }


### PR DESCRIPTION
Volume generated from snap using genrateVolFromSnap
already copies volume ID correctly, therefore removing
`vol.VolID = rbdVol.VolID` which wrongly copies parent
Volume ID instead leading to error from copyEncryption()
on parent and clone volume ID being equal.

Signed-off-by: Rakshith R <rar@redhat.com>

<details>
<summary>
Logs
</summary>

```
I0709 05:48:19.899510       1 identityserver-default.go:38] ID: 20 Using default GetPluginInfo
I0709 05:48:19.899585       1 utils.go:182] ID: 20 GRPC response: {"name":"rook-ceph.rbd.csi.ceph.com","vendor_version":"canary"}
I0709 05:48:19.903851       1 utils.go:171] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC call: /csi.v1.Controller/CreateSnapshot
I0709 05:48:19.904174       1 utils.go:175] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC request: {"name":"snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2","parameters":{"clusterID":"rook-ceph"},"secrets":"***stripped***","source_volume_id":"0001-0009-rook-ceph-0000000000000001-9c4c4997-e078-11eb-9aa0-0242ac110005"}
I0709 05:48:19.918382       1 omap.go:84] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 got omap values: (pool="replicapool", namespace="", name="csi.volume.9c4c4997-e078-11eb-9aa0-0242ac110005"): map[csi.imageid:116b87d2743c csi.imagename:csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005 csi.volname:pvc-4dc3aa8b-1fea-4e78-9f85-9beecf39639a csi.volume.encryptKMS:user-ns-secrets-metadata-test csi.volume.owner:rook-ceph]
E0709 05:48:19.937789       1 omap.go:77] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 omap not found (pool="replicapool", namespace="", name="csi.snaps.default"): rados: ret=-2, No such file or directory
I0709 05:48:19.952186       1 omap.go:148] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 set omap keys (pool="replicapool", namespace="", name="csi.snaps.default"): map[csi.snap.snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2:43e1f4b4-e079-11eb-bda3-0242ac110005])
I0709 05:48:19.954816       1 omap.go:148] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 set omap keys (pool="replicapool", namespace="", name="csi.snap.43e1f4b4-e079-11eb-bda3-0242ac110005"): map[csi.imagename:csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 csi.snapname:snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 csi.source:csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005 csi.volume.encryptKMS:user-ns-secrets-metadata-test csi.volume.owner:rook-ceph])
I0709 05:48:19.954834       1 rbd_journal.go:408] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 generated Volume ID (0001-0009-rook-ceph-0000000000000001-43e1f4b4-e079-11eb-bda3-0242ac110005) and image name (csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005) for request name (snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2)
I0709 05:48:19.954868       1 rbd_util.go:1142] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 rbd: snap create replicapool/csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005@csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 using mon 192.168.39.136:6789
I0709 05:48:20.162401       1 rbd_util.go:1199] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 rbd: clone replicapool/csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005@csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 replicapool/csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 (features: [layering deep-flatten]) using mon 192.168.39.136:6789
I0709 05:48:20.201395       1 rbd_util.go:1154] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 rbd: snap rm replicapool/csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005@csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 using mon 192.168.39.136:6789
I0709 05:48:20.423415       1 encryption.go:75] image replicapool/csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005 encrypted state metadata reports "encryptionPrepared"
I0709 05:48:20.498974       1 omap.go:148] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 set omap keys (pool="replicapool", namespace="", name="csi.snap.43e1f4b4-e079-11eb-bda3-0242ac110005"): map[csi.imageid:11c953ba8286])
I0709 05:48:20.529096       1 rbd_util.go:677] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 clone depth is (1), configured softlimit (4) and hardlimit (8) for replicapool/csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005
I0709 05:48:20.529362       1 utils.go:182] ID: 21 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC response: {"snapshot":{"creation_time":{"nanos":176795825,"seconds":1625809700},"size_bytes":1073741824,"snapshot_id":"0001-0009-rook-ceph-0000000000000001-43e1f4b4-e079-11eb-bda3-0242ac110005","source_volume_id":"0001-0009-rook-ceph-0000000000000001-9c4c4997-e078-11eb-9aa0-0242ac110005"}}
I0709 05:48:20.568957       1 utils.go:171] ID: 22 GRPC call: /csi.v1.Identity/GetPluginInfo
I0709 05:48:20.568997       1 utils.go:175] ID: 22 GRPC request: {}
I0709 05:48:20.569020       1 identityserver-default.go:38] ID: 22 Using default GetPluginInfo
I0709 05:48:20.569040       1 utils.go:182] ID: 22 GRPC response: {"name":"rook-ceph.rbd.csi.ceph.com","vendor_version":"canary"}
I0709 05:48:20.569539       1 utils.go:171] ID: 23 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC call: /csi.v1.Controller/CreateSnapshot
I0709 05:48:20.569608       1 utils.go:175] ID: 23 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC request: {"name":"snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2","parameters":{"clusterID":"rook-ceph"},"secrets":"***stripped***","source_volume_id":"0001-0009-rook-ceph-0000000000000001-9c4c4997-e078-11eb-9aa0-0242ac110005"}
I0709 05:48:20.570437       1 omap.go:84] ID: 23 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 got omap values: (pool="replicapool", namespace="", name="csi.volume.9c4c4997-e078-11eb-9aa0-0242ac110005"): map[csi.imageid:116b87d2743c csi.imagename:csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005 csi.volname:pvc-4dc3aa8b-1fea-4e78-9f85-9beecf39639a csi.volume.encryptKMS:user-ns-secrets-metadata-test csi.volume.owner:rook-ceph]
I0709 05:48:20.596760       1 omap.go:84] ID: 23 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 got omap values: (pool="replicapool", namespace="", name="csi.snaps.default"): map[csi.snap.snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2:43e1f4b4-e079-11eb-bda3-0242ac110005]
I0709 05:48:20.597293       1 omap.go:84] ID: 23 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 got omap values: (pool="replicapool", namespace="", name="csi.snap.43e1f4b4-e079-11eb-bda3-0242ac110005"): map[csi.imageid:11c953ba8286 csi.imagename:csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 csi.snapname:snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 csi.source:csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005 csi.volume.encryptKMS:user-ns-secrets-metadata-test csi.volume.owner:rook-ceph]
I0709 05:48:20.639290       1 rbd_util.go:1142] ID: 23 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 rbd: snap create replicapool/csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005@csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 using mon 192.168.39.136:6789
E0709 05:48:21.169785       1 utils.go:180] ID: 23 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC error: rpc error: code = Internal desc = snapshot not found: snap replicapool/csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005@csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 not found
I0709 05:48:21.179357       1 utils.go:171] ID: 24 GRPC call: /csi.v1.Identity/GetPluginInfo
I0709 05:48:21.179534       1 utils.go:175] ID: 24 GRPC request: {}
I0709 05:48:21.179545       1 identityserver-default.go:38] ID: 24 Using default GetPluginInfo
I0709 05:48:21.179605       1 utils.go:182] ID: 24 GRPC response: {"name":"rook-ceph.rbd.csi.ceph.com","vendor_version":"canary"}
I0709 05:48:21.182207       1 utils.go:171] ID: 25 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC call: /csi.v1.Controller/CreateSnapshot
I0709 05:48:21.182402       1 utils.go:175] ID: 25 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC request: {"name":"snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2","parameters":{"clusterID":"rook-ceph"},"secrets":"***stripped***","source_volume_id":"0001-0009-rook-ceph-0000000000000001-9c4c4997-e078-11eb-9aa0-0242ac110005"}
I0709 05:48:21.189749       1 omap.go:84] ID: 25 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 got omap values: (pool="replicapool", namespace="", name="csi.volume.9c4c4997-e078-11eb-9aa0-0242ac110005"): map[csi.imageid:116b87d2743c csi.imagename:csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005 csi.volname:pvc-4dc3aa8b-1fea-4e78-9f85-9beecf39639a csi.volume.encryptKMS:user-ns-secrets-metadata-test csi.volume.owner:rook-ceph]
I0709 05:48:21.227420       1 omap.go:84] ID: 25 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 got omap values: (pool="replicapool", namespace="", name="csi.snaps.default"): map[csi.snap.snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2:43e1f4b4-e079-11eb-bda3-0242ac110005]
I0709 05:48:21.227920       1 omap.go:84] ID: 25 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 got omap values: (pool="replicapool", namespace="", name="csi.snap.43e1f4b4-e079-11eb-bda3-0242ac110005"): map[csi.imageid:11c953ba8286 csi.imagename:csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005 csi.snapname:snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 csi.source:csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005 csi.volume.encryptKMS:user-ns-secrets-metadata-test csi.volume.owner:rook-ceph]
I0709 05:48:21.256230       1 rbd_journal.go:233] ID: 25 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 found existing image (0001-0009-rook-ceph-0000000000000001-43e1f4b4-e079-11eb-bda3-0242ac110005) with name (csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005) for request (snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2)
E0709 05:48:21.256484       1 utils.go:180] ID: 25 Req-ID: snapshot-bba33d6c-d407-4bfa-a6c9-e6238e6750c2 GRPC error: rpc error: code = Internal desc = BUG: "replicapool/csi-vol-9c4c4997-e078-11eb-9aa0-0242ac110005" and "replicapool/csi-snap-43e1f4b4-e079-11eb-bda3-0242ac110005" have the same VolID (0001-0009-rook-ceph-0000000000000001-9c4c4997-e078-11eb-9aa0-0242ac110005) set!? Call stack: goroutine 93 [running]:
github.com/ceph/ceph-csi/internal/util.CallStack(...)
	/go/src/github.com/ceph/ceph-csi/internal/util/util.go:349
github.com/ceph/ceph-csi/internal/rbd.(*rbdImage).copyEncryptionConfig(0xc000620540, 0xc0006208c0, 0x0, 0x0)
	/go/src/github.com/ceph/ceph-csi/internal/rbd/encryption.go:121 +0x551
github.com/ceph/ceph-csi/internal/rbd.cloneFromSnapshot(0x1fb9658, 0xc0006cf0b0, 0xc000620540, 0xc000666240, 0xc0004b0360, 0x0, 0x0, 0x0)
	/go/src/github.com/ceph/ceph-csi/internal/rbd/controllerserver.go:1001 +0x219
github.com/ceph/ceph-csi/internal/rbd.(*ControllerServer).CreateSnapshot(0xc00031e7a0, 0x1fb9658, 0xc0006cf0b0, 0xc000676af0, 0x0, 0x0, 0x0)
	/go/src/github.com/ceph/ceph-csi/internal/rbd/controllerserver.go:935 +0xc8c
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateSnapshot_Handler.func1(0x1fb9658, 0xc0006cf0b0, 0x1bb6cc0, 0xc000676af0, 0x0, 0x0, 0x1, 0xc0003a9040)
	/go/src/github.com/ceph/ceph-csi/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi.pb.go:5820 +0x89
github.com/ceph/ceph-csi/internal/csi-common.panicHandler(0x1fb9658, 0xc0006cf0b0, 0x1bb6cc0, 0xc000676af0, 0xc0004b02a0, 0xc00000e7c8, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/ceph/ceph-csi/internal/csi-common/utils.go:199 +0x96
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x1fb9658, 0xc0006cf0b0, 0x1bb6cc0, 0xc000676af0, 0xc0000e3980, 0x1, 0x1, 0x30)
	/go/src/github.com/ceph/ceph-csi/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:25 +0x63
github.com/ceph/ceph-csi/internal/csi-common.logGRPC(0x1fb9658, 0xc0006cf0b0, 0x1bb6cc0, 0xc000676af0, 0xc0004b02a0, 0xc0004b0300, 0x1b7e8c0, 0xc0006cf0b0, 0x19e1f80, 0xc0003a8e40)
	/go/src/github.com/ceph/ceph-csi/internal/csi-common/utils.go:178 +0x206
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x1fb9658, 0xc0006cf0b0, 0x1bb6cc0, 0xc000676af0, 0x19e8700, 0xc0003a8e50, 0x1fb9658, 0xc0006cf0b0)
	/go/src/github.com/ceph/ceph-csi/vendor/github.com/grpc-ecosystem/go-grpc-middleware/cha
```
</details>

Code change to simulate `readyToUse` being set to false (will happen when number of snapshots hits flatten limit)  https://github.com/Rakshith-R/ceph-csi/commit/2097d4fa87d7a91f9cb3ccad628cacb2b6fee384

Reproducible image: http://ghcr.io/rakshith-r/cephcsi:buggy-snap
Steps: 
- Create encrypted pvc
- Create encrypted snapshot

Fixes: #2285
Fixes: #1883 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
