### PR TITLE
deploy: add non-default namespace support for rbd kubernetes manifest files

### DIFF
--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rbd-csi-nodeplugin
+  # replace with non-default namespace name
+  namespace: default
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -36,6 +38,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rbd-csi-nodeplugin
+    # replace with non-default namespace name
     namespace: default
 roleRef:
   kind: ClusterRole

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rbd-csi-provisioner
+  # replace with non-default namespace name
+  namespace: default
 
 ---
 kind: ClusterRole
@@ -66,6 +68,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rbd-csi-provisioner
+    # replace with non-default namespace name
     namespace: default
 roleRef:
   kind: ClusterRole

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -3,6 +3,8 @@ kind: Service
 apiVersion: v1
 metadata:
   name: csi-rbdplugin-provisioner
+  # replace with non-default namespace name
+  namespace: default
   labels:
     app: csi-metrics
 spec:
@@ -19,6 +21,8 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-rbdplugin-provisioner
+  # replace with non-default namespace name
+  namespace: default
 spec:
   replicas: 3
   selector:
@@ -135,10 +139,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # - name: POD_NAMESPACE
-            #   valueFrom:
-            #     fieldRef:
-            #       fieldPath: spec.namespace
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # - name: KMS_CONFIGMAP_NAME
             #   value: encryptionConfig
             - name: CSI_ENDPOINT

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -3,6 +3,8 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: csi-rbdplugin
+  # replace with non-default namespace name
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -73,10 +75,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # - name: POD_NAMESPACE
-            #   valueFrom:
-            #     fieldRef:
-            #       fieldPath: spec.namespace
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # - name: KMS_CONFIGMAP_NAME
             #   value: encryptionConfig
             - name: CSI_ENDPOINT
@@ -173,6 +175,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: csi-metrics-rbdplugin
+  # replace with non-default namespace name
+  namespace: default
   labels:
     app: csi-metrics
 spec:


### PR DESCRIPTION
# Describe what this PR does #

Allow users to deploy ceph-csi-rbd on non-default namespace by provide a working example in manifest files.

Users can search for `# replace with non-default namespace name` comment and modifying `namespace: default` to whatever namespace they want.

This changes is already deployed on my test cluster and production clusters.

Signed-off-by: rtsp <git@rtsp.us>

## Is there anything that requires special attention ##

> Is the change backward compatible?

Yes, without modifying anything, those manifests will deploy on `default` namespace as usual.

> Are there concerns around backward compatibility?

No.

> Provide any external context for the change, if any.

This also fix incorrect namespace reference in deployment spec from `spec.namespace` to `metadata.namespace` because `spec.namespace` is not really exist.

- https://github.com/rtsp/ceph-csi/blob/devel/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml#L145
- https://github.com/rtsp/ceph-csi/blob/devel/deploy/rbd/kubernetes/csi-rbdplugin.yaml#L81

## Related issues ##

N/A

## Future concerns ##

N/A