### PR TITLE
ci: add unit test for toError()

### DIFF
--- a/internal/cephfs/clone_test.go
+++ b/internal/cephfs/clone_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloneStateToError(t *testing.T) {
+	errorState := make(map[cephFSCloneState]error)
+	errorState[cephFSCloneComplete] = nil
+	errorState[cephFSCloneError] = ErrInvalidClone
+	errorState[cephFSCloneInprogress] = ErrCloneInProgress
+	errorState[cephFSClonePending] = ErrClonePending
+	errorState[cephFSCloneFailed] = ErrCloneFailed
+
+	for state, err := range errorState {
+		assert.Equal(t, state.toError(), err)
+	}
+}


### PR DESCRIPTION
This commit adds unit test for the
func converting cephFSCloneState to error.

Fixes: #2259

Signed-off-by: Yati Padia <ypadia@redhat.com>
