### PR TITLE
ci: add `--ignore-not-found=true` to delete namespace in helm cleanup

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -188,7 +188,7 @@ node('cico-workspace') {
 			timeout(time: 30, unit: 'MINUTES') {
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh cleanup-cephcsi --namespace '${namespace}'"
 				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/install-helm.sh clean'
-				ssh "kubectl delete namespace '${namespace}'"
+				ssh "kubectl delete namespace '${namespace}' --ignore-not-found=true"
 			}
 		}
 	}


### PR DESCRIPTION
 helm e2e ci at https://github.com/ceph/ceph-csi/pull/2377 is failing because, install_helm.sh script cleanup deletes namespace then the following cmd will try to delete namespace and fail with `NotFound`
https://github.com/ceph/ceph-csi/blob/e6c04e1414b56900786e151af804d77fdafcb10e/mini-e2e-helm.groovy#L191
ex : https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e-helm_k8s-1.19/detail/mini-e2e-helm_k8s-1.19/2452/pipeline

This commit is added to facilitate merging of
https://github.com/ceph/ceph-csi/pull/2377 into devel and release
branches.

https://github.com/ceph/ceph-csi/pull/2378 will remove create &
delete namespace cmds from helm e2e jobs later on.

Signed-off-by: Rakshith R <rar@redhat.com>
