### PR TITLE
rbd: use rados namespace for manager command

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1945,6 +1945,11 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to delete PVC with error %v", err)
 					}
 					validateRBDImageCount(f, 0, defaultRBDPool)
+
+					err = waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to validate rbd images in pool %s trash with error %v", rbdOptions(defaultRBDPool), err)
+					}
 				}
 
 				// delete RBD provisioner secret

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -881,7 +881,7 @@ func listRBDImagesInTrash(f *framework.Framework, poolName string) ([]trashInfo,
 	var trashInfos []trashInfo
 
 	stdout, stdErr, err := execCommandInToolBoxPod(f,
-		fmt.Sprintf("rbd trash ls --format=json %s", poolName), rookNamespace)
+		fmt.Sprintf("rbd trash ls --format=json %s", rbdOptions(poolName)), rookNamespace)
 	if err != nil {
 		return trashInfos, err
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -523,6 +523,16 @@ func addRbdManagerTask(ctx context.Context, pOpts *rbdVolume, arg []string) (boo
 	return supported, err
 }
 
+// getTrashPath returns the image path for trash operation.
+func (rv *rbdVolume) getTrashPath() string {
+	trashPath := rv.Pool
+	if rv.RadosNamespace != "" {
+		trashPath = trashPath + "/" + rv.RadosNamespace
+	}
+
+	return trashPath + "/" + rv.ImageID
+}
+
 // deleteImage deletes a ceph image with provision and volume options.
 func deleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) error {
 	image := pOpts.RbdImageName
@@ -556,9 +566,10 @@ func deleteImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 	}
 
 	// attempt to use Ceph manager based deletion support if available
+
 	args := []string{
 		"trash", "remove",
-		pOpts.Pool + "/" + pOpts.ImageID,
+		pOpts.getTrashPath(),
 		"--id", cr.ID,
 		"--keyfile=" + cr.KeyFile,
 		"-m", pOpts.Monitors,


### PR DESCRIPTION
 Currently, we have a bug that we are not using rados namespace when adding the ceph manager command to remove the image from the trash. This PR adds the missing rados namespace when adding the ceph manager task.

without fix the image will be moved to trash and no task will be added to remove from the trash. it will become ceph responsibility to remove the image from trash when it will cleanup the trash.

workaroud: manually purge the trash
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>