### PR TITLE
deploy: enable podInfoOnMount flag in csidriver object

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -8,4 +8,4 @@ metadata:
   name: {{ .Values.driverName }}
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -8,4 +8,4 @@ metadata:
   name: {{ .Values.driverName }}
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true

--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -7,4 +7,4 @@ metadata:
   name: cephfs.csi.ceph.com
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -7,4 +7,4 @@ metadata:
   name: rbd.csi.ceph.com
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true


### PR DESCRIPTION
This flag enables CSI driver to get the pod name, namespace, uid
and service account as part of the nodepublish request.
This come handy while we enhance features like encryption, namespace
transfer...etc. Enabling this flag as part of this patchset. This is
similar to the extra metadata CSI driver receive as part of PVC but
for pod.

Fixes https://github.com/ceph/ceph-csi/issues/2441

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

