### PR TITLE
rbd: rename encryption metadata keys to enable mirroring

### DIFF
--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -494,7 +494,7 @@ func validateThickImageMetadata(f *framework.Framework, pvc *v1.PersistentVolume
 // - Metadata of the image should be set with the encryption state;
 // - The pvc should be mounted by a pod, so the filesystem type can be fetched.
 func validateEncryptedImage(f *framework.Framework, rbdImageSpec string, app *v1.Pod) error {
-	encryptedState, err := getImageMeta(rbdImageSpec, ".rbd.csi.ceph.com/encrypted", f)
+	encryptedState, err := getImageMeta(rbdImageSpec, "rbd.csi.ceph.com/encrypted", f)
 	if err != nil {
 		return err
 	}

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -53,16 +53,18 @@ const (
 	rbdImageRequiresEncryption = rbdEncryptionState("requiresEncryption")
 
 	// image metadata key for encryption.
-	encryptionMetaKey = ".rbd.csi.ceph.com/encrypted"
+	encryptionMetaKey    = "rbd.csi.ceph.com/encrypted"
+	oldEncryptionMetaKey = ".rbd.csi.ceph.com/encrypted"
 
 	// metadataDEK is the key in the image metadata where the (encrypted)
 	// DEK is stored.
-	metadataDEK = ".rbd.csi.ceph.com/dek"
+	metadataDEK    = "rbd.csi.ceph.com/dek"
+	oldMetadataDEK = ".rbd.csi.ceph.com/dek"
 )
 
 // checkRbdImageEncrypted verifies if rbd image was encrypted when created.
 func (ri *rbdImage) checkRbdImageEncrypted(ctx context.Context) (rbdEncryptionState, error) {
-	value, err := ri.GetMetadata(encryptionMetaKey)
+	value, err := ri.MigrateMetadata(oldEncryptionMetaKey, encryptionMetaKey, string(rbdImageEncryptionUnknown))
 	if errors.Is(err, librbd.ErrNotFound) {
 		util.DebugLog(ctx, "image %s encrypted state not set", ri)
 
@@ -317,7 +319,7 @@ func (ri *rbdImage) FetchDEK(volumeID string) (string, error) {
 		return "", fmt.Errorf("volume %q can not fetch DEK for %q", ri, volumeID)
 	}
 
-	return ri.GetMetadata(metadataDEK)
+	return ri.MigrateMetadata(oldMetadataDEK, metadataDEK, "")
 }
 
 // RemoveDEK does not need to remove the DEK from the metadata, the image is


### PR DESCRIPTION
The new MigrateMetadata() function can be used to get the metadata of an
image with a deprecated and new key. Renaming metadata keys can be done
easily this way.

A default value will be set in the image metadata when it is missing
completely. But if the deprecated key was set, the data is stored under
the new key and the deprecated key is removed.

RBD image metadata keys that start with '.rbd' are expected to be
internal to RBD itself and are not mirrored to remote sites. Renaming
the keys (dropping the '.rbd' prefix) and using the new
MigrateMetadata() function now makes the keys available on remote sites
too.

Closes: #2219

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
