### PR TITLE
deploy: adjust terminationGracePeriodSeconds to help rbd-nbd

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -35,6 +35,7 @@ spec:
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet
+      terminationGracePeriodSeconds: {{ .Values.nodeplugin.terminationGracePeriodSeconds }}
       containers:
         - name: driver-registrar
           # This is necessary only for systems with SELinux, where

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -53,6 +53,7 @@ nodeplugin:
   priorityClassName: system-node-critical
   # if you are using rbd-nbd client set this value to OnDelete
   updateStrategy: RollingUpdate
+  terminationGracePeriodSeconds: 180
 
   httpMetrics:
     # Metrics only available for cephcsi/cephcsi => 1.2.0

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -19,6 +19,7 @@ spec:
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet
+      terminationGracePeriodSeconds: 180
       containers:
         - name: driver-registrar
           # This is necessary only for systems with SELinux, where


### PR DESCRIPTION
# Describe what this PR does #

As part of pod termination, Kubernetes initially sends SIGTERM to rbd-nbd and waits for ~30 sec i.e default `terminationGracePeriodSeconds` and then sends SIGKILL as part of ungraceful termination sequence. This is where some of the IO goes unhandled and mount point may turn out to read-only.

rbd-nbd expects some time for it to handle pending IO after SIGTERM is issued, currently at the rados level `rados_osd_op_timeout` is unlimited (wait forever), this means we never know when the IO will finish, if rbd-nbd can set the IO ops some timeout via `rados_osd_op_timeout` (in the rbd-nbd) then its possible for us at ceph-csi to exactly define time to wait for rbd-nbd at rbd nodeplugin.

But till we have the fix in rbd-nbd, to avoid the frequency of hitting such issue at the csi level, we should consider increasing `terminationGracePeriodSeconds` to a good value from the current 30 sec.

`terminationGracePeriodSeconds` field of a Pod spec instructs Kubernetes to wait for a given number of seconds before killing a container after termination. This leaves the processes time to free resources and flush any important data.

updates: #2204 

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>
