### PR TITLE
util: make ceph.conf as configurable during installation

### DIFF
--- a/charts/ceph-csi-cephfs/templates/ceph-conf.yaml
+++ b/charts/ceph-csi-cephfs/templates/ceph-conf.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-cephfs.name" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  ceph.conf: |
+{{ tpl .Values.cephconf . | indent 4 }}
+  keyring: ""

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -118,6 +118,8 @@ spec:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - name: ceph-config
+              mountPath: /etc/ceph/
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
@@ -182,6 +184,9 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -173,6 +173,8 @@ spec:
               readOnly: true
             - name: host-dev
               mountPath: /dev
+            - name: ceph-config
+              mountPath: /etc/ceph/
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
@@ -217,6 +219,9 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -275,6 +275,26 @@ secret:
   adminID: <plaintext ID>
   adminKey: <Ceph auth key corresponding to ID above>
 
+# This is a sample configmap that helps define a Ceph configuration as required
+# by the CSI plugins.
+# Sample ceph.conf available at
+# https://github.com/ceph/ceph/blob/master/src/sample.ceph.conf Detailed
+# documentation is available at
+# https://docs.ceph.com/en/latest/rados/configuration/ceph-conf/
+cephconf: |
+  [global]
+    auth_cluster_required = cephx
+    auth_service_required = cephx
+    auth_client_required = cephx
+
+    # Workaround for http://tracker.ceph.com/issues/23446
+    fuse_set_user_groups = false
+
+    # ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
+    # adding 'fuse_big_writes = true' option by default to override this limit
+    # see https://github.com/ceph/ceph-csi/issues/1928
+    fuse_big_writes = true
+
 #########################################################
 # Variables for 'internal' use please use with caution! #
 #########################################################

--- a/charts/ceph-csi-rbd/templates/ceph-conf.yaml
+++ b/charts/ceph-csi-rbd/templates/ceph-conf.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  ceph.conf: |
+{{ tpl .Values.cephconf . | indent 4 }}
+  keyring: ""

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -114,6 +114,8 @@ spec:
               readOnly: true
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
+            - name: ceph-config
+              mountPath: /etc/ceph/
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: plugin-dir
@@ -190,6 +192,9 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -181,6 +181,8 @@ spec:
               readOnly: true
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
+            - name: ceph-config
+              mountPath: /etc/ceph/
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: keys-tmp-dir
@@ -213,6 +215,8 @@ spec:
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: ceph-config
+              mountPath: /etc/ceph/
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
 {{- end }}
@@ -254,6 +258,9 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: {{ .Values.configMapName | quote }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -372,6 +372,26 @@ secret:
   # Encryption passphrase
   encryptionPassphrase: test_passphrase
 
+# This is a sample configmap that helps define a Ceph configuration as required
+# by the CSI plugins.
+# Sample ceph.conf available at
+# https://github.com/ceph/ceph/blob/master/src/sample.ceph.conf Detailed
+# documentation is available at
+# https://docs.ceph.com/en/latest/rados/configuration/ceph-conf/
+cephconf: |
+  [global]
+    auth_cluster_required = cephx
+    auth_service_required = cephx
+    auth_client_required = cephx
+
+    # Workaround for http://tracker.ceph.com/issues/23446
+    fuse_set_user_groups = false
+
+    # ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
+    # adding 'fuse_big_writes = true' option by default to override this limit
+    # see https://github.com/ceph/ceph-csi/issues/1928
+    fuse_big_writes = true
+
 #########################################################
 # Variables for 'internal' use please use with caution! #
 #########################################################

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -143,6 +143,8 @@ spec:
               readOnly: true
             - name: host-dev
               mountPath: /dev
+            - name: ceph-config
+              mountPath: /etc/ceph/
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
@@ -181,6 +183,9 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -94,6 +94,8 @@ spec:
               mountPath: /dev
             - name: host-mount
               mountPath: /run/mount
+            - name: ceph-config
+              mountPath: /etc/ceph/
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
@@ -152,6 +154,9 @@ spec:
         - name: host-mount
           hostPath:
             path: /run/mount
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -164,6 +164,8 @@ spec:
               mountPath: /etc/ceph-csi-encryption-kms-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: ceph-config
+              mountPath: /etc/ceph/
         - name: csi-rbdplugin-controller
           securityContext:
             privileged: true
@@ -187,6 +189,8 @@ spec:
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: ceph-config
+              mountPath: /etc/ceph/
         - name: liveness-prometheus
           image: quay.io/cephcsi/cephcsi:canary
           args:
@@ -221,6 +225,9 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -113,6 +113,8 @@ spec:
               mountPath: /tmp/csi/keys
             - name: ceph-logdir
               mountPath: /var/log/ceph
+            - name: ceph-config
+              mountPath: /etc/ceph/
         - name: liveness-prometheus
           securityContext:
             privileged: true
@@ -171,6 +173,9 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+        - name: ceph-config
+          configMap:
+            name: ceph-config
         - name: ceph-csi-config
           configMap:
             name: ceph-csi-config

--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -157,6 +157,12 @@ within the Ceph CSI plugin pods. To add a specific Ceph clusters configuration
 details, refer to [Creating CSI configuration](../examples/README.md#creating-csi-configuration)
 for more information.
 
+**Deploy Ceph configuration ConfigMap for CSI pods:**
+
+```bash
+kubectl create -f ../example/ceph-config.yaml
+```
+
 **Deploy CSI sidecar containers:**
 
 ```bash

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -126,6 +126,12 @@ details, refer to [Creating CSI configuration for RBD based
 provisioning](../examples/README.md#creating-csi-configuration-for-rbd-based-provisioning)
 for more information.
 
+**Deploy Ceph configuration ConfigMap for CSI pods:**
+
+```bash
+kubectl create -f ../example/ceph-config.yaml
+```
+
 **Deploy CSI sidecar containers:**
 
 ```bash

--- a/examples/ceph-conf.yaml
+++ b/examples/ceph-conf.yaml
@@ -1,0 +1,28 @@
+---
+# This is a sample configmap that helps define a Ceph configuration as required
+# by the CSI plugins.
+
+# Sample ceph.conf available at
+# https://github.com/ceph/ceph/blob/master/src/sample.ceph.conf Detailed
+# documentation is available at
+# https://docs.ceph.com/en/latest/rados/configuration/ceph-conf/
+apiVersion: v1
+kind: ConfigMap
+data:
+  ceph.conf: |
+    [global]
+    auth_cluster_required = cephx
+    auth_service_required = cephx
+    auth_client_required = cephx
+
+    # Workaround for http://tracker.ceph.com/issues/23446
+    fuse_set_user_groups = false
+
+    # ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
+    # adding 'fuse_big_writes = true' option by default to override this limit
+    # see https://github.com/ceph/ceph-csi/issues/1928
+    fuse_big_writes = true
+  # keyring is a required key and its value should be empty
+  keyring: |
+metadata:
+  name: ceph-config

--- a/internal/util/cephconf.go
+++ b/internal/util/cephconf.go
@@ -50,11 +50,16 @@ func createCephConfigRoot() error {
 // WriteCephConfig writes out a basic ceph.conf file, making it easy to use
 // ceph related CLIs.
 func WriteCephConfig() error {
-	if err := createCephConfigRoot(); err != nil {
+	var err error
+	if err = createCephConfigRoot(); err != nil {
 		return err
 	}
 
-	err := ioutil.WriteFile(CephConfigPath, cephConfig, 0o600)
+	// create config file if it does not exist to support backward compatibility
+	if _, err = os.Stat(CephConfigPath); os.IsNotExist(err) {
+		err = ioutil.WriteFile(CephConfigPath, cephConfig, 0o600)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -71,7 +76,11 @@ if any ceph commands fails it will log below error message
 */
 // createKeyRingFile creates the keyring files to fix above error message logging.
 func createKeyRingFile() error {
-	_, err := os.Create(keyRing)
+	var err error
+	// create keyring file if it does not exist to support backward compatibility
+	if _, err = os.Stat(keyRing); os.IsNotExist(err) {
+		_, err = os.Create(keyRing)
+	}
 
 	return err
 }

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -173,9 +173,11 @@ install_cephcsi_helm_charts() {
     check_deployment_status app=ceph-csi-cephfs ${NAMESPACE}
     check_daemonset_status app=ceph-csi-cephfs ${NAMESPACE}
 
-    # deleting configmap as a workaround to avoid configmap already present
+    # deleting configmaps as a workaround to avoid configmap already present
     # issue when installing ceph-csi-rbd
     kubectl_retry delete cm ceph-csi-config --namespace ${NAMESPACE}
+    kubectl_retry delete cm ceph-config --namespace ${NAMESPACE}
+
     # shellcheck disable=SC2086
     "${HELM}" install --namespace ${NAMESPACE} --set provisioner.fullnameOverride=csi-rbdplugin-provisioner --set nodeplugin.fullnameOverride=csi-rbdplugin --set configMapName=ceph-csi-config --set provisioner.podSecurityPolicy.enabled=true --set nodeplugin.podSecurityPolicy.enabled=true --set provisioner.replicaCount=1 ${SET_SC_TEMPLATE_VALUES} ${RBD_SECRET_TEMPLATE_VALUES} ${RBD_CHART_NAME} "${SCRIPT_DIR}"/../charts/ceph-csi-rbd --set topology.enabled=true --set topology.domainLabels="{${NODE_LABEL_REGION},${NODE_LABEL_ZONE}}" --set provisioner.maxSnapshotsOnImage=3 --set provisioner.minSnapshotsOnImage=2
 


### PR DESCRIPTION
Moved the ceph.conf to a new configmap so that users can customize the ceph.conf before/after installation of cephcsi.

fixes: #1815
fixes: #1799

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Note:- this is backward compatible with older templates also

up for initial review.

TODO:-

- [x] E2E update
