### PR TITLE
cleanup: resolves gofumpt for cmd

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -50,9 +50,7 @@ const (
 	defaultNS = "default"
 )
 
-var (
-	conf util.Config
-)
+var conf util.Config
 
 func init() {
 	// common flags


### PR DESCRIPTION
This commit resolves gofumpt linter for
cmd folder

Updates: 1586

Signed-off-by: Yati Padia <ypadia@redhat.com>
