### PR TITLE
rbd: retry creating snapshot in case flattening is in progress

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -505,7 +505,14 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			return status.Error(codes.Internal, err.Error())
 		}
 
-		return status.Errorf(codes.ResourceExhausted, "rbd image %s has %d snapshots", rbdVol, len(snaps))
+		// Abort current try, flattening is likely to be in progress, a
+		// next retry might succeed
+		return status.Errorf(
+			codes.Aborted,
+			"rbd image %s has %d snapshots (max %d)",
+			rbdVol,
+			len(snaps),
+			maxSnapshotsOnImage)
 	}
 
 	if len(snaps) > int(minSnapshotsOnImageToStartFlatten) {


### PR DESCRIPTION
When `RESOURCE_EXHAUSTED` is returned, Kubernetes aborts the
CreateSnapshot request, and does not retry it. It is expected that
flattening was started for some RBD images, so a next call to
CreateSnapshot might succeed.

Instead of returning `RESOURCE_EXHAUSTED`, return `ABORTED`, so that
Kubernetes retries CreateSnapshot with an exponential backoff.

Fixes: #2469

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
