### PR TITLE
ci: tag ceph image with quay.io

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -137,10 +137,19 @@ node('cico-workspace') {
 						script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 						returnStdout: true
 					).trim()
-					def d_io_regex = ~"^docker.io/"
+					def quay = "quay.io"
+					def docker = "docker.io"
 
+					if (base_image.startsWith(quay)){
+					def q_io_regex = ~"^quay.io/"
+					// base_image is like quay.io/ceph/ceph:v15, strip "quay.io/"
+					podman_pull(ci_registry, quay, "${base_image}" - q_io_regex)
+					}else{
+					def d_io_regex = ~"^docker.io/"
 					// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
-					podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
+					podman_pull(ci_registry, docker , "${base_image}" - d_io_regex)
+					}
+
 				}
 			}
 		}


### PR DESCRIPTION
added if-else check to check the image starting with quay.io. If yes, pull and tag the image with quay.io

currently, https://github.com/ceph/ceph-csi/pull/2419 is failing with the below error message 

```
+ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@n26.dusty.ci.centos.org 'podman pull --authfile=~/.podman-auth.json registry-ceph-csi.apps.ocp.ci.centos.org/quay.io/ceph/ceph:v16 && podman tag registry-ceph-csi.apps.ocp.ci.centos.org/quay.io/ceph/ceph:v16 quay.io/ceph/ceph:v16 docker.io/quay.io/ceph/ceph:v16'

Warning: Permanently added 'n26.dusty.ci.centos.org,172.19.2.90' (ECDSA) to the list of known hosts.

Trying to pull registry-ceph-csi.apps.ocp.ci.centos.org/quay.io/ceph/ceph:v16...

Error: Error initializing source docker://registry-ceph-csi.apps.ocp.ci.centos.org/quay.io/ceph/ceph:v16: Error reading manifest v16 in registry-ceph-csi.apps.ocp.ci.centos.org/quay.io/ceph/ceph: manifest unknown: manifest unknown

script returned exit code 125
```


Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>


**Note:-**  just changed in one place. If the changes look okay i will make changes in other places also