### PR TITLE
cephfs: no need to check for zero volume size

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Card](https://goreportcard.com/badge/github.com/ceph/ceph-csi)](https://goreport
 - [Ceph CSI](#ceph-csi)
   - [Overview](#overview)
   - [Project status](#project-status)
-  - [Supported CO platforms](#supported-co-platforms)
+  - [Known to work CO platforms](#known-to-work-co-platforms)
   - [Support Matrix](#support-matrix)
     - [Ceph-CSI features and available versions](#ceph-csi-features-and-available-versions)
     - [CSI spec and Kubernetes version compatibility](#csi-spec-and-kubernetes-version-compatibility)
@@ -47,11 +47,18 @@ NOTE:
 
 Status: **GA**
 
-## Supported CO platforms
+## Known to work CO platforms
 
 Ceph CSI drivers are currently developed and tested **exclusively** on Kubernetes
-environments. There is work in progress to make this CO independent and thus
-support other orchestration environments in the future.
+environments.
+
+| Ceph CSI Version | Container Orchestrator Name | Version Tested|
+| -----------------| --------------------------- | --------------|
+| v3.4.0 | Kubernetes | v1.20, v1.21, v1.22|
+| v3.3.0 | Kubernetes | v1.20, v1.21, v1.22|
+
+There is work in progress to make this CO independent and thus
+support other orchestration environments (Nomad, Mesos..etc) in the future.
 
 NOTE:
 

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -188,7 +188,6 @@ func (cs *ControllerServer) CreateVolume(
 	if req.GetCapacityRange() != nil {
 		volOptions.Size = util.RoundOffBytes(req.GetCapacityRange().GetRequiredBytes())
 	}
-	// TODO need to add check for 0 volume size
 
 	parentVol, pvID, sID, err := checkContentSource(ctx, req, cr)
 	if err != nil {


### PR DESCRIPTION
    At present there is a 'todo' to check for zero volume size
    in the createVolume request which in unwanted, ie the pvc
    creation with size 0 fail from the kubernetes api validation itself:
    
    For ex:
    
    ```
    ..spec.resources[storage]: Invalid value: "0": must be greater than zero```
    ```
    so we dont need any extra check in the controller server


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

