### PR TITLE
rbd-nbd: add tests with different accessModes and volumeModes

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -282,7 +282,7 @@ var _ = Describe("cephfs", func() {
 			appEphemeralPath := cephFSExamplePath + "pod-ephemeral.yaml"
 
 			By("checking provisioner deployment is running", func() {
-				err := waitForDeploymentComplete(cephFSDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+				err := waitForDeploymentComplete(f.ClientSet, cephFSDeploymentName, cephCSINamespace, deployTimeout)
 				if err != nil {
 					e2elog.Failf("timeout waiting for deployment %s: %v", cephFSDeploymentName, err)
 				}

--- a/e2e/deployment.go
+++ b/e2e/deployment.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+)
+
+// execCommandInPodWithName run command in pod using podName.
+func execCommandInPodWithName(
+	f *framework.Framework,
+	cmdString,
+	podName,
+	containerName,
+	nameSpace string) (string, string, error) {
+	cmd := []string{"/bin/sh", "-c", cmdString}
+	podOpt := framework.ExecOptions{
+		Command:            cmd,
+		PodName:            podName,
+		Namespace:          nameSpace,
+		ContainerName:      containerName,
+		Stdin:              nil,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: true,
+	}
+
+	return f.ExecWithOptions(podOpt)
+}
+
+// loadAppDeployment loads the deployment app config and return deployment
+// object.
+func loadAppDeployment(path string) (*appsv1.Deployment, error) {
+	deploy := appsv1.Deployment{}
+	if err := unmarshal(path, &deploy); err != nil {
+		return nil, err
+	}
+
+	return &deploy, nil
+}
+
+// createDeploymentApp creates the deployment object and waits for it to be in
+// Available state.
+func createDeploymentApp(clientSet kubernetes.Interface, app *appsv1.Deployment, deployTimeout int) error {
+	_, err := clientSet.AppsV1().Deployments(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create deploy: %w", err)
+	}
+
+	return waitForDeploymentInAvailableState(clientSet, app.Name, app.Namespace, deployTimeout)
+}
+
+// deleteDeploymentApp deletes the deployment object.
+func deleteDeploymentApp(clientSet kubernetes.Interface, name, ns string, deployTimeout int) error {
+	timeout := time.Duration(deployTimeout) * time.Minute
+	err := clientSet.AppsV1().Deployments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete deployment: %w", err)
+	}
+	start := time.Now()
+	e2elog.Logf("Waiting for deployment %q to be deleted", name)
+
+	return wait.PollImmediate(poll, timeout, func() (bool, error) {
+		_, err := clientSet.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			if apierrs.IsNotFound(err) {
+				return true, nil
+			}
+			e2elog.Logf("%q deployment to be deleted (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
+
+			return false, fmt.Errorf("failed to get deployment: %w", err)
+		}
+
+		return false, nil
+	})
+}
+
+// waitForDeploymentInAvailableState wait for deployment to be in Available state.
+func waitForDeploymentInAvailableState(clientSet kubernetes.Interface, name, ns string, deployTimeout int) error {
+	timeout := time.Duration(deployTimeout) * time.Minute
+	start := time.Now()
+	e2elog.Logf("Waiting up to %q to be in Available state", name)
+
+	return wait.PollImmediate(poll, timeout, func() (bool, error) {
+		d, err := clientSet.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			e2elog.Logf("%q deployment to be Available (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
+
+			return false, err
+		}
+		cond := deploymentutil.GetDeploymentCondition(d.Status, appsv1.DeploymentAvailable)
+
+		return cond != nil, nil
+	})
+}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -254,7 +254,7 @@ var _ = Describe("RBD", func() {
 		deployVault(f.ClientSet, deployTimeout)
 
 		// wait for provisioner deployment
-		err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+		err = waitForDeploymentComplete(f.ClientSet, rbdDeploymentName, cephCSINamespace, deployTimeout)
 		if err != nil {
 			e2elog.Failf("timeout waiting for deployment %s: %v", rbdDeploymentName, err)
 		}
@@ -2414,7 +2414,7 @@ var _ = Describe("RBD", func() {
 					if err != nil {
 						e2elog.Failf("timeout waiting for daemonset pods: %v", err)
 					}
-					err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+					err = waitForDeploymentComplete(f.ClientSet, rbdDeploymentName, cephCSINamespace, deployTimeout)
 					if err != nil {
 						e2elog.Failf("timeout waiting for deployment to be in running state: %v", err)
 					}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -997,7 +997,7 @@ func recreateCSIRBDPods(f *framework.Framework) error {
 	if err != nil {
 		return fmt.Errorf("timeout waiting for daemonset pods: %w", err)
 	}
-	err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+	err = waitForDeploymentComplete(f.ClientSet, rbdDeploymentName, cephCSINamespace, deployTimeout)
 	if err != nil {
 		return fmt.Errorf("timeout waiting for deployment to be in running state: %w", err)
 	}

--- a/e2e/templates/rbd-block-deployment.yaml
+++ b/e2e/templates/rbd-block-deployment.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-block-rx-volume
+  labels:
+    app: pod-block-rx-volume
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: pod-block-rx-volume
+  template:
+    metadata:
+      labels:
+        app: pod-block-rx-volume
+    spec:
+      containers:
+        - name: centos
+          image: quay.io/centos/centos:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sleep", "infinity"]
+          volumeDevices:
+            - name: data
+              devicePath: /dev/xvda
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: raw-block-pvc
+            readOnly: false

--- a/e2e/templates/rbd-fs-deployment.yaml
+++ b/e2e/templates/rbd-fs-deployment.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-fs-rx-volume
+  labels:
+    app: pod-fs-rx-volume
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: pod-fs-rx-volume
+  template:
+    metadata:
+      labels:
+        app: pod-fs-rx-volume
+    spec:
+      containers:
+        - name: web-server
+          image: docker.io/library/nginx:latest
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: mypvc
+              mountPath: /var/lib/www/html
+      volumes:
+        - name: mypvc
+          persistentVolumeClaim:
+            claimName: rbd-pvc
+            readOnly: false

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -148,7 +148,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 	Context("Cephfs Upgrade Test", func() {
 		It("Cephfs Upgrade Test", func() {
 			By("checking provisioner deployment is running", func() {
-				err = waitForDeploymentComplete(cephFSDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+				err = waitForDeploymentComplete(f.ClientSet, cephFSDeploymentName, cephCSINamespace, deployTimeout)
 				if err != nil {
 					e2elog.Failf("timeout waiting for deployment %s: %v", cephFSDeploymentName, err)
 				}
@@ -241,7 +241,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				}
 				deployCephfsPlugin()
 
-				err = waitForDeploymentComplete(cephFSDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+				err = waitForDeploymentComplete(f.ClientSet, cephFSDeploymentName, cephCSINamespace, deployTimeout)
 				if err != nil {
 					e2elog.Failf("timeout waiting for upgraded deployment %s: %v", cephFSDeploymentName, err)
 				}

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -165,7 +165,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 			appPath := rbdExamplePath + "pod.yaml"
 
 			By("checking provisioner deployment is running", func() {
-				err := waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+				err := waitForDeploymentComplete(f.ClientSet, rbdDeploymentName, cephCSINamespace, deployTimeout)
 				if err != nil {
 					e2elog.Failf("timeout waiting for deployment %s: %v", rbdDeploymentName, err)
 				}
@@ -260,7 +260,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 
 				deployRBDPlugin()
 
-				err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
+				err = waitForDeploymentComplete(f.ClientSet, rbdDeploymentName, cephCSINamespace, deployTimeout)
 				if err != nil {
 					e2elog.Failf("timeout waiting for upgraded deployment %s: %v", rbdDeploymentName, err)
 				}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #


* Added tests using different accessModes and volumeModes for rbd-nbd
  * ReadWriteOnce   [RWO]:
    * Currently available tests already cover it.
  * Read Write Many [RWX]:
    * Added test for Block Volume Mode only.
    * RWX is restricted for FileSystem VolumeMode at ceph-csi see https://github.com/ceph/ceph-csi/pull/261 for more details
  * ReadOnlyMany    [ROX]:
    *  Added tests for Block and Filesystem Volume Modes

* Added helper functions to use deployment kind objects

Note: This PR doesn't consider the new accessMode ReadWriteOncePod [RWOP], this will be a future item to cover tests for both krbd and nbd.

## Related issues ##
Fixes: #2262