### PR TITLE
cleanup: Adds t.Helper() to test helper function

### DIFF
--- a/internal/util/topology_test.go
+++ b/internal/util/topology_test.go
@@ -24,12 +24,14 @@ import (
 )
 
 func checkError(t *testing.T, msg string, err error) {
+	t.Helper()
 	if err == nil {
 		t.Errorf(msg)
 	}
 }
 
 func checkAndReportError(t *testing.T, msg string, err error) {
+	t.Helper()
 	if err != nil {
 		t.Errorf("%s (%v)", msg, err)
 	}


### PR DESCRIPTION
This commit adds t.Helper() to the test helper
function. With this call go test prints correct lines of
code for failed tests. Otherwise, printed lines will be
inside helper functions.

Updates: #1586

Signed-off-by: Yati Padia <ypadia@redhat.com>
