### PR TITLE
ci: automatically run k8s-e2e-external-storage/1.22 job

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -7,7 +7,7 @@
       - '1.21':
           only_run_on_request: false
       - '1.22':
-          only_run_on_request: true
+          only_run_on_request: false
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 


### PR DESCRIPTION
The job is currently stable and passes usually. It can now be used for
validation.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
