### PR TITLE
ci: update build.env

### DIFF
--- a/build.env
+++ b/build.env
@@ -44,7 +44,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.6.2
+ROOK_VERSION=v1.7.1
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=docker.io/ceph/ceph:v16
 

--- a/build.env
+++ b/build.env
@@ -12,7 +12,7 @@
 CSI_IMAGE_VERSION=canary
 
 # Ceph version to use
-BASE_IMAGE=docker.io/ceph/ceph:v16
+BASE_IMAGE=quay.io/ceph/ceph:v16
 CEPH_VERSION=octopus
 
 # standard Golang options
@@ -46,7 +46,7 @@ CHANGE_MINIKUBE_NONE_USER=true
 # Rook options
 ROOK_VERSION=v1.7.1
 # Provide ceph image path
-ROOK_CEPH_CLUSTER_IMAGE=docker.io/ceph/ceph:v16
+ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v16
 
 # CSI sidecar version
 CSI_ATTACHER_VERSION=v3.3.0


### PR DESCRIPTION
This PR updates below items

* update rook to v1.7.1 release

updated rook version to latest 1.7.1 release.

* pull ceph base image from quay.io

pull the ceph image from quay.io instead of docker hub.
From ceph doc, the images are available in both quay and dockerhub https://docs.ceph.com/en/latest/install/containers/#official-releases

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>