### PR TITLE
ci: use pre-pulled image for building e2e.test

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -134,7 +134,7 @@ node('cico-workspace') {
 			// build container image
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make image-cephcsi GOARCH=amd64 CONTAINER_CMD=podman'
 			// build e2e.test executable
-			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
+			ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test ENV_CSI_IMAGE_NAME=${ci_registry}/ceph-csi USE_PULLED_IMAGE=yes"
 		}
 		stage("deploy k8s-${k8s_version} and rook") {
 			def rook_version = sh(

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -131,7 +131,7 @@ node('cico-workspace') {
 			// build container image
 			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make image-cephcsi GOARCH=amd64 CONTAINER_CMD=podman'
 			// build e2e.test executable
-			ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test'
+			ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make containerized-build CONTAINER_CMD=podman TARGET=e2e.test ENV_CSI_IMAGE_NAME=${ci_registry}/ceph-csi USE_PULLED_IMAGE=yes"
 		}
 		stage("deploy k8s-${k8s_version} and rook") {
 			def rook_version = sh(


### PR DESCRIPTION
The 'mini-e2e' job uses the pre-pulled container image for building the
e2e.test executable. The building of the executable takes less than 2
minutes, while building with preparing the container image takes close
to 5 minutes.

This reduces consumption of network bandwith, and might speed up other
parallel builds.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
