### PR TITLE
e2e: retry on kubectl  known error failures

### DIFF
--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -17,12 +17,8 @@ import (
 
 func deleteConfigMap(pluginPath string) error {
 	path := pluginPath + configMap
-	_, err := framework.RunKubectl(cephCSINamespace, "delete", "-f", path, ns)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return retryKubectlFile(cephCSINamespace, kubectlDelete, path, deployTimeout)
 }
 
 func createConfigMap(pluginPath string, c kubernetes.Interface, f *framework.Framework) error {

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega" // nolint
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
@@ -25,13 +24,12 @@ var (
 func deployVault(c kubernetes.Interface, deployTimeout int) {
 	// hack to make helm E2E pass as helm charts creates this configmap as part
 	// of cephcsi deployment
-	_, err := framework.RunKubectl(
+	err := retryKubectlArgs(
 		cephCSINamespace,
-		"delete",
+		kubectlDelete,
+		deployTimeout,
 		"cm",
 		"ceph-csi-encryption-kms-config",
-		"--namespace",
-		cephCSINamespace,
 		"--ignore-not-found=true")
 	Expect(err).Should(BeNil())
 

--- a/e2e/errors_test.go
+++ b/e2e/errors_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+)
+
+// nolint:lll // error string cannot be split into multiple lines as is a
+// output from kubectl.
+func TestGetStdErr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                string
+		errString           string
+		expected            string
+		isAlreadyExistError bool
+	}{
+		{
+			name: "stdErr output when error is found",
+			errString: `
+error running /usr/local/bin/kubectl --server=https://192.168.39.67:8443 --kubeconfig=***** --namespace=default create -f -:
+Command stdout:
+
+stderr:
+Error from server (AlreadyExists): error when creating "STDIN": services "csi-rbdplugin-provisioner" already exists
+Error from server (AlreadyExists): error when creating "STDIN": deployments.apps "csi-rbdplugin-provisioner" already exists
+
+error:
+exit status 1`,
+			expected: `Error from server (AlreadyExists): error when creating "STDIN": services "csi-rbdplugin-provisioner" already exists
+Error from server (AlreadyExists): error when creating "STDIN": deployments.apps "csi-rbdplugin-provisioner" already exists
+
+`,
+			isAlreadyExistError: true,
+		},
+		{
+			name: "stdErr output when stderr: string is not found",
+			errString: `
+error running /usr/local/bin/kubectl --server=https://192.168.39.67:8443 --kubeconfig=***** --namespace=default create -f -:
+Command stdout:
+
+error:
+exit status 1`,
+			expected:            "",
+			isAlreadyExistError: false,
+		},
+		{
+			name: "stdErr output when error: string is not found",
+			errString: `
+error running /usr/local/bin/kubectl --server=https://192.168.39.67:8443 --kubeconfig=***** --namespace=default create -f -:
+Command stdout:
+
+stderr:
+Error from server (AlreadyExists): error when creating "STDIN": services "csi-rbdplugin-provisioner" already exists
+Error from server (AlreadyExists): error when creating "STDIN": deployments.apps "csi-rbdplugin-provisioner" already exists`,
+			expected:            "",
+			isAlreadyExistError: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := getStdErr(tt.errString); got != tt.expected {
+				t.Errorf("getStdErr() output = %v, expected %v", got, tt.expected)
+			}
+
+			if got := isAlreadyExistsCLIError(fmt.Errorf("%s", tt.errString)); got != tt.isAlreadyExistError {
+				t.Errorf("isAlreadyExistsCLIError() output = %v, expected %v", got, tt.isAlreadyExistError)
+			}
+		})
+	}
+}

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -375,7 +375,14 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 }
 
 func deletePodWithLabel(label, ns string, skipNotFound bool) error {
-	_, err := framework.RunKubectl(ns, "delete", "po", "-l", label, fmt.Sprintf("--ignore-not-found=%t", skipNotFound))
+	err := retryKubectlArgs(
+		ns,
+		kubectlDelete,
+		deployTimeout,
+		"po",
+		"-l",
+		label,
+		fmt.Sprintf("--ignore-not-found=%t", skipNotFound))
 	if err != nil {
 		e2elog.Logf("failed to delete pod %v", err)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -127,7 +127,7 @@ func deleteResource(scPath string) error {
 	if err != nil {
 		e2elog.Logf("failed to read content from %s %v", scPath, err)
 	}
-	_, err = framework.RunKubectlInput(cephCSINamespace, data, ns, "delete", "-f", "-")
+	err = retryKubectlInput(cephCSINamespace, kubectlDelete, data, deployTimeout)
 	if err != nil {
 		e2elog.Logf("failed to delete %s %v", scPath, err)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1252,6 +1252,9 @@ func retryKubectlInput(namespace string, action kubectlAction, data string, t in
 			if isRetryableAPIError(err) {
 				return false, nil
 			}
+			if isAlreadyExistsCLIError(err) {
+				return true, nil
+			}
 			e2elog.Logf(
 				"will run kubectl (%s) again (%d seconds elapsed)",
 				action,
@@ -1277,6 +1280,9 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 		if err != nil {
 			if isRetryableAPIError(err) {
 				return false, nil
+			}
+			if isAlreadyExistsCLIError(err) {
+				return true, nil
 			}
 			e2elog.Logf(
 				"will run kubectl (%s -f %q) again (%d seconds elapsed)",

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1296,3 +1296,33 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 		return true, nil
 	})
 }
+
+// retryKubectlArgs takes a namespace and action telling kubectl what to do
+// with the passed arguments. This function retries until no error occurred, or
+// the timeout passed.
+func retryKubectlArgs(namespace string, action kubectlAction, t int, args ...string) error {
+	timeout := time.Duration(t) * time.Minute
+	args = append([]string{string(action)}, args...)
+	e2elog.Logf("waiting for kubectl (%s args) to finish", args)
+	start := time.Now()
+
+	return wait.PollImmediate(poll, timeout, func() (bool, error) {
+		_, err := framework.RunKubectl(namespace, args...)
+		if err != nil {
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			if isAlreadyExistsCLIError(err) {
+				return true, nil
+			}
+			e2elog.Logf(
+				"will run kubectl (%s) again (%d seconds elapsed)",
+				args,
+				int(time.Since(start).Seconds()))
+
+			return false, fmt.Errorf("failed to run kubectl: %w", err)
+		}
+
+		return true, nil
+	})
+}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1241,13 +1241,19 @@ func (ka kubectlAction) String() string {
 // retryKubectlInput takes a namespace and action telling kubectl what to do,
 // it then feeds data through stdin to the process. This function retries until
 // no error occurred, or the timeout passed.
-func retryKubectlInput(namespace string, action kubectlAction, data string, t int) error {
+func retryKubectlInput(namespace string, action kubectlAction, data string, t int, args ...string) error {
 	timeout := time.Duration(t) * time.Minute
-	e2elog.Logf("waiting for kubectl (%s) to finish", action)
+	e2elog.Logf("waiting for kubectl (%s -f %q args %s) to finish", action, args)
 	start := time.Now()
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
-		_, err := framework.RunKubectlInput(namespace, data, string(action), "-f", "-")
+		cmd := []string{}
+		if len(args) != 0 {
+			cmd = append(cmd, strings.Join(args, ""))
+		}
+		cmd = append(cmd, []string{string(action), "-f", "-"}...)
+
+		_, err := framework.RunKubectlInput(namespace, data, cmd...)
 		if err != nil {
 			if isRetryableAPIError(err) {
 				return false, nil
@@ -1256,8 +1262,9 @@ func retryKubectlInput(namespace string, action kubectlAction, data string, t in
 				return true, nil
 			}
 			e2elog.Logf(
-				"will run kubectl (%s) again (%d seconds elapsed)",
+				"will run kubectl (%s) args (%s) again (%d seconds elapsed)",
 				action,
+				args,
 				int(time.Since(start).Seconds()))
 
 			return false, fmt.Errorf("failed to run kubectl: %w", err)
@@ -1268,15 +1275,21 @@ func retryKubectlInput(namespace string, action kubectlAction, data string, t in
 }
 
 // retryKubectlFile takes a namespace and action telling kubectl what to do
-// with the passed filename. This function retries until no error occurred, or
-// the timeout passed.
-func retryKubectlFile(namespace string, action kubectlAction, filename string, t int) error {
+// with the passed filename and arguments. This function retries until no error
+// occurred, or the timeout passed.
+func retryKubectlFile(namespace string, action kubectlAction, filename string, t int, args ...string) error {
 	timeout := time.Duration(t) * time.Minute
-	e2elog.Logf("waiting for kubectl (%s -f %q) to finish", action, filename)
+	e2elog.Logf("waiting for kubectl (%s -f %q args %s) to finish", action, filename, args)
 	start := time.Now()
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
-		_, err := framework.RunKubectl(namespace, string(action), "-f", filename)
+		cmd := []string{}
+		if len(args) != 0 {
+			cmd = append(cmd, strings.Join(args, ""))
+		}
+		cmd = append(cmd, []string{string(action), "-f", filename}...)
+
+		_, err := framework.RunKubectl(namespace, cmd...)
 		if err != nil {
 			if isRetryableAPIError(err) {
 				return false, nil
@@ -1285,9 +1298,10 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 				return true, nil
 			}
 			e2elog.Logf(
-				"will run kubectl (%s -f %q) again (%d seconds elapsed)",
+				"will run kubectl (%s -f %q args %s) again (%d seconds elapsed)",
 				action,
 				filename,
+				args,
 				int(time.Since(start).Seconds()))
 
 			return false, fmt.Errorf("failed to run kubectl: %w", err)


### PR DESCRIPTION
By using retryKubectl helper function, a retry will be done, and the known error messages will be skipped till timeout is reached.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

covering other cases than https://github.com/ceph/ceph-csi/pull/2325