### PR TITLE
rbd: consider empty mirroring mode

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -130,7 +130,7 @@ func getMirroringMode(ctx context.Context, parameters map[string]string) (librbd
 
 // getSchedulingDetails gets the mirroring mode and scheduling details from the
 // input GRPC request parameters and validates the scheduling is only supported
-// for mirroring mode.
+// for snapshot mirroring mode.
 func getSchedulingDetails(parameters map[string]string) (admin.Interval, admin.StartTime, error) {
 	admInt := admin.NoInterval
 	adminStartTime := admin.NoStartTime
@@ -140,6 +140,10 @@ func getSchedulingDetails(parameters map[string]string) (admin.Interval, admin.S
 
 	switch imageMirroringMode(val) {
 	case imageMirrorModeSnapshot:
+	// If mirroring mode is not set in parameters, we are defaulting mirroring
+	// mode to snapshot. Discard empty mirroring mode from validation as it is
+	// an optional parameter.
+	case "":
 	default:
 		return admInt, adminStartTime, status.Error(codes.InvalidArgument, "scheduling is only supported for snapshot mode")
 	}

--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -138,6 +138,23 @@ func TestGetSchedulingDetails(t *testing.T) {
 			admin.NoStartTime,
 			false,
 		},
+		{
+			"when no parameters and scheduling details are specified",
+			map[string]string{},
+			admin.NoInterval,
+			admin.NoStartTime,
+			false,
+		},
+		{
+			"when no mirroring mode is specified",
+			map[string]string{
+				schedulingIntervalKey:  "1h",
+				schedulingStartTimeKey: "14:00:00-05:00",
+			},
+			admin.Interval("1h"),
+			admin.StartTime("14:00:00-05:00"),
+			false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
consider the empty mirroring mode when validating the snapshot interval and the scheduling time. Even if the mirroring Mode is not set validate the snapshot scheduling details as cephcsi sets the mirroring mode to default snapshot.

fixes #2373 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

