### PR TITLE
correct interface name and remove redundancy in the interface name

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -25,10 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
-// ContollerManager is the interface that will wrap Add function.
+// Manager is the interface that will wrap Add function.
 // The New controllers which gets added, as to implement Add function to get
 // started by the manager.
-type ContollerManager interface {
+type Manager interface {
 	Add(manager.Manager, Config) error
 }
 
@@ -39,7 +39,7 @@ type Config struct {
 }
 
 // ControllerList holds the list of managers need to be started.
-var ControllerList []ContollerManager
+var ControllerList []Manager
 
 // addToManager calls the registered managers Add method.
 func addToManager(mgr manager.Manager, config Config) error {

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -45,8 +45,8 @@ type ReconcilePersistentVolume struct {
 }
 
 var (
-	_ reconcile.Reconciler  = &ReconcilePersistentVolume{}
-	_ ctrl.ContollerManager = &ReconcilePersistentVolume{}
+	_ reconcile.Reconciler = &ReconcilePersistentVolume{}
+	_ ctrl.Manager         = &ReconcilePersistentVolume{}
 )
 
 // Init will add the ReconcilePersistentVolume to the list.


### PR DESCRIPTION
Note for reviewer: 

`ContollerManager` had a typo in it, and if we correct it, linter ( CI was failing) will fail and suggest not to use `controller.ControllerManager` as it is redundant, keeping `manager` as the interface name which is the practice  and also address the linter issues.  

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>