### PR TITLE
ci: do not run commitlint GitHub Action for dependabot

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   commitlint:
     name: commitlint
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The commit messages that Dependabot (@app/dependabot) creates are not
always accepted by the commitlint check. The configuration for
dependabot does not give a lot of options to customize the message, so
instead of adjusting the message to pass commitlint, just skip the check
(Mergify does not require commitlint status either).

See-also: #2460

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
