### PR TITLE
util: NodeGetVolumeStatsResponse.Usage may not contain negative values

### DIFF
--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -263,17 +263,30 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
 			{
-				Available: available,
-				Total:     capacity,
-				Used:      used,
+				Available: requirePositive(available),
+				Total:     requirePositive(capacity),
+				Used:      requirePositive(used),
 				Unit:      csi.VolumeUsage_BYTES,
 			},
 			{
-				Available: inodesFree,
-				Total:     inodes,
-				Used:      inodesUsed,
+				Available: requirePositive(inodesFree),
+				Total:     requirePositive(inodes),
+				Used:      requirePositive(inodesUsed),
 				Unit:      csi.VolumeUsage_INODES,
 			},
 		},
 	}, nil
+}
+
+// requirePositive returns the value for `x` when it is greater or equal to 0,
+// or returns 0 in the acse `x` is negative.
+//
+// This is used for VolumeUsage entries in the NodeGetVolumeStatsResponse. The
+// CSI spec does not allow negative values in the VolumeUsage objects.
+func requirePositive(x int64) int64 {
+	if x >= 0 {
+		return x
+	}
+
+	return 0
 }


### PR DESCRIPTION
Following the CSI specification, values that are included in the
VolumeUsage MUST NOT be negative. However, CephFS seems to return -1 for
the number of inodes that are available. Instead of returning a
negative value, set it to 0 so that it will not get included in the
encoded JSON response.

Updates: #2579
See-also: https://github.com/container-storage-interface/spec/blob/5b0d4540158a260cb3347ef1c87ede8600afb9bf/spec.md?plain=1#L2477-L2487

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
