### PR TITLE
RBD: Fix encrypted restore with different kms config

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1102,7 +1102,8 @@ var _ = Describe("RBD", func() {
 						snapshotPath,
 						pvcClonePath,
 						appClonePath,
-						noKMS,
+						noKMS, noKMS,
+						defaultSCName,
 						f)
 				}
 			})
@@ -1169,7 +1170,11 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 
-				validatePVCSnapshot(1, pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath, vaultKMS, f)
+				validatePVCSnapshot(1,
+					pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath,
+					vaultKMS, vaultKMS,
+					defaultSCName,
+					f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1186,6 +1186,63 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("Validate PVC restore from vaultKMS to vaultTenantSAKMS", func() {
+				if !k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
+					Skip("pvc clone is only supported from v1.16+")
+				}
+				restoreSCName := "restore-sc"
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass: %v", err)
+				}
+				scOpts := map[string]string{
+					"encrypted":       "true",
+					"encryptionKMSID": "vault-test",
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+
+				scOpts = map[string]string{
+					"encrypted":       "true",
+					"encryptionKMSID": "vault-tenant-sa-test",
+				}
+				err = createRBDStorageClass(f.ClientSet, f, restoreSCName, nil, scOpts, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+
+				err = createTenantServiceAccount(f.ClientSet, f.UniqueName)
+				if err != nil {
+					e2elog.Failf("failed to create ServiceAccount: %v", err)
+				}
+				defer deleteTenantServiceAccount(f.UniqueName)
+
+				validatePVCSnapshot(1,
+					pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath,
+					vaultKMS, vaultTenantSAKMS,
+					restoreSCName, f)
+
+				err = retryKubectlArgs(cephCSINamespace, kubectlDelete, deployTimeout, "storageclass", restoreSCName)
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass %q: %v", restoreSCName, err)
+				}
+
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass: %v", err)
+				}
+
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+			})
+
 			By("create an encrypted PVC-PVC clone and bind it to an app", func() {
 				if !k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					Skip("pvc clone is only supported from v1.16+")

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1243,6 +1243,78 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("Validate thick PVC restore from vaultKMS to userSecretsMetadataKMS", func() {
+				if !k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
+					Skip("pvc clone is only supported from v1.16+")
+				}
+				restoreSCName := "restore-sc"
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass: %v", err)
+				}
+				scOpts := map[string]string{
+					"encrypted":       "true",
+					"encryptionKMSID": "vault-test",
+					"thickProvision":  "true",
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+
+				scOpts = map[string]string{
+					"encrypted":       "true",
+					"encryptionKMSID": "user-secrets-metadata-test",
+					"thickProvision":  "true",
+				}
+				err = createRBDStorageClass(f.ClientSet, f, restoreSCName, nil, scOpts, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+
+				// PVC creation namespace where secret will be created
+				namespace := f.UniqueName
+
+				// create user Secret
+				err = retryKubectlFile(namespace, kubectlCreate, vaultExamplePath+vaultUserSecret, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create user Secret: %v", err)
+				}
+
+				validatePVCSnapshot(1,
+					pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath,
+					vaultKMS, secretsMetadataKMS,
+					restoreSCName, f)
+
+				// delete user secret
+				err = retryKubectlFile(namespace,
+					kubectlDelete,
+					vaultExamplePath+vaultUserSecret,
+					deployTimeout,
+					"--ignore-not-found=true")
+				if err != nil {
+					e2elog.Failf("failed to delete user Secret: %v", err)
+				}
+
+				err = retryKubectlArgs(cephCSINamespace, kubectlDelete, deployTimeout, "storageclass", restoreSCName)
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass %q: %v", restoreSCName, err)
+				}
+
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass: %v", err)
+				}
+
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+			})
+
 			By("create an encrypted PVC-PVC clone and bind it to an app", func() {
 				if !k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					Skip("pvc clone is only supported from v1.16+")

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1358,6 +1358,7 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 // retryKubectlArgs takes a namespace and action telling kubectl what to do
 // with the passed arguments. This function retries until no error occurred, or
 // the timeout passed.
+// nolint:unparam // retryKubectlArgs will be used with kubectlDelete arg later on.
 func retryKubectlArgs(namespace string, action kubectlAction, t int, args ...string) error {
 	timeout := time.Duration(t) * time.Minute
 	args = append([]string{string(action)}, args...)

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -161,7 +161,7 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 	}
 
 	if parentVol.isEncrypted() {
-		err = parentVol.copyEncryptionConfig(&rv.rbdImage)
+		err = parentVol.copyEncryptionConfig(&rv.rbdImage, false)
 		if err != nil {
 			return fmt.Errorf("failed to copy encryption config for %q: %w", rv, err)
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1105,7 +1105,7 @@ func cloneFromSnapshot(
 	defer vol.Destroy()
 
 	if rbdVol.isEncrypted() {
-		err = rbdVol.copyEncryptionConfig(&vol.rbdImage)
+		err = rbdVol.copyEncryptionConfig(&vol.rbdImage, false)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -1224,7 +1224,7 @@ func (cs *ControllerServer) doSnapshotClone(
 	}()
 
 	if parentVol.isEncrypted() {
-		cryptErr := parentVol.copyEncryptionConfig(&cloneRbd.rbdImage)
+		cryptErr := parentVol.copyEncryptionConfig(&cloneRbd.rbdImage, false)
 		if cryptErr != nil {
 			log.WarningLog(ctx, "failed copy encryption "+
 				"config for %q: %v", cloneRbd, cryptErr)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -603,6 +603,10 @@ func (cs *ControllerServer) createVolumeFromSnapshot(
 		if err != nil {
 			return status.Errorf(codes.Internal, "failed to mark %q thick-provisioned: %s", rbdVol, err)
 		}
+		err = parentVol.copyEncryptionConfig(&rbdVol.rbdImage, true)
+		if err != nil {
+			return status.Errorf(codes.Internal, err.Error())
+		}
 	} else {
 		// create clone image and delete snapshot
 		err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap, parentVol)

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -334,7 +334,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 	}
 
 	if parentVol != nil && parentVol.isEncrypted() {
-		err = parentVol.copyEncryptionConfig(&rv.rbdImage)
+		err = parentVol.copyEncryptionConfig(&rv.rbdImage, false)
 		if err != nil {
 			log.ErrorLog(ctx, err.Error())
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1400,7 +1400,7 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(
 	if pSnapOpts.isEncrypted() {
 		pSnapOpts.conn = rv.conn.Copy()
 
-		err = pSnapOpts.copyEncryptionConfig(&rv.rbdImage)
+		err = pSnapOpts.copyEncryptionConfig(&rv.rbdImage, true)
 		if err != nil {
 			return fmt.Errorf("failed to clone encryption config: %w", err)
 		}


### PR DESCRIPTION
- rbd: modify copyEncryptionConfig to accept copyOnlyPassphrase arg 

`During PVC snapshot/clone both kms config and passphrase needs to copied,
while for PVC restore only passphrase needs to be copied to dest rbdvol
since destination storageclass may have another kms config.`

- e2e: modify validatePVCSnapshot() to use restoreSCName & restoreKMS

- e2e: add testcase for PVC restore from vaultKMS to vaultTenantSAKMS 
- e2e: add test for PVC restore from vaultKMS to userSecretMetadataKMS


Example of failed e2e run when vaultTenantSAKMS is used as restore SC 
https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e_k8s-1.20/detail/mini-e2e_k8s-1.20/2627/pipeline

search for `secret ID` , mount fails because it can't find encryption passphrase.