### PR TITLE
e2e: enable ISS validation for Vault

### DIFF
--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -78,6 +78,7 @@ data:
     # write configuration to use your cluster
     vault write auth/${CLUSTER_IDENTIFIER}/config \
       token_reviewer_jwt=@${SERVICE_ACCOUNT_TOKEN_PATH}/token \
+      issuer="${K8S_HOST}" \
       kubernetes_host="${K8S_HOST}" \
       kubernetes_ca_cert=@${SERVICE_ACCOUNT_TOKEN_PATH}/ca.crt
 
@@ -101,13 +102,6 @@ data:
         bound_service_account_names="${SERVICE_ACCOUNTS}" \
         bound_service_account_namespaces="${SERVICE_ACCOUNTS_NAMESPACE}" \
         policies="${CLUSTER_IDENTIFIER}"
-
-    # disable iss validation
-    # from: external-secrets/kubernetes-external-secrets#721
-    vault write auth/${CLUSTER_IDENTIFIER}/config \
-      token_reviewer_jwt=@${SERVICE_ACCOUNT_TOKEN_PATH}/token \
-      kubernetes_host="${K8S_HOST}" \
-      disable_iss_validation=true
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
Disabling ISS validation while configuring Kubernetes Auth for HashiCorp
Vault is not very nice. It seems that passing the 'issuer' option should
make it possible to keep ISS validation enabled.

See-also: https://github.com/external-secrets/kubernetes-external-secrets/issues/721#issuecomment-924896198

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
