### PR TITLE
build: install specific commitlint version

### DIFF
--- a/build.env
+++ b/build.env
@@ -19,6 +19,9 @@ CEPH_VERSION=octopus
 GOLANG_VERSION=1.16.4
 GO111MODULE=on
 
+# commitlint version
+COMMITLINT_VERSION=12.1.4
+
 # static checks and linters
 GOLANGCI_VERSION=v1.39.0
 GOSEC_VERSION=v2.7.0

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -44,7 +44,7 @@ RUN source /build.env \
     && curl -L https://git.io/get_helm.sh | bash -s -- --version "${HELM_VERSION}" \
     && mkdir /opt/commitlint && pushd /opt/commitlint \
     && npm init -y \
-    && npm install @commitlint/cli \
+    && npm install @commitlint/cli@"${COMMITLINT_VERSION}" \
     && popd \
     && true
 


### PR DESCRIPTION
commitlint 13.1.0 is causing issues when PR is backported from devel branch to release branch https://github.com/ceph/ceph-csi/pull/2332#issuecomment-888325775. Let's revert back to commitlint 12.1.4 where we have not seen any issue with backports to release branch.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

