### PR TITLE
RBD Async DR: Handle DisableReplication/DeleteVolume for mirrored secondary image

### DIFF
--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -128,3 +128,24 @@ func (ri *rbdImage) getImageMirroringStatus() (*librbd.GlobalMirrorImageStatus, 
 
 	return &statusInfo, nil
 }
+
+// getLocalState returns the local state of the image.
+func (ri *rbdImage) getLocalState() (librbd.SiteMirrorImageStatus, error) {
+	localStatus := librbd.SiteMirrorImageStatus{}
+	image, err := ri.open()
+	if err != nil {
+		return localStatus, fmt.Errorf("failed to open image %q with error: %w", ri, err)
+	}
+	defer image.Close()
+
+	statusInfo, err := image.GetGlobalMirrorStatus()
+	if err != nil {
+		return localStatus, fmt.Errorf("failed to get image mirroring status %q with error: %w", ri, err)
+	}
+	localStatus, err = statusInfo.LocalStatus()
+	if err != nil {
+		return localStatus, fmt.Errorf("failed to get local status: %w", err)
+	}
+
+	return localStatus, nil
+}


### PR DESCRIPTION
This PR does the follow

* Return succuss for DisableVolumeReplication if the image is healthy secondary

If the image is in a secondary state and it's up+replaying means it's a healthy secondary and the image is primary somewhere in the remote cluster and the local image is getting replayed.  Return success for the Disabling mirroring as we cannot disable the mirroring on the secondary state, when the image on the remote site gets disabled the image on all the remote (secondary)
will get auto-deleted. This helps in garbage collecting the volume replication Kubernetes artifacts

* Cleanup OMAP data During DeleteVolume for secondary image
    
If the image is in a secondary state and it's up+replaying means it's a healthy secondary and the image is primary somewhere in the remote cluster and the local image is getting replayed. Delete the OMAP data generated as we cannot delete the secondary image. When the image on the primary cluster gets deleted/mirroring disabled, the image on all the remote (secondary) clusters will get auto-deleted. This helps in garbage collecting the OMAP, PVC, and PV objects after failback operation.

More details about this at https://github.com/csi-addons/volume-replication-operator/issues/100

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

TODO:

- [x] E2E testing
