### PR TITLE
rbd: add features to rbd controller for mirroring

### DIFF
--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -19,6 +19,7 @@ var (
 	vaultConfigPath      = "kms-config.yaml"
 	vaultTenantPath      = "tenant-sa.yaml"
 	vaultTenantAdminPath = "tenant-sa-admin.yaml"
+	vaultUserSecret      = "user-secret.yaml"
 )
 
 func deployVault(c kubernetes.Interface, deployTimeout int) {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -815,7 +815,7 @@ var _ = Describe("RBD", func() {
 				namespace := cephCSINamespace
 
 				// create user Secret
-				err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+"user-secret.yaml", deployTimeout)
+				err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+vaultUserSecret, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create user Secret: %v", err)
 				}
@@ -830,7 +830,7 @@ var _ = Describe("RBD", func() {
 				// delete user secret
 				err = retryKubectlFile(namespace,
 					kubectlDelete,
-					vaultExamplePath+"user-secret.yaml",
+					vaultExamplePath+vaultUserSecret,
 					deployTimeout,
 					"--ignore-not-found=true")
 				if err != nil {
@@ -867,7 +867,7 @@ var _ = Describe("RBD", func() {
 					namespace := f.UniqueName
 
 					// create user Secret
-					err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+"user-secret.yaml", deployTimeout)
+					err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+vaultUserSecret, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to create user Secret: %v", err)
 					}
@@ -883,7 +883,7 @@ var _ = Describe("RBD", func() {
 					err = retryKubectlFile(
 						namespace,
 						kubectlDelete,
-						vaultExamplePath+"user-secret.yaml",
+						vaultExamplePath+vaultUserSecret,
 						deployTimeout,
 						"--ignore-not-found=true")
 					if err != nil {
@@ -2402,7 +2402,7 @@ var _ = Describe("RBD", func() {
 				namespace := f.UniqueName
 
 				// create user Secret
-				err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+"user-secret.yaml", deployTimeout)
+				err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+vaultUserSecret, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create user Secret: %v", err)
 				}
@@ -2419,10 +2419,9 @@ var _ = Describe("RBD", func() {
 				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				// delete user secret
-				err = retryKubectlFile(
-					namespace,
+				err = retryKubectlFile(namespace,
 					kubectlDelete,
-					vaultExamplePath+"user-secret.yaml",
+					vaultExamplePath+vaultUserSecret,
 					deployTimeout,
 					"--ignore-not-found=true")
 				if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -2366,17 +2366,23 @@ var _ = Describe("RBD", func() {
 			By("validate the functionality of controller", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass : %v", err)
 				}
-				err = validateController(f, pvcPath, appPath, rbdExamplePath+"storageclass.yaml")
+				scParams := map[string]string{
+					"volumeNamePrefix": "test-",
+				}
+				err = validateController(f,
+					pvcPath, appPath, rbdExamplePath+"storageclass.yaml",
+					nil,
+					scParams)
 				if err != nil {
-					e2elog.Failf("failed to validate controller with error %v", err)
+					e2elog.Failf("failed to validate controller : %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass : %v", err)
 				}
 			})
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -815,11 +815,7 @@ var _ = Describe("RBD", func() {
 				namespace := cephCSINamespace
 
 				// create user Secret
-				secret, err := getSecret(vaultExamplePath + "user-secret.yaml")
-				if err != nil {
-					e2elog.Failf("failed to load user Secret: %v", err)
-				}
-				_, err = c.CoreV1().Secrets(namespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
+				err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+"user-secret.yaml", deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create user Secret: %v", err)
 				}
@@ -832,7 +828,11 @@ var _ = Describe("RBD", func() {
 				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				// delete user secret
-				err = c.CoreV1().Secrets(namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
+				err = retryKubectlFile(namespace,
+					kubectlDelete,
+					vaultExamplePath+"user-secret.yaml",
+					deployTimeout,
+					"--ignore-not-found=true")
 				if err != nil {
 					e2elog.Failf("failed to delete user Secret: %v", err)
 				}
@@ -867,11 +867,7 @@ var _ = Describe("RBD", func() {
 					namespace := f.UniqueName
 
 					// create user Secret
-					secret, err := getSecret(vaultExamplePath + "user-secret.yaml")
-					if err != nil {
-						e2elog.Failf("failed to load user Secret: %v", err)
-					}
-					_, err = c.CoreV1().Secrets(namespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
+					err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+"user-secret.yaml", deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to create user Secret: %v", err)
 					}
@@ -884,7 +880,12 @@ var _ = Describe("RBD", func() {
 					validateRBDImageCount(f, 0, defaultRBDPool)
 
 					// delete user secret
-					err = c.CoreV1().Secrets(namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
+					err = retryKubectlFile(
+						namespace,
+						kubectlDelete,
+						vaultExamplePath+"user-secret.yaml",
+						deployTimeout,
+						"--ignore-not-found=true")
 					if err != nil {
 						e2elog.Failf("failed to delete user Secret: %v", err)
 					}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -770,6 +770,15 @@ func checkPVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeCl
 	return nil
 }
 
+// deleteJournalInfoInPool deletes all omap data regarding pvc.
+func deleteJournalInfoInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, pool string) error {
+	if err := deletePVCImageJournalInPool(f, pvc, pool); err != nil {
+		return err
+	}
+
+	return deletePVCCSIJournalInPool(f, pvc, pool)
+}
+
 func deletePVCImageJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, pool string) error {
 	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
 	if err != nil {

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -123,7 +124,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 		opt["imageFeatures"] = "layering"
 	}
 	opt["pool"] = defaultRBDPool
-	opt["staticVolume"] = "true"
+	opt["staticVolume"] = strconv.FormatBool(true)
 	if radosNamespace != "" {
 		opt["radosNamespace"] = radosNamespace
 	}
@@ -279,7 +280,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 
 	opt["clusterID"] = fsID
 	opt["fsName"] = fsName
-	opt["staticVolume"] = "true"
+	opt["staticVolume"] = strconv.FormatBool(true)
 	opt["rootPath"] = rootPath
 	pv := getStaticPV(pvName, pvName, "4Gi", secretName, cephCSINamespace, sc, "cephfs.csi.ceph.com", false, opt)
 	_, err = c.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1091,10 +1092,7 @@ func validateController(
 	if err != nil {
 		return fmt.Errorf("failed to load PVC: %w", err)
 	}
-	resizePvc, err := loadPVC(pvcPath)
-	if err != nil {
-		return fmt.Errorf("failed to load PVC: %w", err)
-	}
+	resizePvc := pvc.DeepCopy()
 	resizePvc.Namespace = f.UniqueName
 
 	pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(size)
@@ -1119,11 +1117,7 @@ func validateController(
 		return fmt.Errorf("failed to create storageclass: %w", err)
 	}
 	// delete omap data
-	err = deletePVCImageJournalInPool(f, pvc, poolName)
-	if err != nil {
-		return err
-	}
-	err = deletePVCCSIJournalInPool(f, pvc, poolName)
+	err = deleteJournalInfoInPool(f, pvc, poolName)
 	if err != nil {
 		return err
 	}
@@ -1156,22 +1150,29 @@ func validateController(
 	if err != nil {
 		return err
 	}
-	// resize PVC
-	err = expandPVCSize(f.ClientSet, resizePvc, expandSize, deployTimeout)
-	if err != nil {
-		return err
-	}
-	if *pvc.Spec.VolumeMode == v1.PersistentVolumeFilesystem {
-		err = checkDirSize(app, f, &opt, expandSize)
+	if scParams["encrypted"] == strconv.FormatBool(true) {
+		// check encryption
+		err = isEncryptedPVC(f, resizePvc, app)
 		if err != nil {
 			return err
 		}
-	}
-
-	if *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock {
-		err = checkDeviceSize(app, f, &opt, expandSize)
+	} else {
+		// resize PVC
+		err = expandPVCSize(f.ClientSet, resizePvc, expandSize, deployTimeout)
 		if err != nil {
 			return err
+		}
+		switch *pvc.Spec.VolumeMode {
+		case v1.PersistentVolumeFilesystem:
+			err = checkDirSize(app, f, &opt, expandSize)
+			if err != nil {
+				return err
+			}
+		case v1.PersistentVolumeBlock:
+			err = checkDeviceSize(app, f, &opt, expandSize)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	// delete pvc and storageclass

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1071,13 +1071,17 @@ func validatePVCSnapshot(
 // Mount the PVC to application (NodeStage/NodePublish should work)
 // Resize the PVC
 // Delete the Application and PVC.
-func validateController(f *framework.Framework, pvcPath, appPath, scPath string) error {
+func validateController(
+	f *framework.Framework,
+	pvcPath, appPath, scPath string,
+	scOptions, scParams map[string]string) error {
 	size := "1Gi"
 	poolName := defaultRBDPool
 	expandSize := "10Gi"
 	var err error
 	// create storageclass with retain
-	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, retainPolicy)
+	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, scOptions, scParams,
+		retainPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass: %w", err)
 	}
@@ -1109,7 +1113,8 @@ func validateController(f *framework.Framework, pvcPath, appPath, scPath string)
 	if err != nil {
 		return fmt.Errorf("failed to delete storageclass: %w", err)
 	}
-	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+	err = createRBDStorageClass(f.ClientSet, f, defaultSCName, scOptions, scParams,
+		deletePolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create storageclass: %w", err)
 	}

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -172,10 +172,7 @@ func (r ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime.
 	if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != r.config.DriverName {
 		return nil
 	}
-	pool := pv.Spec.CSI.VolumeAttributes["pool"]
-	journalPool := pv.Spec.CSI.VolumeAttributes["journalPool"]
 	requestName := pv.Name
-	imageName := pv.Spec.CSI.VolumeAttributes["imageName"]
 	volumeHandler := pv.Spec.CSI.VolumeHandle
 	secretName := ""
 	secretNamespace := ""
@@ -210,7 +207,7 @@ func (r ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime.
 	}
 	defer cr.DeleteCredentials()
 
-	rbdVolID, err := rbd.RegenerateJournal(imageName, volumeHandler, pool, journalPool, requestName, cr)
+	rbdVolID, err := rbd.RegenerateJournal(pv.Spec.CSI.VolumeAttributes, volumeHandler, requestName, cr)
 	if err != nil {
 		util.ErrorLogMsg("failed to regenerate journal %s", err)
 

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -523,6 +523,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 
 // RegenerateJournal performs below operations
 // Extract parameters journalPool, pool from volumeAttributes
+// Extract optional parameter volumeNamePrefix from volumeAttributes
 // Extract information from volumeID
 // Get pool ID from pool name
 // Extract uuid from volumeID
@@ -587,7 +588,7 @@ func RegenerateJournal(
 	}
 
 	rbdVol.RequestName = requestName
-	// TODO add Nameprefix also
+	rbdVol.NamePrefix = volumeAttributes["volumeNamePrefix"]
 
 	kmsID := ""
 	imageData, err := j.CheckReservation(

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -569,7 +569,7 @@ func RegenerateJournal(
 	if rbdVol.JournalPool == "" {
 		rbdVol.JournalPool = rbdVol.Pool
 	}
-	volJournal = journal.NewCSIVolumeJournal("default")
+	volJournal = journal.NewCSIVolumeJournal(CSIInstanceID)
 	j, err := volJournal.Connect(rbdVol.Monitors, rbdVol.RadosNamespace, cr)
 	if err != nil {
 		return "", err

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 )
 
@@ -58,6 +59,25 @@ type VolumeEncryption struct {
 	dekStore DEKStore
 
 	id string
+}
+
+// FetchEncryptionKMSID returns non-empty kmsID if 'encrypted' parameter is evaluated as true.
+func FetchEncryptionKMSID(encrypted, kmsID string) (string, error) {
+	isEncrypted, err := strconv.ParseBool(encrypted)
+	if err != nil {
+		return "", fmt.Errorf(
+			"invalid value set in 'encrypted': %s (should be \"true\" or \"false\"): %w",
+			encrypted, err)
+	}
+	if !isEncrypted {
+		return "", nil
+	}
+
+	if kmsID == "" {
+		kmsID = defaultKMSType
+	}
+
+	return kmsID, nil
 }
 
 // NewVolumeEncryption creates a new instance of VolumeEncryption and


### PR DESCRIPTION
- e2e: add prefixname & encryption tests for rbd controller
- rbd: extract kmsID from volumeAttributes in RegenerateJournal()
- rbd: extract volumeNamePrefix in RegenerateJournal()
- rbd: refractor RegenerateJournal() to take in volumeAttributes
- rbd: use `CSIInstanceID` var instead of "default" in RegenrateJournal()
- rbd: extract rbd owner from volumeAttributes in RegenerateJournal()
- e2e: add prefixname & encryption tests for rbd controller (pv,pvc,sc,omap deleted then recreated)
  - e2e with pefixname set 
  - e2e with various encryption types enabled 

Closes: #2032  

- [x] Has all the required e2e
- [x] make sure e2e passes
- [x] manually test various encryption types according https://github.com/ceph/ceph-csi/pull/2296#issuecomment-886577722
