### PR TITLE
util: allow configuring VAULT_BACKEND for Vault connection

### DIFF
--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -9,6 +9,7 @@ data:
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
         "vaultAuthPath": "/v1/auth/kubernetes/login",
         "vaultRole": "csi-kubernetes",
+        "vaultBackend": "kv-v2",
         "vaultPassphraseRoot": "/v1/secret",
         "vaultPassphrasePath": "ceph-csi/",
         "vaultCAVerify": "false"
@@ -16,6 +17,7 @@ data:
       "vault-tokens-test": {
           "encryptionKMSType": "vaulttokens",
           "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+          "vaultBackend": "kv-v2",
           "vaultBackendPath": "secret/",
           "vaultTLSServerName": "vault.default.svc.cluster.local",
           "vaultCAVerify": "false",
@@ -34,6 +36,7 @@ data:
       "vault-tenant-sa-test": {
           "encryptionKMSType": "vaulttenantsa",
           "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+          "vaultBackend": "kv-v2",
           "vaultBackendPath": "shared-secrets",
           "vaultTLSServerName": "vault.default.svc.cluster.local",
           "vaultCAVerify": "false",

--- a/examples/kms/vault/tenant-config.yaml
+++ b/examples/kms/vault/tenant-config.yaml
@@ -7,6 +7,7 @@ metadata:
   name: ceph-csi-kms-config
 data:
   vaultAddress: "http://vault.default.svc.cluster.local:8200"
+  vaultBackend: "kv-v1"
   vaultBackendPath: "secret/"
   vaultTLSServerName: "vault.default.svc.cluster.local"
   vaultCAVerify: "false"

--- a/examples/kms/vault/tenant-sa-admin.yaml
+++ b/examples/kms/vault/tenant-sa-admin.yaml
@@ -21,7 +21,7 @@ data:
     vault login ${VAULT_DEV_ROOT_TOKEN_ID}
 
     # create a secret store for the tenant
-    vault secrets enable -path="tenant" kv
+    vault secrets enable -version=2 -path="tenant" kv
 
     # create a policy for the tenant
     vault policy write "${TENANT_NAMESPACE}" - << EOS

--- a/examples/kms/vault/tenant-sa.yaml
+++ b/examples/kms/vault/tenant-sa.yaml
@@ -19,5 +19,6 @@ kind: ConfigMap
 metadata:
   name: ceph-csi-kms-config
 data:
+  vaultBackend: kv-v2
   vaultBackendPath: tenant
   vaultRole: ceph-csi-tenant

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -132,6 +132,16 @@ func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 	}
 	// default: !firstInit
 
+	vaultBackend := "" // optional
+	err = setConfigString(&vaultBackend, config, "vaultBackend")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+	// set the option if the value was not invalid
+	if !errors.Is(err, errConfigOptionMissing) {
+		vaultConfig[vault.VaultBackendKey] = vaultBackend
+	}
+
 	vaultBackendPath := "" // optional
 	err = setConfigString(&vaultBackendPath, config, "vaultBackendPath")
 	if errors.Is(err, errConfigOptionInvalid) {

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -57,6 +57,7 @@ const (
 type standardVault struct {
 	KmsPROVIDER        string `json:"KMS_PROVIDER"`
 	VaultADDR          string `json:"VAULT_ADDR"`
+	VaultBackend       string `json:"VAULT_BACKEND"`
 	VaultBackendPath   string `json:"VAULT_BACKEND_PATH"`
 	VaultCACert        string `json:"VAULT_CACERT"`
 	VaultTLSServerName string `json:"VAULT_TLS_SERVER_NAME"`
@@ -69,6 +70,7 @@ type standardVault struct {
 type vaultTokenConf struct {
 	EncryptionKMSType            string `json:"encryptionKMSType"`
 	VaultAddress                 string `json:"vaultAddress"`
+	VaultBackend                 string `json:"vaultBackend"`
 	VaultBackendPath             string `json:"vaultBackendPath"`
 	VaultCAFromSecret            string `json:"vaultCAFromSecret"`
 	VaultTLSServerName           string `json:"vaultTLSServerName"`
@@ -81,6 +83,7 @@ type vaultTokenConf struct {
 func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 	v.EncryptionKMSType = s.KmsPROVIDER
 	v.VaultAddress = s.VaultADDR
+	v.VaultBackend = s.VaultBackend
 	v.VaultBackendPath = s.VaultBackendPath
 	v.VaultCAFromSecret = s.VaultCACert
 	v.VaultClientCertFromSecret = s.VaultClientCert
@@ -147,6 +150,7 @@ Example JSON structure in the KMS config is,
     "vault-with-tokens": {
         "encryptionKMSType": "vaulttokens",
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackend": "kv-v2",
         "vaultBackendPath": "secret/",
         "vaultTLSServerName": "vault.default.svc.cluster.local",
         "vaultCAFromSecret": "vault-ca",
@@ -515,6 +519,7 @@ func (vtc *vaultTenantConnection) getCertificate(tenant, secretName, key string)
 func isTenantConfigOption(opt string) bool {
 	switch opt {
 	case "vaultAddress":
+	case "vaultBackend":
 	case "vaultBackendPath":
 	case "vaultTLSServerName":
 	case "vaultCAFromSecret":

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -125,6 +125,7 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 	vaultConfigMap := `{
 		"KMS_PROVIDER":"vaulttokens",
 		"VAULT_ADDR":"https://vault.example.com",
+		"VAULT_BACKEND":"kv-v2",
 		"VAULT_BACKEND_PATH":"/secret",
 		"VAULT_CACERT":"",
 		"VAULT_TLS_SERVER_NAME":"vault.example.com",
@@ -150,6 +151,8 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 		t.Errorf("unexpected value for EncryptionKMSType: %s", v.EncryptionKMSType)
 	case v.VaultAddress != "https://vault.example.com":
 		t.Errorf("unexpected value for VaultAddress: %s", v.VaultAddress)
+	case v.VaultBackend != "kv-v2":
+		t.Errorf("unexpected value for VaultBackend: %s", v.VaultBackend)
 	case v.VaultBackendPath != "/secret":
 		t.Errorf("unexpected value for VaultBackendPath: %s", v.VaultBackendPath)
 	case v.VaultCAFromSecret != "":
@@ -172,6 +175,7 @@ func TestTransformConfig(t *testing.T) {
 	cm := make(map[string]interface{})
 	cm["KMS_PROVIDER"] = "vaulttokens"
 	cm["VAULT_ADDR"] = "https://vault.example.com"
+	cm["VAULT_BACKEND"] = "kv-v2"
 	cm["VAULT_BACKEND_PATH"] = "/secret"
 	cm["VAULT_CACERT"] = ""
 	cm["VAULT_TLS_SERVER_NAME"] = "vault.example.com"
@@ -184,6 +188,7 @@ func TestTransformConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config["encryptionKMSType"], cm["KMS_PROVIDER"])
 	assert.Equal(t, config["vaultAddress"], cm["VAULT_ADDR"])
+	assert.Equal(t, config["vaultBackend"], cm["VAULT_BACKEND"])
 	assert.Equal(t, config["vaultBackendPath"], cm["VAULT_BACKEND_PATH"])
 	assert.Equal(t, config["vaultCAFromSecret"], cm["VAULT_CACERT"])
 	assert.Equal(t, config["vaultTLSServerName"], cm["VAULT_TLS_SERVER_NAME"])


### PR DESCRIPTION
It seems that the version of the key/value engine can not always be
detected for Hashicorp Vault. In certain cases, it is required to
configure the `VAULT_BACKEND` (or `vaultBackend`) option so that a
successful connection to the service can be made.

The `kv-v2` is the current default for development deployments of
Hashicorp Vault (what we use for automated testing). Production
deployments default to version 1 for now.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
