### PR TITLE
rbd: fix mapOptions passing with rbd-nbd mounter

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -268,6 +268,10 @@ var _ = Describe("RBD", func() {
 		if err != nil {
 			e2elog.Failf("failed to get the kernel version with error %v", err)
 		}
+		// default io-timeout=0, needs kernel >= 5.4
+		if !util.CheckKernelSupport(kernelRelease, nbdZeroIOtimeoutSupport) {
+			nbdMapOptions = "debug-rbd=20,io-timeout=330"
+		}
 	})
 
 	AfterEach(func() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -20,7 +20,6 @@ import (
 	scv1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
@@ -230,12 +229,12 @@ func validatePVCAndAppBinding(pvcPath, appPath string, f *framework.Framework) e
 	return err
 }
 
-func getMountType(appName, appNamespace, mountPath string, f *framework.Framework) (string, error) {
+func getMountType(selector, mountPath string, f *framework.Framework) (string, error) {
 	opt := metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("metadata.name", appName).String(),
+		LabelSelector: selector,
 	}
 	cmd := fmt.Sprintf("lsblk -o TYPE,MOUNTPOINT | grep '%s' | awk '{print $1}'", mountPath)
-	stdOut, stdErr, err := execCommandInPod(f, cmd, appNamespace, &opt)
+	stdOut, stdErr, err := execCommandInContainer(f, cmd, cephCSINamespace, "csi-rbdplugin", &opt)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
* rbd: fix mapOptions passing with rbd-nbd mounter
This was a regression introduced by:
https://github.com/ceph/ceph-csi/pull/2556

* e2e: adding io-timeout for lower kernel versions
This got removed unintentionally with
https://github.com/ceph/ceph-csi/pull/2628

* e2e: validate encrypted image mount inside the nodeplugin
currently, the mount type validation of the encrypted volume is done in the application, we should rather validate this inside the nodeplugin pod.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>


Fixes: #2610.
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
