### PR TITLE
e2e: mark "etcdserver: request timed out" errors as retryable

### DIFF
--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -17,6 +17,8 @@ limitations under the License.
 package e2e
 
 import (
+	"strings"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
@@ -32,5 +34,11 @@ func isRetryableAPIError(err error) bool {
 	if _, shouldRetry := apierrors.SuggestsClientDelay(err); shouldRetry {
 		return true
 	}
+
+	// "etcdserver: request timed out" does not seem to match the timeout errors above
+	if strings.HasSuffix(err.Error(), "etcdserver: request timed out") {
+		return true
+	}
+
 	return false
 }

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -61,13 +61,13 @@ func createPVCAndvalidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 
 		pv, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
 		if err != nil {
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			if apierrs.IsNotFound(err) {
+				return false, nil
+			}
 			return false, fmt.Errorf("failed to get pv: %w", err)
-		}
-		if isRetryableAPIError(err) {
-			return false, nil
-		}
-		if apierrs.IsNotFound(err) {
-			return false, nil
 		}
 		err = e2epv.WaitOnPVandPVC(
 			c,

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -38,14 +38,15 @@ func createPVCAndvalidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 		return nil
 	}
 	name := pvc.Name
+	namespace := pvc.Namespace
 	start := time.Now()
 	e2elog.Logf("Waiting up to %v to be in Bound state", pvc)
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
-		e2elog.Logf("waiting for PVC %s (%d seconds elapsed)", pvc.Name, int(time.Since(start).Seconds()))
-		pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		e2elog.Logf("waiting for PVC %s (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
+		pvc, err = c.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			e2elog.Logf("Error getting pvc in namespace: '%s': %v", pvc.Namespace, err)
+			e2elog.Logf("Error getting pvc %q in namespace %q: %v", name, namespace, err)
 			if isRetryableAPIError(err) {
 				return false, nil
 			}
@@ -72,7 +73,7 @@ func createPVCAndvalidatePV(c kubernetes.Interface, pvc *v1.PersistentVolumeClai
 		err = e2epv.WaitOnPVandPVC(
 			c,
 			&framework.TimeoutContext{ClaimBound: timeout, PVBound: timeout},
-			pvc.Namespace,
+			namespace,
 			pv,
 			pvc)
 		if err != nil {


### PR DESCRIPTION
There are regular CI failures where etcdserver times out. These errors
seem not to get caught by any of the existing error comparing. Matching
the error by string should prevent temporary etcdserver issues now too.

Updates: #2218
Closes: #1969

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
