### PR TITLE
ci: quote username for podman_login()

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -17,7 +17,7 @@ def ssh(cmd) {
 }
 
 def podman_login(registry, username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -18,7 +18,7 @@ def ssh(cmd) {
 }
 
 def podman_login(registry, username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -17,7 +17,7 @@ def ssh(cmd) {
 }
 
 def podman_login(registry, username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -19,7 +19,7 @@ def ssh(cmd) {
 }
 
 def podman_login(registry, username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -16,7 +16,7 @@ def ssh(cmd) {
 }
 
 def podman_login(registry, username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -16,7 +16,7 @@ def ssh(cmd) {
 }
 
 def podman_login(registry, username, passwd) {
-	ssh "podman login --authfile=~/.podman-auth.json --username=${username} --password='${passwd}' ${registry}"
+	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it


### PR DESCRIPTION
Jenkins does not like the passing of the username as variable to the
podman_login() function. Calling the function results in an error like

    Warning: A secret was passed to "sh" using Groovy String interpolation, which is insecure.
        Affected argument(s) used the following variable(s): [CREDS_USER]
        See https://jenkins.io/redirect/groovy-string-interpolation for details.
    + ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@n7.pufty.ci.centos.org 'podman login --authfile=~/.podman-auth.json --username=$CREDS_USER --password=**** registry-****.apps.ocp.ci.centos.org'
    Username: Error: error getting username and password: error reading username: EOF

By single quoting the username, just like the password, it may work
better.

Fixes: aca3745e2 ("ci: do not use Groovy string interpolation for credentials")

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
