### PR TITLE
build: set build environment variables

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -13,6 +13,7 @@ jobs:
   push:
     name: Publish artifacts
     runs-on: ubuntu-latest
+    if: github.repository == 'ceph/ceph-csi'
     steps:
       - uses: actions/checkout@v2
 
@@ -27,9 +28,13 @@ jobs:
         if: github.ref == 'refs/heads/devel'
         run: echo "BRANCH_NAME=devel" >> $GITHUB_ENV
 
+      - name: Set build environment variables
+        run: |
+          echo "GITHUB_USER=${{ secrets.CEPH_CSI_BOT_NAME }}" >> $GITHUB_ENV
+          echo "GITHUB_EMAIL=${{ secrets.CEPH_CSI_BOT_EMAIL }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.CEPH_CSI_BOT_TOKEN }}" >> $GITHUB_ENV
       - name: publish artifacts
         # podman cannot pull images with both tag and digest
         # https://github.com/containers/buildah/issues/1407
         # use docker to build images
-        # yamllint disable-line rule:line-length
-        run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} CONTAINER_CMD=docker ./deploy.sh
+        run: CONTAINER_CMD=docker ./deploy.sh


### PR DESCRIPTION
Currently, GitHub action is failing to push the helm charts and some changes from #2151 need to be backported to release-v3.3 branch

Note:- build is failing at https://github.com/ceph/ceph-csi/runs/3628967761?check_suite_focus=true
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

