### PR TITLE
ci: disable fsGroupChangePolicy change test for cephfs

### DIFF
--- a/scripts/k8s-storage/driver-cephfs.yaml
+++ b/scripts/k8s-storage/driver-cephfs.yaml
@@ -34,7 +34,7 @@ DriverInfo:
     persistence: true
 
     # Volume ownership via fsGroup
-    fsGroup: true
+    fsGroup: false
 
     # Raw block mode
     block: false


### PR DESCRIPTION
Instead of failing the test suite on all the PR's disabling fsGroupChangePolicy test suite for cephfs for now.

updates: #2017

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

