### PR TITLE
rbd: check for clusterid mapping in genVolFromVolumeOptions()

### DIFF
--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -595,7 +595,7 @@ func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (sn
 	cephfsSnap.RequestName = req.GetName()
 	snapOptions := req.GetParameters()
 
-	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
+	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(ctx, snapOptions, false)
 	if err != nil {
 		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -595,7 +595,11 @@ func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (sn
 	cephfsSnap.RequestName = req.GetName()
 	snapOptions := req.GetParameters()
 
-	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(ctx, snapOptions, false)
+	clusterID, err := util.GetClusterID(snapOptions)
+	if err != nil {
+		return nil, err
+	}
+	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(ctx, clusterID, false)
 	if err != nil {
 		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -123,7 +123,10 @@ func (cs *ControllerServer) parseVolCreateRequest(
 	}
 
 	// if it's NOT SINGLE_NODE_WRITER and it's BLOCK we'll set the parameter to ignore the in-use checks
-	rbdVol, err := genVolFromVolumeOptions(ctx, req.GetParameters(), req.GetSecrets(), (isMultiNode && isBlock))
+	rbdVol, err := genVolFromVolumeOptions(
+		ctx,
+		req.GetParameters(), req.GetSecrets(),
+		(isMultiNode && isBlock), false)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -178,7 +178,7 @@ func populateRbdVol(
 		disableInUseChecks = true
 	}
 
-	rv, err := genVolFromVolumeOptions(ctx, req.GetVolumeContext(), req.GetSecrets(), disableInUseChecks)
+	rv, err := genVolFromVolumeOptions(ctx, req.GetVolumeContext(), req.GetSecrets(), disableInUseChecks, true)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -866,7 +866,7 @@ func genSnapFromSnapID(
 	rbdSnap.ClusterID = vi.ClusterID
 	options["clusterID"] = rbdSnap.ClusterID
 
-	rbdSnap.Monitors, _, err = util.GetMonsAndClusterID(options)
+	rbdSnap.Monitors, _, err = util.GetMonsAndClusterID(ctx, options, false)
 	if err != nil {
 		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 
@@ -950,12 +950,11 @@ func generateVolumeFromVolumeID(
 	//              Mounter, MultiNodeWritable
 	rbdVol = &rbdVolume{}
 	rbdVol.VolID = volumeID
-	// TODO check clusterID mapping exists
 
 	rbdVol.ClusterID = vi.ClusterID
 	options["clusterID"] = rbdVol.ClusterID
 
-	rbdVol.Monitors, _, err = util.GetMonsAndClusterID(options)
+	rbdVol.Monitors, _, err = util.GetMonsAndClusterID(ctx, options, false)
 	if err != nil {
 		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 
@@ -1153,7 +1152,7 @@ func generateVolumeFromMapping(
 func genVolFromVolumeOptions(
 	ctx context.Context,
 	volOptions, credentials map[string]string,
-	disableInUseChecks bool) (*rbdVolume, error) {
+	disableInUseChecks, checkClusterIDMapping bool) (*rbdVolume, error) {
 	var (
 		ok         bool
 		err        error
@@ -1171,7 +1170,7 @@ func genVolFromVolumeOptions(
 		rbdVol.NamePrefix = namePrefix
 	}
 
-	rbdVol.Monitors, rbdVol.ClusterID, err = util.GetMonsAndClusterID(volOptions)
+	rbdVol.Monitors, rbdVol.ClusterID, err = util.GetMonsAndClusterID(ctx, volOptions, checkClusterIDMapping)
 	if err != nil {
 		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 
@@ -1248,7 +1247,7 @@ func genSnapFromOptions(ctx context.Context, rbdVol *rbdVolume, snapOptions map[
 	rbdSnap.JournalPool = rbdVol.JournalPool
 	rbdSnap.RadosNamespace = rbdVol.RadosNamespace
 
-	rbdSnap.Monitors, rbdSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
+	rbdSnap.Monitors, rbdSnap.ClusterID, err = util.GetMonsAndClusterID(ctx, snapOptions, false)
 	if err != nil {
 		log.ErrorLog(ctx, "failed getting mons (%s)", err)
 

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -131,10 +132,18 @@ func CephFSSubvolumeGroup(pathToConfig, clusterID string) (string, error) {
 
 // GetMonsAndClusterID returns monitors and clusterID information read from
 // configfile.
-func GetMonsAndClusterID(options map[string]string) (string, string, error) {
+func GetMonsAndClusterID(ctx context.Context, options map[string]string, checkClusterIDMapping bool) (string, string, error) {
 	clusterID, ok := options["clusterID"]
 	if !ok {
 		return "", "", errors.New("clusterID must be set")
+	}
+	if checkClusterIDMapping {
+		monitors, mappedClusterID, err := FetchMappedClusterIDAndMons(ctx, clusterID)
+		if err != nil {
+			return "", "", err
+		}
+
+		return monitors, mappedClusterID, nil
 	}
 
 	monitors, err := Mons(CsiConfigFile, clusterID)

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -32,6 +31,9 @@ const (
 
 	// CsiConfigFile is the location of the CSI config file.
 	CsiConfigFile = "/etc/ceph-csi-config/config.json"
+
+	// ClusterIDKey is the name of the key containing clusterID.
+	clusterIDKey = "clusterID"
 )
 
 // ClusterInfo strongly typed JSON spec for the below JSON structure.
@@ -132,11 +134,7 @@ func CephFSSubvolumeGroup(pathToConfig, clusterID string) (string, error) {
 
 // GetMonsAndClusterID returns monitors and clusterID information read from
 // configfile.
-func GetMonsAndClusterID(ctx context.Context, options map[string]string, checkClusterIDMapping bool) (string, string, error) {
-	clusterID, ok := options["clusterID"]
-	if !ok {
-		return "", "", errors.New("clusterID must be set")
-	}
+func GetMonsAndClusterID(ctx context.Context, clusterID string, checkClusterIDMapping bool) (string, string, error) {
 	if checkClusterIDMapping {
 		monitors, mappedClusterID, err := FetchMappedClusterIDAndMons(ctx, clusterID)
 		if err != nil {
@@ -152,4 +150,14 @@ func GetMonsAndClusterID(ctx context.Context, options map[string]string, checkCl
 	}
 
 	return monitors, clusterID, nil
+}
+
+// GetClusterID fetches clusterID from given options map.
+func GetClusterID(options map[string]string) (string, error) {
+	clusterID, ok := options[clusterIDKey]
+	if !ok {
+		return "", ErrClusterIDNotSet
+	}
+
+	return clusterID, nil
 }

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -33,6 +33,8 @@ var (
 	ErrSnapNameConflict = errors.New("snapshot name conflict")
 	// ErrPoolNotFound is returned when pool is not found.
 	ErrPoolNotFound = errors.New("pool not found")
+	// ErrClusterIDNotSet is returned when cluster id is not set.
+	ErrClusterIDNotSet = errors.New("clusterID must be set")
 )
 
 type errorPair struct {


### PR DESCRIPTION
This commit adds capability to genVolFromVolumeOptions() to fetch
mapped clusted-id & mon-ips for mirrored PVC on secondary cluster
which may have different cluster-id.

This is required for NodeStageVolume().

We also don't need to check for mapping during volume create requests,
so it can be disabled by passing a bool checkClusterIDMapping as false.


Signed-off-by: Rakshith R <rar@redhat.com>
