### PR TITLE
util: allow configuring VAULT_AUTH_MOUNT_PATH for Vault Tenant SA KMS

### DIFF
--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -39,6 +39,7 @@ const (
 
 	// vault configuration defaults.
 	vaultDefaultAuthPath       = "/v1/auth/kubernetes/login"
+	vaultDefaultAuthMountPath  = "kubernetes" // main component of vaultAuthPath
 	vaultDefaultRole           = "csi-kubernetes"
 	vaultDefaultNamespace      = ""
 	vaultDefaultPassphrasePath = ""

--- a/internal/util/vault_sa_test.go
+++ b/internal/util/vault_sa_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,4 +27,51 @@ func TestVaultTenantSAKMSRegistered(t *testing.T) {
 	t.Parallel()
 	_, ok := kmsManager.providers[kmsTypeVaultTenantSA]
 	assert.True(t, ok)
+}
+
+func TestTenantSAParseConfig(t *testing.T) {
+	t.Parallel()
+	vts := VaultTenantSA{}
+
+	config := make(map[string]interface{})
+
+	// empty config map
+	err := vts.parseConfig(config)
+	if !errors.Is(err, errConfigOptionMissing) {
+		t.Errorf("unexpected error (%T): %s", err, err)
+	}
+
+	// fill default options (normally done in initVaultTokensKMS)
+	config["vaultAddress"] = "https://vault.bob.cluster.svc"
+	config["vaultAuthPath"] = "/v1/auth/kube-auth/login"
+
+	// parsing with all required options
+	err = vts.parseConfig(config)
+	switch {
+	case err != nil:
+		t.Errorf("unexpected error: %s", err)
+	case vts.vaultConfig["VAULT_AUTH_MOUNT_PATH"] != "kube-auth":
+		t.Errorf("vaultAuthPath set to unexpected value: %s", vts.vaultConfig["VAULT_AUTH_MOUNT_PATH"])
+	}
+
+	// tenant "bob" uses a different auth mount path
+	bob := make(map[string]interface{})
+	bob["vaultAuthPath"] = "/v1/auth/bobs-cluster/login"
+	err = vts.parseConfig(bob)
+	switch {
+	case err != nil:
+		t.Errorf("unexpected error: %s", err)
+	case vts.vaultConfig["VAULT_AUTH_MOUNT_PATH"] != "bobs-cluster":
+		t.Errorf("vaultAuthPath set to unexpected value: %s", vts.vaultConfig["VAULT_AUTH_MOUNT_PATH"])
+	}
+
+	// auth mount path can be passed like VAULT_AUTH_MOUNT_PATH too
+	bob["vaultAuthPath"] = "bobs-2nd-cluster"
+	err = vts.parseConfig(bob)
+	switch {
+	case err != nil:
+		t.Errorf("unexpected error: %s", err)
+	case vts.vaultConfig["VAULT_AUTH_MOUNT_PATH"] != "bobs-2nd-cluster":
+		t.Errorf("vaultAuthPath set to unexpected value: %s", vts.vaultConfig["VAULT_AUTH_MOUNT_PATH"])
+	}
 }


### PR DESCRIPTION
The VAULT_AUTH_MOUNT_PATH is a Vault configuration parameter that allows
a user to set a non default path for the Kubernetes ServiceAccount
integration. This can already be configured for the Vault KMS, and is
now added to the Vault Tenant SA KMS as well.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
