### PR TITLE
e2e: set rbd-nbd mounter tests cephLogStrategy to preserve

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -60,7 +60,8 @@ var (
 	snapshotPath           = rbdExamplePath + "snapshot.yaml"
 	defaultCloneCount      = 10
 
-	nbdMapOptions = "debug-rbd=20"
+	nbdMapOptions             = "debug-rbd=20"
+	e2eDefaultCephLogStrategy = "preserve"
 )
 
 func deployRBDPlugin() {
@@ -477,8 +478,9 @@ var _ = Describe("RBD", func() {
 					defaultSCName,
 					nil,
 					map[string]string{
-						"mounter":    "rbd-nbd",
-						"mapOptions": nbdMapOptions,
+						"mounter":         "rbd-nbd",
+						"mapOptions":      nbdMapOptions,
+						"cephLogStrategy": e2eDefaultCephLogStrategy,
 					},
 					deletePolicy)
 				if err != nil {
@@ -513,8 +515,9 @@ var _ = Describe("RBD", func() {
 						defaultSCName,
 						nil,
 						map[string]string{
-							"mounter":    "rbd-nbd",
-							"mapOptions": nbdMapOptions,
+							"mounter":         "rbd-nbd",
+							"mapOptions":      nbdMapOptions,
+							"cephLogStrategy": e2eDefaultCephLogStrategy,
 						},
 						deletePolicy)
 					if err != nil {
@@ -558,8 +561,9 @@ var _ = Describe("RBD", func() {
 					defaultSCName,
 					nil,
 					map[string]string{
-						"mounter":    "rbd-nbd",
-						"mapOptions": nbdMapOptions,
+						"mounter":         "rbd-nbd",
+						"mapOptions":      nbdMapOptions,
+						"cephLogStrategy": e2eDefaultCephLogStrategy,
 					},
 					deletePolicy)
 				if err != nil {
@@ -712,9 +716,10 @@ var _ = Describe("RBD", func() {
 					defaultSCName,
 					nil,
 					map[string]string{
-						"mounter":    "rbd-nbd",
-						"mapOptions": nbdMapOptions,
-						"encrypted":  "true",
+						"mounter":         "rbd-nbd",
+						"mapOptions":      nbdMapOptions,
+						"cephLogStrategy": e2eDefaultCephLogStrategy,
+						"encrypted":       "true",
 					},
 					deletePolicy)
 				if err != nil {
@@ -1069,9 +1074,10 @@ var _ = Describe("RBD", func() {
 						defaultSCName,
 						nil,
 						map[string]string{
-							"imageFeatures": "layering,journaling,exclusive-lock",
-							"mounter":       "rbd-nbd",
-							"mapOptions":    nbdMapOptions,
+							"imageFeatures":   "layering,journaling,exclusive-lock",
+							"mounter":         "rbd-nbd",
+							"mapOptions":      nbdMapOptions,
+							"cephLogStrategy": e2eDefaultCephLogStrategy,
 						},
 						deletePolicy)
 					if err != nil {


### PR DESCRIPTION
# Describe what this PR does #

This is to preserve the rbd-nbd logs post unmap, so that the CI can dump
the available logs from logdir.

Fixes: #2451
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
