### PR TITLE
ci: add the root user to the libvirt group

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -80,6 +80,10 @@ set -x
 
 dnf -y install git podman make
 
+# minikube wants the user (everything runs as root) to be in the libvirt group
+getent group libvirt || groupadd --system libvirt
+usermod --append --groups libvirt root
+
 # if --history is passed, don't pass --depth=1
 depth='--depth=1'
 if [[ "${history}" == 'yes' ]]


### PR DESCRIPTION
When starting a minikube VM, there are always warning messages like
this:

    X libvirt group membership check failed:
    user is not a member of the appropriate libvirt group

The CI jobs run as root, so minikube works just fine. By adding the root
user to the libvirt group, the warning is hopefully removed.

Note that the libvirt group may not exist yet, as the packages will get
installed in a later stage. This change also adds a check to create the
libvirt group in case it is missing.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
