### PR TITLE
cleanup: move log functions to new internal/util/log package

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/liveness"
 	"github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"k8s.io/klog/v2"
 )
@@ -164,7 +165,7 @@ func main() {
 		}
 		os.Exit(0)
 	}
-	util.DefaultLog("Driver version: %s and Git version: %s", util.DriverVersion, util.GitCommit)
+	log.DefaultLog("Driver version: %s and Git version: %s", util.DriverVersion, util.GitCommit)
 
 	if conf.Vtype == "" {
 		logAndExit("driver type not specified")
@@ -182,15 +183,15 @@ func main() {
 		if pidErr != nil {
 			klog.Errorf("Failed to get the PID limit, can not reconfigure: %v", pidErr)
 		} else {
-			util.DefaultLog("Initial PID limit is set to %d", currentLimit)
+			log.DefaultLog("Initial PID limit is set to %d", currentLimit)
 			err = util.SetPIDLimit(conf.PidLimit)
 			switch {
 			case err != nil:
 				klog.Errorf("Failed to set new PID limit to %d: %v", conf.PidLimit, err)
 			case conf.PidLimit == -1:
-				util.DefaultLog("Reconfigured PID limit to %d (max)", conf.PidLimit)
+				log.DefaultLog("Reconfigured PID limit to %d (max)", conf.PidLimit)
 			default:
-				util.DefaultLog("Reconfigured PID limit to %d", conf.PidLimit)
+				log.DefaultLog("Reconfigured PID limit to %d", conf.PidLimit)
 			}
 		}
 	}
@@ -209,7 +210,7 @@ func main() {
 		}
 	}
 
-	util.DefaultLog("Starting driver type: %v with name: %v", conf.Vtype, dname)
+	log.DefaultLog("Starting driver type: %v with name: %v", conf.Vtype, dname)
 	switch conf.Vtype {
 	case rbdType:
 		validateCloneDepthFlag(&conf)

--- a/internal/cephfs/cephfs_util.go
+++ b/internal/cephfs/cephfs_util.go
@@ -21,19 +21,20 @@ import (
 	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 func (vo *volumeOptions) getFscID(ctx context.Context) (int64, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem ID for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem ID for %s:", vo.FsName, err)
 
 		return 0, err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
-		util.ErrorLog(ctx, "could not list volumes, can not fetch filesystem ID for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem ID for %s:", vo.FsName, err)
 
 		return 0, err
 	}
@@ -44,7 +45,7 @@ func (vo *volumeOptions) getFscID(ctx context.Context) (int64, error) {
 		}
 	}
 
-	util.ErrorLog(ctx, "failed to list volume %s", vo.FsName)
+	log.ErrorLog(ctx, "failed to list volume %s", vo.FsName)
 
 	return 0, ErrVolumeNotFound
 }
@@ -52,14 +53,14 @@ func (vo *volumeOptions) getFscID(ctx context.Context) (int64, error) {
 func (vo *volumeOptions) getMetadataPool(ctx context.Context) (string, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s:", vo.FsName, err)
 
 		return "", err
 	}
 
 	fsPoolInfos, err := fsa.ListFileSystems()
 	if err != nil {
-		util.ErrorLog(ctx, "could not list filesystems, can not fetch metadata pool for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not list filesystems, can not fetch metadata pool for %s:", vo.FsName, err)
 
 		return "", err
 	}
@@ -76,14 +77,14 @@ func (vo *volumeOptions) getMetadataPool(ctx context.Context) (string, error) {
 func (vo *volumeOptions) getFsName(ctx context.Context) (string, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem name for ID %d:", vo.FscID, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem name for ID %d:", vo.FscID, err)
 
 		return "", err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
-		util.ErrorLog(ctx, "could not list volumes, can not fetch filesystem name for ID %d:", vo.FscID, err)
+		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem name for ID %d:", vo.FscID, err)
 
 		return "", err
 	}

--- a/internal/cephfs/clone.go
+++ b/internal/cephfs/clone.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // cephFSCloneState describes the status of the clone.
@@ -64,7 +64,7 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 	snapshotID := cloneID
 	err := parentvolOpt.createSnapshot(ctx, snapshotID, volID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to create snapshot %s %v", snapshotID, err)
+		log.ErrorLog(ctx, "failed to create snapshot %s %v", snapshotID, err)
 
 		return err
 	}
@@ -78,57 +78,57 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 		if protectErr != nil {
 			err = parentvolOpt.deleteSnapshot(ctx, snapshotID, volID)
 			if err != nil {
-				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
+				log.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			}
 		}
 
 		if cloneErr != nil {
 			if err = volOpt.purgeVolume(ctx, cloneID, true); err != nil {
-				util.ErrorLog(ctx, "failed to delete volume %s: %v", cloneID, err)
+				log.ErrorLog(ctx, "failed to delete volume %s: %v", cloneID, err)
 			}
 			if err = parentvolOpt.unprotectSnapshot(ctx, snapshotID, volID); err != nil {
 				// In case the snap is already unprotected we get ErrSnapProtectionExist error code
 				// in that case we are safe and we could discard this error and we are good to go
 				// ahead with deletion
 				if !errors.Is(err, ErrSnapProtectionExist) {
-					util.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapshotID, err)
+					log.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapshotID, err)
 				}
 			}
 			if err = parentvolOpt.deleteSnapshot(ctx, snapshotID, volID); err != nil {
-				util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
+				log.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 			}
 		}
 	}()
 	protectErr = parentvolOpt.protectSnapshot(ctx, snapshotID, volID)
 	if protectErr != nil {
-		util.ErrorLog(ctx, "failed to protect snapshot %s %v", snapshotID, protectErr)
+		log.ErrorLog(ctx, "failed to protect snapshot %s %v", snapshotID, protectErr)
 
 		return protectErr
 	}
 
 	cloneErr = parentvolOpt.cloneSnapshot(ctx, volID, snapshotID, cloneID, volOpt)
 	if cloneErr != nil {
-		util.ErrorLog(ctx, "failed to clone snapshot %s %s to %s %v", volID, snapshotID, cloneID, cloneErr)
+		log.ErrorLog(ctx, "failed to clone snapshot %s %s to %s %v", volID, snapshotID, cloneID, cloneErr)
 
 		return cloneErr
 	}
 
 	cloneState, cloneErr := volOpt.getCloneState(ctx, cloneID)
 	if cloneErr != nil {
-		util.ErrorLog(ctx, "failed to get clone state: %v", cloneErr)
+		log.ErrorLog(ctx, "failed to get clone state: %v", cloneErr)
 
 		return cloneErr
 	}
 
 	if cloneState != cephFSCloneComplete {
-		util.ErrorLog(ctx, "clone %s did not complete: %v", cloneID, cloneState.toError())
+		log.ErrorLog(ctx, "clone %s did not complete: %v", cloneID, cloneState.toError())
 
 		return cloneState.toError()
 	}
 	// This is a work around to fix sizing issue for cloned images
 	err = volOpt.resizeVolume(ctx, cloneID, volOpt.Size)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to expand volume %s: %v", cloneID, err)
+		log.ErrorLog(ctx, "failed to expand volume %s: %v", cloneID, err)
 
 		return err
 	}
@@ -138,13 +138,13 @@ func createCloneFromSubvolume(ctx context.Context, volID, cloneID volumeID, volO
 		// in that case we are safe and we could discard this error and we are good to go
 		// ahead with deletion
 		if !errors.Is(err, ErrSnapProtectionExist) {
-			util.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapshotID, err)
+			log.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapshotID, err)
 
 			return err
 		}
 	}
 	if err = parentvolOpt.deleteSnapshot(ctx, snapshotID, volID); err != nil {
-		util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
+		log.ErrorLog(ctx, "failed to delete snapshot %s %v", snapshotID, err)
 
 		return err
 	}
@@ -171,14 +171,14 @@ func cleanupCloneFromSubvolumeSnapshot(
 	if snapInfo.Protected == snapshotIsProtected {
 		err = parentVolOpt.unprotectSnapshot(ctx, snapShotID, volID)
 		if err != nil {
-			util.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapShotID, err)
+			log.ErrorLog(ctx, "failed to unprotect snapshot %s %v", snapShotID, err)
 
 			return err
 		}
 	}
 	err = parentVolOpt.deleteSnapshot(ctx, snapShotID, volID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to delete snapshot %s %v", snapShotID, err)
+		log.ErrorLog(ctx, "failed to delete snapshot %s %v", snapShotID, err)
 
 		return err
 	}
@@ -206,7 +206,7 @@ func createCloneFromSnapshot(
 		if err != nil {
 			if !isCloneRetryError(err) {
 				if dErr := volOptions.purgeVolume(ctx, volumeID(vID.FsSubvolName), true); dErr != nil {
-					util.ErrorLog(ctx, "failed to delete volume %s: %v", vID.FsSubvolName, dErr)
+					log.ErrorLog(ctx, "failed to delete volume %s: %v", vID.FsSubvolName, dErr)
 				}
 			}
 		}
@@ -214,7 +214,7 @@ func createCloneFromSnapshot(
 
 	cloneState, err := volOptions.getCloneState(ctx, volumeID(vID.FsSubvolName))
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get clone state: %v", err)
+		log.ErrorLog(ctx, "failed to get clone state: %v", err)
 
 		return err
 	}
@@ -227,7 +227,7 @@ func createCloneFromSnapshot(
 	// in the new cloned volume too. Till then we are explicitly making the size set
 	err = volOptions.resizeVolume(ctx, volumeID(vID.FsSubvolName), volOptions.Size)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to expand volume %s with error: %v", vID.FsSubvolName, err)
+		log.ErrorLog(ctx, "failed to expand volume %s with error: %v", vID.FsSubvolName, err)
 
 		return err
 	}
@@ -238,7 +238,7 @@ func createCloneFromSnapshot(
 func (vo *volumeOptions) getCloneState(ctx context.Context, volID volumeID) (cephFSCloneState, error) {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(
+		log.ErrorLog(
 			ctx,
 			"could not get FSAdmin, can get clone status for volume %s with ID %s: %v",
 			vo.FsName,
@@ -250,7 +250,7 @@ func (vo *volumeOptions) getCloneState(ctx context.Context, volID volumeID) (cep
 
 	cs, err := fsa.CloneStatus(vo.FsName, vo.SubvolumeGroup, string(volID))
 	if err != nil {
-		util.ErrorLog(ctx, "could not get clone state for volume %s with ID %s: %v", vo.FsName, string(volID), err)
+		log.ErrorLog(ctx, "could not get clone state for volume %s with ID %s: %v", vo.FsName, string(volID), err)
 
 		return cephFSCloneError, err
 	}

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 )
@@ -112,7 +113,7 @@ func checkVolExists(ctx context.Context,
 		if cloneState == cephFSCloneFailed {
 			err = volOptions.purgeVolume(ctx, volumeID(vid.FsSubvolName), true)
 			if err != nil {
-				util.ErrorLog(ctx, "failed to delete volume %s: %v", vid.FsSubvolName, err)
+				log.ErrorLog(ctx, "failed to delete volume %s: %v", vid.FsSubvolName, err)
 
 				return nil, err
 			}
@@ -171,7 +172,7 @@ func checkVolExists(ctx context.Context,
 		return nil, err
 	}
 
-	util.DebugLog(ctx, "Found existing volume (%s) with subvolume name (%s) for request (%s)",
+	log.DebugLog(ctx, "Found existing volume (%s) with subvolume name (%s) for request (%s)",
 		vid.VolumeID, vid.FsSubvolName, volOptions.RequestName)
 
 	if parentVolOpt != nil && pvID != nil {
@@ -269,7 +270,7 @@ func reserveVol(ctx context.Context, volOptions *volumeOptions, secret map[strin
 		return nil, err
 	}
 
-	util.DebugLog(ctx, "Generated Volume ID (%s) and subvolume name (%s) for request name (%s)",
+	log.DebugLog(ctx, "Generated Volume ID (%s) and subvolume name (%s) for request name (%s)",
 		vid.VolumeID, vid.FsSubvolName, volOptions.RequestName)
 
 	return &vid, nil
@@ -311,7 +312,7 @@ func reserveSnap(
 		return nil, err
 	}
 
-	util.DebugLog(ctx, "Generated Snapshot ID (%s) for request name (%s)",
+	log.DebugLog(ctx, "Generated Snapshot ID (%s) for request name (%s)",
 		vid.SnapshotID, snap.RequestName)
 
 	return &vid, nil
@@ -392,14 +393,14 @@ func checkSnapExists(
 		if err != nil {
 			err = volOptions.deleteSnapshot(ctx, volumeID(snapID), volumeID(parentSubVolName))
 			if err != nil {
-				util.ErrorLog(ctx, "failed to delete snapshot %s: %v", snapID, err)
+				log.ErrorLog(ctx, "failed to delete snapshot %s: %v", snapID, err)
 
 				return
 			}
 			err = j.UndoReservation(ctx, volOptions.MetadataPool,
 				volOptions.MetadataPool, snapID, snap.RequestName)
 			if err != nil {
-				util.ErrorLog(ctx, "removing reservation failed for snapshot %s: %v", snapID, err)
+				log.ErrorLog(ctx, "removing reservation failed for snapshot %s: %v", snapID, err)
 			}
 		}
 	}()
@@ -415,7 +416,7 @@ func checkSnapExists(
 	if err != nil {
 		return nil, nil, err
 	}
-	util.DebugLog(ctx, "Found existing snapshot (%s) with subvolume name (%s) for request (%s)",
+	log.DebugLog(ctx, "Found existing snapshot (%s) with subvolume name (%s) for request (%s)",
 		snapData.ImageAttributes.RequestName, parentSubVolName, sid.FsSnapshotName)
 
 	return sid, &snapInfo, nil

--- a/internal/cephfs/snapshot.go
+++ b/internal/cephfs/snapshot.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/ceph/go-ceph/cephfs/admin"
 	"github.com/ceph/go-ceph/rados"
@@ -51,14 +51,14 @@ type cephfsSnapshot struct {
 func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volumeID) error {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+		log.ErrorLog(ctx, "could not get FSAdmin: %s", err)
 
 		return err
 	}
 
 	err = fsa.CreateSubVolumeSnapshot(vo.FsName, vo.SubvolumeGroup, string(volID), string(snapID))
 	if err != nil {
-		util.ErrorLog(ctx, "failed to create subvolume snapshot %s %s in fs %s: %s",
+		log.ErrorLog(ctx, "failed to create subvolume snapshot %s %s in fs %s: %s",
 			string(snapID), string(volID), vo.FsName, err)
 
 		return err
@@ -70,14 +70,14 @@ func (vo *volumeOptions) createSnapshot(ctx context.Context, snapID, volID volum
 func (vo *volumeOptions) deleteSnapshot(ctx context.Context, snapID, volID volumeID) error {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+		log.ErrorLog(ctx, "could not get FSAdmin: %s", err)
 
 		return err
 	}
 
 	err = fsa.ForceRemoveSubVolumeSnapshot(vo.FsName, vo.SubvolumeGroup, string(volID), string(snapID))
 	if err != nil {
-		util.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s in fs %s: %s",
+		log.ErrorLog(ctx, "failed to delete subvolume snapshot %s %s in fs %s: %s",
 			string(snapID), string(volID), vo.FsName, err)
 
 		return err
@@ -97,7 +97,7 @@ func (vo *volumeOptions) getSnapshotInfo(ctx context.Context, snapID, volID volu
 	snap := snapshotInfo{}
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+		log.ErrorLog(ctx, "could not get FSAdmin: %s", err)
 
 		return snap, err
 	}
@@ -107,7 +107,7 @@ func (vo *volumeOptions) getSnapshotInfo(ctx context.Context, snapID, volID volu
 		if errors.Is(err, rados.ErrNotFound) {
 			return snap, ErrSnapNotFound
 		}
-		util.ErrorLog(
+		log.ErrorLog(
 			ctx,
 			"failed to get subvolume snapshot info %s %s in fs %s with error %s",
 			string(volID),
@@ -132,7 +132,7 @@ func (vo *volumeOptions) protectSnapshot(ctx context.Context, snapID, volID volu
 	}
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+		log.ErrorLog(ctx, "could not get FSAdmin: %s", err)
 
 		return err
 	}
@@ -143,7 +143,7 @@ func (vo *volumeOptions) protectSnapshot(ctx context.Context, snapID, volID volu
 		if errors.Is(err, rados.ErrObjectExists) {
 			return nil
 		}
-		util.ErrorLog(
+		log.ErrorLog(
 			ctx,
 			"failed to protect subvolume snapshot %s %s in fs %s with error: %s",
 			string(volID),
@@ -165,7 +165,7 @@ func (vo *volumeOptions) unprotectSnapshot(ctx context.Context, snapID, volID vo
 	}
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+		log.ErrorLog(ctx, "could not get FSAdmin: %s", err)
 
 		return err
 	}
@@ -178,7 +178,7 @@ func (vo *volumeOptions) unprotectSnapshot(ctx context.Context, snapID, volID vo
 		if errors.Is(err, rados.ErrObjectExists) {
 			return nil
 		}
-		util.ErrorLog(
+		log.ErrorLog(
 			ctx,
 			"failed to unprotect subvolume snapshot %s %s in fs %s with error: %s",
 			string(volID),
@@ -199,7 +199,7 @@ func (vo *volumeOptions) cloneSnapshot(
 ) error {
 	fsa, err := vo.conn.GetFSAdmin()
 	if err != nil {
-		util.ErrorLog(ctx, "could not get FSAdmin: %s", err)
+		log.ErrorLog(ctx, "could not get FSAdmin: %s", err)
 
 		return err
 	}
@@ -212,7 +212,7 @@ func (vo *volumeOptions) cloneSnapshot(
 
 	err = fsa.CloneSubVolumeSnapshot(vo.FsName, vo.SubvolumeGroup, string(volID), string(snapID), string(cloneID), co)
 	if err != nil {
-		util.ErrorLog(
+		log.ErrorLog(
 			ctx,
 			"failed to clone subvolume snapshot %s %s in fs %s with error: %s",
 			string(volID),

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/protobuf/ptypes"
@@ -130,7 +131,7 @@ func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (sn
 
 	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
 	if err != nil {
-		util.ErrorLog(ctx, "failed getting mons (%s)", err)
+		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (sn
 func parseTime(ctx context.Context, createTime time.Time) (*timestamp.Timestamp, error) {
 	tm, err := ptypes.TimestampProto(createTime)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to convert time %s %v", createTime, err)
+		log.ErrorLog(ctx, "failed to convert time %s %v", createTime, err)
 
 		return tm, err
 	}

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (
@@ -75,7 +76,7 @@ func loadAvailableMounters(conf *util.Config) error {
 
 	err := kernelMounterProbe.Run()
 	if err != nil {
-		util.ErrorLogMsg("failed to run mount.ceph %v", err)
+		log.ErrorLogMsg("failed to run mount.ceph %v", err)
 	} else {
 		// fetch the current running kernel info
 		release, kvErr := util.GetKernelVersion()
@@ -84,18 +85,18 @@ func loadAvailableMounters(conf *util.Config) error {
 		}
 
 		if conf.ForceKernelCephFS || util.CheckKernelSupport(release, quotaSupport) {
-			util.DefaultLog("loaded mounter: %s", volumeMounterKernel)
+			log.DefaultLog("loaded mounter: %s", volumeMounterKernel)
 			availableMounters = append(availableMounters, volumeMounterKernel)
 		} else {
-			util.DefaultLog("kernel version < 4.17 might not support quota feature, hence not loading kernel client")
+			log.DefaultLog("kernel version < 4.17 might not support quota feature, hence not loading kernel client")
 		}
 	}
 
 	err = fuseMounterProbe.Run()
 	if err != nil {
-		util.ErrorLogMsg("failed to run ceph-fuse %v", err)
+		log.ErrorLogMsg("failed to run ceph-fuse %v", err)
 	} else {
-		util.DefaultLog("loaded mounter: %s", volumeMounterFuse)
+		log.DefaultLog("loaded mounter: %s", volumeMounterFuse)
 		availableMounters = append(availableMounters, volumeMounterFuse)
 	}
 
@@ -131,7 +132,7 @@ func newMounter(volOptions *volumeOptions) (volumeMounter, error) {
 	if chosenMounter == "" {
 		// Otherwise pick whatever is left
 		chosenMounter = availableMounters[0]
-		util.DebugLogMsg("requested mounter: %s, chosen mounter: %s", wantMounter, chosenMounter)
+		log.DebugLogMsg("requested mounter: %s, chosen mounter: %s", wantMounter, chosenMounter)
 	}
 
 	// Create the mounter
@@ -291,10 +292,10 @@ func unmountVolume(ctx context.Context, mountPoint string) error {
 	if ok {
 		p, err := os.FindProcess(pid)
 		if err != nil {
-			util.WarningLog(ctx, "failed to find process %d: %v", pid, err)
+			log.WarningLog(ctx, "failed to find process %d: %v", pid, err)
 		} else {
 			if _, err = p.Wait(); err != nil {
-				util.WarningLog(ctx, "%d is not a child process: %v", pid, err)
+				log.WarningLog(ctx, "%d is not a child process: %v", pid, err)
 			}
 		}
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -18,7 +18,7 @@ package controller
 import (
 	"fmt"
 
-	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	clientConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -65,19 +65,19 @@ func Start(config Config) error {
 	}
 	mgr, err := manager.New(clientConfig.GetConfigOrDie(), opts)
 	if err != nil {
-		util.ErrorLogMsg("failed to create manager %s", err)
+		log.ErrorLogMsg("failed to create manager %s", err)
 
 		return err
 	}
 	err = addToManager(mgr, config)
 	if err != nil {
-		util.ErrorLogMsg("failed to add manager %s", err)
+		log.ErrorLogMsg("failed to add manager %s", err)
 
 		return err
 	}
 	err = mgr.Start(signals.SetupSignalHandler())
 	if err != nil {
-		util.ErrorLogMsg("failed to start manager %s", err)
+		log.ErrorLogMsg("failed to start manager %s", err)
 	}
 
 	return err

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -24,6 +24,7 @@ import (
 	ctrl "github.com/ceph/ceph-csi/internal/controller"
 	"github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,7 +99,7 @@ func (r *ReconcilePersistentVolume) getCredentials(
 
 	if name == "" || namespace == "" {
 		errStr := "secret name or secret namespace is empty"
-		util.ErrorLogMsg(errStr)
+		log.ErrorLogMsg(errStr)
 
 		return nil, errors.New(errStr)
 	}
@@ -117,7 +118,7 @@ func (r *ReconcilePersistentVolume) getCredentials(
 
 	cr, err = util.NewUserCredentials(credentials)
 	if err != nil {
-		util.ErrorLogMsg("failed to get user credentials %s", err)
+		log.ErrorLogMsg("failed to get user credentials %s", err)
 
 		return nil, err
 	}
@@ -201,7 +202,7 @@ func (r ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime.
 
 	cr, err := r.getCredentials(ctx, secretName, secretNamespace)
 	if err != nil {
-		util.ErrorLogMsg("failed to get credentials from secret %s", err)
+		log.ErrorLogMsg("failed to get credentials from secret %s", err)
 
 		return err
 	}
@@ -209,14 +210,14 @@ func (r ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime.
 
 	rbdVolID, err := rbd.RegenerateJournal(pv.Spec.CSI.VolumeAttributes, volumeHandler, requestName, cr)
 	if err != nil {
-		util.ErrorLogMsg("failed to regenerate journal %s", err)
+		log.ErrorLogMsg("failed to regenerate journal %s", err)
 
 		return err
 	}
 	if rbdVolID != volumeHandler {
 		err = r.storeVolumeIDInPV(ctx, pv, rbdVolID)
 		if err != nil {
-			util.ErrorLogMsg("failed to store volumeID in PV %s", err)
+			log.ErrorLogMsg("failed to store volumeID in PV %s", err)
 
 			return err
 		}

--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -19,7 +19,7 @@ package csicommon
 import (
 	"context"
 
-	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -71,7 +71,7 @@ func (cs *DefaultControllerServer) GetCapacity(
 func (cs *DefaultControllerServer) ControllerGetCapabilities(
 	ctx context.Context,
 	req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	util.TraceLog(ctx, "Using default ControllerGetCapabilities")
+	log.TraceLog(ctx, "Using default ControllerGetCapabilities")
 	if cs.Driver == nil {
 		return nil, status.Error(codes.Unimplemented, "Controller server is not enabled")
 	}

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -19,12 +19,12 @@ package csicommon
 import (
 	"fmt"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
-
-	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // CSIDriver stores driver information.
@@ -91,7 +91,7 @@ func (d *CSIDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceC
 	csc := make([]*csi.ControllerServiceCapability, 0, len(cl))
 
 	for _, c := range cl {
-		util.DefaultLog("Enabling controller service capability: %v", c.String())
+		log.DefaultLog("Enabling controller service capability: %v", c.String())
 		csc = append(csc, NewControllerServiceCapability(c))
 	}
 
@@ -103,7 +103,7 @@ func (d *CSIDriver) AddVolumeCapabilityAccessModes(
 	vc []csi.VolumeCapability_AccessMode_Mode) []*csi.VolumeCapability_AccessMode {
 	vca := make([]*csi.VolumeCapability_AccessMode, 0, len(vc))
 	for _, c := range vc {
-		util.DefaultLog("Enabling volume access mode: %v", c.String())
+		log.DefaultLog("Enabling volume access mode: %v", c.String())
 		vca = append(vca, NewVolumeCapabilityAccessMode(c))
 	}
 	d.vc = vca

--- a/internal/csi-common/identityserver-default.go
+++ b/internal/csi-common/identityserver-default.go
@@ -19,7 +19,7 @@ package csicommon
 import (
 	"context"
 
-	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -35,7 +35,7 @@ type DefaultIdentityServer struct {
 func (ids *DefaultIdentityServer) GetPluginInfo(
 	ctx context.Context,
 	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	util.TraceLog(ctx, "Using default GetPluginInfo")
+	log.TraceLog(ctx, "Using default GetPluginInfo")
 
 	if ids.Driver.name == "" {
 		return nil, status.Error(codes.Unavailable, "Driver name not configured")
@@ -60,7 +60,7 @@ func (ids *DefaultIdentityServer) Probe(ctx context.Context, req *csi.ProbeReque
 func (ids *DefaultIdentityServer) GetPluginCapabilities(
 	ctx context.Context,
 	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	util.TraceLog(ctx, "Using default capabilities")
+	log.TraceLog(ctx, "Using default capabilities")
 
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -19,7 +19,7 @@ package csicommon
 import (
 	"context"
 
-	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -57,7 +57,7 @@ func (ns *DefaultNodeServer) NodeExpandVolume(
 func (ns *DefaultNodeServer) NodeGetInfo(
 	ctx context.Context,
 	req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	util.TraceLog(ctx, "Using default NodeGetInfo")
+	log.TraceLog(ctx, "Using default NodeGetInfo")
 
 	csiTopology := &csi.Topology{
 		Segments: ns.Driver.topology,
@@ -73,7 +73,7 @@ func (ns *DefaultNodeServer) NodeGetInfo(
 func (ns *DefaultNodeServer) NodeGetCapabilities(
 	ctx context.Context,
 	req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	util.TraceLog(ctx, "Using default NodeGetCapabilities")
+	log.TraceLog(ctx, "Using default NodeGetCapabilities")
 
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{

--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/csi-addons/spec/lib/go/replication"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -30,8 +32,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
-
-	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // NonBlockingGRPCServer defines Non blocking GRPC server interfaces.
@@ -128,7 +128,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint, hstOptions string, srv Servers, 
 		replication.RegisterControllerServer(server, srv.RS)
 	}
 
-	util.DefaultLog("Listening for connections on address: %#v", listener.Addr())
+	log.DefaultLog("Listening for connections on address: %#v", listener.Addr())
 	if metrics {
 		ho := strings.Split(hstOptions, ",")
 		const expectedHo = 3

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/ceph/go-ceph/rados"
 )
@@ -74,7 +75,7 @@ func getOMapValues(
 
 	if err != nil {
 		if errors.Is(err, rados.ErrNotFound) {
-			util.ErrorLog(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v",
+			log.ErrorLog(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v",
 				poolName, namespace, oid, err)
 
 			return nil, util.JoinErrors(util.ErrKeyNotFound, err)
@@ -83,7 +84,7 @@ func getOMapValues(
 		return nil, err
 	}
 
-	util.DebugLog(ctx, "got omap values: (pool=%q, namespace=%q, name=%q): %+v",
+	log.DebugLog(ctx, "got omap values: (pool=%q, namespace=%q, name=%q): %+v",
 		poolName, namespace, oid, results)
 
 	return results, nil
@@ -110,16 +111,16 @@ func removeMapKeys(
 			// the previous implementation of removing omap keys (via the cli)
 			// treated failure to find the omap as a non-error. Do so here to
 			// mimic the previous behavior.
-			util.DebugLog(ctx, "when removing omap keys, omap not found (pool=%q, namespace=%q, name=%q): %+v",
+			log.DebugLog(ctx, "when removing omap keys, omap not found (pool=%q, namespace=%q, name=%q): %+v",
 				poolName, namespace, oid, keys)
 		} else {
-			util.ErrorLog(ctx, "failed removing omap keys (pool=%q, namespace=%q, name=%q): %v",
+			log.ErrorLog(ctx, "failed removing omap keys (pool=%q, namespace=%q, name=%q): %v",
 				poolName, namespace, oid, err)
 
 			return err
 		}
 	}
-	util.DebugLog(ctx, "removed omap keys (pool=%q, namespace=%q, name=%q): %+v",
+	log.DebugLog(ctx, "removed omap keys (pool=%q, namespace=%q, name=%q): %+v",
 		poolName, namespace, oid, keys)
 
 	return nil
@@ -146,12 +147,12 @@ func setOMapKeys(
 	}
 	err = ioctx.SetOmap(oid, bpairs)
 	if err != nil {
-		util.ErrorLog(ctx, "failed setting omap keys (pool=%q, namespace=%q, name=%q, pairs=%+v): %v",
+		log.ErrorLog(ctx, "failed setting omap keys (pool=%q, namespace=%q, name=%q, pairs=%+v): %v",
 			poolName, namespace, oid, pairs, err)
 
 		return err
 	}
-	util.DebugLog(ctx, "set omap keys (pool=%q, namespace=%q, name=%q): %+v)",
+	log.DebugLog(ctx, "set omap keys (pool=%q, namespace=%q, name=%q): %+v)",
 		poolName, namespace, oid, pairs)
 
 	return nil

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/pborman/uuid"
 )
@@ -437,7 +438,7 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 			cj.cephUUIDDirectoryPrefix+imageUUID)
 		if err != nil {
 			if !errors.Is(err, util.ErrObjectNotFound) {
-				util.ErrorLog(ctx, "failed removing oMap %s (%s)", cj.cephUUIDDirectoryPrefix+imageUUID, err)
+				log.ErrorLog(ctx, "failed removing oMap %s (%s)", cj.cephUUIDDirectoryPrefix+imageUUID, err)
 
 				return err
 			}
@@ -448,7 +449,7 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 	err := removeMapKeys(ctx, conn, csiJournalPool, cj.namespace, cj.csiDirectory,
 		[]string{cj.csiNameKeyPrefix + reqName})
 	if err != nil {
-		util.ErrorLog(ctx, "failed removing oMap key %s (%s)", cj.csiNameKeyPrefix+reqName, err)
+		log.ErrorLog(ctx, "failed removing oMap key %s (%s)", cj.csiNameKeyPrefix+reqName, err)
 
 		return err
 	}
@@ -486,7 +487,7 @@ func reserveOMapName(
 			if volUUID == "" && errors.Is(err, util.ErrObjectExists) {
 				attempt++
 				// try again with a different uuid, for maxAttempts tries
-				util.DebugLog(ctx, "uuid (%s) conflict detected, retrying (attempt %d of %d)",
+				log.DebugLog(ctx, "uuid (%s) conflict detected, retrying (attempt %d of %d)",
 					iterUUID, attempt, maxAttempts)
 
 				continue
@@ -590,10 +591,10 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	}
 	defer func() {
 		if err != nil {
-			util.WarningLog(ctx, "reservation failed for volume: %s", reqName)
+			log.WarningLog(ctx, "reservation failed for volume: %s", reqName)
 			errDefer := conn.UndoReservation(ctx, imagePool, journalPool, imageName, reqName)
 			if errDefer != nil {
-				util.WarningLog(ctx, "failed undoing reservation of volume: %s (%v)", reqName, errDefer)
+				log.WarningLog(ctx, "failed undoing reservation of volume: %s (%v)", reqName, errDefer)
 			}
 		}
 	}()
@@ -686,7 +687,7 @@ func (conn *Connection) GetImageAttributes(
 		if !errors.Is(err, util.ErrKeyNotFound) && !errors.Is(err, util.ErrPoolNotFound) {
 			return nil, err
 		}
-		util.WarningLog(ctx, "unable to read omap keys: pool or key missing: %v", err)
+		log.WarningLog(ctx, "unable to read omap keys: pool or key missing: %v", err)
 	}
 
 	var found bool

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	librbd "github.com/ceph/go-ceph/rbd"
 	"google.golang.org/grpc/codes"
@@ -103,14 +103,14 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 	// and add task to flatten temporary cloned image
 	err = rv.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
+		log.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
 		err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", rv.RbdImageName, snap.RbdSnapName, err)
 
 		return false, err
 	}
 	err = tempClone.deleteSnapshot(ctx, snap)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to delete snapshot: %v", err)
+		log.ErrorLog(ctx, "failed to delete snapshot: %v", err)
 
 		return false, err
 	}
@@ -155,7 +155,7 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 
 	err = rv.getImageID()
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get volume id %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to get volume id %s: %v", rv, err)
 
 		return err
 	}
@@ -176,7 +176,7 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to store volume %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to store volume %s: %v", rv, err)
 
 		return err
 	}
@@ -213,7 +213,7 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 		if err != nil || errClone != nil {
 			cErr := cleanUpSnapshot(ctx, tempClone, cloneSnap, rv, rv.conn.Creds)
 			if cErr != nil {
-				util.ErrorLog(ctx, "failed to cleanup image %s or snapshot %s: %v", cloneSnap, tempClone, cErr)
+				log.ErrorLog(ctx, "failed to cleanup image %s or snapshot %s: %v", cloneSnap, tempClone, cErr)
 			}
 		}
 
@@ -222,7 +222,7 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 				// cleanup snapshot
 				cErr := cleanUpSnapshot(ctx, parentVol, tempSnap, tempClone, rv.conn.Creds)
 				if cErr != nil {
-					util.ErrorLog(ctx, "failed to cleanup image %s or snapshot %s: %v", tempSnap, tempClone, cErr)
+					log.ErrorLog(ctx, "failed to cleanup image %s or snapshot %s: %v", tempSnap, tempClone, cErr)
 				}
 			}
 		}

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	librbd "github.com/ceph/go-ceph/rbd"
 )
@@ -65,17 +66,17 @@ const (
 func (ri *rbdImage) checkRbdImageEncrypted(ctx context.Context) (rbdEncryptionState, error) {
 	value, err := ri.MigrateMetadata(oldEncryptionMetaKey, encryptionMetaKey, string(rbdImageEncryptionUnknown))
 	if errors.Is(err, librbd.ErrNotFound) {
-		util.DebugLog(ctx, "image %s encrypted state not set", ri)
+		log.DebugLog(ctx, "image %s encrypted state not set", ri)
 
 		return rbdImageEncryptionUnknown, nil
 	} else if err != nil {
-		util.ErrorLog(ctx, "checking image %s encrypted state metadata failed: %s", ri, err)
+		log.ErrorLog(ctx, "checking image %s encrypted state metadata failed: %s", ri, err)
 
 		return rbdImageEncryptionUnknown, err
 	}
 
 	encrypted := rbdEncryptionState(strings.TrimSpace(value))
-	util.DebugLog(ctx, "image %s encrypted state metadata reports %q", ri, encrypted)
+	log.DebugLog(ctx, "image %s encrypted state metadata reports %q", ri, encrypted)
 
 	return encrypted, nil
 }
@@ -100,7 +101,7 @@ func (ri *rbdImage) isEncrypted() bool {
 func (ri *rbdImage) setupEncryption(ctx context.Context) error {
 	err := ri.encryption.StoreNewCryptoPassphrase(ri.VolID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to save encryption passphrase for "+
+		log.ErrorLog(ctx, "failed to save encryption passphrase for "+
 			"image %s: %s", ri, err)
 
 		return err
@@ -108,7 +109,7 @@ func (ri *rbdImage) setupEncryption(ctx context.Context) error {
 
 	err = ri.ensureEncryptionMetadataSet(rbdImageEncryptionPrepared)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to save encryption status, deleting "+
+		log.ErrorLog(ctx, "failed to save encryption status, deleting "+
 			"image %s: %s", ri, err)
 
 		return err
@@ -185,7 +186,7 @@ func (ri *rbdImage) repairEncryptionConfig(dest *rbdImage) error {
 func (ri *rbdImage) encryptDevice(ctx context.Context, devicePath string) error {
 	passphrase, err := ri.encryption.GetCryptoPassphrase(ri.VolID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get crypto passphrase for %s: %v",
+		log.ErrorLog(ctx, "failed to get crypto passphrase for %s: %v",
 			ri, err)
 
 		return err
@@ -193,14 +194,14 @@ func (ri *rbdImage) encryptDevice(ctx context.Context, devicePath string) error 
 
 	if err = util.EncryptVolume(ctx, devicePath, passphrase); err != nil {
 		err = fmt.Errorf("failed to encrypt volume %s: %w", ri, err)
-		util.ErrorLog(ctx, err.Error())
+		log.ErrorLog(ctx, err.Error())
 
 		return err
 	}
 
 	err = ri.ensureEncryptionMetadataSet(rbdImageEncrypted)
 	if err != nil {
-		util.ErrorLog(ctx, err.Error())
+		log.ErrorLog(ctx, err.Error())
 
 		return err
 	}
@@ -211,7 +212,7 @@ func (ri *rbdImage) encryptDevice(ctx context.Context, devicePath string) error 
 func (rv *rbdVolume) openEncryptedDevice(ctx context.Context, devicePath string) (string, error) {
 	passphrase, err := rv.encryption.GetCryptoPassphrase(rv.VolID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get passphrase for encrypted device %s: %v",
+		log.ErrorLog(ctx, "failed to get passphrase for encrypted device %s: %v",
 			rv, err)
 
 		return "", err
@@ -221,16 +222,16 @@ func (rv *rbdVolume) openEncryptedDevice(ctx context.Context, devicePath string)
 
 	isOpen, err := util.IsDeviceOpen(ctx, mapperFilePath)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to check device %s encryption status: %s", devicePath, err)
+		log.ErrorLog(ctx, "failed to check device %s encryption status: %s", devicePath, err)
 
 		return devicePath, err
 	}
 	if isOpen {
-		util.DebugLog(ctx, "encrypted device is already open at %s", mapperFilePath)
+		log.DebugLog(ctx, "encrypted device is already open at %s", mapperFilePath)
 	} else {
 		err = util.OpenEncryptedVolume(ctx, devicePath, mapperFile, passphrase)
 		if err != nil {
-			util.ErrorLog(ctx, "failed to open device %s: %v",
+			log.ErrorLog(ctx, "failed to open device %s: %v",
 				rv, err)
 
 			return devicePath, err
@@ -270,7 +271,7 @@ func (ri *rbdImage) ParseEncryptionOpts(ctx context.Context, volOptions map[stri
 	// FIXME: this works only on Kubernetes, how do other CO supply metadata?
 	ri.Owner, ok = volOptions["csi.storage.k8s.io/pvc/namespace"]
 	if !ok {
-		util.DebugLog(ctx, "could not detect owner for %s", ri)
+		log.DebugLog(ctx, "could not detect owner for %s", ri)
 	}
 
 	encrypted, ok = volOptions["encrypted"]

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (
@@ -167,7 +168,7 @@ func checkSnapCloneExists(
 			err = parentVol.deleteSnapshot(ctx, rbdSnap)
 			if err != nil {
 				if !errors.Is(err, ErrSnapNotFound) {
-					util.ErrorLog(ctx, "failed to delete snapshot %s: %v", rbdSnap, err)
+					log.ErrorLog(ctx, "failed to delete snapshot %s: %v", rbdSnap, err)
 
 					return false, err
 				}
@@ -198,7 +199,7 @@ func checkSnapCloneExists(
 		// create snapshot
 		sErr := vol.createSnapshot(ctx, rbdSnap)
 		if sErr != nil {
-			util.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, sErr)
+			log.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, sErr)
 			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 
 			return false, err
@@ -211,21 +212,21 @@ func checkSnapCloneExists(
 	if vol.ImageID == "" {
 		sErr := vol.getImageID()
 		if sErr != nil {
-			util.ErrorLog(ctx, "failed to get image id %s: %v", vol, sErr)
+			log.ErrorLog(ctx, "failed to get image id %s: %v", vol, sErr)
 			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 
 			return false, err
 		}
 		sErr = j.StoreImageID(ctx, vol.JournalPool, vol.ReservedID, vol.ImageID)
 		if sErr != nil {
-			util.ErrorLog(ctx, "failed to store volume id %s: %v", vol, sErr)
+			log.ErrorLog(ctx, "failed to store volume id %s: %v", vol, sErr)
 			err = undoSnapshotCloning(ctx, parentVol, rbdSnap, vol, cr)
 
 			return false, err
 		}
 	}
 
-	util.DebugLog(ctx, "found existing image (%s) with name (%s) for request (%s)",
+	log.DebugLog(ctx, "found existing image (%s) with name (%s) for request (%s)",
 		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
 
 	return true, nil
@@ -335,13 +336,13 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 	if parentVol != nil && parentVol.isEncrypted() {
 		err = parentVol.copyEncryptionConfig(&rv.rbdImage)
 		if err != nil {
-			util.ErrorLog(ctx, err.Error())
+			log.ErrorLog(ctx, err.Error())
 
 			return false, err
 		}
 	}
 
-	util.DebugLog(ctx, "found existing volume (%s) with image name (%s) for request (%s)",
+	log.DebugLog(ctx, "found existing volume (%s) with image name (%s) for request (%s)",
 		rv.VolID, rv.RbdImageName, rv.RequestName)
 
 	return true, nil
@@ -357,13 +358,13 @@ func (rv *rbdVolume) repairImageID(ctx context.Context, j *journal.Connection) e
 
 	err := rv.getImageID()
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
 
 		return err
 	}
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
 
 		return err
 	}
@@ -405,7 +406,7 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 		return err
 	}
 
-	util.DebugLog(ctx, "generated Volume ID (%s) and image name (%s) for request name (%s)",
+	log.DebugLog(ctx, "generated Volume ID (%s) and image name (%s) for request name (%s)",
 		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
 
 	return nil
@@ -481,7 +482,7 @@ func reserveVol(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnapshot, cr
 		return err
 	}
 
-	util.DebugLog(ctx, "generated Volume ID (%s) and image name (%s) for request name (%s)",
+	log.DebugLog(ctx, "generated Volume ID (%s) and image name (%s) for request name (%s)",
 		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.RequestName)
 
 	return nil
@@ -566,7 +567,7 @@ func RegenerateJournal(
 
 	rbdVol.Monitors, _, err = util.GetMonsAndClusterID(options)
 	if err != nil {
-		util.ErrorLog(ctx, "failed getting mons (%s)", err)
+		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 
 		return "", err
 	}
@@ -634,7 +635,7 @@ func RegenerateJournal(
 			undoErr := j.UndoReservation(ctx, rbdVol.JournalPool, rbdVol.Pool,
 				rbdVol.RbdImageName, rbdVol.RequestName)
 			if undoErr != nil {
-				util.ErrorLog(ctx, "failed to undo reservation %s: %v", rbdVol, undoErr)
+				log.ErrorLog(ctx, "failed to undo reservation %s: %v", rbdVol, undoErr)
 			}
 		}
 	}()
@@ -644,7 +645,7 @@ func RegenerateJournal(
 		return "", err
 	}
 
-	util.DebugLog(ctx, "re-generated Volume ID (%s) and image name (%s) for request name (%s)",
+	log.DebugLog(ctx, "re-generated Volume ID (%s) and image name (%s) for request name (%s)",
 		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.RequestName)
 	if rbdVol.ImageID == "" {
 		err = rbdVol.storeImageID(ctx, j)
@@ -660,13 +661,13 @@ func RegenerateJournal(
 func (rv *rbdVolume) storeImageID(ctx context.Context, j *journal.Connection) error {
 	err := rv.getImageID()
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
 
 		return err
 	}
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
 
 		return err
 	}

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 func createRBDClone(
@@ -31,7 +32,7 @@ func createRBDClone(
 	// create snapshot
 	err := parentVol.createSnapshot(ctx, snap)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to create snapshot %s: %v", snap, err)
+		log.ErrorLog(ctx, "failed to create snapshot %s: %v", snap, err)
 
 		return err
 	}
@@ -40,7 +41,7 @@ func createRBDClone(
 	// create clone image and delete snapshot
 	err = cloneRbdVol.cloneRbdImageFromSnapshot(ctx, snap, parentVol)
 	if err != nil {
-		util.ErrorLog(
+		log.ErrorLog(
 			ctx,
 			"failed to clone rbd image %s from snapshot %s: %v",
 			cloneRbdVol.RbdImageName,
@@ -54,10 +55,10 @@ func createRBDClone(
 	}
 	errSnap := parentVol.deleteSnapshot(ctx, snap)
 	if errSnap != nil {
-		util.ErrorLog(ctx, "failed to delete snapshot: %v", errSnap)
+		log.ErrorLog(ctx, "failed to delete snapshot: %v", errSnap)
 		delErr := deleteImage(ctx, cloneRbdVol, cr)
 		if delErr != nil {
-			util.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", cloneRbdVol, delErr)
+			log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", cloneRbdVol, delErr)
 		}
 
 		return err
@@ -65,10 +66,10 @@ func createRBDClone(
 
 	err = cloneRbdVol.getImageInfo()
 	if err != nil {
-		util.ErrorLog(ctx, "failed to get rbd image: %s details with error: %v", cloneRbdVol, err)
+		log.ErrorLog(ctx, "failed to get rbd image: %s details with error: %v", cloneRbdVol, err)
 		delErr := deleteImage(ctx, cloneRbdVol, cr)
 		if delErr != nil {
-			util.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", cloneRbdVol, delErr)
+			log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", cloneRbdVol, delErr)
 		}
 
 		return err
@@ -88,7 +89,7 @@ func cleanUpSnapshot(
 	err := parentVol.deleteSnapshot(ctx, rbdSnap)
 	if err != nil {
 		if !errors.Is(err, ErrSnapNotFound) {
-			util.ErrorLog(ctx, "failed to delete snapshot %q: %v", rbdSnap, err)
+			log.ErrorLog(ctx, "failed to delete snapshot %q: %v", rbdSnap, err)
 
 			return err
 		}
@@ -98,7 +99,7 @@ func cleanUpSnapshot(
 		err := deleteImage(ctx, rbdVol, cr)
 		if err != nil {
 			if !errors.Is(err, ErrImageNotFound) {
-				util.ErrorLog(ctx, "failed to delete rbd image %q with error: %v", rbdVol, err)
+				log.ErrorLog(ctx, "failed to delete rbd image %q with error: %v", rbdVol, err)
 
 				return err
 			}
@@ -134,7 +135,7 @@ func undoSnapshotCloning(
 	cr *util.Credentials) error {
 	err := cleanUpSnapshot(ctx, parentVol, rbdSnap, cloneVol, cr)
 	if err != nil {
-		util.ErrorLog(ctx, "failed to clean up  %s or %s: %v", cloneVol, rbdSnap, err)
+		log.ErrorLog(ctx, "failed to clean up  %s or %s: %v", cloneVol, rbdSnap, err)
 
 		return err
 	}

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	"github.com/ceph/go-ceph/rados"
 )
 
@@ -50,14 +52,14 @@ func ExecCommand(ctx context.Context, program string, args ...string) (string, s
 	if err != nil {
 		err = fmt.Errorf("an error (%w) occurred while running %s args: %v", err, program, sanitizedArgs)
 		if ctx != context.TODO() {
-			UsefulLog(ctx, "%s", err)
+			log.UsefulLog(ctx, "%s", err)
 		}
 
 		return stdout, stderr, err
 	}
 
 	if ctx != context.TODO() {
-		UsefulLog(ctx, "command succeeded: %s %v", program, sanitizedArgs)
+		log.UsefulLog(ctx, "command succeeded: %s %v", program, sanitizedArgs)
 	}
 
 	return stdout, stderr, nil
@@ -151,7 +153,7 @@ func CreateObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrObjectExists) {
 		return JoinErrors(ErrObjectExists, err)
 	} else if err != nil {
-		ErrorLog(ctx, "failed creating omap (%s) in pool (%s): (%v)", objectName, poolName, err)
+		log.ErrorLog(ctx, "failed creating omap (%s) in pool (%s): (%v)", objectName, poolName, err)
 
 		return err
 	}
@@ -187,7 +189,7 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 	if errors.Is(err, rados.ErrNotFound) {
 		return JoinErrors(ErrObjectNotFound, err)
 	} else if err != nil {
-		ErrorLog(ctx, "failed removing omap (%s) in pool (%s): (%v)", oMapName, poolName, err)
+		log.ErrorLog(ctx, "failed removing omap (%s) in pool (%s): (%v)", oMapName, poolName, err)
 
 		return err
 	}

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -25,6 +25,8 @@ import (
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (
@@ -262,7 +264,7 @@ func VolumeMapper(volumeID string) (mapperFile, mapperFilePath string) {
 
 // EncryptVolume encrypts provided device with LUKS.
 func EncryptVolume(ctx context.Context, devicePath, passphrase string) error {
-	DebugLog(ctx, "Encrypting device %s with LUKS", devicePath)
+	log.DebugLog(ctx, "Encrypting device %s with LUKS", devicePath)
 	if _, _, err := LuksFormat(devicePath, passphrase); err != nil {
 		return fmt.Errorf("failed to encrypt device %s with LUKS: %w", devicePath, err)
 	}
@@ -272,10 +274,10 @@ func EncryptVolume(ctx context.Context, devicePath, passphrase string) error {
 
 // OpenEncryptedVolume opens volume so that it can be used by the client.
 func OpenEncryptedVolume(ctx context.Context, devicePath, mapperFile, passphrase string) error {
-	DebugLog(ctx, "Opening device %s with LUKS on %s", devicePath, mapperFile)
+	log.DebugLog(ctx, "Opening device %s with LUKS on %s", devicePath, mapperFile)
 	_, stderr, err := LuksOpen(devicePath, mapperFile, passphrase)
 	if err != nil {
-		ErrorLog(ctx, "failed to open LUKS device %q: %s", devicePath, stderr)
+		log.ErrorLog(ctx, "failed to open LUKS device %q: %s", devicePath, stderr)
 	}
 
 	return err
@@ -283,10 +285,10 @@ func OpenEncryptedVolume(ctx context.Context, devicePath, mapperFile, passphrase
 
 // ResizeEncryptedVolume resizes encrypted volume so that it can be used by the client.
 func ResizeEncryptedVolume(ctx context.Context, mapperFile string) error {
-	DebugLog(ctx, "Resizing LUKS device %s", mapperFile)
+	log.DebugLog(ctx, "Resizing LUKS device %s", mapperFile)
 	_, stderr, err := LuksResize(mapperFile)
 	if err != nil {
-		ErrorLog(ctx, "failed to resize LUKS device %s: %s", mapperFile, stderr)
+		log.ErrorLog(ctx, "failed to resize LUKS device %s: %s", mapperFile, stderr)
 	}
 
 	return err
@@ -294,7 +296,7 @@ func ResizeEncryptedVolume(ctx context.Context, mapperFile string) error {
 
 // CloseEncryptedVolume closes encrypted volume so it can be detached.
 func CloseEncryptedVolume(ctx context.Context, mapperFile string) error {
-	DebugLog(ctx, "Closing LUKS device %s", mapperFile)
+	log.DebugLog(ctx, "Closing LUKS device %s", mapperFile)
 	_, _, err := LuksClose(mapperFile)
 
 	return err
@@ -317,7 +319,7 @@ func DeviceEncryptionStatus(ctx context.Context, devicePath string) (mappedDevic
 	mapPath := strings.TrimPrefix(devicePath, mapperFilePathPrefix+"/")
 	stdout, _, err := LuksStatus(mapPath)
 	if err != nil {
-		DebugLog(ctx, "device %s is not an active LUKS device: %v", devicePath, err)
+		log.DebugLog(ctx, "device %s is not an active LUKS device: %v", devicePath, err)
 
 		return devicePath, "", nil
 	}

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -8,6 +8,8 @@ import (
 	runtime_pprof "runtime/pprof"
 	"strconv"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -24,13 +26,13 @@ func StartMetricsServer(c *Config) {
 	http.Handle(c.MetricsPath, promhttp.Handler())
 	err := http.ListenAndServe(addr, nil)
 	if err != nil {
-		FatalLogMsg("failed to listen on address %v: %s", addr, err)
+		log.FatalLogMsg("failed to listen on address %v: %s", addr, err)
 	}
 }
 
 func addPath(name string, handler http.Handler) {
 	http.Handle(name, handler)
-	DebugLogMsg("DEBUG: registered profiling handler on /debug/pprof/%s\n", name)
+	log.DebugLogMsg("DEBUG: registered profiling handler on /debug/pprof/%s\n", name)
 }
 
 // EnableProfiling enables golang profiling.

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -240,6 +242,6 @@ func (ol *OperationLock) release(op operation, volumeID string) {
 			}
 		}
 	default:
-		ErrorLogMsg("%v operation not supported", op)
+		log.ErrorLogMsg("%v operation not supported", op)
 	}
 }

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -19,6 +19,8 @@ package util
 import (
 	"os"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -32,17 +34,17 @@ func NewK8sClient() *k8s.Clientset {
 	if cPath != "" {
 		cfg, err = clientcmd.BuildConfigFromFlags("", cPath)
 		if err != nil {
-			FatalLogMsg("Failed to get cluster config with error: %v\n", err)
+			log.FatalLogMsg("Failed to get cluster config with error: %v\n", err)
 		}
 	} else {
 		cfg, err = rest.InClusterConfig()
 		if err != nil {
-			FatalLogMsg("Failed to get cluster config with error: %v\n", err)
+			log.FatalLogMsg("Failed to get cluster config with error: %v\n", err)
 		}
 	}
 	client, err := k8s.NewForConfig(cfg)
 	if err != nil {
-		FatalLogMsg("Failed to create client with error: %v\n", err)
+		log.FatalLogMsg("Failed to create client with error: %v\n", err)
 	}
 
 	return client

--- a/internal/util/log/log.go
+++ b/internal/util/log/log.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package log
 
 import (
 	"context"

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -59,7 +61,7 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 
 	// Convert passed in labels to a map, and check for uniqueness
 	labelsToRead := strings.SplitN(domainLabels, labelSeparator, -1)
-	DefaultLog("passed in node labels for processing: %+v", labelsToRead)
+	log.DefaultLog("passed in node labels for processing: %+v", labelsToRead)
 
 	labelsIn := make(map[string]bool)
 	labelCount := 0
@@ -106,7 +108,7 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 		return nil, fmt.Errorf("missing domain labels %v on node %q", missingLabels, nodeName)
 	}
 
-	DefaultLog("list of domains processed: %+v", domainMap)
+	log.DefaultLog("list of domains processed: %+v", domainMap)
 
 	topology := make(map[string]string)
 	for domain, value := range domainMap {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ceph/ceph-csi/internal/util/log"
+
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cloud-provider/volume/helpers"
@@ -216,7 +218,7 @@ func parseKernelRelease(release string) (int, int, int, int, error) {
 func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool {
 	version, patchlevel, sublevel, extraversion, err := parseKernelRelease(release)
 	if err != nil {
-		ErrorLogMsg("%v", err)
+		log.ErrorLogMsg("%v", err)
 
 		return false
 	}
@@ -242,7 +244,7 @@ func CheckKernelSupport(release string, supportedVersions []KernelVersion) bool 
 			}
 		}
 	}
-	ErrorLogMsg("kernel %s does not support required features", release)
+	log.ErrorLogMsg("kernel %s does not support required features", release)
 
 	return false
 }


### PR DESCRIPTION
Moving the log functions into its own internal/util/log package makes it
possible to split out the humongous internal/util packages in further
smaller pieces. This reduces the inter-dependencies between utility
functions and components, preventing circular dependencies which are not
allowed in Go.

Updates: #852

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
