### PR TITLE
cleanup: fix beta apiVersion for csidriver

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -1,7 +1,7 @@
 {{ if semverCompare ">=1.18.0-beta.1" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
 {{ else }}
-apiVersion: storage.k8s.io/v1betav1
+apiVersion: storage.k8s.io/v1beta1
 {{ end }}
 kind: CSIDriver
 metadata:

--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -1,6 +1,6 @@
 ---
 # if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1betav1
+# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -1,6 +1,6 @@
 ---
 # if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1betav1
+# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:

--- a/examples/cephfs/snapshot.yaml
+++ b/examples/cephfs/snapshot.yaml
@@ -1,6 +1,6 @@
 ---
 # Snapshot API version compatibility matrix:
-# v1betav1:
+# v1beta1:
 #   v1.17 =< k8s < v1.20
 #   2.x =< snapshot-controller < v4.x
 # v1:

--- a/examples/cephfs/snapshotclass.yaml
+++ b/examples/cephfs/snapshotclass.yaml
@@ -1,6 +1,6 @@
 ---
 # Snapshot API version compatibility matrix:
-# v1betav1:
+# v1beta1:
 #   v1.17 =< k8s < v1.20
 #   2.x =< snapshot-controller < v4.x
 # v1:

--- a/examples/rbd/snapshot.yaml
+++ b/examples/rbd/snapshot.yaml
@@ -1,6 +1,6 @@
 ---
 # Snapshot API version compatibility matrix:
-# v1betav1:
+# v1beta1:
 #   v1.17 =< k8s < v1.20
 #   2.x =< snapshot-controller < v4.x
 # v1:

--- a/examples/rbd/snapshotclass.yaml
+++ b/examples/rbd/snapshotclass.yaml
@@ -1,6 +1,6 @@
 ---
 # Snapshot API version compatibility matrix:
-# v1betav1:
+# v1beta1:
 #   v1.17 =< k8s < v1.20
 #   2.x =< snapshot-controller < v4.x
 # v1:


### PR DESCRIPTION
This change resolves a typo for installing the CSIDriver
resource in Kubernetes clusters before 1.18,
where the apiVersion is incorrect.

See also:
https://kubernetes-csi.github.io/docs/csi-driver-object.html

Closes: #2281

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
