### PR TITLE
util: read ceph.conf by calling conn.ReadConfigFile(CephConfigPath)

### DIFF
--- a/internal/util/conn_pool.go
+++ b/internal/util/conn_pool.go
@@ -145,6 +145,10 @@ func (cp *ConnPool) Get(monitors, user, keyfile string) (*rados.Conn, error) {
 		return nil, fmt.Errorf("parsing cmdline args (%v) failed: %w", args, err)
 	}
 
+	if err = conn.ReadConfigFile(CephConfigPath); err != nil {
+		return nil, fmt.Errorf("failed to read config file %q: %w", CephConfigPath, err)
+	}
+
 	err = conn.Connect()
 	if err != nil {
 		return nil, fmt.Errorf("connecting failed: %w", err)


### PR DESCRIPTION
The configurations in cpeh.conf is not picked up by rados connection
automatically, hence we need to call conn.ReadConfigFile before calling
Connect().

Signed-off-by: Rakshith R <rar@redhat.com>
Screenshot from test trial run. 
Configu
![image](https://user-images.githubusercontent.com/31369230/132341344-67e69b8a-ce4d-469e-8def-15874e3091d3.png)
