### PR TITLE
cephfs: detect corrupted FUSE mounts and try to restore them

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -126,6 +126,8 @@ spec:
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: ceph-csi-mountinfo
+              mountPath: /csi/mountinfo
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
 {{- if .Values.nodeplugin.httpMetrics.enabled }}
@@ -207,6 +209,10 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
+        - name: ceph-csi-mountinfo
+          hostPath:
+            path: {{ .Values.kubeletDir }}/plugins/{{ .Values.driverName }}/mountinfo
+            type: DirectoryOrCreate
 {{- if .Values.nodeplugin.affinity }}
       affinity:
 {{ toYaml .Values.nodeplugin.affinity | indent 8 -}}

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -100,6 +100,8 @@ spec:
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: ceph-csi-mountinfo
+              mountPath: /csi/mountinfo
         - name: liveness-prometheus
           securityContext:
             privileged: true
@@ -164,6 +166,10 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
+        - name: ceph-csi-mountinfo
+          hostPath:
+            path: /var/lib/kubelet/plugins/cephfs.csi.ceph.com/mountinfo
+            type: DirectoryOrCreate
 ---
 # This is a service to expose the liveness metrics
 apiVersion: v1

--- a/docs/ceph-fuse-corruption.md
+++ b/docs/ceph-fuse-corruption.md
@@ -1,0 +1,45 @@
+# ceph-fuse: detection of corrupted mounts and their recovery
+
+Mounts managed by ceph-fuse may get corrupted by e.g. the ceph-fuse process
+exiting abruptly, or its parent Node Plugin container being terminated, taking
+down its child processes with it.
+
+This may manifest in concerned workloads like so:
+
+```
+# mount | grep fuse
+ceph-fuse on /cephfs-share type fuse.ceph-fuse (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
+# ls /cephfs-share
+ls: /cephfs-share: Socket not connected
+```
+
+or,
+
+```
+# stat /home/kubelet/pods/ae344b80-3b07-4589-b1a1-ca75fa9debf2/volumes/kubernetes.io~csi/pvc-ec69de59-7823-4840-8eee-544f8261fef0/mount: transport endpoint is not connected
+```
+
+This feature allows CSI CephFS plugin to be able to detect if a ceph-fuse mount
+is corrupted during the volume publishing phase, and will attempt to recover it
+for the newly scheduled pod. Pods that already reside on a node whose
+ceph-fuse mountpoints were broken may still need to be restarted, however.
+
+## Detection
+
+A mountpoint is deemed corrupted if `stat()`-ing it returns one of the
+following errors:
+
+* `ENOTCONN`
+* `ESTALE`
+* `EIO`
+* `EACCES`
+* `EHOSTDOWN`
+
+## Recovery
+
+Once a mountpoint corruption is detected, its recovery is performed by
+remounting the volume associated with it.
+
+Recovery is attempted only if `/csi/mountinfo` directory is made available to
+CSI CephFS plugin (available by default in the Helm chart and Kubernetes
+manifests).

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -214,6 +214,29 @@ func execCommandInContainer(
 	return stdOut, stdErr, err
 }
 
+func execCommandInContainerByPodName(
+	f *framework.Framework, shellCmd, namespace, podName, containerName string,
+) (string, string, error) {
+	cmd := []string{"/bin/sh", "-c", shellCmd}
+	execOpts := framework.ExecOptions{
+		Command:            cmd,
+		PodName:            podName,
+		Namespace:          namespace,
+		ContainerName:      containerName,
+		Stdin:              nil,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: true,
+	}
+
+	stdOut, stdErr, err := f.ExecWithOptions(execOpts)
+	if stdErr != "" {
+		e2elog.Logf("stdErr occurred: %v", stdErr)
+	}
+
+	return stdOut, stdErr, err
+}
+
 func execCommandInToolBoxPod(f *framework.Framework, c, ns string) (string, string, error) {
 	opt := &metav1.ListOptions{
 		LabelSelector: rookToolBoxPodLabel,

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -984,7 +984,7 @@ var _ = Describe("RBD", func() {
 				}
 				app.Namespace = f.UniqueName
 
-				err = createPVCAndDeploymentApp(f, "", pvc, app, deployTimeout)
+				err = createPVCAndDeploymentApp(f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
@@ -1014,7 +1014,7 @@ var _ = Describe("RBD", func() {
 					}
 				}
 
-				err = deletePVCAndDeploymentApp(f, "", pvc, app)
+				err = deletePVCAndDeploymentApp(f, pvc, app)
 				if err != nil {
 					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
@@ -1093,7 +1093,7 @@ var _ = Describe("RBD", func() {
 				appClone.Namespace = f.UniqueName
 				appClone.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 				appClone.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly = true
-				err = createPVCAndDeploymentApp(f, "", pvcClone, appClone, deployTimeout)
+				err = createPVCAndDeploymentApp(f, pvcClone, appClone, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
@@ -1131,7 +1131,7 @@ var _ = Describe("RBD", func() {
 					}
 				}
 
-				err = deletePVCAndDeploymentApp(f, "", pvcClone, appClone)
+				err = deletePVCAndDeploymentApp(f, pvcClone, appClone)
 				if err != nil {
 					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
@@ -1217,7 +1217,7 @@ var _ = Describe("RBD", func() {
 				appClone.Namespace = f.UniqueName
 				appClone.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 				appClone.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly = true
-				err = createPVCAndDeploymentApp(f, "", pvcClone, appClone, deployTimeout)
+				err = createPVCAndDeploymentApp(f, pvcClone, appClone, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
@@ -1254,7 +1254,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf(stdErr)
 					}
 				}
-				err = deletePVCAndDeploymentApp(f, "", pvcClone, appClone)
+				err = deletePVCAndDeploymentApp(f, pvcClone, appClone)
 				if err != nil {
 					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}

--- a/internal/cephfs/fuserecovery.go
+++ b/internal/cephfs/fuserecovery.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"context"
+
+	"github.com/ceph/ceph-csi/internal/cephfs/mounter"
+	"github.com/ceph/ceph-csi/internal/cephfs/store"
+	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+
+	mountutil "k8s.io/mount-utils"
+)
+
+type (
+	mountState int
+)
+
+const (
+	msUnknown mountState = iota
+	msNotMounted
+	msMounted
+	msCorrupted
+
+	// ceph-fuse fsType in /proc/<PID>/mountinfo.
+	cephFuseFsType = "fuse.ceph-fuse"
+)
+
+func (ms mountState) String() string {
+	return [...]string{
+		"UNKNOWN",
+		"NOT_MOUNTED",
+		"MOUNTED",
+		"CORRUPTED",
+	}[int(ms)]
+}
+
+func getMountState(path string) (mountState, error) {
+	isMnt, err := util.IsMountPoint(path)
+	if err != nil {
+		if util.IsCorruptedMountError(err) {
+			return msCorrupted, nil
+		}
+
+		return msUnknown, err
+	}
+
+	if isMnt {
+		return msMounted, nil
+	}
+
+	return msNotMounted, nil
+}
+
+func findMountinfo(mountpoint string, mis []mountutil.MountInfo) int {
+	for i := range mis {
+		if mis[i].MountPoint == mountpoint {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// Ensures that given mountpoint is of specified fstype.
+// Returns true if fstype matches, or if no such mountpoint exists.
+func validateFsType(mountpoint, fsType string, mis []mountutil.MountInfo) bool {
+	if idx := findMountinfo(mountpoint, mis); idx > 0 {
+		mi := mis[idx]
+
+		if mi.FsType != fsType {
+			return false
+		}
+	}
+
+	return true
+}
+
+// tryRestoreFuseMountsInNodePublish tries to restore staging and publish
+// volume moutpoints inside the NodePublishVolume call.
+//
+// Restoration is performed in following steps:
+// 1. Detection: staging target path must be a working mountpoint, and target
+//    path must not be a corrupted mountpoint (see getMountState()). If either
+//    of those checks fail, mount recovery is performed.
+// 2. Recovery preconditions:
+//    * NodeStageMountinfo is present for this volume,
+//    * if staging target path and target path are mountpoints, they must be
+//      managed by ceph-fuse,
+//    * VolumeOptions.Mounter must evaluate to "fuse".
+// 3. Recovery:
+//    * staging target path is unmounted and mounted again using ceph-fuse,
+//    * target path is only unmounted; NodePublishVolume is then expected to
+//      continue normally.
+func (ns *NodeServer) tryRestoreFuseMountsInNodePublish(
+	ctx context.Context,
+	volID fsutil.VolumeID,
+	stagingTargetPath string,
+	targetPath string,
+	volContext map[string]string,
+) error {
+	// Check if there is anything to restore.
+
+	stagingTargetMs, err := getMountState(stagingTargetPath)
+	if err != nil {
+		return err
+	}
+
+	targetMs, err := getMountState(targetPath)
+	if err != nil {
+		return err
+	}
+
+	if stagingTargetMs == msMounted && targetMs != msCorrupted {
+		// Mounts seem to be fine.
+		return nil
+	}
+
+	// Something is broken. Try to proceed with mount recovery.
+
+	log.WarningLog(ctx, "cephfs: mount problem detected when publishing a volume: %s is %s, %s is %s; attempting recovery",
+		stagingTargetPath, stagingTargetMs, targetPath, targetMs)
+
+	// NodeStageMountinfo entry must be present for this volume.
+
+	var nsMountinfo *fsutil.NodeStageMountinfo
+
+	if nsMountinfo, err = fsutil.GetNodeStageMountinfo(volID); err != nil {
+		return err
+	} else if nsMountinfo == nil {
+		log.WarningLog(ctx, "cephfs: cannot proceed with mount recovery because NodeStageMountinfo record is missing")
+
+		return nil
+	}
+
+	// Check that the existing stage and publish mounts for this volume are
+	// managed by ceph-fuse, and that the mounter is of the FuseMounter type.
+	// Then try to restore them.
+
+	var (
+		volMounter mounter.VolumeMounter
+		volOptions *store.VolumeOptions
+	)
+
+	procMountInfo, err := util.ReadMountInfoForProc("self")
+	if err != nil {
+		return err
+	}
+
+	if !validateFsType(stagingTargetPath, cephFuseFsType, procMountInfo) ||
+		!validateFsType(targetPath, cephFuseFsType, procMountInfo) {
+		// We can't restore mounts not managed by ceph-fuse.
+		log.WarningLog(ctx, "cephfs: cannot proceed with mount recovery on non-FUSE mountpoints")
+
+		return nil
+	}
+
+	volOptions, err = ns.getVolumeOptions(ctx, volID, volContext, nsMountinfo.Secrets)
+	if err != nil {
+		return err
+	}
+
+	volMounter, err = mounter.New(volOptions)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := volMounter.(*mounter.FuseMounter); !ok {
+		// We can't restore mounts with non-FUSE mounter.
+		log.WarningLog(ctx, "cephfs: cannot proceed with mount recovery with non-FUSE mounter")
+
+		return nil
+	}
+
+	// Try to restore mount in staging target path.
+	// Unmount and mount the volume.
+
+	if stagingTargetMs != msMounted {
+		if err := mounter.UnmountVolume(ctx, stagingTargetPath); err != nil {
+			return err
+		}
+
+		if err := ns.mount(
+			ctx,
+			volMounter,
+			volOptions,
+			volID,
+			stagingTargetPath,
+			nsMountinfo.Secrets,
+			nsMountinfo.VolumeCapability,
+		); err != nil {
+			return err
+		}
+	}
+
+	// Try to restore mount in target path.
+	// Only unmount the bind mount. NodePublishVolume should then
+	// create the bind mount by itself.
+
+	if err := mounter.UnmountVolume(ctx, targetPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Try to restore FUSE mount of the staging target path in NodeStageVolume.
+// If corruption is detected, try to only unmount the volume. NodeStageVolume
+// should be able to continue with mounting the volume normally afterwards.
+func (ns *NodeServer) tryRestoreFuseMountInNodeStage(
+	ctx context.Context,
+	mnt mounter.VolumeMounter,
+	stagingTargetPath string,
+) error {
+	// Check if there is anything to restore.
+
+	stagingTargetMs, err := getMountState(stagingTargetPath)
+	if err != nil {
+		return err
+	}
+
+	if stagingTargetMs != msCorrupted {
+		// Mounts seem to be fine.
+		return nil
+	}
+
+	// Something is broken. Try to proceed with mount recovery.
+
+	log.WarningLog(ctx, "cephfs: mountpoint problem detected when staging a volume: %s is %s; attempting recovery",
+		stagingTargetPath, stagingTargetMs)
+
+	// Check that the existing stage mount for this volume is  managed by
+	// ceph-fuse, and that the mounter is FuseMounter. Then try to restore them.
+
+	procMountInfo, err := util.ReadMountInfoForProc("self")
+	if err != nil {
+		return err
+	}
+
+	if !validateFsType(stagingTargetPath, cephFuseFsType, procMountInfo) {
+		// We can't restore mounts not managed by ceph-fuse.
+		log.WarningLog(ctx, "cephfs: cannot proceed with mount recovery on non-FUSE mountpoints")
+
+		return nil
+	}
+
+	if _, ok := mnt.(*mounter.FuseMounter); !ok {
+		// We can't restore mounts with non-FUSE mounter.
+		log.WarningLog(ctx, "cephfs: cannot proceed with mount recovery with non-FUSE mounter")
+
+		return nil
+	}
+
+	// Restoration here means only unmounting the volume.
+	// NodeStageVolume should take care of the rest.
+	return mounter.UnmountVolume(ctx, stagingTargetPath)
+}

--- a/internal/cephfs/util/mountinfo.go
+++ b/internal/cephfs/util/mountinfo.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	// google.golang.org/protobuf/encoding doesn't offer MessageV2().
+	"github.com/golang/protobuf/proto" // nolint:staticcheck // See comment above.
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// This file provides functionality to store various mount information
+// in a file. It's currently used to restore ceph-fuse mounts.
+// Mount info is stored in `/csi/mountinfo`.
+
+const (
+	mountinfoDir = "/csi/mountinfo"
+)
+
+// nodeStageMountinfoRecord describes a single
+// record of mountinfo of a staged volume.
+// encoding/json-friendly format.
+// Only for internal use for marshaling and unmarshaling.
+type nodeStageMountinfoRecord struct {
+	VolumeCapabilityProtoJSON string            `json:",omitempty"`
+	MountOptions              []string          `json:",omitempty"`
+	Secrets                   map[string]string `json:",omitempty"`
+}
+
+// NodeStageMountinfo describes mountinfo of a volume.
+type NodeStageMountinfo struct {
+	VolumeCapability *csi.VolumeCapability
+	Secrets          map[string]string
+	MountOptions     []string
+}
+
+func fmtNodeStageMountinfoFilename(volID VolumeID) string {
+	return path.Join(mountinfoDir, fmt.Sprintf("nodestage-%s.json", volID))
+}
+
+func (mi *NodeStageMountinfo) toNodeStageMountinfoRecord() (*nodeStageMountinfoRecord, error) {
+	bs, err := protojson.Marshal(proto.MessageV2(mi.VolumeCapability))
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodeStageMountinfoRecord{
+		VolumeCapabilityProtoJSON: string(bs),
+		MountOptions:              mi.MountOptions,
+		Secrets:                   mi.Secrets,
+	}, nil
+}
+
+func (r *nodeStageMountinfoRecord) toNodeStageMountinfo() (*NodeStageMountinfo, error) {
+	volCapability := &csi.VolumeCapability{}
+	if err := protojson.Unmarshal([]byte(r.VolumeCapabilityProtoJSON), proto.MessageV2(volCapability)); err != nil {
+		return nil, err
+	}
+
+	return &NodeStageMountinfo{
+		VolumeCapability: volCapability,
+		MountOptions:     r.MountOptions,
+		Secrets:          r.Secrets,
+	}, nil
+}
+
+// WriteNodeStageMountinfo writes mount info to a file.
+func WriteNodeStageMountinfo(volID VolumeID, mi *NodeStageMountinfo) error {
+	// Write NodeStageMountinfo into JSON-formatted byte slice.
+
+	r, err := mi.toNodeStageMountinfoRecord()
+	if err != nil {
+		return err
+	}
+
+	bs, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	// Write the byte slice into file.
+
+	err = os.WriteFile(fmtNodeStageMountinfoFilename(volID), bs, 0o600)
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	return err
+}
+
+// GetNodeStageMountinfo tries to retrieve NodeStageMountinfoRecord for `volID`.
+// If it doesn't exist, `(nil, nil)` is returned.
+func GetNodeStageMountinfo(volID VolumeID) (*NodeStageMountinfo, error) {
+	// Read the file.
+
+	bs, err := os.ReadFile(fmtNodeStageMountinfoFilename(volID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	// Unmarshall JSON-formatted byte slice into NodeStageMountinfo struct.
+
+	r := &nodeStageMountinfoRecord{}
+	if err = json.Unmarshal(bs, r); err != nil {
+		return nil, err
+	}
+
+	mi, err := r.toNodeStageMountinfo()
+	if err != nil {
+		return nil, err
+	}
+
+	return mi, err
+}
+
+// RemoveNodeStageMountinfo tries to remove NodeStageMountinfo for `volID`.
+// If no such record exists for `volID`, it's considered success too.
+func RemoveNodeStageMountinfo(volID VolumeID) error {
+	if err := os.Remove(fmtNodeStageMountinfoFilename(volID)); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -308,6 +308,18 @@ func IsMountPoint(p string) (bool, error) {
 	return !notMnt, nil
 }
 
+// IsCorruptedMountError checks if the given error is a result of a corrupted
+// mountpoint.
+func IsCorruptedMountError(err error) bool {
+	return mount.IsCorruptedMnt(err)
+}
+
+// ReadMountInfoForProc reads /proc/<PID>/mountpoint and marshals it into
+// MountInfo structs.
+func ReadMountInfoForProc(proc string) ([]mount.MountInfo, error) {
+	return mount.ParseMountInfo(fmt.Sprintf("/proc/%s/mountinfo", proc))
+}
+
 // Mount mounts the source to target path.
 func Mount(source, target, fstype string, options []string) error {
 	dummyMount := mount.New("")


### PR DESCRIPTION
# Describe what this PR does #

This PR adds detection and recovery of corrupted mounts to `Node{Stage,Unstage}Volume` and `Node{Publish,Unpublish}Volume` procedures.

When a corruption is detected during volume stage/publish, the volume in question will be unmounted and mounted again, restoring it for workloads on the node. Note that these remounts are done only in case of FUSE.

When a corruption is detected during volume unstage/unpublish, the mountpoint will be unmounted as opposed to just returning an error.

## Is there anything that requires special attention ##

The actual mount corruption is detected by `IsCorruptedMnt` here:

https://github.com/kubernetes/kubernetes/blob/ba944971f66210d09273ee779380d3e116f75880/staging/src/k8s.io/mount-utils/mount_helper_unix.go#L39-L57

In my experience, when a FUSE process exits, accessing the mountpoint results in `ENOTCONN`. The function above includes many other error codes. The more conservative way would be to check only for `ENOTCONN` for now and later add more errno's to the list of recognized errors. On the other hand, using the `IsCorruptedMnt` function catches errors that I haven't been able to trigger with my limited testing methods. Reviewers can decide which one is more sensible.

## Related issues ##

Fixes: #2616

## Future concerns ##

Mount recovery provided by this PR recovers mounts only in newly created Pods.

## Appendix - testing

This PR was tested by following steps:
* create a PVC with `mounter: fuse`,
* create a Deployment with two replicas mounting that PVC,
* delete the ceph-csi-cephfs Node plugin Pod,
* observe that running `$ stat /mnt` in the workload Pods results in an error: `stat: cannot stat '/mnt': Transport endpoint is not connected`,
* delete one of the Deployment replicas. This triggers `NodeUnpublishVolume` and `NodePublishVolume`, which in turn triggers mount recovery,
* observe that running `$ stat /mnt` in the new replica Pod succeeds.

### Before this PR

```
$ kubectl logs -l app=ceph-csi-cephfs,component=nodeplugin -c csi-cephfsplugin
I1111 13:38:51.373446       1 cephcsi.go:167] Driver version: v3.4.0 and Git version: 94ef181bc866c8ccaf507de66f213b26608309ff
I1111 13:38:51.373941       1 cephcsi.go:185] Initial PID limit is set to -1
I1111 13:38:51.374005       1 cephcsi.go:191] Reconfigured PID limit to -1 (max)
I1111 13:38:51.374011       1 cephcsi.go:212] Starting driver type: cephfs with name: cephfs.csi.ceph.com
I1111 13:38:51.387400       1 volumemounter.go:87] loaded mounter: kernel
I1111 13:38:51.400493       1 volumemounter.go:98] loaded mounter: fuse
I1111 13:38:51.401342       1 server.go:131] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
I1111 13:38:52.165347       1 utils.go:176] ID: 1 GRPC call: /csi.v1.Identity/GetPluginInfo
I1111 13:38:52.168260       1 utils.go:180] ID: 1 GRPC request: {}
I1111 13:38:52.168296       1 identityserver-default.go:38] ID: 1 Using default GetPluginInfo
I1111 13:38:52.168379       1 utils.go:187] ID: 1 GRPC response: {"name":"cephfs.csi.ceph.com","vendor_version":"v3.4.0"}
I1111 13:38:52.744387       1 utils.go:176] ID: 2 GRPC call: /csi.v1.Node/NodeGetInfo
I1111 13:38:52.744466       1 utils.go:180] ID: 2 GRPC request: {}
I1111 13:38:52.744479       1 nodeserver-default.go:60] ID: 2 Using default NodeGetInfo
I1111 13:38:52.744620       1 utils.go:187] ID: 2 GRPC response: {"accessible_topology":{},"node_id":"127.0.0.1"}
I1111 13:39:01.848210       1 utils.go:176] ID: 3 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC call: /csi.v1.Node/NodePublishVolume
I1111 13:39:01.848650       1 utils.go:180] ID: 3 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC request: {"secrets":"***stripped***","staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/globalmount","target_path":"/var/lib/kubelet/pods/656f7d40-7c02-4790-bf81-eb7c1d753fd3/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":5}},"volume_context":{"monitors":"188.184.74.8:6789","mounter":"fuse","provisionVolume":"false","rootPath":"/volumes/_nogroup/6dc56738-5c8a-42d4-bfc1-901a65cc84eb/c2bd88ca-f269-4d4c-8cf7-a5eb48e3eaa9"},"volume_id":"8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c"}
I1111 13:39:01.857917       1 mount_linux.go:173] Cannot run systemd-run, assuming non-systemd OS
I1111 13:39:01.857947       1 mount_linux.go:174] systemd-run failed with: exit status 1
I1111 13:39:01.857959       1 mount_linux.go:175] systemd-run output: System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to create bus connection: Host is down
I1111 13:39:01.864268       1 cephcmds.go:60] ID: 3 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c command succeeded: mount [-o bind,_netdev /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/globalmount /var/lib/kubelet/pods/656f7d40-7c02-4790-bf81-eb7c1d753fd3/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount]
I1111 13:39:01.864311       1 nodeserver.go:266] ID: 3 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c cephfs: successfully bind-mounted volume 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c to /var/lib/kubelet/pods/656f7d40-7c02-4790-bf81-eb7c1d753fd3/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount
I1111 13:39:01.864384       1 utils.go:187] ID: 3 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC response: {}
I1111 13:39:02.753991       1 utils.go:176] ID: 4 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC call: /csi.v1.Node/NodeUnpublishVolume
I1111 13:39:02.754148       1 utils.go:180] ID: 4 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC request: {"target_path":"/var/lib/kubelet/pods/5bc657be-656f-406b-bb23-962218259034/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount","volume_id":"8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c"}
I1111 13:39:02.762338       1 mount_linux.go:173] Cannot run systemd-run, assuming non-systemd OS
I1111 13:39:02.762359       1 mount_linux.go:174] systemd-run failed with: exit status 1
I1111 13:39:02.762369       1 mount_linux.go:175] systemd-run output: System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to create bus connection: Host is down
E1111 13:39:02.762485       1 utils.go:185] ID: 4 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC error: rpc error: code = Internal desc = stat /var/lib/kubelet/pods/5bc657be-656f-406b-bb23-962218259034/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount: transport endpoint is not connected
I1111 13:39:03.357951       1 utils.go:176] ID: 5 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC call: /csi.v1.Node/NodeUnpublishVolume
I1111 13:39:03.358107       1 utils.go:180] ID: 5 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC request: {"target_path":"/var/lib/kubelet/pods/5bc657be-656f-406b-bb23-962218259034/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount","volume_id":"8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c"}
I1111 13:39:03.365459       1 mount_linux.go:173] Cannot run systemd-run, assuming non-systemd OS
I1111 13:39:03.365477       1 mount_linux.go:174] systemd-run failed with: exit status 1
I1111 13:39:03.365485       1 mount_linux.go:175] systemd-run output: System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to create bus connection: Host is down
E1111 13:39:03.365533       1 utils.go:185] ID: 5 Req-ID: 8f9e7e53-4c25-4e74-9e1a-6507e32bbc5c GRPC error: rpc error: code = Internal desc = stat /var/lib/kubelet/pods/5bc657be-656f-406b-bb23-962218259034/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount: transport endpoint is not connected
... repeated calls to NodeUnpublishVolume that never succeed ...
```

* `NodePublishVolume` allegedly succeeded, but the Pod won't come up as it end ups in CrashLoopBackOff state. `kubectl describe` reports following error:
   `  Warning  Failed     81s (x5 over 2m44s)   kubelet            Error: failed to start container "test": Error response from daemon: error while creating mount source path '/var/lib/kubelet/pods/656f7d40-7c02-4790-bf81-eb7c1d753fd3/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount': mkdir /var/lib/kubelet/pods/656f7d40-7c02-4790-bf81-eb7c1d753fd3/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount: file exists`
* Running `$ stat /var/lib/kubelet/pods/656f7d40-7c02-4790-bf81-eb7c1d753fd3/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount` on the node reveals the actual problem:
   `stat: cannot statx '/var/lib/kubelet/pods/656f7d40-7c02-4790-bf81-eb7c1d753fd3/volumes/kubernetes.io~csi/pvc-d89978df-6549-4fb0-a72b-0b610c1a8e0c/mount': Transport endpoint is not connected`
* `NodeUnpublishVolume` will never succeed because [`util.IsMountPoint()`](https://github.com/ceph/ceph-csi/blob/b95f3cdcbc1d3659afd48551e96744fd988db6bd/internal/cephfs/nodeserver.go#L294-L303) will keep failing. Admin must unmount the volume on the node manually or restart the node.

### Node plugin logs with this PR

```
$ kubectl logs -l app=ceph-csi-cephfs,component=nodeplugin -c csi-cephfsplugin
I1111 08:58:17.802425       1 cephcsi.go:168] Driver version: canary and Git version: af752dd38f8e74d84987ab14f2ac489a10bb635c
I1111 08:58:17.802753       1 cephcsi.go:186] Initial PID limit is set to -1
I1111 08:58:17.802834       1 cephcsi.go:192] Reconfigured PID limit to -1 (max)
I1111 08:58:17.802859       1 cephcsi.go:217] Starting driver type: cephfs with name: cephfs.csi.ceph.com
I1111 08:58:17.814902       1 volumemounter.go:79] loaded mounter: kernel
I1111 08:58:17.826562       1 volumemounter.go:90] loaded mounter: fuse
I1111 08:58:17.827027       1 server.go:131] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
I1111 08:58:18.611849       1 utils.go:177] ID: 1 GRPC call: /csi.v1.Identity/GetPluginInfo
I1111 08:58:18.614095       1 utils.go:181] ID: 1 GRPC request: {}
I1111 08:58:18.614124       1 identityserver-default.go:38] ID: 1 Using default GetPluginInfo
I1111 08:58:18.614190       1 utils.go:188] ID: 1 GRPC response: {"name":"cephfs.csi.ceph.com","vendor_version":"canary"}
I1111 08:58:18.652409       1 utils.go:177] ID: 2 GRPC call: /csi.v1.Node/NodeGetInfo
I1111 08:58:18.652472       1 utils.go:181] ID: 2 GRPC request: {}
I1111 08:58:18.652494       1 nodeserver-default.go:60] ID: 2 Using default NodeGetInfo
I1111 08:58:18.652598       1 utils.go:188] ID: 2 GRPC response: {"accessible_topology":{},"node_id":"127.0.0.1"}
I1111 08:58:41.227645       1 utils.go:177] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 GRPC call: /csi.v1.Node/NodePublishVolume
I1111 08:58:41.227909       1 utils.go:181] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 GRPC request: {"secrets":"***stripped***","staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/globalmount","target_path":"/var/lib/kubelet/pods/e1c0eb2c-95c4-4fca-85fc-abb185ecd5a9/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":5}},"volume_context":{"monitors":"188.184.74.8:6789","mounter":"fuse","provisionVolume":"false","rootPath":"/volumes/_nogroup/0a8a7a03-61a9-4bda-bd47-067605c11b7a/a00fcddc-617d-4695-9fa7-0885855b3a31"},"volume_id":"49670f1b-26de-4feb-887f-b74eb6ab4488"}
I1111 08:58:41.227986       1 nodeserver.go:528] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 cephfs: detected corrupted FUSE mount in staging target path /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/globalmount during NodePublishVolume, remounting
I1111 08:58:41.239076       1 cephcmds.go:62] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 command succeeded: umount [/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/globalmount]
I1111 08:58:41.239276       1 nodeserver.go:193] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 cephfs: mounting volume 49670f1b-26de-4feb-887f-b74eb6ab4488 with Ceph FUSE driver
I1111 08:58:41.295946       1 cephcmds.go:62] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 command succeeded: ceph-fuse [/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/globalmount -m 188.184.74.8:6789 -c /etc/ceph/ceph.conf -n client.pvc-1e705b75-af6e-4827-ab45-90f2563539f2 --keyfile=***stripped*** -r /volumes/_nogroup/0a8a7a03-61a9-4bda-bd47-067605c11b7a/a00fcddc-617d-4695-9fa7-0885855b3a31 -o nonempty]
I1111 08:59:04.413678       1 cephcmds.go:62] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 command succeeded: mount [-o bind,_netdev /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/globalmount /var/lib/kubelet/pods/e1c0eb2c-95c4-4fca-85fc-abb185ecd5a9/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount]
I1111 08:59:04.413750       1 nodeserver.go:341] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 cephfs: successfully bind-mounted volume 49670f1b-26de-4feb-887f-b74eb6ab4488 to /var/lib/kubelet/pods/e1c0eb2c-95c4-4fca-85fc-abb185ecd5a9/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount
I1111 08:59:04.413937       1 utils.go:188] ID: 3 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 GRPC response: {}
I1111 08:59:04.495789       1 utils.go:177] ID: 4 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 GRPC call: /csi.v1.Node/NodeUnpublishVolume
I1111 08:59:04.495927       1 utils.go:181] ID: 4 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 GRPC request: {"target_path":"/var/lib/kubelet/pods/2df62d3a-b329-4f4a-8483-e98a563463eb/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount","volume_id":"49670f1b-26de-4feb-887f-b74eb6ab4488"}
E1111 08:59:04.495982       1 nodeserver.go:360] ID: 4 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 stat failed: stat /var/lib/kubelet/pods/2df62d3a-b329-4f4a-8483-e98a563463eb/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount: transport endpoint is not connected
I1111 08:59:04.495994       1 nodeserver.go:374] ID: 4 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 cephfs: detected corrupted mount in publish target path /var/lib/kubelet/pods/2df62d3a-b329-4f4a-8483-e98a563463eb/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount, trying to unmount anyway
I1111 08:59:04.504291       1 cephcmds.go:62] ID: 4 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 command succeeded: umount [/var/lib/kubelet/pods/2df62d3a-b329-4f4a-8483-e98a563463eb/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount]
I1111 08:59:04.504397       1 nodeserver.go:396] ID: 4 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 cephfs: successfully unbounded volume 49670f1b-26de-4feb-887f-b74eb6ab4488 from /var/lib/kubelet/pods/2df62d3a-b329-4f4a-8483-e98a563463eb/volumes/kubernetes.io~csi/pvc-1e705b75-af6e-4827-ab45-90f2563539f2/mount
I1111 08:59:04.504473       1 utils.go:188] ID: 4 Req-ID: 49670f1b-26de-4feb-887f-b74eb6ab4488 GRPC response: {}
```

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
