### PR TITLE
[Test] rbd: wipe the disk before luksFormat

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -413,7 +413,23 @@ func (ns *NodeServer) stageTransaction(
 	}
 
 	if volOptions.isEncrypted() {
+		if volOptions.Mounter == rbdNbdMounter {
+			stdout, stderr, saveErr := util.ExecCommand(ctx, "sh", "-c", "ps aux | grep rbd-nbd")
+			if saveErr != nil || stderr != "" {
+				log.WarningLog(ctx, "rbd-nbd: ps command failed, error %v, ps output stdout:%q stderr: %q", saveErr, stdout, stderr)
+			} else {
+				log.UsefulLog(ctx, "rbd-nbd: ps command succeeded, stdout: %q", stdout)
+			}
+		}
 		devicePath, err = ns.processEncryptedDevice(ctx, volOptions, devicePath)
+		if volOptions.Mounter == rbdNbdMounter {
+			stdout, stderr, saveErr := util.ExecCommand(ctx, "sh", "-c", "ps aux | grep rbd-nbd")
+			if saveErr != nil || stderr != "" {
+				log.WarningLog(ctx, "rbd-nbd: ps command failed, error %v, ps output stdout:%q stderr: %q", saveErr, stdout, stderr)
+			} else {
+				log.UsefulLog(ctx, "rbd-nbd: ps command succeeded, stdout: %q", stdout)
+			}
+		}
 		if err != nil {
 			return transaction, err
 		}

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -409,6 +409,35 @@ func createPath(ctx context.Context, volOpt *rbdVolume, device string, cr *util.
 	}
 	devicePath := strings.TrimSuffix(stdout, "\n")
 
+	if isNbd && volOpt.isEncrypted() {
+		stdout, stderr, err := util.ExecCommand(ctx, "sh", "-c", "ps aux | grep rbd-nbd")
+		if err != nil || stderr != "" {
+			log.WarningLog(ctx, "rbd-nbd: ps command failed, error %v, ps output stdout:%q stderr: %q", err, stdout, stderr)
+		} else {
+			log.UsefulLog(ctx, "rbd-nbd: ps command succeeded, stdout: %q", stdout)
+		}
+
+		// FIXME: Just a test
+		wipeArgs := []string{
+			"--all",
+			"--force",
+			devicePath,
+		}
+		stdout, stderr, err = util.ExecCommand(ctx, "wipefs", wipeArgs...)
+		if err != nil {
+			log.WarningLog(ctx, "rbd-nbd: wipefs command failed, error %v, wipefs output stdout:%q stderr: %q", err, stdout, stderr)
+		} else {
+			log.UsefulLog(ctx, "rbd-nbd: wipefsi command succeeded")
+		}
+
+		stdout, stderr, err = util.ExecCommand(ctx, "sh", "-c", "ps aux | grep rbd-nbd")
+		if err != nil || stderr != "" {
+			log.WarningLog(ctx, "rbd-nbd: ps command failed, error %v, ps output stdout:%q stderr: %q", err, stdout, stderr)
+		} else {
+			log.UsefulLog(ctx, "rbd-nbd: ps command succeeded, stdout: %q", stdout)
+		}
+	}
+
 	return devicePath, nil
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

wipe the disk before luksFormat

```
I1112 10:09:57.203540    7805 crypto.go:199] ID: 18 Req-ID: 0001-0024-1ab022f7-6896-4903-92c6-c7a005956a61-0000000000000003-cdc18e1d-439f-11ec-baab-3a7542c390d1 Encrypting device "/dev/nbd0"   with LUKS
E1112 10:09:58.489213    7805 crypto.go:202] ID: 18 Req-ID: 0001-0024-1ab022f7-6896-4903-92c6-c7a005956a61-0000000000000003-cdc18e1d-439f-11ec-baab-3a7542c390d1 failed to encrypt device "/dev/nbd0" with LUKS (an error (exit status 1) occurred while running cryptsetup args: [-q luksFormat --type luks2 --hash sha256 /dev/nbd0 -d /dev/stdin]): Device wipe error, offset 3145728.
Cannot wipe header on device /dev/nbd0.                                                                                          
E1112 10:09:58.489740    7805 encryption.go:204] ID: 18 Req-ID: 0001-0024-1ab022f7-6896-4903-92c6-c7a005956a61-0000000000000003-cdc18e1d-439f-11ec-baab-3a7542c390d1 failed to encrypt volume rbd-pool/csi-vol-cdc18e1d-439f-11ec-baab-3a7542c390d1: an error (exit status 1) occurred while running cryptsetup args: [-q luksFormat --type luks2 --hash sha256 /dev/nbd0 -d /dev/stdin]           
I1112 10:09:58.949286    7805 cephcmds.go:62] ID: 18 Req-ID: 0001-0024-1ab022f7-6896-4903-92c6-c7a005956a61-0000000000000003-cdc18e1d-439f-11ec-baab-3a7542c390d1 command succeeded: rbd [unmap /dev/nbd0 --device-type nbd]                                      
E1112 10:09:58.950524    7805 utils.go:186] ID: 18 Req-ID: 0001-0024-1ab022f7-6896-4903-92c6-c7a005956a61-0000000000000003-cdc18e1d-439f-11ec-baab-3a7542c390d1 GRPC error: rpc error: code = Internal desc = failed to encrypt rbd image rbd-pool/csi-vol-cdc18e1d-439f-11ec-baab-3a7542c390d1: failed to encrypt volume rbd-pool/csi-vol-cdc18e1d-439f-11ec-baab-3a7542c390d1: an error (exit status 1) occurred while running cryptsetup args: [-q luksFormat --type luks2 --hash sha256 /dev/nbd0 -d /dev/stdin]                

```

**Note**: This PR is to understand the root cause for #2610

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
