### PR TITLE
ci : remove support for backward compatibility for psp

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -163,7 +163,7 @@ CSI_NODE_DRIVER_REGISTRAR_VERSION=${CSI_NODE_DRIVER_REGISTRAR_VERSION:-"v2.2.0"}
 K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-"ExpandCSIVolumes=true"}
 
 #extra-config for kube https://minikube.sigs.k8s.io/docs/reference/configuration/kubernetes/
-EXTRA_CONFIG_PSP="--extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy"
+EXTRA_CONFIG_PSP="--extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy --addons=pod-security-policy"
 
 # kubelet.resolv-conf needs to point to a file, not a symlink
 # the default minikube VM has /etc/resolv.conf -> /run/systemd/resolve/resolv.conf


### PR DESCRIPTION
This PR does below

remove minikube workaround for PSP:- as we are no longer using older (<1.11.1) version of minikube, removing the workaround to support the PSP with older minikube versions.

start minikube with PSP addon:-  we need to start minikube with the PodSecurityPolicy admission controller and the pod-security-policy addon enabled for PSP.
    
 Ref:- https://minikube.sigs.k8s.io/docs/tutorials/using_psp/#tutorial

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>