### PR TITLE
cleanup: refactor e2e KMS configuration and usage

### DIFF
--- a/e2e/kms.go
+++ b/e2e/kms.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// defaultVaultBackendPath is the default VAULT_BACKEND_PATH for secrets
+	defaultVaultBackendPath = "secret/"
+)
+
+// kmsConfig is an interface that should be used when passing a configuration
+// for a KMS to validation functions. This allows the validation functions to
+// work independently from the actual KMS.
+type kmsConfig interface {
+	canGetPassphrase() bool
+	getPassphrase(f *framework.Framework, key string) (string, string)
+}
+
+// simpleKMS is to be used for KMS configurations that do not offer options to
+// validate the passphrase stored in the KMS.
+type simpleKMS struct {
+	provider string
+}
+
+// vaultConfig describes the configuration of the Hashicorp Vault service that
+// is used to store the encryption passphrase in.
+type vaultConfig struct {
+	*simpleKMS
+	backendPath string
+}
+
+// The following variables describe different KMS services as they are defined
+// in the kms-config.yaml file. These variables can be passed on to validation
+// functions when a StorageClass has a KMS enabled.
+var (
+	noKMS kmsConfig = nil
+
+	secretsMetadataKMS = &simpleKMS{
+		provider: "secrets-metadata",
+	}
+
+	vaultKMS = &vaultConfig{
+		simpleKMS: &simpleKMS{
+			provider: "vault",
+		},
+		backendPath: defaultVaultBackendPath + "ceph-csi/",
+	}
+	vaultTokensKMS = &vaultConfig{
+		simpleKMS: &simpleKMS{
+			provider: "vaulttokens",
+		},
+		backendPath: defaultVaultBackendPath,
+	}
+)
+
+func (sk *simpleKMS) String() string {
+	return sk.provider
+}
+
+// canGetPassphrase returns false for the basic KMS configuration as there is
+// currently no way to fetch the passphrase.
+func (sk *simpleKMS) canGetPassphrase() bool {
+	return false
+}
+
+func (sk *simpleKMS) getPassphrase(f *framework.Framework, key string) (string, string) {
+	return "", ""
+}
+
+func (vc *vaultConfig) String() string {
+	return fmt.Sprintf("%s (backend path %q)", vc.simpleKMS, vc.backendPath)
+}
+
+// canGetPassphrase returns true for the Hashicorp Vault KMS configurations as
+// the Vault CLI can be used to retrieve the passphrase.
+func (vc *vaultConfig) canGetPassphrase() bool {
+	return true
+}
+
+// getPassphrase method will execute few commands to try read the secret for
+// specified key from inside the vault container:
+//  * authenticate with vault and ignore any stdout (we do not need output)
+//  * issue get request for particular key
+// resulting in stdOut (first entry in tuple) - output that contains the key
+// or stdErr (second entry in tuple) - error getting the key.
+func (vc *vaultConfig) getPassphrase(f *framework.Framework, key string) (string, string) {
+	vaultAddr := fmt.Sprintf("http://vault.%s.svc.cluster.local:8200", cephCSINamespace)
+	loginCmd := fmt.Sprintf("vault login -address=%s sample_root_token_id > /dev/null", vaultAddr)
+	readSecret := fmt.Sprintf("vault kv get -address=%s -field=data %s%s",
+		vaultAddr, vc.backendPath, key)
+	cmd := fmt.Sprintf("%s && %s", loginCmd, readSecret)
+	opt := metav1.ListOptions{
+		LabelSelector: "app=vault",
+	}
+	stdOut, stdErr := execCommandInPodAndAllowFail(f, cmd, cephCSINamespace, &opt)
+	return strings.TrimSpace(stdOut), strings.TrimSpace(stdErr)
+}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -697,7 +697,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
-				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, "", f)
+				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, noKMS, f)
 				if err != nil {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
@@ -726,7 +726,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
-				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, "vault", f)
+				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, vaultKMS, f)
 				if err != nil {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
@@ -769,7 +769,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create Secret with tenant token: %v", err)
 				}
 
-				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, "vaulttokens", f)
+				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, vaultTokensKMS, f)
 				if err != nil {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
@@ -805,7 +805,7 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
-				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, "", f)
+				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, noKMS, f)
 				if err != nil {
 					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
 				}
@@ -848,7 +848,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create user Secret: %v", err)
 				}
 
-				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, "", f)
+				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, noKMS, f)
 				if err != nil {
 					e2elog.Failf("failed to validate encrypted pvc: %v", err)
 				}
@@ -900,7 +900,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to create user Secret: %v", err)
 					}
 
-					err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, "", f)
+					err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, noKMS, f)
 					if err != nil {
 						e2elog.Failf("failed to validate encrypted pvc: %v", err)
 					}
@@ -965,7 +965,7 @@ var _ = Describe("RBD", func() {
 						snapshotPath,
 						pvcClonePath,
 						appClonePath,
-						noKms,
+						noKMS,
 						f)
 				}
 			})
@@ -979,7 +979,7 @@ var _ = Describe("RBD", func() {
 						appPath,
 						pvcSmartClonePath,
 						appSmartClonePath,
-						noKms,
+						noKMS,
 						noPVCValidation,
 						f)
 				}
@@ -1001,7 +1001,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, noKms, isThickPVC, f)
+				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, noKMS, isThickPVC, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1031,7 +1031,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCSnapshot(1, pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, "vault", f)
+				validatePVCSnapshot(1, pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, vaultKMS, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1061,7 +1061,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, "secrets-metadata", isEncryptedPVC, f)
+				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, secretsMetadataKMS, isEncryptedPVC, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1091,7 +1091,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, "vault", isEncryptedPVC, f)
+				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, vaultKMS, isEncryptedPVC, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1122,7 +1122,7 @@ var _ = Describe("RBD", func() {
 						rawAppPath,
 						pvcBlockSmartClonePath,
 						appBlockSmartClonePath,
-						noKms,
+						noKMS,
 						noPVCValidation,
 						f)
 				}


### PR DESCRIPTION
This adds a new `kmsConfig` interface that can be used to validate
different KMS services and setting. It makes checking for the available
support easier, and fetching the passphrase simpler.

The basicKMS mirrors the current validation of the KMS implementations
that use secrets and metadata. vaultKMS can be used to validate the
passphrase stored in a Vault service.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
