### PR TITLE
e2e: improve the debug logs for rbd-nbd

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -410,7 +410,10 @@ var _ = Describe("RBD", func() {
 					f,
 					defaultSCName,
 					nil,
-					map[string]string{"mounter": "rbd-nbd"},
+					map[string]string{
+						"mounter":    "rbd-nbd",
+						"mapOptions": "debug-rbd=20",
+					},
 					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
@@ -447,7 +450,10 @@ var _ = Describe("RBD", func() {
 						f,
 						defaultSCName,
 						nil,
-						map[string]string{"mounter": "rbd-nbd"},
+						map[string]string{
+							"mounter":    "rbd-nbd",
+							"mapOptions": "debug-rbd=20",
+						},
 						deletePolicy)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)
@@ -489,7 +495,10 @@ var _ = Describe("RBD", func() {
 					f,
 					defaultSCName,
 					nil,
-					map[string]string{"mounter": "rbd-nbd"},
+					map[string]string{
+						"mounter":    "rbd-nbd",
+						"mapOptions": "debug-rbd=20",
+					},
 					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
@@ -640,7 +649,11 @@ var _ = Describe("RBD", func() {
 					f,
 					defaultSCName,
 					nil,
-					map[string]string{"mounter": "rbd-nbd", "encrypted": "true"},
+					map[string]string{
+						"mounter":    "rbd-nbd",
+						"mapOptions": "debug-rbd=20",
+						"encrypted":  "true",
+					},
 					deletePolicy)
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
@@ -993,7 +1006,11 @@ var _ = Describe("RBD", func() {
 						f,
 						defaultSCName,
 						nil,
-						map[string]string{"imageFeatures": "layering,journaling,exclusive-lock", "mounter": "rbd-nbd"},
+						map[string]string{
+							"imageFeatures": "layering,journaling,exclusive-lock",
+							"mounter":       "rbd-nbd",
+							"mapOptions":    "debug-rbd=20",
+						},
 						deletePolicy)
 					if err != nil {
 						e2elog.Failf("failed to create storageclass with error %v", err)


### PR DESCRIPTION
# Describe what this PR does #
 
Ceph’s logging levels operate on a scale of 1 to 20, where 1 is terse and 20 is verbose.
 
Format:
debug-{subsystem} = {log-level}
 
Setting `rbd` loglevel to 20 at our rbd-nbd e2e tests.
 
Also see:

- https://github.com/ceph/ceph-csi/pull/2406
- https://github.com/ceph/ceph-csi/pull/2407

 
 
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
