### PR TITLE
util: remove deleteLock while we acquire clone operation lock

### DIFF
--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -119,15 +119,11 @@ func (ol *OperationLock) tryAcquire(op operation, volumeID string) error {
 		val := ol.locks[createOp][volumeID]
 		ol.locks[createOp][volumeID] = val + 1
 	case cloneOpt:
-		// During clone operation we need to check any ongoing delete,expand
-		// operation. if yes we need to return an error to avoid issues.
+		// During clone operation, controller make sure no pvc deletion happens on the
+		// referred PVC datasource, so we are safe from source PVC delete.
 
-		// check any delete operation is going on for given volume ID
-		if _, ok := ol.locks[deleteOp][volumeID]; ok {
-			return fmt.Errorf("a Delete operation with given id %s already exists", volumeID)
-		}
-
-		// check any expand operation is going on for given volume ID
+		// Check any expand operation is going on for given volume ID.
+		// if yes we need to return an error to avoid issues.
 		if _, ok := ol.locks[expandOp][volumeID]; ok {
 			return fmt.Errorf("an Expand operation with given id %s already exists", volumeID)
 		}


### PR DESCRIPTION
clone controller make sure there is no delete operation happens
on the source PVC which has been referred as the datasource of
clone PVC, we are safe to operate without looking at delete
operation lock in this case.

Subjected code in the controller:

...
if claim.Spec.DataSource != nil && rc.clone {
		err = p.setCloneFinalizer(ctx, claim)
		...
}

if !checkFinalizer(claim, pvcCloneFinalizer) {
		claim.Finalizers = append(claim.Finalizers, pvcCloneFinalizer)
		_, err := p.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(..claim..)
	}

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

