### PR TITLE
e2e: retry when a "transport is closing" error is hit

### DIFF
--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -41,6 +41,11 @@ func isRetryableAPIError(err error) bool {
 		return true
 	}
 
+	// "transport is closing" is an internal gRPC err, we can not use ErrConnClosing
+	if strings.Contains(err.Error(), "transport is closing") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
There have been occasional CI job failures due to "transport is closing"
errors. Adding this error to the isRetryableAPIError() function should
make sure to retry the request until the connection is restored.

Fixes: #2613

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
