### PR TITLE
ci: prevent mergify conflict message for dependabot PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,6 +26,7 @@ pull_request_rules:
   - name: ask to resolve conflict
     conditions:
       - conflict
+      - author!=dependabot[bot]
     actions:
       comment:
         # yamllint disable-line rule:truthy


### PR DESCRIPTION
There is no use in having Mergify posting messages to Dependabot and
asking for resolving of merge conflicts. Dependabot will try to do that
automatically, and posts a message when some other action is needed.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
