### PR TITLE
[WIP] util: remove deleteLock validation for clone and snap creation scenarios

### DIFF
--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -135,20 +135,12 @@ func (ol *OperationLock) tryAcquire(op operation, volumeID string) error {
 		val := ol.locks[cloneOpt][volumeID]
 		ol.locks[cloneOpt][volumeID] = val + 1
 	case deleteOp:
-		// / During delete operation the volume should not be under expand,
-		// clone or snapshot operation.
+		// During delete operation the volume should not be under expand,
 		// check any expand operation is going on for given volume ID
 		if _, ok := ol.locks[expandOp][volumeID]; ok {
 			return fmt.Errorf("an Expand operation with given id %s already exists", volumeID)
 		}
-		// check any clone operation is going on for given volume ID
-		if _, ok := ol.locks[cloneOpt][volumeID]; ok {
-			return fmt.Errorf("a Clone operation with given id %s already exists", volumeID)
-		}
-		// check any delete operation is going on for given volume ID
-		if _, ok := ol.locks[createOp][volumeID]; ok {
-			return fmt.Errorf("a Create operation with given id %s already exists", volumeID)
-		}
+
 		// check any restore operation is going on for given volume ID
 		if _, ok := ol.locks[restoreOp][volumeID]; ok {
 			return fmt.Errorf("a Restore operation with given id %s already exists", volumeID)


### PR DESCRIPTION
considering clone and snapshot controllers ensure, the parent volumeID
deletion is not allowed while these operations are in progress, we dont
want to check this while acquiring the deleteLock

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


