### PR TITLE
e2e: Add testing for erasure coded pools

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -515,6 +515,27 @@ var _ = Describe("RBD", func() {
 					f)
 			})
 
+			By("create an erasure coded PVC and validate PVC-PVC clone", func() {
+				validatePVCClone(
+					defaultCloneCount,
+					pvcPath,
+					appPath,
+					pvcSmartClonePath,
+					appSmartClonePath,
+					erasureCodedPool,
+					noKMS,
+					noPVCValidation,
+					f)
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete storageclass: %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+			})
+
 			By("create a PVC and bind it to an app with ext4 as the FS ", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1536,6 +1557,7 @@ var _ = Describe("RBD", func() {
 					appPath,
 					pvcSmartClonePath,
 					appSmartClonePath,
+					noDataPool,
 					noKMS,
 					noPVCValidation,
 					f)
@@ -1553,7 +1575,15 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
-				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, noKMS, isThickPVC, f)
+				validatePVCClone(1,
+					pvcPath,
+					appPath,
+					pvcSmartClonePath,
+					appSmartClonePath,
+					noDataPool,
+					noKMS,
+					isThickPVC,
+					f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1732,7 +1762,15 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
-				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, secretsMetadataKMS, isEncryptedPVC, f)
+				validatePVCClone(1,
+					pvcPath,
+					appPath,
+					pvcSmartClonePath,
+					appSmartClonePath,
+					noDataPool,
+					secretsMetadataKMS,
+					isEncryptedPVC,
+					f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1758,7 +1796,15 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
-				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, vaultKMS, isEncryptedPVC, f)
+				validatePVCClone(1,
+					pvcPath,
+					appPath,
+					pvcSmartClonePath,
+					appSmartClonePath,
+					noDataPool,
+					vaultKMS,
+					isEncryptedPVC,
+					f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
@@ -1787,6 +1833,7 @@ var _ = Describe("RBD", func() {
 					rawAppPath,
 					pvcBlockSmartClonePath,
 					appBlockSmartClonePath,
+					noDataPool,
 					noKMS,
 					noPVCValidation,
 					f)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -802,9 +802,8 @@ func validatePVCClone(
 func validatePVCSnapshot(
 	totalCount int,
 	pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath string,
-	kms, restoreKMS kmsConfig,
-	restoreSCName string,
-	f *framework.Framework) {
+	kms, restoreKMS kmsConfig, restoreSCName,
+	dataPool string, f *framework.Framework) {
 	var wg sync.WaitGroup
 	wgErrs := make([]error, totalCount)
 	chErrs := make([]error, totalCount)
@@ -1020,6 +1019,10 @@ func validatePVCSnapshot(
 			name := fmt.Sprintf("%s%d", f.UniqueName, n)
 			p.Spec.DataSource.Name = name
 			wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
+			if wgErrs[n] == nil && dataPool != noDataPool {
+				wgErrs[n] = checkPVCDataPoolForImageInPool(f, &p, defaultRBDPool, dataPool)
+			}
+
 			wg.Done()
 		}(i, *pvcClone, *appClone)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -594,7 +594,8 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 // nolint:gocyclo,gocognit,nestif,cyclop // reduce complexity
 func validatePVCClone(
 	totalCount int,
-	sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath string,
+	sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath,
+	dataPool string,
 	kms kmsConfig,
 	validatePVC validateFunc,
 	f *framework.Framework) {
@@ -662,6 +663,9 @@ func validatePVCClone(
 				LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
 			}
 			wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
+			if wgErrs[n] == nil && dataPool != noDataPool {
+				wgErrs[n] = checkPVCDataPoolForImageInPool(f, &p, defaultRBDPool, dataPool)
+			}
 			if wgErrs[n] == nil && kms != noKMS {
 				if kms.canGetPassphrase() {
 					imageData, sErr := getImageInfoFromPVC(p.Namespace, name, f)


### PR DESCRIPTION
Verify if basic csi features work with a pvc created via an erasure-coded pool.

Updates: #2566 
Depends on: #2653 #2654 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
