### PR TITLE
cleanup: log the image name and pool name

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -440,7 +440,7 @@ func (ns *NodeServer) stageTransaction(
 		ok, err = resizer.NeedResize(devicePath, stagingTargetPath)
 		if err != nil {
 			return transaction, status.Errorf(codes.Internal,
-				"Need resize check failed on devicePath %s and staingPath %s, error: %v",
+				"need resize check failed on devicePath %s and staingPath %s, error: %v",
 				devicePath,
 				stagingTargetPath,
 				err)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -394,8 +394,8 @@ func (ns *NodeServer) stageTransaction(
 	}
 	transaction.devicePath = devicePath
 
-	log.DebugLog(ctx, "rbd image: %s/%s was successfully mapped at %s\n",
-		req.GetVolumeId(), volOptions.Pool, devicePath)
+	log.DebugLog(ctx, "rbd image: %s was successfully mapped at %s\n",
+		volOptions, devicePath)
 
 	// userspace mounters like nbd need the device path as a reference while
 	// restarting the userspace processes on a nodeplugin restart. For kernel


### PR DESCRIPTION
instead of logging the volumeID and the pool name. log the poolname and image name for better debugging and also change case of error message as per standard

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

