### PR TITLE
rbd: use String() method of MirrorImageState in return error

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -324,8 +324,7 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	case librbd.MirrorImageEnabled:
 		return disableVolumeReplication(rbdVol, mirroringInfo, force)
 	default:
-		// TODO: use string instead of int for returning valid error message
-		return nil, status.Errorf(codes.InvalidArgument, "image is in %d Mode", mirroringInfo.State)
+		return nil, status.Errorf(codes.InvalidArgument, "image is in %s Mode", mirroringInfo.State)
 	}
 
 	return &replication.DisableVolumeReplicationResponse{}, nil


### PR DESCRIPTION
MirrorImageState (type C.rbd_mirror_image_state_t) has a string
method which can be used while returning error in the replication
controller. Previously, we were using int return in the error which
is not the proper usage.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
