### PR TITLE
cephfs: support selinux mount options

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -112,6 +112,9 @@ spec:
               name: host-mount
             - mountPath: /sys
               name: host-sys
+            - mountPath: /etc/selinux
+              name: etc-selinux
+              readOnly: true
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
@@ -167,6 +170,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
         - name: host-mount
           hostPath:
             path: /run/mount

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
@@ -38,6 +38,8 @@ spec:
       readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
+    - pathPrefix: '/etc/selinux'
+      readOnly: true
     - pathPrefix: '/lib/modules'
       readOnly: true
     - pathPrefix: '{{ .Values.kubeletDir }}'

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -106,6 +106,9 @@ spec:
               name: host-mount
             - mountPath: /sys
               name: host-sys
+            - mountPath: /etc/selinux
+              name: etc-selinux
+              readOnly: true
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
@@ -175,6 +178,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
         - name: lib-modules
           hostPath:
             path: /lib/modules

--- a/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
@@ -38,6 +38,8 @@ spec:
       readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
+    - pathPrefix: '/etc/selinux'
+      readOnly: true
     - pathPrefix: '/lib/modules'
       readOnly: true
     - pathPrefix: '{{ .Values.kubeletDir }}'

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -84,6 +84,9 @@ spec:
               mountPropagation: "Bidirectional"
             - name: host-sys
               mountPath: /sys
+            - name: etc-selinux
+              mountPath: /etc/selinux
+              readOnly: true
             - name: lib-modules
               mountPath: /lib/modules
               readOnly: true
@@ -137,6 +140,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
         - name: lib-modules
           hostPath:
             path: /lib/modules

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
@@ -32,6 +32,8 @@ spec:
       readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
+    - pathPrefix: '/etc/selinux'
+      readOnly: true
     - pathPrefix: '/lib/modules'
       readOnly: true
     - pathPrefix: '/var/lib/kubelet/pods'

--- a/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
@@ -32,6 +32,8 @@ spec:
       readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
+    - pathPrefix: '/etc/selinux'
+      readOnly: true
     - pathPrefix: '/lib/modules'
       readOnly: true
     - pathPrefix: '/var/lib/kubelet/pods'

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -93,6 +93,9 @@ spec:
               name: host-sys
             - mountPath: /run/mount
               name: host-mount
+            - mountPath: /etc/selinux
+              name: etc-selinux
+              readOnly: true
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
@@ -153,6 +156,9 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
         - name: host-mount
           hostPath:
             path: /run/mount

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -411,6 +411,14 @@ func newVolumeOptionsFromMonitorList(
 		}
 	}
 
+	if err = extractOptionalOption(&opts.KernelMountOptions, "kernelMountOptions", options); err != nil {
+		return nil, nil, err
+	}
+
+	if err = extractOptionalOption(&opts.FuseMountOptions, "fuseMountOptions", options); err != nil {
+		return nil, nil, err
+	}
+
 	if err = extractMounter(&opts.Mounter, options); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- mount host's /etc/selinux in node plugins
- process mount options in all code paths for cephfs volume options

Signed-off-by: Alexandre Lossent <alexandre.lossent@cern.ch>

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Make it possible to specify selinux-related mount options like `context`. Details about use cases in https://github.com/ceph/ceph-csi/issues/2295

- mount host's /etc/selinux in node plugins - without this, `libmount` silently ignores the selinux-related mount options
- process mount options in all code paths for cephfs volume options - in some cases, the `kernelMountOptions` and `fuseMountOptions` would be ignored

## Is there anything that requires special attention ##

Do you have any questions?

I added the /etc/selinux bind-mount in RDB node plugins too for consistency and to allow use of selinux mount options with RBD too, let me know if this is relevant.

Is the change backward compatible? 

Yes, there is no change in behavior until selinux-related mount options are specified.

Are there concerns around backward compatibility? 

I don't think so, nodes without selinux at all would just bind-mount an empty /etc/selinux folder.

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #2295

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
