### PR TITLE
cephfs: remove explicit size setting of cloned volume

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -147,7 +147,7 @@ func checkContentSource(
 }
 
 // CreateVolume creates a reservation and the volume in backend, if it is not already present.
-// nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
+// nolint:gocyclo,cyclop // TODO: reduce complexity
 func (cs *ControllerServer) CreateVolume(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
@@ -209,31 +209,6 @@ func (cs *ControllerServer) CreateVolume(
 	// TODO return error message if requested vol size greater than found volume return error
 
 	if vID != nil {
-		if sID != nil || pvID != nil {
-			// while cloning the volume the size is not populated properly to the new volume now.
-			// it will be fixed in cephfs soon with the parentvolume size. Till then by below
-			// resize we are making sure we return or satisfy the requested size by setting the size
-			// explicitly
-			err = volOptions.resizeVolume(ctx, volumeID(vID.FsSubvolName), volOptions.Size)
-			if err != nil {
-				purgeErr := volOptions.purgeVolume(ctx, volumeID(vID.FsSubvolName), false)
-				if purgeErr != nil {
-					log.ErrorLog(ctx, "failed to delete volume %s: %v", requestName, purgeErr)
-					// All errors other than ErrVolumeNotFound should return an error back to the caller
-					if !errors.Is(purgeErr, cerrors.ErrVolumeNotFound) {
-						return nil, status.Error(codes.Internal, purgeErr.Error())
-					}
-				}
-				errUndo := undoVolReservation(ctx, volOptions, *vID, secret)
-				if errUndo != nil {
-					log.WarningLog(ctx, "failed undoing reservation of volume: %s (%s)",
-						requestName, errUndo)
-				}
-				log.ErrorLog(ctx, "failed to expand volume %s: %v", volumeID(vID.FsSubvolName), err)
-
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-		}
 		volumeContext := req.GetParameters()
 		volumeContext["subvolumeName"] = vID.FsSubvolName
 		volumeContext["subvolumePath"] = volOptions.RootPath


### PR DESCRIPTION
CephFS csi driver explictly set the size of the cloned volume
to the size of parent volume as cephfs mgr was lacking this
functionality previously. However it has been addressed in cephfs
so we dont need explicit size setting.

Ref# https://tracker.ceph.com/issues/46163
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

