### PR TITLE
ci: do not use Groovy string interpolation for credentials

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -102,7 +102,7 @@ node('cico-workspace') {
 				returnStatus: true)
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
+				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
 			parallel test: {

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -120,7 +120,7 @@ node('cico-workspace') {
 			def d_io_regex = ~"^docker.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
+				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
 			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -122,7 +122,7 @@ node('cico-workspace') {
 			def d_io_regex = ~"^docker.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
+				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
 			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -119,7 +119,7 @@ node('cico-workspace') {
 			def d_io_regex = ~"^docker.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
+				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
 			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -119,7 +119,7 @@ node('cico-workspace') {
 			def d_io_regex = ~"^docker.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
-				podman_login(ci_registry, "${CREDS_USER}", "${CREDS_PASSWD}")
+				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
 			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"


### PR DESCRIPTION
Jenkins warns in the output of CI jobs about the following:

    Warning: A secret was passed to "sh" using Groovy String interpolation, which is insecure.
        Affected argument(s) used the following variable(s): [CREDS_PASSWD, CREDS_USER]
        See https://jenkins.io/redirect/groovy-string-interpolation for details.

Variable with 'single quotes' and without the {curly brackets} are
expecred to not be affected. There is some indirection in the strings
passed to the `sh` function, so this approach might not fix it?

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
