### PR TITLE
e2e: use official CentOS container location

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -254,7 +254,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 			Containers: []v1.Container{
 				{
 					Name:    "write-pod",
-					Image:   "registry.centos.org/centos:latest",
+					Image:   "quay.io/centos/centos:latest",
 					Command: []string{"/bin/sleep", "999999"},
 					SecurityContext: &v1.SecurityContext{
 						RunAsUser: &user,

--- a/examples/rbd/block-pod-clone.yaml
+++ b/examples/rbd/block-pod-clone.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: centos
-      image: registry.centos.org/centos:latest
+      image: quay.io/centos/centos:latest
       command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data

--- a/examples/rbd/raw-block-pod.yaml
+++ b/examples/rbd/raw-block-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: centos
-      image: registry.centos.org/centos:latest
+      image: quay.io/centos/centos:latest
       command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data


### PR DESCRIPTION
registry.centos.org is not officially maintained by the CentOS
infrastructure team. The container images on quay.io are the official
once and we should use those instead.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
