### PR TITLE
ci: fix yamllint error in generated golangci.yml file

### DIFF
--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -176,5 +176,6 @@ linters:
     - gomoddirectives
     # TODO: enable gci
     - gci
-    # TODO: enable wrapcheck linter, see: https://github.com/ceph/ceph-csi/pull/2268
+    # TODO: enable wrapcheck linter
+    # See: https://github.com/ceph/ceph-csi/pull/2268
     - wrapcheck


### PR DESCRIPTION
When running 'make containerized-test' the following error gets
reported:

    yamllint -s -d '{extends: default, rules: {line-length: {allow-non-breakable-inline-mappings: true}},ignore: charts/*/templates/*.yaml}' ./scripts/golangci.yml
    ./scripts/golangci.yml
      179:81    error    line too long (84 > 80 characters)  (line-length)

The golangci.yml.in is used to generate golangci.yml, addressing the
line-length there resolves the issue.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
