### PR TITLE
e2e: use original namespace for retrying resize check

### DIFF
--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -19,9 +19,10 @@ import (
 
 func expandPVCSize(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, size string, t int) error {
 	pvcName := pvc.Name
+	pvcNamespace := pvc.Namespace
 
 	updatedPVC, err := c.CoreV1().
-		PersistentVolumeClaims(pvc.Namespace).
+		PersistentVolumeClaims(pvcNamespace).
 		Get(context.TODO(), pvcName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error fetching pvc %q with %w", pvcName, err)
@@ -38,12 +39,12 @@ func expandPVCSize(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, size s
 	e2elog.Logf("Waiting up to %v to be in Resized state", pvc)
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
-		e2elog.Logf("waiting for PVC %s (%d seconds elapsed)", updatedPVC.Name, int(time.Since(start).Seconds()))
+		e2elog.Logf("waiting for PVC %s (%d seconds elapsed)", pvcName, int(time.Since(start).Seconds()))
 		updatedPVC, err = c.CoreV1().
-			PersistentVolumeClaims(updatedPVC.Namespace).
+			PersistentVolumeClaims(pvcNamespace).
 			Get(context.TODO(), pvcName, metav1.GetOptions{})
 		if err != nil {
-			e2elog.Logf("Error getting pvc in namespace: '%s': %v", updatedPVC.Namespace, err)
+			e2elog.Logf("Error getting pvc in namespace: '%s': %v", pvcNamespace, err)
 			if isRetryableAPIError(err) {
 				return false, nil
 			}


### PR DESCRIPTION
expandPVCSize() uses the namespace of the PVC that was checked. In case
the .Get() call fails, the PVC will not have its namespace set, and
subsequent tries will fail with errors like:

    Error getting pvc in namespace: '': etcdserver: request timed out
    waiting for PVC  (9 seconds elapsed)
    Error getting pvc in namespace: '': an empty namespace may not be set when a resource name is provided

By using the original namespace of the PVC stored in a separate variable
as is done with the name of the PVC, this problem should not occur
anymore.

Fixes: https://github.com/ceph/ceph-csi/pull/2322#issuecomment-891911906
Closes: #1874

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
