### PR TITLE
util: get clusterID for the passed in mon string

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1435,6 +1435,24 @@ var _ = Describe("RBD", func() {
 				validateRBDImageCount(f, 0, defaultRBDPool)
 			})
 
+			By("validate RBD migration+static FileSystem PVC", func() {
+				err := validateRBDStaticMigrationPV(f, appPath, false)
+				if err != nil {
+					e2elog.Failf("failed to validate rbd migrated static pv with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+			})
+
+			By("validate RBD migration+static Block PVC", func() {
+				err := validateRBDStaticMigrationPV(f, rawAppPath, true)
+				if err != nil {
+					e2elog.Failf("failed to validate rbd migrated static block pv with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+			})
+
 			By("validate failure of RBD static PVC without imageFeatures parameter", func() {
 				err := validateRBDStaticPV(f, rawAppPath, true, true)
 				if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -73,6 +73,10 @@ const (
 	// thick provisioned or thin provisioned.
 	thickProvisionMetaData = "true"
 	thinProvisionMetaData  = "false"
+
+	// these are the migration label key and value for parameters in volume context.
+	intreeMigrationKey   = "migration"
+	intreeMigrationLabel = "true"
 )
 
 // rbdImage contains common attributes and methods for the rbdVolume and

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -34,7 +34,7 @@ func cleanupTestData() {
 	os.RemoveAll(basePath)
 }
 
-//  nolint:gocyclo,cyclop // TODO: make this function less complex.
+// nolint:gocyclo,cyclop // TODO: make this function less complex.
 func TestCSIConfig(t *testing.T) {
 	t.Parallel()
 	var err error

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -34,7 +34,7 @@ func cleanupTestData() {
 	os.RemoveAll(basePath)
 }
 
-// TODO: make this function less complex.
+//  nolint:gocyclo,cyclop // TODO: make this function less complex.
 func TestCSIConfig(t *testing.T) {
 	t.Parallel()
 	var err error
@@ -131,5 +131,43 @@ func TestCSIConfig(t *testing.T) {
 	content, err = Mons(pathToConfig, clusterID1)
 	if err != nil || content != "mon4,mon5,mon6" {
 		t.Errorf("Failed: want (%s), got (%s) (%v)", "mon4,mon5,mon6", content, err)
+	}
+
+	data = "[{\"clusterID\":\"" + clusterID2 + "\",\"monitors\":[\"mon1\",\"mon2\",\"mon3\"]}," +
+		"{\"clusterID\":\"" + clusterID1 + "\",\"monitors\":[\"mon4\",\"mon5\",\"mon6\"]}]"
+	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	if err != nil {
+		t.Errorf("Test setup error %s", err)
+	}
+
+	// TEST: Should pass as clusterID is present in config
+	content, err = readClusterInfoWithMon(pathToConfig, "mon1")
+	if err != nil || content != "test2" {
+		t.Errorf("Failed: want (%s), got (%s) (%v)", "test2", content, err)
+	}
+
+	// TEST: Should pass as clusterID is present in config
+	content, err = readClusterInfoWithMon(pathToConfig, "mon5")
+	if err != nil || content != "test1" {
+		t.Errorf("Failed: want (%s), got (%s) (%v)", "test1", content, err)
+	}
+
+	// TEST: Should fail as clusterID is not present in config
+	content, err = readClusterInfoWithMon(pathToConfig, "mon8")
+	if err == nil {
+		t.Errorf("Failed: got (%s)", content)
+	}
+
+	data = "[{\"clusterID\":\"" + clusterID2 + "\", \"radosNamespace\": \"ns1\", \"monitors\":[\"mon1\"]}," +
+		"{\"clusterID\":\"" + clusterID1 + "\",\"monitors\":[\"mon1\"]}]"
+	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	if err != nil {
+		t.Errorf("Test setup error %s", err)
+	}
+
+	// TEST: Should pass as clusterID is present in config
+	content, err = readClusterInfoWithMon(pathToConfig, "mon1")
+	if err != nil || content != clusterID1 {
+		t.Errorf("Failed: want (%s), got (%s) (%v)", "test2", content, err)
 	}
 }

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -35,6 +35,8 @@ var (
 	ErrPoolNotFound = errors.New("pool not found")
 	// ErrClusterIDNotSet is returned when cluster id is not set.
 	ErrClusterIDNotSet = errors.New("clusterID must be set")
+	// ErrMissingConfigForMonitor is returned when clusterID is not found for the mon.
+	ErrMissingConfigForMonitor = errors.New("missing configuration of cluster ID for monitor")
 )
 
 type errorPair struct {


### PR DESCRIPTION
as part of migration support, the clusterID has to be fetched
from passed in mon. Because the intree RBD storage class only
got monitor and not `clusterID` parameter support. However, in
CSI, SC has the `clusterID` parameter support but not mon. Due
to that we have to fetch the clusterID from config file for the
passed in mon and use it in our operations. This adds a helper
function to retrieve clusterID from passed in mon string.

Updates https://github.com/ceph/ceph-csi/issues/2509

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
