### PR TITLE
rbd: add EnsureImageCleanup to ensure image cleanup from trash 

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1383,7 +1383,12 @@ func (cs *ControllerServer) DeleteSnapshot(
 
 	err = rbdVol.getImageInfo()
 	if err != nil {
-		if !errors.Is(err, ErrImageNotFound) {
+		if errors.Is(err, ErrImageNotFound) {
+			err = rbdVol.ensureImageCleanup(ctx)
+			if err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
+		} else {
 			log.ErrorLog(ctx, "failed to delete rbd image: %s/%s with error: %v", rbdVol.Pool, rbdVol.VolName, err)
 
 			return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION

After moving moving image to trash, if `trash remove` step fails,
then external-provisioner will issue subsequent requests, in which
image will be absent in pool( will be in trash) and omap cleanup will
be done with stale image left in trash with no `trash remove` step on it.

To avoid this scenario list trash images and find corresponding id for given
image name and add a task to flatten when we encounter a ErrImageNotFound.

Fixes: ceph#1728