### PR TITLE
e2e: do not delete the namespace and contents after a failure

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -180,7 +180,7 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='--deploy-cephfs=false --deploy-rbd=false --helm-test=true'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='--delete-namespace-on-failure=false --deploy-cephfs=false --deploy-rbd=false --helm-test=true'"
 			}
 		}
 		stage('cleanup ceph-csi deployment') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -167,7 +167,7 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {
-				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e'
+				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS="--delete-namespace-on-failure=false"'
 			}
 		}
 	}


### PR DESCRIPTION
When a failure occurs, by default the test namespace is removed. This
makes it impossible to fetch the logs of the containers where the
failure was discovered. Pass --delete-namespace-on-failure=false as an
additional argument to the `run-e2e` make target, so that the namespace
is kept.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
