### PR TITLE
e2e: increase E2E_TIMEOUT to 120m

### DIFF
--- a/build.env
+++ b/build.env
@@ -59,5 +59,5 @@ CSI_NODE_DRIVER_REGISTRAR_VERSION=v2.3.0
 # - enable CEPH_CSI_RUN_ALL_TESTS when running tests with if it has root
 #   permissions on the host
 #CEPH_CSI_RUN_ALL_TESTS=true
-E2E_TIMEOUT=90m
+E2E_TIMEOUT=120m
 DEPLOY_TIMEOUT=10


### PR DESCRIPTION
This commit increases E2E_TIMEOUT to 120m, to avoid
frequent test fails due to timeout.

Signed-off-by: Rakshith R <rar@redhat.com>

Ex: https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e-helm_k8s-1.20/detail/mini-e2e-helm_k8s-1.20/2796/pipeline

---


<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
