### PR TITLE
e2e: add a monitor container to the vault Pod

### DIFF
--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -48,6 +48,8 @@ spec:
               value: sample_root_token_id
             - name: SKIP_SETCAP
               value: any
+            - name: HOME
+              value: /home
           livenessProbe:
             exec:
               command:
@@ -58,6 +60,28 @@ spec:
           ports:
             - containerPort: 8200
               name: vault-api
+          volumeMounts:
+            - name: home
+              mountPath: /home
+        - name: monitor
+          image: docker.io/library/vault:latest
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsUser: 100
+          env:
+            - name: VAULT_ADDR
+              value: http://localhost:8200
+            - name: HOME
+              value: /home
+          command:
+            - vault
+            - monitor
+          volumeMounts:
+            - name: home
+              mountPath: /home
+      volumes:
+        - name: home
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
The command `vault monitor` can be used to stream logging from the Vault
service. This is very helpful while debugging Vault configuration
failures.

By adding a 2nd container to the Vault deployment, it is now possible to
get the messages from the Vault service by running

    $ kubectl logs -c monitor <vault-pod-0123abcd>

This will be very useful when the e2e tests do not delete the deployment
after a failure and fetch the logs from all containers.

See-also: #2577

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
