### PR TITLE
rbd: skip volumeattachment processing if pv marked for deletion

### DIFF
--- a/internal/rbd/rbd_healer.go
+++ b/internal/rbd/rbd_healer.go
@@ -153,9 +153,8 @@ func runVolumeHealer(ns *NodeServer, conf *util.Config) error {
 
 			continue
 		}
-		// TODO: check with pv delete annotations, for eg: what happens when the pv is marked for delete
-		// skip this volumeattachment if its pv is not bound
-		if pv.Status.Phase != v1.VolumeBound {
+		// skip this volumeattachment if its pv is not bound or marked for deletion
+		if pv.Status.Phase != v1.VolumeBound || pv.DeletionTimestamp != nil {
 			continue
 		}
 		// skip if mounter is not rbd-nbd


### PR DESCRIPTION
if the volumeattachment has been fetched but marked for deletion
the nbd healer dont want to process further on this pv. This patch
adds a check for pv is marked for deletion and if so, make the
healer skip processing the same

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

