### PR TITLE
rbd: check for clusterid mapping in RegenerateJournal()

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1105,7 +1105,7 @@ func generateVolumeFromMapping(
 	// extract clusterID mapping
 	for _, cm := range *mapping {
 		for key, val := range cm.ClusterIDMapping {
-			mappedClusterID := getMappedID(key, val, vi.ClusterID)
+			mappedClusterID := util.GetMappedID(key, val, vi.ClusterID)
 			if mappedClusterID == "" {
 				continue
 			}
@@ -1119,7 +1119,7 @@ func generateVolumeFromMapping(
 			poolID := fmt.Sprintf("%d", (vi.LocationID))
 			for _, pools := range cm.RBDpoolIDMappingInfo {
 				for key, val := range pools {
-					mappedPoolID := getMappedID(key, val, poolID)
+					mappedPoolID := util.GetMappedID(key, val, poolID)
 					if mappedPoolID == "" {
 						continue
 					}
@@ -1144,20 +1144,6 @@ func generateVolumeFromMapping(
 	}
 
 	return vol, util.ErrPoolNotFound
-}
-
-// getMappedID check the input id is matching key or value.
-// If key==id the value will be returned.
-// If value==id the key will be returned.
-func getMappedID(key, value, id string) string {
-	if key == id {
-		return value
-	}
-	if value == id {
-		return key
-	}
-
-	return ""
 }
 
 func genVolFromVolumeOptions(

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -138,58 +138,6 @@ func TestValidateImageFeatures(t *testing.T) {
 	}
 }
 
-func TestGetMappedID(t *testing.T) {
-	t.Parallel()
-	type args struct {
-		key   string
-		value string
-		id    string
-	}
-	tests := []struct {
-		name     string
-		args     args
-		expected string
-	}{
-		{
-			name: "test for matching key",
-			args: args{
-				key:   "cluster1",
-				value: "cluster2",
-				id:    "cluster1",
-			},
-			expected: "cluster2",
-		},
-		{
-			name: "test for matching value",
-			args: args{
-				key:   "cluster1",
-				value: "cluster2",
-				id:    "cluster2",
-			},
-			expected: "cluster1",
-		},
-		{
-			name: "test for invalid match",
-			args: args{
-				key:   "cluster1",
-				value: "cluster2",
-				id:    "cluster3",
-			},
-			expected: "",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			val := getMappedID(tt.args.key, tt.args.value, tt.args.id)
-			if val != tt.expected {
-				t.Errorf("getMappedID() got = %v, expected %v", val, tt.expected)
-			}
-		})
-	}
-}
-
 func TestGetCephClientLogFileName(t *testing.T) {
 	t.Parallel()
 	type args struct {

--- a/internal/util/cluster_mapping.go
+++ b/internal/util/cluster_mapping.go
@@ -120,3 +120,17 @@ func getClusterMappingInfo(clusterID, filename string) (*[]ClusterMappingInfo, e
 func GetClusterMappingInfo(clusterID string) (*[]ClusterMappingInfo, error) {
 	return getClusterMappingInfo(clusterID, clusterMappingConfigFile)
 }
+
+// GetMappedID check the input id is matching key or value.
+// If key==id the value will be returned.
+// If value==id the key will be returned.
+func GetMappedID(key, value, id string) string {
+	if key == id {
+		return value
+	}
+	if value == id {
+		return key
+	}
+
+	return ""
+}

--- a/internal/util/cluster_mapping_test.go
+++ b/internal/util/cluster_mapping_test.go
@@ -239,3 +239,55 @@ func validateMapping(t *testing.T, clusterID, rbdPoolID, cephFSPoolID string, ma
 
 	return nil
 }
+
+func TestGetMappedID(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		key   string
+		value string
+		id    string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected string
+	}{
+		{
+			name: "test for matching key",
+			args: args{
+				key:   "cluster1",
+				value: "cluster2",
+				id:    "cluster1",
+			},
+			expected: "cluster2",
+		},
+		{
+			name: "test for matching value",
+			args: args{
+				key:   "cluster1",
+				value: "cluster2",
+				id:    "cluster2",
+			},
+			expected: "cluster1",
+		},
+		{
+			name: "test for invalid match",
+			args: args{
+				key:   "cluster1",
+				value: "cluster2",
+				id:    "cluster3",
+			},
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			val := GetMappedID(tt.args.key, tt.args.value, tt.args.id)
+			if val != tt.expected {
+				t.Errorf("getMappedID() got = %v, expected %v", val, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- rbd: move GetMappedID() to util package
and 

- rbd: check for clusterid mapping in RegenerateJournal()

This commit adds fetchMappedClusterIDAndMons() which returns
monitors and clusterID info after checking cluster mapping info.
This is required for regenerating omap entries in mirrored cluster
with different clusterID.

Signed-off-by: Rakshith R <rar@redhat.com>

Tested with mapping clusterid "rook-ceph":"rook-ceph-1"
With no corresponding mon ip list for "rook-ceph"
Works ! 
```
I0826 11:50:58.585164       1 rbd_util.go:1175] found new clusterID mapping "rook-ceph-1" for existing clusterID "rook-ceph"
E0826 11:50:58.588179       1 omap.go:78] omap not found (pool="replicapool", namespace="", name="csi.volumes.default"): rados: ret=-2, No such file or directory
I0826 11:50:58.621629       1 omap.go:155] set omap keys (pool="replicapool", namespace="", name="csi.volumes.default"): map[csi.volume.pvc-278e6845-46a3-4603-97d4-272b3bbe6747:3c742b18-0663-11ec-88bd-0242ac110005])
I0826 11:50:58.633764       1 omap.go:155] set omap keys (pool="replicapool", namespace="", name="csi.volume.3c742b18-0663-11ec-88bd-0242ac110005"): map[csi.imagename:csi-vol-3c742b18-0663-11ec-88bd-0242ac110005 csi.volname:pvc-278e6845-46a3-4603-97d4-272b3bbe6747 csi.volume.owner:rook-ceph])
I0826 11:50:58.633806       1 rbd_journal.go:641] re-generated Volume ID (0001-000b-rook-ceph-1-0000000000000001-3c742b18-0663-11ec-88bd-0242ac110005) and image name (csi-vol-3c742b18-0663-11ec-88bd-0242ac110005) for request name (pvc-278e6845-46a3-4603-97d4-272b3bbe6747)
I0826 11:50:58.689962       1 omap.go:155] set omap keys (pool="replicapool", namespace="", name="csi.volume.3c742b18-0663-11ec-88bd-0242ac110005"): map[csi.imageid:12955994250b])
I0826 11:50:58.690234       1 rbd_util.go:1175] found new clusterID mapping "rook-ceph-1" for existing clusterID "rook-ceph"
I0826 11:50:58.693026       1 omap.go:87] got omap values: (pool="replicapool", namespace="", name="csi.volumes.default"): map[csi.volume.pvc-278e6845-46a3-4603-97d4-272b3bbe6747:3c742b18-0663-11ec-88bd-0242ac110005]
I0826 11:50:58.693548       1 omap.go:87] got omap values: (pool="replicapool", namespace="", name="csi.volume.3c742b18-0663-11ec-88bd-0242ac110005"): map[csi.imageid:12955994250b csi.imagename:csi-vol-3c742b18-0663-11ec-88bd-0242ac110005 csi.volname:pvc-278e6845-46a3-4603-97d4-272b3bbe6747 csi.volume.owner:rook-ceph]

```