### PR TITLE
ci: run tests on k8s v1.22 in place of v1.19

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -3,13 +3,13 @@
     name: mini-e2e
     k8s_version:
       - '1.19':
-          only_run_on_request: false
+          only_run_on_request: true
       - '1.20':
           only_run_on_request: false
       - '1.21':
           only_run_on_request: false
       - '1.22':
-          only_run_on_request: true
+          only_run_on_request: false
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
As kubernetes v1.19 is heading towards its EOL
on 2021-09-30, run tests on kubernetes v1.22
and require it to pass for merging.

Updates: #2402 

Signed-off-by: Yug Gupta <yuggupta27@gmail.com>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
