### PR TITLE
ci: add Mergify backport rules for release-v3.4

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -271,6 +271,43 @@ pull_request_rules:
       merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
+  - name: backport patches to release-v3.4 branch
+    conditions:
+      - base=devel
+      - label=backport-to-release-v3.4
+    actions:
+      backport:
+        branches:
+          - release-v3.4
+  # automerge backports if CI successfully ran
+  - name: automerge backport release-v3.4
+    conditions:
+      - author=mergify[bot]
+      - base=release-v3.4
+      - label!=DNM
+      - "#approved-reviews-by>=1"
+      - "status-success=codespell"
+      - "status-success=multi-arch-build"
+      - "status-success=go-test"
+      - "status-success=golangci-lint"
+      - "status-success=gosec"
+      - "status-success=commitlint"
+      - "status-success=mod-check"
+      - "status-success=lint-extras"
+      - "#changes-requested-reviews-by=0"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.19"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.20"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.21"
+      - "status-success=ci/centos/mini-e2e/k8s-1.19"
+      - "status-success=ci/centos/mini-e2e/k8s-1.20"
+      - "status-success=ci/centos/mini-e2e/k8s-1.21"
+      - "status-success=ci/centos/upgrade-tests-cephfs"
+      - "status-success=ci/centos/upgrade-tests-rbd"
+      - "status-success=DCO"
+    actions:
+      merge: {}
+      dismiss_reviews: {}
+      delete_head_branch: {}
   - name: remove outdated approvals on ci/centos
     conditions:
       - base=ci/centos


### PR DESCRIPTION
The new `backport-to-release-v3.4` label can be added to PRs and Mergify
will create a backport once the PR for the devel branch has been merged.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
