### PR TITLE
helm: csi-rbd Fix invalid yaml generation on ceph-csi-config

### DIFF
--- a/charts/ceph-csi-rbd/templates/csiplugin-configmap.yaml
+++ b/charts/ceph-csi-rbd/templates/csiplugin-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.json: |-
-{{ toJson .Values.csiConfig | indent 4 -}}
+{{ toJson .Values.csiConfig | indent 4 }}
   cluster-mapping.json: |-
-{{ toJson .Values.csiMapping | indent 4 -}}
+{{ toJson .Values.csiMapping | indent 4 }}
 {{- end }}


### PR DESCRIPTION
# Describe what this PR does #

When rendering the configuration map for the csiPlugin the yaml is currently output as shown;

``` yaml
---
# Source: csi-ceph-rbd/charts/ceph-csi-rbd/templates/csiplugin-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "ceph-csi-config"
...
data:
  config.json: |-
    [{"clusterID":"...","monitors":["..."]}]cluster-mapping.json: |-
    []
```

Which has `cluster-mapping.json` placed after the config and is invalid.

This change updates the templates such that the `toYaml` block is trailed by a newline to ensure subsequent configuration elements are correctly rendered.


## Is there anything that requires special attention ##

Do you have any questions? No

Is the change backward compatible? Yes

Are there concerns around backward compatibility? No

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
