### PR TITLE
cleanup: refactor cephfs util  helper functions

### DIFF
--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -26,8 +26,6 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 )
 
-type volumeID string
-
 func parseTime(ctx context.Context, createTime time.Time) (*timestamp.Timestamp, error) {
 	tm, err := ptypes.TimestampProto(createTime)
 	if err != nil {

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/golang/protobuf/ptypes"
@@ -28,12 +27,6 @@ import (
 )
 
 type volumeID string
-
-func execCommandErr(ctx context.Context, program string, args ...string) error {
-	_, _, err := util.ExecCommand(ctx, program, args...)
-
-	return err
-}
 
 func parseTime(ctx context.Context, createTime time.Time) (*timestamp.Timestamp, error) {
 	tm, err := ptypes.TimestampProto(createTime)

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
-	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 )
@@ -34,24 +33,6 @@ func execCommandErr(ctx context.Context, program string, args ...string) error {
 	_, _, err := util.ExecCommand(ctx, program, args...)
 
 	return err
-}
-
-func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (snap *cephfsSnapshot, err error) {
-	cephfsSnap := &cephfsSnapshot{}
-	cephfsSnap.RequestName = req.GetName()
-	snapOptions := req.GetParameters()
-
-	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
-	if err != nil {
-		log.ErrorLog(ctx, "failed getting mons (%s)", err)
-
-		return nil, err
-	}
-	if namePrefix, ok := snapOptions["snapshotNamePrefix"]; ok {
-		cephfsSnap.NamePrefix = namePrefix
-	}
-
-	return cephfsSnap, nil
 }
 
 func parseTime(ctx context.Context, createTime time.Time) (*timestamp.Timestamp, error) {

--- a/internal/cephfs/util.go
+++ b/internal/cephfs/util.go
@@ -18,7 +18,6 @@ package cephfs
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/ceph/ceph-csi/internal/util"
@@ -27,8 +26,6 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type volumeID string
@@ -37,91 +34,6 @@ func execCommandErr(ctx context.Context, program string, args ...string) error {
 	_, _, err := util.ExecCommand(ctx, program, args...)
 
 	return err
-}
-
-// Controller service request validation.
-func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
-	if err := cs.Driver.ValidateControllerServiceRequest(
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
-		return fmt.Errorf("invalid CreateVolumeRequest: %w", err)
-	}
-
-	if req.GetName() == "" {
-		return status.Error(codes.InvalidArgument, "volume Name cannot be empty")
-	}
-
-	reqCaps := req.GetVolumeCapabilities()
-	if reqCaps == nil {
-		return status.Error(codes.InvalidArgument, "volume Capabilities cannot be empty")
-	}
-
-	for _, capability := range reqCaps {
-		if capability.GetBlock() != nil {
-			return status.Error(codes.Unimplemented, "block volume not supported")
-		}
-	}
-
-	// Allow readonly access mode for volume with content source
-	err := util.CheckReadOnlyManyIsSupported(req)
-	if err != nil {
-		return err
-	}
-
-	if req.VolumeContentSource != nil {
-		volumeSource := req.VolumeContentSource
-		switch volumeSource.Type.(type) {
-		case *csi.VolumeContentSource_Snapshot:
-			snapshot := req.VolumeContentSource.GetSnapshot()
-			// CSI spec requires returning NOT_FOUND when the volumeSource is missing/incorrect.
-			if snapshot == nil {
-				return status.Error(codes.NotFound, "volume Snapshot cannot be empty")
-			}
-			if snapshot.GetSnapshotId() == "" {
-				return status.Error(codes.NotFound, "volume Snapshot ID cannot be empty")
-			}
-		case *csi.VolumeContentSource_Volume:
-			// CSI spec requires returning NOT_FOUND when the volumeSource is missing/incorrect.
-			vol := req.VolumeContentSource.GetVolume()
-			if vol == nil {
-				return status.Error(codes.NotFound, "volume cannot be empty")
-			}
-			if vol.GetVolumeId() == "" {
-				return status.Error(codes.NotFound, "volume ID cannot be empty")
-			}
-
-		default:
-			return status.Error(codes.InvalidArgument, "unsupported volume data source")
-		}
-	}
-
-	return nil
-}
-
-func (cs *ControllerServer) validateDeleteVolumeRequest() error {
-	if err := cs.Driver.ValidateControllerServiceRequest(
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
-		return fmt.Errorf("invalid DeleteVolumeRequest: %w", err)
-	}
-
-	return nil
-}
-
-// Controller expand volume request validation.
-func (cs *ControllerServer) validateExpandVolumeRequest(req *csi.ControllerExpandVolumeRequest) error {
-	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_EXPAND_VOLUME); err != nil {
-		return fmt.Errorf("invalid ExpandVolumeRequest: %w", err)
-	}
-
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
-	}
-
-	capRange := req.GetCapacityRange()
-	if capRange == nil {
-		return status.Error(codes.InvalidArgument, "CapacityRange cannot be empty")
-	}
-
-	return nil
 }
 
 func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (snap *cephfsSnapshot, err error) {

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"fmt"
+
+	"github.com/ceph/ceph-csi/internal/util"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Controller service request validation.
+func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
+		return fmt.Errorf("invalid CreateVolumeRequest: %w", err)
+	}
+
+	if req.GetName() == "" {
+		return status.Error(codes.InvalidArgument, "volume Name cannot be empty")
+	}
+
+	reqCaps := req.GetVolumeCapabilities()
+	if reqCaps == nil {
+		return status.Error(codes.InvalidArgument, "volume Capabilities cannot be empty")
+	}
+
+	for _, capability := range reqCaps {
+		if capability.GetBlock() != nil {
+			return status.Error(codes.Unimplemented, "block volume not supported")
+		}
+	}
+
+	// Allow readonly access mode for volume with content source
+	err := util.CheckReadOnlyManyIsSupported(req)
+	if err != nil {
+		return err
+	}
+
+	if req.VolumeContentSource != nil {
+		volumeSource := req.VolumeContentSource
+		switch volumeSource.Type.(type) {
+		case *csi.VolumeContentSource_Snapshot:
+			snapshot := req.VolumeContentSource.GetSnapshot()
+			// CSI spec requires returning NOT_FOUND when the volumeSource is missing/incorrect.
+			if snapshot == nil {
+				return status.Error(codes.NotFound, "volume Snapshot cannot be empty")
+			}
+			if snapshot.GetSnapshotId() == "" {
+				return status.Error(codes.NotFound, "volume Snapshot ID cannot be empty")
+			}
+		case *csi.VolumeContentSource_Volume:
+			// CSI spec requires returning NOT_FOUND when the volumeSource is missing/incorrect.
+			vol := req.VolumeContentSource.GetVolume()
+			if vol == nil {
+				return status.Error(codes.NotFound, "volume cannot be empty")
+			}
+			if vol.GetVolumeId() == "" {
+				return status.Error(codes.NotFound, "volume ID cannot be empty")
+			}
+
+		default:
+			return status.Error(codes.InvalidArgument, "unsupported volume data source")
+		}
+	}
+
+	return nil
+}
+
+func (cs *ControllerServer) validateDeleteVolumeRequest() error {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
+		return fmt.Errorf("invalid DeleteVolumeRequest: %w", err)
+	}
+
+	return nil
+}
+
+// Controller expand volume request validation.
+func (cs *ControllerServer) validateExpandVolumeRequest(req *csi.ControllerExpandVolumeRequest) error {
+	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_EXPAND_VOLUME); err != nil {
+		return fmt.Errorf("invalid ExpandVolumeRequest: %w", err)
+	}
+
+	if req.GetVolumeId() == "" {
+		return status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
+	}
+
+	capRange := req.GetCapacityRange()
+	if capRange == nil {
+		return status.Error(codes.InvalidArgument, "CapacityRange cannot be empty")
+	}
+
+	return nil
+}

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Controller service request validation.
+// validateCreateVolumeRequest validates the Controller CreateVolume request.
 func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -94,7 +94,7 @@ func (cs *ControllerServer) validateDeleteVolumeRequest() error {
 	return nil
 }
 
-// Controller expand volume request validation.
+// validateExpandVolumeRequest validates the Controller ExpandVolume request.
 func (cs *ControllerServer) validateExpandVolumeRequest(req *csi.ControllerExpandVolumeRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_EXPAND_VOLUME); err != nil {
 		return fmt.Errorf("invalid ExpandVolumeRequest: %w", err)

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -84,6 +84,7 @@ func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeReq
 	return nil
 }
 
+// validateDeleteVolumeRequest validates the Controller DeleteVolume request.
 func (cs *ControllerServer) validateDeleteVolumeRequest() error {
 	if err := cs.Driver.ValidateControllerServiceRequest(
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {

--- a/internal/cephfs/volumemounter.go
+++ b/internal/cephfs/volumemounter.go
@@ -66,6 +66,12 @@ var (
 	}
 )
 
+func execCommandErr(ctx context.Context, program string, args ...string) error {
+	_, _, err := util.ExecCommand(ctx, program, args...)
+
+	return err
+}
+
 // Load available ceph mounters installed on system into availableMounters
 // Called from driver.go's Run().
 func loadAvailableMounters(conf *util.Config) error {

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -30,6 +30,8 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
+type volumeID string
+
 type volumeOptions struct {
 	TopologyPools       *[]util.TopologyConstrainedPool
 	TopologyRequirement *csi.TopologyRequirement

--- a/internal/cephfs/volumeoptions.go
+++ b/internal/cephfs/volumeoptions.go
@@ -27,6 +27,7 @@ import (
 
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 type volumeOptions struct {
@@ -585,4 +586,22 @@ func newSnapshotOptionsFromID(
 	}
 
 	return &volOptions, &info, &sid, nil
+}
+
+func genSnapFromOptions(ctx context.Context, req *csi.CreateSnapshotRequest) (snap *cephfsSnapshot, err error) {
+	cephfsSnap := &cephfsSnapshot{}
+	cephfsSnap.RequestName = req.GetName()
+	snapOptions := req.GetParameters()
+
+	cephfsSnap.Monitors, cephfsSnap.ClusterID, err = util.GetMonsAndClusterID(snapOptions)
+	if err != nil {
+		log.ErrorLog(ctx, "failed getting mons (%s)", err)
+
+		return nil, err
+	}
+	if namePrefix, ok := snapOptions["snapshotNamePrefix"]; ok {
+		cephfsSnap.NamePrefix = namePrefix
+	}
+
+	return cephfsSnap, nil
 }


### PR DESCRIPTION
as part of the refactoring, moving the help functions to new files with the appropriate name and also moved few functions to the caller files as there were no multiple consumers.

updates #852

Signed-off-by: Madhu Rajanna madhupr007@gmail.com