### PR TITLE
util: call WriteCephConfig() in cephcsi.go

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -210,6 +210,10 @@ func main() {
 		}
 	}
 
+	if err = util.WriteCephConfig(); err != nil {
+		log.FatalLogMsg("failed to write ceph configuration file (%v)", err)
+	}
+
 	log.DefaultLog("Starting driver type: %v with name: %v", conf.Vtype, dname)
 	switch conf.Vtype {
 	case rbdType:

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -97,10 +97,6 @@ func (fs *Driver) Run(conf *util.Config) {
 		log.FatalLogMsg("cephfs: failed to load ceph mounters: %v", err)
 	}
 
-	if err = util.WriteCephConfig(); err != nil {
-		log.FatalLogMsg("failed to write ceph configuration file: %v", err)
-	}
-
 	// Use passed in instance ID, if provided for omap suffix naming
 	if conf.InstanceID != "" {
 		CSIInstanceID = conf.InstanceID

--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -106,11 +106,6 @@ func (r *Driver) Run(conf *util.Config) {
 	var err error
 	var topology map[string]string
 
-	// Create ceph.conf for use with CLI commands
-	if err = util.WriteCephConfig(); err != nil {
-		log.FatalLogMsg("failed to write ceph configuration file (%v)", err)
-	}
-
 	// Use passed in instance ID, if provided for omap suffix naming
 	if conf.InstanceID != "" {
 		CSIInstanceID = conf.InstanceID


### PR DESCRIPTION
This commit calls WriteCephConfig() in cephcsi.go to
create ceph.conf and keyring if it is not mounted to
be used by all cli calls and conn cmds.

Before this change, rbd-controller/omap-generator did not create
ceph.conf on startup.

Signed-off-by: Rakshith R <rar@redhat.com>
