### PR TITLE
util: remove the deleteLock acquistion check for clone and snapshot

### DIFF
--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -130,19 +130,10 @@ func (ol *OperationLock) tryAcquire(op operation, volumeID string) error {
 		val := ol.locks[cloneOpt][volumeID]
 		ol.locks[cloneOpt][volumeID] = val + 1
 	case deleteOp:
-		// / During delete operation the volume should not be under expand,
-		// clone or snapshot operation.
+		// During delete operation the volume should not be under expand,
 		// check any expand operation is going on for given volume ID
 		if _, ok := ol.locks[expandOp][volumeID]; ok {
 			return fmt.Errorf("an Expand operation with given id %s already exists", volumeID)
-		}
-		// check any clone operation is going on for given volume ID
-		if _, ok := ol.locks[cloneOpt][volumeID]; ok {
-			return fmt.Errorf("a Clone operation with given id %s already exists", volumeID)
-		}
-		// check any delete operation is going on for given volume ID
-		if _, ok := ol.locks[createOp][volumeID]; ok {
-			return fmt.Errorf("a Create operation with given id %s already exists", volumeID)
 		}
 		// check any restore operation is going on for given volume ID
 		if _, ok := ol.locks[restoreOp][volumeID]; ok {

--- a/internal/util/idlocker_test.go
+++ b/internal/util/idlocker_test.go
@@ -60,10 +60,6 @@ func TestOperationLocks(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to acquire clone lock for %s %s", volumeID, err)
 	}
-	err = lock.GetDeleteLock(volumeID)
-	if err == nil {
-		t.Errorf("expected to fail for GetDeleteLock for %s", volumeID)
-	}
 
 	err = lock.GetExpandLock(volumeID)
 	if err == nil {
@@ -106,11 +102,6 @@ func TestOperationLocks(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to acquire restore lock for %s %s", volumeID, err)
 	}
-	// try for snapshot delete lock
-	err = lock.GetDeleteLock(volumeID)
-	if err == nil {
-		t.Errorf("expected to fail for GetDeleteLock for %s", volumeID)
-	}
 	// release all restore locks
 	lock.ReleaseRestoreLock(volumeID)
 	lock.ReleaseRestoreLock(volumeID)
@@ -119,10 +110,6 @@ func TestOperationLocks(t *testing.T) {
 	err = lock.GetSnapshotCreateLock(volumeID)
 	if err != nil {
 		t.Errorf("failed to acquire createSnapshot lock for %s %s", volumeID, err)
-	}
-	err = lock.GetDeleteLock(volumeID)
-	if err == nil {
-		t.Errorf("expected to fail for GetDeleteLock for %s", volumeID)
 	}
 	lock.ReleaseSnapshotCreateLock(volumeID)
 


### PR DESCRIPTION
At present while acquiring the deleteLock on the volume, we check
for ongoing clone and snapshot creation operations on the same.
Considering snapshot and clone controllers does not allow parent
volume deletion on subjected operations, we can be free from this
extra check.

Updates: #2197  

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

