### PR TITLE
ci: avoid preleased bits

### DIFF
--- a/scripts/get_patch_release.py
+++ b/scripts/get_patch_release.py
@@ -77,7 +77,9 @@ def get_releases(gh_releases):
     '''
     releases = list()
     for release in gh_releases:
-        releases.append(release['name'].split()[-1])
+        # ignore prereleases
+        if not release['prerelease']:
+            releases.append(release['name'].split()[-1])
     return releases
 
 


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Skip testing with prereleased content, for example
v1.23.0-alpha.4
v1.23.0-alpha.3
v1.23.0-alpha.2
v1.23.0-alpha.1
v1.22.0-rc.0
v1.22.0-beta.2
v1.22.0-beta.1
v1.22.0-beta.0
v1.22.0-alpha.3
v1.22.0-alpha.2

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
