### PR TITLE
cleanup: run codespell on containerized testing

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -14,9 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: codespell
-        uses: codespell-project/actions-codespell@master
-        with:
-          skip: .git,./vendor,./docs/design/proposals/images
-          check_filenames: true
-          ignore_words_list: ExtraVersion,extraversion,ba
-          check_hidden: true
+        run: CONTAINER_CMD=docker make containerized-test TARGET=codespell

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ endif
 
 all: cephcsi
 
-.PHONY: go-test static-check mod-check go-lint lint-extras gosec commitlint
+.PHONY: go-test static-check mod-check go-lint lint-extras gosec commitlint codespell
 ifeq ($(CONTAINERIZED),no)
 # include mod-check in non-containerized runs
 test: go-test static-check mod-check
@@ -95,7 +95,7 @@ else
 # exclude mod-check for containerized runs (CI runs it separately)
 test: go-test static-check
 endif
-static-check: check-env go-lint lint-extras gosec
+static-check: check-env codespell go-lint lint-extras gosec
 
 go-test: TEST_COVERAGE ?= $(shell . $(CURDIR)/build.env ; echo $${TEST_COVERAGE})
 go-test: GO_COVER_DIR ?= $(shell . $(CURDIR)/build.env ; echo $${GO_COVER_DIR})
@@ -139,6 +139,8 @@ func-test:
 check-env:
 	@./scripts/check-env.sh
 
+codespell:
+	codespell --config scripts/codespell.conf
 #
 # commitlint will do a rebase on top of GIT_SINCE when REBASE=1 is passed.
 #

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -29,6 +29,7 @@ RUN source /build.env \
 	librbd-devel \
 	rubygems \
 	ShellCheck \
+      codespell \
 	yamllint \
 	npm \
 	diffutils \

--- a/scripts/codespell.conf
+++ b/scripts/codespell.conf
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,./vendor,./docs/design/proposals/images
+ignore-words-list = ExtraVersion,extraversion,ba
+check-filenames = true


### PR DESCRIPTION
This commit adds a new target codespell to the
make containerized-test.

Fixes: #2229

Signed-off-by: Yati Padia <ypadia@redhat.com>