### PR TITLE
helm: update updateStrategy 

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -11,6 +11,12 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.provisioner.replicaCount }}
+  strategy:
+    type: {{ .Values.provisioner.strategy.type }}
+{{- if eq .Values.provisioner.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.provisioner.strategy.rollingUpdate.maxUnavailable }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ include "ceph-csi-cephfs.name" . }}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -109,6 +109,14 @@ nodeplugin:
 provisioner:
   name: provisioner
   replicaCount: 3
+  strategy:
+    # RollingUpdate strategy replaces old pods with new ones gradually,
+    # without incurring downtime.
+    type: RollingUpdate
+    rollingUpdate:
+      # maxUnavailable is the maximum number of pods that can be
+      # unavailable during the update process.
+      maxUnavailable: 50%
   # Timeout for waiting for creation or deletion of a volume
   timeout: 60s
 

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -11,6 +11,12 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.provisioner.replicaCount }}
+  strategy:
+    type: {{ .Values.provisioner.strategy.type }}
+{{- if eq .Values.provisioner.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.provisioner.strategy.rollingUpdate.maxUnavailable }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ include "ceph-csi-rbd.name" . }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -117,6 +117,14 @@ nodeplugin:
 provisioner:
   name: provisioner
   replicaCount: 3
+  strategy:
+    # RollingUpdate strategy replaces old pods with new ones gradually,
+    # without incurring downtime.
+    type: RollingUpdate
+    rollingUpdate:
+      # maxUnavailable is the maximum number of pods that can be
+      # unavailable during the update process.
+      maxUnavailable: 50%
   # if fstype is not specified in storageclass, ext4 is default
   defaultFSType: ext4
   # deployController to enable or disable the deployment of controller which


### PR DESCRIPTION
Update the provisioner and nodeplugin updatestrategy
to allow maxUnavailable and maxSurge
pods at a time to be 50%

Fixes: #2335 

Signed-off-by: Yug Gupta <yuggupta27@gmail.com>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
