### PR TITLE
build: use `BUILD_TAGS` instead of `CEPH_VERSION`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,12 @@ LDFLAGS += -X $(GO_PROJECT)/internal/util.DriverVersion=$(CSI_IMAGE_VERSION)
 
 BASE_IMAGE ?= $(shell . $(CURDIR)/build.env ; echo $${BASE_IMAGE})
 
-ifndef CEPH_VERSION
-	CEPH_VERSION = $(shell . $(CURDIR)/build.env ; echo $${CEPH_VERSION})
+ifndef BUILD_TAGS
+	BUILD_TAGS = $(shell . $(CURDIR)/build.env ; echo $${BUILD_TAGS})
 endif
-ifdef CEPH_VERSION
+ifdef BUILD_TAGS
 	# pass -tags to go commands (for go-ceph build constraints)
-	GO_TAGS = -tags=$(CEPH_VERSION)
+	GO_TAGS = -tags=$(BUILD_TAGS)
 endif
 
 # passing TARGET=static-check on the 'make containerized-test' or 'make
@@ -110,7 +110,7 @@ mod-check: check-env
 	@go mod verify && [ "$(shell sha512sum go.mod)" = "`sha512sum go.mod`" ] || ( echo "ERROR: go.mod was modified by 'go mod verify'" && false )
 
 scripts/golangci.yml: build.env scripts/golangci.yml.in
-	sed "s/@@CEPH_VERSION@@/$(CEPH_VERSION)/g" < scripts/golangci.yml.in > scripts/golangci.yml
+	sed "s/@@BUILD_TAGS@@/$(BUILD_TAGS)/g" < scripts/golangci.yml.in > scripts/golangci.yml
 
 go-lint: scripts/golangci.yml
 	./scripts/lint-go.sh

--- a/build.env
+++ b/build.env
@@ -13,7 +13,7 @@ CSI_IMAGE_VERSION=canary
 
 # Ceph version to use
 BASE_IMAGE=docker.io/ceph/ceph:v16
-CEPH_VERSION=octopus
+BUILD_TAGS=octopus
 
 # standard Golang options
 GOLANG_VERSION=1.16.4

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -6,7 +6,7 @@
 # options for analysis running
 run:
   build-tags:
-    - @@CEPH_VERSION@@
+    - @@BUILD_TAGS@@
 
   # default concurrency is a available CPU number
   concurrency: 4


### PR DESCRIPTION
Ceph base container images have predefined value
for CEPH_VERSION env variable. Hence, use BUILD_TAGS
as variable name instead to avoid mismatch.

Signed-off-by: Rakshith R <rar@redhat.com>

For example, in build run https://github.com/ceph/ceph-csi/runs/4144225306?check_suite_focus=true 
build tag is set as `pacific` which should have been `octopus` sourced from `build.env` file
```
GOOS=linux go build -tags=pacific -mod vendor -a -ldflags ' -X github.com/ceph/ceph-csi/internal/util.GitCommit=f4a756eeb1c4d7215a90588fb9b401d5a49327df -X github.com/ceph/ceph-csi/internal/util.DriverVersion=canary' -o _output/cephcsi ./cmd/
```
