### PR TITLE
 rbd: add generic ephemeral volume validation

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -279,6 +279,7 @@ var _ = Describe("cephfs", func() {
 			appClonePath := cephFSExamplePath + "pod-restore.yaml"
 			appSmartClonePath := cephFSExamplePath + "pod-clone.yaml"
 			snapshotPath := cephFSExamplePath + "snapshot.yaml"
+			appEphemeralPath := cephFSExamplePath + "pod-ephemeral.yaml"
 
 			By("checking provisioner deployment is running", func() {
 				err := waitForDeploymentComplete(cephFSDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
@@ -312,6 +313,37 @@ var _ = Describe("cephfs", func() {
 					}
 				})
 			}
+			By("verify generic ephemeral volume support", func() {
+				// generic ephemeral volume support is beta since v1.21.
+				if !k8sVersionGreaterEquals(f.ClientSet, 1, 21) {
+					Skip("generic ephemeral volume only supported from v1.21+")
+				}
+				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
+				if err != nil {
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
+				}
+				// create application
+				app, err := loadApp(appEphemeralPath)
+				if err != nil {
+					e2elog.Failf("failed to load application: %v", err)
+				}
+				app.Namespace = f.UniqueName
+				err = createApp(f.ClientSet, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create application: %v", err)
+				}
+				validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
+				// delete pod
+				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete application: %v", err)
+				}
+				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
+				}
+			})
 
 			By("check static PVC", func() {
 				scPath := cephFSExamplePath + "secret.yaml"

--- a/examples/cephfs/pod-ephemeral.yaml
+++ b/examples/cephfs/pod-ephemeral.yaml
@@ -1,0 +1,23 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-cephfs-demo-ephemeral-pod
+spec:
+  containers:
+    - name: web-server
+      image: docker.io/library/nginx:latest
+      volumeMounts:
+        - mountPath: /myspace
+          name: mypvc
+  volumes:
+    - name: mypvc
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            storageClassName: csi-cephfs-sc
+            resources:
+              requests:
+                storage: 1Gi

--- a/examples/rbd/pod-ephemeral.yaml
+++ b/examples/rbd/pod-ephemeral.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csi-rbd-demo-ephemeral-pod
+spec:
+  containers:
+    - name: web-server
+      image: docker.io/library/nginx:latest
+      volumeMounts:
+        - mountPath: /myspace
+          name: mypvc
+  volumes:
+    - name: mypvc
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            storageClassName: csi-rbd-sc
+            resources:
+              requests:
+                storage: 1Gi

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -160,7 +160,7 @@ CSI_RESIZER_VERSION=${CSI_RESIZER_VERSION:-"v1.2.0"}
 CSI_NODE_DRIVER_REGISTRAR_VERSION=${CSI_NODE_DRIVER_REGISTRAR_VERSION:-"v2.2.0"}
 
 #feature-gates for kube
-K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-"ExpandCSIVolumes=true"}
+K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-""}
 
 #extra-config for kube https://minikube.sigs.k8s.io/docs/reference/configuration/kubernetes/
 EXTRA_CONFIG_PSP="--extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy --addons=pod-security-policy"


### PR DESCRIPTION
    rbd: add generic ephemeral volume validation
    
    This commit adds the validation of csi RBD driver to work with
    ephemeral volume support. With ephemeral volume support a user can
    specify ephemeral volumes in its pod spec and tie the lifecycle
    of the PVC with the POD.
    
    An example POD spec looks like this:
    
    kind: Pod
    apiVersion: v1
    metadata:
      name: my-app
       spec:
      containers:
        - name: csi-rbd-demo-pod
          image: busybox
          volumeMounts:
            - mountPath: "/scratch"
              name: mypvc
          command: [ "sleep", "1000000" ]
      volumes:
        - name: mypvc
          ephemeral:
            volumeClaimTemplate:
              spec:
                accessModes: [ "ReadWriteOnce" ]
                storageClassName: "csi-rbd-sc"
                resources:
                  requests:
                    storage: 1Gi

Additional Ref # https://github.com/rook/rook/pull/9055

Updates #2587 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

