### PR TITLE
ci: skip commitlint for dependabot PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,6 +32,35 @@ pull_request_rules:
         message: "This pull request now has conflicts with the target branch.
         Could you please resolve conflicts and force push the corrected
         changes? 🙏"
+  - name: update dependencies by dependabot (skip commitlint)
+    conditions:
+      - author=dependabot[bot]
+      - label!=DNM
+      - base~=^(devel)|(release-.+)$
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - "approved-reviews-by=@ceph/ceph-csi-contributors"
+      - "approved-reviews-by=@ceph/ceph-csi-maintainers"
+      - "status-success=codespell"
+      - "status-success=multi-arch-build"
+      - "status-success=go-test"
+      - "status-success=golangci-lint"
+      - "status-success=gosec"
+      - "status-success=mod-check"
+      - "status-success=lint-extras"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.20"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.21"
+      - "status-success=ci/centos/mini-e2e-helm/k8s-1.22"
+      - "status-success=ci/centos/mini-e2e/k8s-1.20"
+      - "status-success=ci/centos/mini-e2e/k8s-1.21"
+      - "status-success=ci/centos/mini-e2e/k8s-1.22"
+      - "status-success=ci/centos/upgrade-tests-cephfs"
+      - "status-success=ci/centos/upgrade-tests-rbd"
+      - "status-success=DCO"
+    actions:
+      merge: {}
+      dismiss_reviews: {}
+      delete_head_branch: {}
   - name: automatic merge
     conditions:
       - label!=DNM


### PR DESCRIPTION
Dependabot creates commit messages that commitlint fails to parse
correctly. The messages contain simple references to which dependencies
are updated, and do not need full validation like manual written
messages do.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
