### PR TITLE
ci: dump the rbd-nbd logs

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -39,6 +39,9 @@ log minikube_ssh journalctl --boot
 log df -hT
 log minikube_ssh df -hT
 
+# get the rbd-nbd logs from the VM and write them to stdout
+log minikube_ssh "sudo find /var/log/ceph/ -type f | xargs sudo tail -n +1"
+
 # fetch all logs from /var/lib/rook in the VM and write them to stdout
 log minikube_ssh sudo tar c /var/lib/rook | tar xvO
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #


print the rbd-nbd logs from the VM location /var/log/ceph/

Depends-on: https://github.com/ceph/ceph-csi/pull/2406
Also see: https://github.com/ceph/ceph-csi/pull/2393

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
