### PR TITLE
ci: remove create & delete namespace commands from helm jobs

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -175,7 +175,6 @@ node('cico-workspace') {
 					deploy_param = '--deploy-sc --deploy-secret'
 				}
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh up'
-				ssh "kubectl create namespace '${namespace}'"
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh install-cephcsi --namespace '${namespace}' ${deploy_param}"
 			}
 		}
@@ -188,7 +187,6 @@ node('cico-workspace') {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh cleanup-cephcsi --namespace '${namespace}'"
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh clean'
-				ssh "kubectl delete namespace '${namespace}' --ignore-not-found=true"
 			}
 		}
 	}


### PR DESCRIPTION
 Skip namespace creation in the job since this will be done internally by intall_helm.sh script with kubectl_retry

Closes: #2309
Depends-on: #2377 
Depends-on: #2399  
Depends-on: #2400  
Depends-on: #2401   

Signed-off-by: Rakshith R <rar@redhat.com>
