### PR TITLE
fix incorrect beta apiVersion for csidriver used in older kubernetes versions

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -1,7 +1,7 @@
 {{ if semverCompare ">=1.18.0-beta.1" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
 {{ else }}
-apiVersion: storage.k8s.io/v1betav1
+apiVersion: storage.k8s.io/v1beta1
 {{ end }}
 kind: CSIDriver
 metadata:

--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -1,6 +1,6 @@
 ---
 # if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1betav1
+# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -1,6 +1,6 @@
 ---
 # if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1betav1
+# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Ran into this when installing this on a 1.17 cluster.
This MR fixes a typo for installing the CSIDriver resource in Kubernetes versions before 1.18. This should have been `storage.k8s.io/v1beta1`.
See: https://kubernetes-csi.github.io/docs/csi-driver-object.html#changes-from-alpha-to-beta

## Is there anything that requires special attention ##

n/a

## Related issues ##

n/a

## Future concerns ##

n/a

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
