### PR TITLE
rbd: fix rbd-nbd io-timeout to never abort

### DIFF
--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -406,3 +406,22 @@ func calculateSHA512sum(f *framework.Framework, app *v1.Pod, filePath string, op
 
 	return checkSum, nil
 }
+
+// getKernelVersionFromDaemonset gets the kernel version from the specified container.
+func getKernelVersionFromDaemonset(f *framework.Framework, ns, dsn, cn string) (string, error) {
+	selector, err := getDaemonSetLabelSelector(f, ns, dsn)
+	if err != nil {
+		return "", err
+	}
+
+	opt := metav1.ListOptions{
+		LabelSelector: selector,
+	}
+
+	kernelRelease, stdErr, err := execCommandInContainer(f, "uname -r", ns, cn, &opt)
+	if err != nil || stdErr != "" {
+		return "", err
+	}
+
+	return kernelRelease, nil
+}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -40,6 +40,28 @@ var nbdResizeSupport = []util.KernelVersion{
 	}, // standard 5.3+ versions
 }
 
+// To use `io-timeout=0` we need
+// www.mail-archive.com/linux-block@vger.kernel.org/msg38060.html
+// nolint:gomnd // numbers specify Kernel versions.
+var nbdZeroIOtimeoutSupport = []util.KernelVersion{
+	{
+		Version:      5,
+		PatchLevel:   4,
+		SubLevel:     0,
+		ExtraVersion: 0,
+		Distribution: "",
+		Backport:     false,
+	}, // standard 5.4+ versions
+	{
+		Version:      4,
+		PatchLevel:   18,
+		SubLevel:     0,
+		ExtraVersion: 305,
+		Distribution: ".el8",
+		Backport:     true,
+	}, // CentOS 8.4
+}
+
 func imageSpec(pool, image string) string {
 	if radosNamespace != "" {
 		return pool + "/" + radosNamespace + "/" + image

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -48,9 +48,16 @@ const (
 	rbdUnmapCmdNbdMissingMap  = "rbd-nbd: %s is not mapped"
 	rbdMapConnectionTimeout   = "Connection timed out"
 
-	defaultNbdReAttachTimeout = 300
+	defaultNbdReAttachTimeout = 300 /* in seconds */
 
-	useNbdNetlink  = "try-netlink"
+	// The default way of creating nbd devices via rbd-nbd is through the
+	// legacy ioctl interface, to take advantage of netlink features we
+	// should specify `try-netlink` flag explicitly.
+	useNbdNetlink = "try-netlink"
+
+	// `reattach-timeout` of rbd-nbd is to tweak NBD_ATTR_DEAD_CONN_TIMEOUT.
+	// It specifies how long the device should be held waiting for the
+	// userspace process to come back to life.
 	setNbdReattach = "reattach-timeout"
 )
 

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -49,6 +49,7 @@ const (
 	rbdMapConnectionTimeout   = "Connection timed out"
 
 	defaultNbdReAttachTimeout = 300 /* in seconds */
+	defaultNbdIOTimeout       = 0   /* do not abort the requests */
 
 	// The default way of creating nbd devices via rbd-nbd is through the
 	// legacy ioctl interface, to take advantage of netlink features we
@@ -59,6 +60,10 @@ const (
 	// It specifies how long the device should be held waiting for the
 	// userspace process to come back to life.
 	setNbdReattach = "reattach-timeout"
+
+	// `io-timeout` of rbd-nbd is to tweak NBD_ATTR_TIMEOUT. It specifies
+	// how long the IO should wait to get handled before bailing out.
+	setNbdIOTimeout = "io-timeout"
 )
 
 var hasNBD = false
@@ -256,6 +261,9 @@ func appendDeviceTypeAndOptions(cmdArgs []string, isNbd, isThick bool, userOptio
 		if !strings.Contains(userOptions, setNbdReattach) {
 			cmdArgs = append(cmdArgs, "--options", fmt.Sprintf("%s=%d", setNbdReattach, defaultNbdReAttachTimeout))
 		}
+		if !strings.Contains(userOptions, setNbdIOTimeout) {
+			cmdArgs = append(cmdArgs, "--options", fmt.Sprintf("%s=%d", setNbdIOTimeout, defaultNbdIOTimeout))
+		}
 	}
 	if isThick {
 		// When an image is thick-provisioned, any discard/unmap/trim
@@ -279,6 +287,9 @@ func appendRbdNbdCliOptions(cmdArgs []string, userOptions string) []string {
 	}
 	if !strings.Contains(userOptions, setNbdReattach) {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--%s=%d", setNbdReattach, defaultNbdReAttachTimeout))
+	}
+	if !strings.Contains(userOptions, setNbdIOTimeout) {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--%s=%d", setNbdIOTimeout, defaultNbdIOTimeout))
 	}
 	if userOptions != "" {
 		options := strings.Split(userOptions, ",")


### PR DESCRIPTION
# Describe what this PR does #

* Fix rbd-nbd io-timeout to match reattach-timeout

With the tests at CI, it kind of looks like that the IO is timing out after 30 seconds (default with rbd-nbd). Since we have tweaked reattach-timeout to 300 seconds at ceph-csi, we need to explicitly set io-timeout on the device too, as it doesn't make any sense to keep `io-timeout < reattach-timeout`
                                                                            
Hence we set io-timeout for rbd nbd to 0. Specifying io-timeout 0 tells the nbd driver to not abort the request and instead see if it can be restarted on another socket.                                                

---
* At our e2e, use io-timeout conditionally based on kernel version             
                                                                      
We need https://www.mail-archive.com/linux-block@vger.kernel.org/msg38060.html inorder to use `--io-timeout=0`. This patch is part of kernel v5.4. Since minikube doesn't have a v5.4 kernel yet, let's use io-timeout value conditionally based on the kernel version at our e2e.                       

---

Thanks @idryomov for the timeout suggestion.

Updates: #2204

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>
Suggested-by: Ilya Dryomov <idryomov@redhat.com>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
