### PR TITLE
cleanup: remove extra permission in templates

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
@@ -29,7 +29,6 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
     - pathPrefix: '/dev'

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -84,8 +84,6 @@ spec:
           env:
             - name: ADDRESS
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -158,11 +156,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/ceph-csi-cephfs/templates/provisioner-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-psp.yaml
@@ -10,12 +10,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - 'SYS_ADMIN'
   fsGroup:
     rule: RunAsAny
-  privileged: true
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -27,7 +23,6 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
     - pathPrefix: '/dev'

--- a/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
@@ -29,7 +29,6 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
     - pathPrefix: '/dev'

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -105,8 +105,6 @@ spec:
           env:
             - name: ADDRESS
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -164,11 +162,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -205,11 +198,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
           volumeMounts:
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/

--- a/charts/ceph-csi-rbd/templates/provisioner-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-psp.yaml
@@ -10,12 +10,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - 'SYS_ADMIN'
   fsGroup:
     rule: RunAsAny
-  privileged: true
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -27,7 +23,6 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
     - pathPrefix: '/dev'

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -86,8 +86,6 @@ spec:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -106,10 +104,6 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
           image: quay.io/cephcsi/cephcsi:canary
           args:

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
@@ -23,7 +23,6 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
     - pathPrefix: '/dev'

--- a/deploy/cephfs/kubernetes/csi-provisioner-psp.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-psp.yaml
@@ -4,12 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: cephfs-csi-provisioner-psp
 spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - 'SYS_ADMIN'
   fsGroup:
     rule: RunAsAny
-  privileged: true
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -21,7 +17,6 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
     - pathPrefix: '/dev'

--- a/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
@@ -22,9 +22,8 @@ spec:
     - 'configMap'
     - 'emptyDir'
     - 'projected'
-    - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
+    - 'secret'
   allowedHostPaths:
     - pathPrefix: '/dev'
       readOnly: false

--- a/deploy/rbd/kubernetes/csi-provisioner-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-psp.yaml
@@ -4,12 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: rbd-csi-provisioner-psp
 spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - 'SYS_ADMIN'
   fsGroup:
     rule: RunAsAny
-  privileged: true
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -21,7 +17,6 @@ spec:
     - 'emptyDir'
     - 'projected'
     - 'secret'
-    - 'downwardAPI'
     - 'hostPath'
   allowedHostPaths:
     - pathPrefix: '/dev'

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -77,8 +77,6 @@ spec:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -113,10 +111,6 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
           image: quay.io/cephcsi/cephcsi:canary
           args:
@@ -167,10 +161,6 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: csi-rbdplugin-controller
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
           # for stable functionality replace canary with latest release version
           image: quay.io/cephcsi/cephcsi:canary
           args:

--- a/scripts/snapshot-controller-psp.yaml
+++ b/scripts/snapshot-controller-psp.yaml
@@ -19,9 +19,8 @@ spec:
   volumes:
     - "configMap"
     - "emptyDir"
-    - "projected"
     - "secret"
-    - "downwardAPI"
+    - "projected"
     - "hostPath"
 
 ---


### PR DESCRIPTION
This PR removes all the extra permissions provided for CephFS, RBD, and snapshot templates and also it removes extra PSP permission and helps us to keep the minimal permission required for cephcsi to work.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>