### PR TITLE
rbd: migration secret support

### DIFF
--- a/e2e/ceph_user.go
+++ b/e2e/ceph_user.go
@@ -21,6 +21,8 @@ const (
 	rbdProvisionerSecretName          = "cephcsi-rbd-provisioner"
 	rbdNamespaceNodePluginSecretName  = "cephcsi-rbd-ns-node"
 	rbdNamespaceProvisionerSecretName = "cephcsi-rbd-ns-provisioner"
+	rbdMigrationNodePluginSecretName  = "cephcsi-rbd-mig-node"
+	rbdMigrationProvisionerSecretName = "cephcsi-rbd-mig-provisioner"
 	cephFSNodePluginSecretName        = "cephcsi-cephfs-node"
 	cephFSProvisionerSecretName       = "cephcsi-cephfs-provisioner"
 )

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -374,7 +374,9 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to generate clusterID configmap with error %v", err)
 				}
-				err = createRBDStorageClass(f.ClientSet, f, "migrationsc", nil, nil, deletePolicy)
+
+				// create a sc with different migration secret
+				err = createMigrationUserSecretAndSC(f, "migrationsc")
 				if err != nil {
 					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
@@ -391,6 +393,15 @@ var _ = Describe("RBD", func() {
 				err = createConfigMap(rbdDirPath, f.ClientSet, f)
 				if err != nil {
 					e2elog.Failf("failed to create configmap with error %v", err)
+				}
+
+				err = deleteProvNodeMigrationSecret(f, true, true)
+				if err != nil {
+					e2elog.Failf("failed to delete migration users and Secrets associated with error %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass with error %v", err)
 				}
 			})
 
@@ -1606,12 +1617,24 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to generate clusterID configmap with error %v", err)
 				}
-				err = validateRBDStaticMigrationPV(f, appPath, false)
+				// create node user and migration secret.
+				err = createProvNodeCephUserAndSecret(f, false, true)
+				if err != nil {
+					e2elog.Failf("failed to create users and secret with error %v", err)
+				}
+
+				err = validateRBDStaticMigrationPV(f, appPath, rbdMigrationNodePluginSecretName, false)
 				if err != nil {
 					e2elog.Failf("failed to validate rbd migrated static pv with error %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				err = deleteProvNodeMigrationSecret(f, false, true)
+				if err != nil {
+					e2elog.Failf("failed to delete users and secret with error %v", err)
+				}
+
 				err = deleteConfigMap(rbdDirPath)
 				if err != nil {
 					e2elog.Failf("failed to delete configmap with error %v", err)
@@ -1627,12 +1650,24 @@ var _ = Describe("RBD", func() {
 				if err != nil {
 					e2elog.Failf("failed to generate clusterID configmap with error %v", err)
 				}
-				err = validateRBDStaticMigrationPV(f, rawAppPath, true)
+				// create node user and migration secret.
+				err = createProvNodeCephUserAndSecret(f, false, true)
+				if err != nil {
+					e2elog.Failf("failed to create users and secret with error %v", err)
+				}
+
+				err = validateRBDStaticMigrationPV(f, rawAppPath, rbdMigrationNodePluginSecretName, true)
 				if err != nil {
 					e2elog.Failf("failed to validate rbd migrated static block pv with error %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				err = deleteProvNodeMigrationSecret(f, false, true)
+				if err != nil {
+					e2elog.Failf("failed to delete users and secret with error %v", err)
+				}
+
 				err = deleteConfigMap(rbdDirPath)
 				if err != nil {
 					e2elog.Failf("failed to delete configmap with error %v", err)

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -221,7 +221,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 	return err
 }
 
-func validateRBDStaticMigrationPV(f *framework.Framework, appPath string, isBlock bool) error {
+func validateRBDStaticMigrationPV(f *framework.Framework, appPath, nodeSecretName string, isBlock bool) error {
 	opt := make(map[string]string)
 	var (
 		rbdImageName = "test-static-pv"
@@ -254,6 +254,9 @@ func validateRBDStaticMigrationPV(f *framework.Framework, appPath string, isBloc
 	if e != "" {
 		return fmt.Errorf("failed to create rbd image %s", e)
 	}
+	if nodeSecretName == "" {
+		nodeSecretName = rbdNodePluginSecretName
+	}
 
 	opt["migration"] = "true"
 	opt["clusterID"] = getMonsHash(mon)
@@ -265,7 +268,7 @@ func validateRBDStaticMigrationPV(f *framework.Framework, appPath string, isBloc
 		pvName,
 		rbdImageName,
 		size,
-		rbdNodePluginSecretName,
+		nodeSecretName,
 		cephCSINamespace,
 		sc,
 		"rbd.csi.ceph.com",

--- a/internal/rbd/migration.go
+++ b/internal/rbd/migration.go
@@ -74,15 +74,10 @@ func parseMigrationVolID(vh string) (*migrationVolID, error) {
 	return mh, nil
 }
 
-// parseAndDeleteMigratedVolume get rbd volume details from the migration volID
+// deleteMigratedVolume get rbd volume details from the migration volID
 // and delete the volume from the cluster, return err if there was an error on the process.
-func parseAndDeleteMigratedVolume(ctx context.Context, volumeID string, cr *util.Credentials) error {
-	parsedMigHandle, err := parseMigrationVolID(volumeID)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to parse migration volumeID: %s , err: %v", volumeID, err)
-
-		return err
-	}
+func deleteMigratedVolume(ctx context.Context, parsedMigHandle *migrationVolID, cr *util.Credentials) error {
+	var err error
 	rv := &rbdVolume{}
 
 	// fill details to rv struct from parsed migration handle

--- a/internal/util/credentials_test.go
+++ b/internal/util/credentials_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsMigrationSecret(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		vc   map[string]string
+		want bool
+	}{
+		{
+			"proper migration secret key set",
+			map[string]string{"key": "QVFBOFF2SlZheUJQRVJBQWgvS2cwT1laQUhPQno3akZwekxxdGc9PQ=="},
+			true,
+		},
+		{
+			"no key set",
+			map[string]string{"": ""},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		newtt := tt
+		t.Run(newtt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsMigrationSecret(newtt.vc); got != newtt.want {
+				t.Errorf("isMigrationSecret() = %v, want %v", got, newtt.want)
+			}
+		})
+	}
+}
+
+func TestParseAndSetSecretMapFromMigSecret(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		secretmap map[string]string
+		want      map[string]string
+		wantErr   bool
+	}{
+		{
+			"valid migration secret key set",
+			map[string]string{"key": "QVFBOFF2SlZheUJQRVJBQWgvS2cwT1laQUhPQno3akZwekxxdGc9PQ=="},
+			map[string]string{"userKey": "QVFBOFF2SlZheUJQRVJBQWgvS2cwT1laQUhPQno3akZwekxxdGc9PQ==", "userID": "admin"},
+			false,
+		},
+		{
+			"migration secret key value nil",
+			map[string]string{"key": ""},
+			nil,
+			true,
+		},
+		{
+			"migration secret key field nil",
+			map[string]string{"": ""},
+			nil,
+			true,
+		},
+		{
+			"valid migration secret key and userID set",
+			map[string]string{"key": "QVFBOFF2SlZheUJQRVJBQWgvS2cwT1laQUhPQno3akZwekxxdGc9PQ==", "adminId": "pooladmin"},
+			map[string]string{"userKey": "QVFBOFF2SlZheUJQRVJBQWgvS2cwT1laQUhPQno3akZwekxxdGc9PQ==", "userID": "pooladmin"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		newtt := tt
+		t.Run(newtt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseAndSetSecretMapFromMigSecret(newtt.secretmap)
+			if (err != nil) != newtt.wantErr {
+				t.Errorf("ParseAndSetSecretMapFromMigSecret() error = %v, wantErr %v", err, newtt.wantErr)
+
+				return
+			}
+			if !reflect.DeepEqual(got, newtt.want) {
+				t.Errorf("ParseAndSetSecretMapFromMigSecret() got = %v, want %v", got, newtt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
    rbd: parse migration secret and set it for CSI driver operations
    
    The intree secret has a data field called "key" which is the base64
    admin secret key. The ceph CSI driver currently expect the secret to
    contain data field "UserKey" for the equivalant. The CSI driver also
    expect the "UserID" field which is not available in the in-tree secret
    by deafult. This missing userID will be filled (if the username differ
    than 'admin') in the migration secret as 'adminId' field in the
    migration request, this commit adds the logic to parse this migration
    secret as below:
    
    "key" field value will be picked up from the migraion secret to "UserKey"
    field.
    "adminId" field value will be picked up from the migration secret to "UserID"
    field
    
    if `adminId` field is nil or not set, `UserID` field will be filled with
    default value ie `admin`.The above logic get activated only when the secret
    is a migration secret, otherwise skipped to the normal workflow as we have
    today.

Note:
E2E tests are added to make sure migration kind of secret is passed in tests.

Additional note:
The initial plan was to ask the admin to adjust the secret as a pre-upgrade step
for migration which avoid this change in the CSI driver, however taking out admin burden
is the main ask from kubernetes community so this change is introduced. None of the
existing workflow is broken for CSI driver with this change.

Updates #2509 


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

