### PR TITLE
util: NewK8sClient() should not panic on non-Kubernetes clusters

### DIFF
--- a/internal/kms/aws_metadata.go
+++ b/internal/kms/aws_metadata.go
@@ -125,7 +125,12 @@ func initAWSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 }
 
 func (kms *AWSMetadataKMS) getSecrets() (map[string]interface{}, error) {
-	c := k8s.NewK8sClient()
+	c, err := k8s.NewK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Kubernetes to "+
+			"get Secret %s/%s: %w", kms.namespace, kms.secretName, err)
+	}
+
 	secret, err := c.CoreV1().Secrets(kms.namespace).Get(context.TODO(),
 		kms.secretName, metav1.GetOptions{})
 	if err != nil {

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -154,7 +154,12 @@ func getKMSConfigMap() (map[string]interface{}, error) {
 	}
 	cmName := getKMSConfigMapName()
 
-	c := k8s.NewK8sClient()
+	c, err := k8s.NewK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("can not get ConfigMap %q, failed to "+
+			"connect to Kubernetes: %w", cmName, err)
+	}
+
 	cm, err := c.CoreV1().ConfigMaps(ns).Get(context.Background(),
 		cmName, metav1.GetOptions{})
 	if err != nil {

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -159,7 +159,12 @@ func (kms SecretsMetadataKMS) fetchEncryptionPassphrase(
 		secretNamespace = defaultNamespace
 	}
 
-	c := k8s.NewK8sClient()
+	c, err := k8s.NewK8sClient()
+	if err != nil {
+		return "", fmt.Errorf("can not get Secret %s/%s, failed to "+
+			"connect to Kubernetes: %w", secretNamespace, secretName, err)
+	}
+
 	secret, err := c.CoreV1().Secrets(secretNamespace).Get(context.TODO(),
 		secretName, metav1.GetOptions{})
 	if err != nil {

--- a/internal/rbd/rbd_healer.go
+++ b/internal/rbd/rbd_healer.go
@@ -129,7 +129,13 @@ func callNodeStageVolume(ns *NodeServer, c *k8s.Clientset, pv *v1.PersistentVolu
 
 // runVolumeHealer heal the volumes attached on a node.
 func runVolumeHealer(ns *NodeServer, conf *util.Config) error {
-	c := kubeclient.NewK8sClient()
+	c, err := kubeclient.NewK8sClient()
+	if err != nil {
+		log.ErrorLogMsg("failed to connect to Kubernetes: %v", err)
+
+		return err
+	}
+
 	val, err := c.StorageV1().VolumeAttachments().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		log.ErrorLogMsg("list volumeAttachments failed, err: %v", err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1064,7 +1064,11 @@ func genVolFromVolID(
 	// be the same in the PV.Spec.CSI.VolumeHandle. Check the PV annotation for
 	// the new volumeHandle. If the new volumeHandle is found, generate the RBD
 	// volume structure from the new volumeHandle.
-	c := k8s.NewK8sClient()
+	c, cErr := k8s.NewK8sClient()
+	if cErr != nil {
+		return vol, cErr
+	}
+
 	listOpt := metav1.ListOptions{
 		LabelSelector: PVReplicatedLabelKey,
 	}

--- a/internal/util/k8s/client.go
+++ b/internal/util/k8s/client.go
@@ -17,9 +17,8 @@ limitations under the License.
 package k8s
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -27,25 +26,25 @@ import (
 )
 
 // NewK8sClient create kubernetes client.
-func NewK8sClient() *kubernetes.Clientset {
+func NewK8sClient() (*kubernetes.Clientset, error) {
 	var cfg *rest.Config
 	var err error
 	cPath := os.Getenv("KUBERNETES_CONFIG_PATH")
 	if cPath != "" {
 		cfg, err = clientcmd.BuildConfigFromFlags("", cPath)
 		if err != nil {
-			log.FatalLogMsg("Failed to get cluster config with error: %v\n", err)
+			return nil, fmt.Errorf("failed to get cluster config from %q: %w", cPath, err)
 		}
 	} else {
 		cfg, err = rest.InClusterConfig()
 		if err != nil {
-			log.FatalLogMsg("Failed to get cluster config with error: %v\n", err)
+			return nil, fmt.Errorf("failed to get cluster config: %w", err)
 		}
 	}
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		log.FatalLogMsg("Failed to create client with error: %v\n", err)
+		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
-	return client
+	return client, nil
 }

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -35,7 +35,12 @@ const (
 )
 
 func k8sGetNodeLabels(nodeName string) (map[string]string, error) {
-	client := k8s.NewK8sClient()
+	client, err := k8s.NewK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("can not get node %q information, failed "+
+			"to connect to Kubernetes: %w", nodeName, err)
+	}
+
 	node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node %q information: %w", nodeName, err)


### PR DESCRIPTION
When NewK8sClient() detects and error, it used to call FatalLogMsg()
which causes a panic. There are additional features that can be used on
Kubernetes clusters, but these are not a requirement for most
functionalities of the driver.

Instead of causing a panic, returning and logging the issue should
suffice. This allows using the driver on non-Kubernetes clusters again.

Fixes: #2452

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
