### PR TITLE
Make use of subvolumeinfo's state field 

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -595,7 +595,7 @@ func (cs *ControllerServer) CreateSnapshot(
 	info, err := parentVolOptions.getSubVolumeInfo(ctx, volumeID(vid.FsSubvolName))
 	if err != nil {
 		// Check error code value against ErrInvalidCommand to understand the cluster
-		// support it or not, its safe to evaluat as the filtering
+		// support it or not, It's safe to evaluate as the filtering
 		// is already done from getSubVolumeInfo() and send out the error here.
 		if errors.Is(err, ErrInvalidCommand) {
 			return nil, status.Error(

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -345,7 +345,7 @@ volume names as requested by the CSI drivers. Hence, these need to be invoked on
 respective CSI driver generated volume name based locks are held, as otherwise racy
 access to these omaps may end up leaving them in an inconsistent state.
 
-These functions also cleanup omap reservations that are stale. I.e when omap entries exist and
+These functions also cleanup omap reservations that are stale. I.e. when omap entries exist and
 backing subvolumes are missing, or one of the omaps exist and the next is missing. This is
 because, the order of omap creation and deletion are inverse of each other, and protected by the
 request name lock, and hence any stale omaps are leftovers from incomplete transactions and are

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -308,7 +308,7 @@ func (ns *NodeServer) NodeUnpublishVolume(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	util.DebugLog(ctx, "cephfs: successfully unbinded volume %s from %s", req.GetVolumeId(), targetPath)
+	util.DebugLog(ctx, "cephfs: successfully unbounded volume %s from %s", req.GetVolumeId(), targetPath)
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }

--- a/internal/cephfs/volume.go
+++ b/internal/cephfs/volume.go
@@ -109,9 +109,7 @@ func (vo *volumeOptions) getSubVolumeInfo(ctx context.Context, volID volumeID) (
 		// If info.BytesQuota == Infinite (in case it is not set)
 		// or nil (in case the subvolume is in snapshot-retained state),
 		// just continue without returning quota information.
-		// TODO: make use of subvolume "state" attribute once
-		// https://github.com/ceph/go-ceph/issues/453 is fixed.
-		if !(info.BytesQuota == fsAdmin.Infinite || info.BytesQuota == nil) {
+		if !(info.BytesQuota == fsAdmin.Infinite || info.State == fsAdmin.StateSnapRetained) {
 			return nil, fmt.Errorf("subvolume %s has unsupported quota: %v", string(volID), info.BytesQuota)
 		}
 	} else {


### PR DESCRIPTION
cephfs: make use of subvolumeInfo.state to determine quota
    
https://github.com/ceph/go-ceph/pull/455/ added `state` field
to subvolume info struct which helps to identify the snapshot
retention state in the caller.

This PR also address few typos in cephfs driver code
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>