### PR TITLE
rbd: use go-ceph rbd admin task api for 'trash remove' & 'flatten'

### DIFF
--- a/build.env
+++ b/build.env
@@ -13,7 +13,7 @@ CSI_IMAGE_VERSION=canary
 
 # Ceph version to use
 BASE_IMAGE=docker.io/ceph/ceph:v16
-CEPH_VERSION=octopus
+CEPH_VERSION=pacific
 
 # standard Golang options
 GOLANG_VERSION=1.17.5

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/keyprotect-go-client v0.7.0
 	github.com/aws/aws-sdk-go v1.42.7
 	github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000
-	github.com/ceph/go-ceph v0.12.0
+	github.com/ceph/go-ceph v0.13.0
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/csi-addons/replication-lib-utils v0.2.0
 	github.com/csi-addons/spec v0.1.2-0.20211220083702-c779b23cf97c

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
-github.com/ceph/go-ceph v0.12.0 h1:nlFgKQZXOFR4oMnzXsKwTr79Y6EYDwqTrpigICGy/Tw=
-github.com/ceph/go-ceph v0.12.0/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
+github.com/ceph/go-ceph v0.13.0 h1:69dgIPlNHD2OCz98T0benI4++vcnShGcpQK4RIALjw4=
+github.com/ceph/go-ceph v0.13.0/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -363,7 +363,7 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 					rbdVol,
 					err)
 			} else if !thick {
-				err = deleteImage(ctx, rbdVol, cr)
+				err = rbdVol.deleteImage(ctx)
 				if err != nil {
 					return nil, status.Errorf(codes.Aborted, "failed to remove partially cloned volume %q: %s", rbdVol, err)
 				}
@@ -434,7 +434,7 @@ func cleanupThickClone(ctx context.Context,
 	parentVol *rbdVolume,
 	rbdSnap *rbdSnapshot,
 	cr *util.Credentials) error {
-	err := cleanUpSnapshot(ctx, parentVol, rbdSnap, rbdVol, cr)
+	err := cleanUpSnapshot(ctx, parentVol, rbdSnap, rbdVol)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to remove partially cloned volume %q: %s", rbdVol, err)
 	}
@@ -521,12 +521,12 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 // return success,the hardlimit is reached it starts a task to flatten the
 // image and return Aborted.
 func checkFlatten(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials) error {
-	err := rbdVol.flattenRbdImage(ctx, cr, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
+	err := rbdVol.flattenRbdImage(ctx, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 	if err != nil {
 		if errors.Is(err, ErrFlattenInProgress) {
 			return status.Error(codes.Aborted, err.Error())
 		}
-		if errDefer := deleteImage(ctx, rbdVol, cr); errDefer != nil {
+		if errDefer := rbdVol.deleteImage(ctx); errDefer != nil {
 			log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", rbdVol, errDefer)
 
 			return status.Error(codes.Internal, err.Error())
@@ -660,7 +660,7 @@ func (cs *ControllerServer) createBackingImage(
 	defer func() {
 		if err != nil {
 			if !errors.Is(err, ErrFlattenInProgress) {
-				if deleteErr := deleteImage(ctx, rbdVol, cr); deleteErr != nil {
+				if deleteErr := rbdVol.deleteImage(ctx); deleteErr != nil {
 					log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", rbdVol, deleteErr)
 				}
 			}
@@ -672,7 +672,7 @@ func (cs *ControllerServer) createBackingImage(
 	}
 
 	if rbdSnap != nil {
-		err = rbdVol.flattenRbdImage(ctx, cr, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
+		err = rbdVol.flattenRbdImage(ctx, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 		if err != nil {
 			log.ErrorLog(ctx, "failed to flatten image %s: %v", rbdVol, err)
 
@@ -919,7 +919,7 @@ func cleanupRBDImage(ctx context.Context,
 	// delete the temporary rbd image created as part of volume clone during
 	// create volume
 	tempClone := rbdVol.generateTempClone()
-	err = deleteImage(ctx, tempClone, cr)
+	err = tempClone.deleteImage(ctx)
 	if err != nil {
 		if errors.Is(err, ErrImageNotFound) {
 			err = tempClone.ensureImageCleanup(ctx)
@@ -937,7 +937,7 @@ func cleanupRBDImage(ctx context.Context,
 
 	// Deleting rbd image
 	log.DebugLog(ctx, "deleting image %s", rbdVol.RbdImageName)
-	if err = deleteImage(ctx, rbdVol, cr); err != nil {
+	if err = rbdVol.deleteImage(ctx); err != nil {
 		log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v",
 			rbdVol, err)
 
@@ -1142,7 +1142,7 @@ func cloneFromSnapshot(
 		}
 	}
 
-	err = vol.flattenRbdImage(ctx, cr, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
+	err = vol.flattenRbdImage(ctx, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 	if errors.Is(err, ErrFlattenInProgress) {
 		// if flattening is in progress, return error and do not cleanup
 		return nil, status.Errorf(codes.Internal, err.Error())
@@ -1210,7 +1210,7 @@ func (cs *ControllerServer) doSnapshotClone(
 		return cloneRbd, err
 	}
 
-	err = createRBDClone(ctx, parentVol, cloneRbd, rbdSnap, cr)
+	err = createRBDClone(ctx, parentVol, cloneRbd, rbdSnap)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create snapshot: %v", err)
 
@@ -1221,7 +1221,7 @@ func (cs *ControllerServer) doSnapshotClone(
 		if err != nil {
 			if !errors.Is(err, ErrFlattenInProgress) {
 				// cleanup clone and snapshot
-				errCleanUp := cleanUpSnapshot(ctx, cloneRbd, rbdSnap, cloneRbd, cr)
+				errCleanUp := cleanUpSnapshot(ctx, cloneRbd, rbdSnap, cloneRbd)
 				if errCleanUp != nil {
 					log.ErrorLog(ctx, "failed to cleanup snapshot and clone: %v", errCleanUp)
 				}
@@ -1287,7 +1287,7 @@ func (cs *ControllerServer) doSnapshotClone(
 		return cloneRbd, err
 	}
 
-	err = cloneRbd.flattenRbdImage(ctx, cr, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
+	err = cloneRbd.flattenRbdImage(ctx, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 	if err != nil {
 		return cloneRbd, err
 	}
@@ -1387,7 +1387,7 @@ func (cs *ControllerServer) DeleteSnapshot(
 	rbdVol.ImageID = rbdSnap.ImageID
 	// update parent name to delete the snapshot
 	rbdSnap.RbdImageName = rbdVol.RbdImageName
-	err = cleanUpSnapshot(ctx, rbdVol, rbdSnap, rbdVol, cr)
+	err = cleanUpSnapshot(ctx, rbdVol, rbdSnap, rbdVol)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to delete image: %v", err)
 

--- a/internal/rbd/migration.go
+++ b/internal/rbd/migration.go
@@ -82,7 +82,7 @@ func deleteMigratedVolume(ctx context.Context, parsedMigHandle *migrationVolID, 
 		return err
 	}
 	defer rv.Destroy()
-	err = deleteImage(ctx, rv, cr)
+	err = rv.deleteImage(ctx)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to delete rbd image: %s, err: %v", rv, err)
 	}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -375,7 +375,7 @@ func (ns *NodeServer) stageTransaction(
 		volOptions.readOnly = true
 	}
 
-	err = flattenImageBeforeMapping(ctx, volOptions, cr)
+	err = flattenImageBeforeMapping(ctx, volOptions)
 	if err != nil {
 		return transaction, err
 	}
@@ -527,8 +527,7 @@ func resizeEncryptedDevice(ctx context.Context, volID, stagingTargetPath, device
 
 func flattenImageBeforeMapping(
 	ctx context.Context,
-	volOptions *rbdVolume,
-	cr *util.Credentials) error {
+	volOptions *rbdVolume) error {
 	var err error
 	var feature bool
 	var depth uint
@@ -550,7 +549,7 @@ func flattenImageBeforeMapping(
 			return err
 		}
 		if feature || depth != 0 {
-			err = volOptions.flattenRbdImage(ctx, cr, true, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
+			err = volOptions.flattenRbdImage(ctx, true, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
 			if err != nil {
 				return err
 			}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -676,15 +676,13 @@ func (rv *rbdVolume) deleteImage(ctx context.Context) error {
 // otherwise removes the image from trash.
 func (rv *rbdVolume) trashRemoveImage(ctx context.Context) error {
 	// attempt to use Ceph manager based deletion support if available
+	log.DebugLog(ctx, "rbd: adding task to remove image %s with id %s from trash", rv, rv.ImageID)
 
-	ra, err := rv.conn.GetRBDAdmin()
+	ta, err := rv.conn.GetTaskAdmin()
 	if err != nil {
 		return err
 	}
 
-	log.DebugLog(ctx, "rbd: adding task to remove image %s with id %s from trash", rv, rv.ImageID)
-
-	ta := ra.Task()
 	_, err = ta.AddTrashRemove(admin.NewImageSpec(rv.Pool, rv.RadosNamespace, rv.ImageID))
 
 	rbdCephMgrSupported := isCephMgrSupported(ctx, rv.ClusterID, err)
@@ -828,14 +826,13 @@ func (rv *rbdVolume) flattenRbdImage(
 		return nil
 	}
 
-	ra, err := rv.conn.GetRBDAdmin()
+	log.DebugLog(ctx, "rbd: adding task to flatten image %q", rv)
+
+	ta, err := rv.conn.GetTaskAdmin()
 	if err != nil {
 		return err
 	}
 
-	log.DebugLog(ctx, "rbd: adding task to flatten image %s", rv)
-
-	ta := ra.Task()
 	_, err = ta.AddFlatten(admin.NewImageSpec(rv.Pool, rv.RadosNamespace, rv.RbdImageName))
 	rbdCephMgrSupported := isCephMgrSupported(ctx, rv.ClusterID, err)
 	if rbdCephMgrSupported {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -676,7 +676,7 @@ func (rv *rbdVolume) deleteImage(ctx context.Context) error {
 // otherwise removes the image from trash.
 func (rv *rbdVolume) trashRemoveImage(ctx context.Context) error {
 	// attempt to use Ceph manager based deletion support if available
-	log.DebugLog(ctx, "rbd: adding task to remove image %s with id %s from trash", rv, rv.ImageID)
+	log.DebugLog(ctx, "rbd: adding task to remove image %q with id %q from trash", rv, rv.ImageID)
 
 	ta, err := rv.conn.GetTaskAdmin()
 	if err != nil {
@@ -700,7 +700,7 @@ func (rv *rbdVolume) trashRemoveImage(ctx context.Context) error {
 			return err
 		}
 	} else {
-		log.DebugLog(ctx, "rbd: successfully added task to move image %s with id %s to trash", rv, rv.ImageID)
+		log.DebugLog(ctx, "rbd: successfully added task to move image %q with id %q to trash", rv, rv.ImageID)
 	}
 
 	return nil
@@ -849,7 +849,7 @@ func (rv *rbdVolume) flattenRbdImage(
 		if forceFlatten || depth >= hardlimit {
 			return fmt.Errorf("%w: flatten is in progress for image %s", ErrFlattenInProgress, rv.RbdImageName)
 		}
-		log.DebugLog(ctx, "successfully added task to flatten image %s", rv)
+		log.DebugLog(ctx, "successfully added task to flatten image %q", rv)
 	}
 	if !rbdCephMgrSupported {
 		log.ErrorLog(

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -617,16 +617,6 @@ func isCephMgrSupported(ctx context.Context, clusterID string, err error) bool {
 	return true
 }
 
-// getTrashPath returns the image path for trash operation.
-func (rv *rbdVolume) getTrashPath() string {
-	trashPath := rv.Pool
-	if rv.RadosNamespace != "" {
-		trashPath = trashPath + "/" + rv.RadosNamespace
-	}
-
-	return trashPath + "/" + rv.ImageID
-}
-
 // ensureImageCleanup finds image in trash and if found removes it
 // from trash.
 func (rv *rbdVolume) ensureImageCleanup(ctx context.Context) error {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -871,10 +871,6 @@ func (rv *rbdVolume) flattenRbdImage(
 			"task manager does not support flatten,image will be flattened once hardlimit is reached: %v",
 			err)
 		if forceFlatten || depth >= hardlimit {
-			err = rv.Connect(cr)
-			if err != nil {
-				return err
-			}
 			err := rv.flatten()
 			if err != nil {
 				log.ErrorLog(ctx, "rbd failed to flatten image %s %s: %v", rv.Pool, rv.RbdImageName, err)

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -349,7 +349,7 @@ func repairDummyImage(ctx context.Context, dummyVol *rbdVolume) error {
 
 	// deleting and recreating the dummy image will not impact anything as its
 	// a workaround to fix the scheduling problem.
-	err := deleteImage(ctx, dummyVol, dummyVol.conn.Creds)
+	err := dummyVol.deleteImage(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -131,6 +131,16 @@ func (cc *ClusterConnection) GetRBDAdmin() (*ra.RBDAdmin, error) {
 	return ra.NewFromConn(cc.conn), nil
 }
 
+// GetTaskAdmin returns TaskAdmin to add tasks on rbd images.
+func (cc *ClusterConnection) GetTaskAdmin() (*ra.TaskAdmin, error) {
+	rbdAdmin, err := cc.GetRBDAdmin()
+	if err != nil {
+		return nil, err
+	}
+
+	return rbdAdmin.Task(), nil
+}
+
 // DisableDiscardOnZeroedWriteSame enables the
 // `rbd_discard_on_zeroed_write_same` option in the cluster connection, so that
 // writing zero blocks of data are actual writes on the OSDs (doing

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/bytecount.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/bytecount.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 import (

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/clone.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/clone.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 import (

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/flags.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/flags.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 // For APIs that accept extra sets of "boolean" flags we may end up wanting

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/fsadmin.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/fsadmin.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 import (

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/mgrmodule.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/mgrmodule.go
@@ -52,3 +52,32 @@ func (fsa *FSAdmin) EnableMirroringModule(force bool) error {
 func (fsa *FSAdmin) DisableMirroringModule() error {
 	return fsa.DisableModule(mirroring)
 }
+
+type moduleInfo struct {
+	EnabledModules []string `json:"enabled_modules"`
+	//DisabledModules []string `json:"disabled_modules"`
+	// DisabledModules is documented in ceph as a list of string
+	// but that's not what comes back from the server (on pacific).
+	// Since we don't need this today, we're just going to ignore
+	// it, but if we ever want to support this for external consumers
+	// we'll need to figure out the real structure of this.
+}
+
+func parseModuleInfo(res response) (*moduleInfo, error) {
+	m := &moduleInfo{}
+	if err := res.NoStatus().Unmarshal(m).End(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// listModules returns moduleInfo or error. it is not exported because
+// this is really not a cephfs specific thing but we needed it
+// for cephfs tests. maybe lift it somewhere else someday.
+func (fsa *FSAdmin) listModules() (*moduleInfo, error) {
+	m := map[string]string{
+		"prefix": "mgr module ls",
+		"format": "json",
+	}
+	return parseModuleInfo(commands.MarshalMonCommand(fsa.conn, m))
+}

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/response.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/response.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 import (

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/subvolume.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/subvolume.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 // this is the internal type used to create JSON for ceph.

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/subvolumegroup.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/subvolumegroup.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 // this is the internal type used to create JSON for ceph.

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/timestamp.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/timestamp.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 import (

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/volume.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/volume.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package admin
 
 import (

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/aliases.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/aliases.go
@@ -23,6 +23,9 @@ const (
 	SizeTSize = C.sizeof_size_t
 )
 
+// Compile-time assertion ensuring that Go's `int` is at least as large as C's.
+const _ = unsafe.Sizeof(int(0)) - C.sizeof_int
+
 // SizeT wraps size_t from C.
 type SizeT C.size_t
 

--- a/vendor/github.com/ceph/go-ceph/rados/read_op.go
+++ b/vendor/github.com/ceph/go-ceph/rados/read_op.go
@@ -77,8 +77,8 @@ func (r *ReadOp) GetOmapValues(startAfter, filterPrefix string, maxReturn uint64
 		gos.cFilterPrefix,
 		C.uint64_t(gos.maxReturn),
 		&gos.iter,
-		&gos.more,
-		&gos.rval,
+		gos.more,
+		gos.rval,
 	)
 	return gos
 }

--- a/vendor/github.com/ceph/go-ceph/rados/write_op_preview.go
+++ b/vendor/github.com/ceph/go-ceph/rados/write_op_preview.go
@@ -1,0 +1,63 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+import (
+	"unsafe"
+)
+
+// WriteOpCmpExtStep holds result of the CmpExt write operation.
+// Result is valid only after Operate() was called.
+type WriteOpCmpExtStep struct {
+	// C returned data:
+	prval *C.int
+
+	// Result of the CmpExt write operation.
+	Result int
+}
+
+func (s *WriteOpCmpExtStep) update() error {
+	s.Result = int(*s.prval)
+	return nil
+}
+
+func (s *WriteOpCmpExtStep) free() {
+	C.free(unsafe.Pointer(s.prval))
+	s.prval = nil
+}
+
+func newWriteOpCmpExtStep() *WriteOpCmpExtStep {
+	return &WriteOpCmpExtStep{
+		prval: (*C.int)(C.malloc(C.sizeof_int)),
+	}
+}
+
+// CmpExt ensures that given object range (extent) satisfies comparison.
+//  PREVIEW
+//
+// Implements:
+//  void rados_write_op_cmpext(rados_write_op_t write_op,
+//                             const char * cmp_buf,
+//                             size_t cmp_len,
+//                             uint64_t off,
+//                             int * prval);
+func (w *WriteOp) CmpExt(b []byte, offset uint64) *WriteOpCmpExtStep {
+	oe := newWriteStep(b, 0, offset)
+	cmpExtStep := newWriteOpCmpExtStep()
+	w.steps = append(w.steps, oe, cmpExtStep)
+	C.rados_write_op_cmpext(
+		w.op,
+		oe.cBuffer,
+		oe.cDataLen,
+		oe.cOffset,
+		cmpExtStep.prval)
+
+	return cmpExtStep
+}

--- a/vendor/github.com/ceph/go-ceph/rados/write_step.go
+++ b/vendor/github.com/ceph/go-ceph/rados/write_step.go
@@ -25,7 +25,7 @@ type writeStep struct {
 func newWriteStep(b []byte, writeLen, offset uint64) *writeStep {
 	return &writeStep{
 		b:         b,
-		cBuffer:   (*C.char)(unsafe.Pointer(&b[0])),
+		cBuffer:   (*C.char)(unsafe.Pointer(&b[0])), // TODO: must be pinned
 		cDataLen:  C.size_t(len(b)),
 		cWriteLen: C.size_t(writeLen),
 		cOffset:   C.uint64_t(offset),

--- a/vendor/github.com/ceph/go-ceph/rbd/admin/imagespec.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/admin/imagespec.go
@@ -1,5 +1,5 @@
-//go:build !nautilus && ceph_preview
-// +build !nautilus,ceph_preview
+//go:build !nautilus
+// +build !nautilus
 
 package admin
 
@@ -10,14 +10,12 @@ import (
 // ImageSpec values are used to identify an RBD image wherever Ceph APIs
 // require an image_spec/image_id_spec using image name/id and optional
 // pool and namespace.
-//  PREVIEW
 type ImageSpec struct {
 	spec string
 }
 
 // NewImageSpec is used to construct an ImageSpec given an image name/id
 // and optional namespace and pool names.
-//  PREVIEW
 //
 // NewImageSpec constructs an ImageSpec to identify an RBD image and thus
 // requires image name/id, whereas NewLevelSpec constructs LevelSpec to
@@ -37,7 +35,6 @@ func NewImageSpec(pool, namespace, image string) ImageSpec {
 
 // NewRawImageSpec returns a ImageSpec directly based on the spec string
 // argument without constructing it from component values.
-//  PREVIEW
 //
 // This should only be used if NewImageSpec can not create the imagespec value
 // you want to pass to ceph.

--- a/vendor/github.com/ceph/go-ceph/rbd/admin/task.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/admin/task.go
@@ -1,5 +1,5 @@
-//go:build !nautilus && ceph_preview
-// +build !nautilus,ceph_preview
+//go:build !nautilus
+// +build !nautilus
 
 package admin
 
@@ -9,19 +9,16 @@ import (
 )
 
 // TaskAdmin encapsulates management functions for ceph rbd task operations.
-//  PREVIEW
 type TaskAdmin struct {
 	conn ccom.MgrCommander
 }
 
 // Task returns a TaskAdmin type for managing ceph rbd task operations.
-//  PREVIEW
 func (ra *RBDAdmin) Task() *TaskAdmin {
 	return &TaskAdmin{conn: ra.conn}
 }
 
 // TaskRefs contains the action name and information about the image.
-//  PREVIEW
 type TaskRefs struct {
 	Action        string `json:"action"`
 	PoolName      string `json:"pool_name"`
@@ -31,7 +28,6 @@ type TaskRefs struct {
 }
 
 // TaskResponse contains the information about the task added on an image.
-//  PREVIEW
 type TaskResponse struct {
 	Sequence      int      `json:"sequence"`
 	ID            string   `json:"id"`
@@ -58,7 +54,6 @@ func parseTaskResponseList(res commands.Response) ([]TaskResponse, error) {
 
 // AddFlatten adds a background task to flatten a cloned image based on the
 // supplied image spec.
-//  PREVIEW
 //
 // Similar To:
 //  rbd task add flatten <image_spec>
@@ -73,7 +68,6 @@ func (ta *TaskAdmin) AddFlatten(img ImageSpec) (TaskResponse, error) {
 
 // AddRemove adds a background task to remove an image based on the supplied
 // image spec.
-//  PREVIEW
 //
 // Similar To:
 //  rbd task add remove <image_spec>
@@ -88,7 +82,6 @@ func (ta *TaskAdmin) AddRemove(img ImageSpec) (TaskResponse, error) {
 
 // AddTrashRemove adds a background task to remove an image from the trash based
 // on the supplied image id spec.
-//  PREVIEW
 //
 // Similar To:
 //  rbd task add trash remove <image_id_spec>
@@ -102,7 +95,6 @@ func (ta *TaskAdmin) AddTrashRemove(img ImageSpec) (TaskResponse, error) {
 }
 
 // List pending or running asynchronous tasks.
-//  PREVIEW
 //
 // Similar To:
 //  rbd task list
@@ -115,7 +107,6 @@ func (ta *TaskAdmin) List() ([]TaskResponse, error) {
 }
 
 // GetTaskByID returns pending or running asynchronous task using id.
-//  PREVIEW
 //
 // Similar To:
 //  rbd task list <task_id>
@@ -129,7 +120,6 @@ func (ta *TaskAdmin) GetTaskByID(taskID string) (TaskResponse, error) {
 }
 
 // Cancel a pending or running asynchronous task.
-//  PREVIEW
 //
 // Similar To:
 //  rbd task cancel <task_id>

--- a/vendor/github.com/ceph/go-ceph/rbd/features_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/features_nautilus.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 package rbd
 
 // #include <rbd/librbd.h>

--- a/vendor/github.com/ceph/go-ceph/rbd/namespace_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/namespace_nautilus.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 //
 // Ceph Nautilus is the first release that includes rbd_namespace_create(),
 // rbd_namespace_remove(), rbd_namespace_exists() and rbd_namespace_list().

--- a/vendor/github.com/ceph/go-ceph/rbd/pool_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/pool_nautilus.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 //
 // Ceph Nautilus is the first release that includes rbd_pool_metadata_get(),
 // rbd_pool_metadata_set() and rbd_pool_metadata_remove().

--- a/vendor/github.com/ceph/go-ceph/rbd/rbd.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/rbd.go
@@ -951,6 +951,11 @@ func (image *Image) GetId() (string, error) {
 
 }
 
+// GetName returns the image name.
+func (image *Image) GetName() string {
+	return image.name
+}
+
 // SetSnapshot updates the rbd image (not the Snapshot) such that the snapshot
 // is the source of readable data.
 //

--- a/vendor/github.com/ceph/go-ceph/rbd/rbd_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/rbd_nautilus.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 //
 // Ceph Nautilus is the first release that includes rbd_list2() and
 // rbd_get_create_timestamp().

--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_namespace.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_namespace.go
@@ -1,6 +1,3 @@
-//go:build !luminous
-// +build !luminous
-
 //
 // Ceph Mimic introduced rbd_snap_get_namespace_type().
 

--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_nautilus.go
@@ -1,6 +1,3 @@
-//go:build !luminous && !mimic
-// +build !luminous,!mimic
-
 //
 // Ceph Nautilus introduced rbd_get_parent() and deprecated rbd_get_parent_info().
 // Ceph Nautilus introduced rbd_list_children3() and deprecated rbd_list_children().

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/cenkalti/backoff/v3
 ## explicit; go 1.16
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.12.0
+# github.com/ceph/go-ceph v0.13.0
 ## explicit; go 1.12
 github.com/ceph/go-ceph/cephfs/admin
 github.com/ceph/go-ceph/common/commands


### PR DESCRIPTION
- rebase: use go-ceph v0.13.0
- rbd: use go-ceph rbd admin task api instead of cli   
- rbd: remove redundant rbdVolume.connect() in flattneRbdImage() 
- rbd: remove redundant util.Credentials arg from flattenRbdImage() 
- rbd: refractor deleteImage() & trashRemoveImage() 

Closes: #2186 


New Mgr Not Supported errors thrown by go-ceph
- `API call not implemented server-side: No handler found for 'rbd task add trash remove'` (rook 1.2.0, ceph v:14.2.2)
- `rados: ret=-13, Permission denied: "access denied: does your client key have mgr caps? See http://docs.ceph.com/en/latest/mgr/administrator/#client-authentication"` (when user secret does not have mgr caps)

