### PR TITLE
util: fix unit-test for GetClusterMappingInfo()

### DIFF
--- a/internal/util/cluster_mapping.go
+++ b/internal/util/cluster_mapping.go
@@ -65,9 +65,9 @@ type ClusterMappingInfo struct {
 // ...
 // }]
 
-func readClusterMappingInfo() (*[]ClusterMappingInfo, error) {
+func readClusterMappingInfo(filename string) (*[]ClusterMappingInfo, error) {
 	var info []ClusterMappingInfo
-	content, err := ioutil.ReadFile(clusterMappingConfigFile)
+	content, err := ioutil.ReadFile(filename) // #nosec:G304, file inclusion via variable.
 	if err != nil {
 		err = fmt.Errorf("error fetching clusterID mapping %w", err)
 
@@ -83,11 +83,11 @@ func readClusterMappingInfo() (*[]ClusterMappingInfo, error) {
 	return &info, nil
 }
 
-// GetClusterMappingInfo returns corresponding cluster details like clusterID's
-// poolID,fscID lists read from configfile.
-func GetClusterMappingInfo(clusterID string) (*[]ClusterMappingInfo, error) {
+// getClusterMappingInfo returns corresponding cluster details like clusterID's
+// poolID,fscID lists read from 'filename'.
+func getClusterMappingInfo(clusterID, filename string) (*[]ClusterMappingInfo, error) {
 	var mappingInfo []ClusterMappingInfo
-	info, err := readClusterMappingInfo()
+	info, err := readClusterMappingInfo(filename)
 	if err != nil {
 		// discard not found error as this file is expected to be created by
 		// the admin in case of failover.
@@ -113,4 +113,10 @@ func GetClusterMappingInfo(clusterID string) (*[]ClusterMappingInfo, error) {
 	}
 
 	return &mappingInfo, nil
+}
+
+// GetClusterMappingInfo returns corresponding cluster details like clusterID's
+// poolID,fscID lists read from configfile.
+func GetClusterMappingInfo(clusterID string) (*[]ClusterMappingInfo, error) {
+	return getClusterMappingInfo(clusterID, clusterMappingConfigFile)
 }

--- a/internal/util/cluster_mapping_test.go
+++ b/internal/util/cluster_mapping_test.go
@@ -138,19 +138,19 @@ func TestGetClusterMappingInfo(t *testing.T) {
 		currentTT := tt
 		t.Run(currentTT.name, func(t *testing.T) {
 			t.Parallel()
-			clusterMappingConfigFile = fmt.Sprintf("%s/mapping-%d.json", mappingBasePath, currentI)
+			mappingConfigFile := fmt.Sprintf("%s/mapping-%d.json", mappingBasePath, currentI)
 			if len(currentTT.mappingFilecontent) != 0 {
-				err = ioutil.WriteFile(clusterMappingConfigFile, currentTT.mappingFilecontent, 0o600)
+				err = ioutil.WriteFile(mappingConfigFile, currentTT.mappingFilecontent, 0o600)
 				if err != nil {
-					t.Errorf("GetClusterMappingInfo() error = %v", err)
+					t.Errorf("failed to write to %q, error = %v", mappingConfigFile, err)
 				}
 			}
-			data, mErr := GetClusterMappingInfo(currentTT.clusterID)
+			data, mErr := getClusterMappingInfo(currentTT.clusterID, mappingConfigFile)
 			if (mErr != nil) != currentTT.expectErr {
-				t.Errorf("GetClusterMappingInfo() error = %v, expected Error %v", mErr, currentTT.expectErr)
+				t.Errorf("getClusterMappingInfo() error = %v, expected Error %v", mErr, currentTT.expectErr)
 			}
 			if !reflect.DeepEqual(data, currentTT.expectedData) {
-				t.Errorf("GetClusterMappingInfo() = %v, expected data %v", data, currentTT.expectedData)
+				t.Errorf("getClusterMappingInfo() = %v, expected data %v", data, currentTT.expectedData)
 			}
 		})
 	}


### PR DESCRIPTION
Unit-testing often fails due to a race condition while writing the
clusterMappingConfigFile from multiple go-routines at the same time.
Failures from `make containerized-test` look like this:

```
=== CONT  TestGetClusterMappingInfo/site2-storage_cluster-id_mapping
    cluster_mapping_test.go:153: GetClusterMappingInfo() = <nil>, expected data &[{map[site1-storage:site2-storage] [map[1:3]] [map[11:5]]} {map[site3-storage:site2-storage] [map[8:3]] [map[10:5]]}]
=== CONT  TestGetClusterMappingInfo/site3-storage_cluster-id_mapping
    cluster_mapping_test.go:153: GetClusterMappingInfo() = <nil>, expected data &[{map[site3-storage:site2-storage] [map[8:3]] [map[10:5]]}]
--- FAIL: TestGetClusterMappingInfo (0.01s)
    --- PASS: TestGetClusterMappingInfo/mapping_file_not_found (0.00s)
    --- PASS: TestGetClusterMappingInfo/mapping_file_found_with_empty_data (0.00s)
    --- PASS: TestGetClusterMappingInfo/cluster-id_mapping_not_found (0.00s)
    --- FAIL: TestGetClusterMappingInfo/site2-storage_cluster-id_mapping (0.00s)
    --- FAIL: TestGetClusterMappingInfo/site3-storage_cluster-id_mapping (0.00s)
    --- PASS: TestGetClusterMappingInfo/site1-storage_cluster-id_mapping (0.00s)
```

By splitting the public GetClusterMappingInfo() function into an
internal getClusterMappingInfo() that takes a filename, unit-testing can
use different files for each go-routine, and testing becomes more
predictable.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
