### PR TITLE
cleanup: resolve revive linter issue

### DIFF
--- a/e2e/kms.go
+++ b/e2e/kms.go
@@ -38,7 +38,7 @@ type vaultConfig struct {
 // in the kms-config.yaml file. These variables can be passed on to validation
 // functions when a StorageClass has a KMS enabled.
 var (
-	noKMS kmsConfig = nil
+	noKMS kmsConfig
 
 	secretsMetadataKMS = &simpleKMS{
 		provider: "secrets-metadata",

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -434,7 +434,7 @@ type validateFunc func(f *framework.Framework, pvc *v1.PersistentVolumeClaim, ap
 
 // noPVCValidation can be used to pass to validatePVCClone when no extra
 // validation of the PVC is needed.
-var noPVCValidation validateFunc = nil
+var noPVCValidation validateFunc
 
 func isEncryptedPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, app *v1.Pod) error {
 	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -644,8 +644,8 @@ func (conn *Connection) GetImageAttributes(
 	snapSource bool) (*ImageAttributes, error) {
 	var (
 		err             error
-		imageAttributes *ImageAttributes = &ImageAttributes{}
-		cj                               = conn.config
+		imageAttributes = &ImageAttributes{}
+		cj              = conn.config
 	)
 
 	if snapSource && cj.cephSnapSourceKey == "" {


### PR DESCRIPTION
revive linter checks for var-declaration
format.
For example:
`e2e/rbd_helper.go:441:36: var-declaration:
should drop = nil from declaration of
var noPVCValidation; it is the zero value (revive)
var noPVCValidation validateFunc = nil`

Updates: #1586

Signed-off-by: Yati Padia <ypadia@redhat.com>

