### PR TITLE
rbd: provide a way to supply mounter specific mapOptions from sc

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -362,6 +362,11 @@ storageClass:
   # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
   # For nbd options refer
   # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+  # Format:
+  # mapOptions: "<mounter>:op1,op2;<mounter>:op1,op2"
+  # An empty mounter field is treated as krbd type for compatibility.
+  # eg:
+  # mapOptions: "krbd:lock_on_read,queue_depth=1024;nbd:try-netlink"
   mapOptions: ""
 
   # (optional) unmapOptions is a comma-separated list of unmap options.
@@ -369,6 +374,11 @@ storageClass:
   # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
   # For nbd options refer
   # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+  # Format:
+  # unmapOptions: "<mounter>:op1,op2;<mounter>:op1,op2"
+  # An empty mounter field is treated as krbd type for compatibility.
+  # eg:
+  # unmapOptions: "krbd:force;nbd:force"
   unmapOptions: ""
 
   # The secrets have to contain Ceph credentials with required access

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -61,7 +61,7 @@ var (
 	snapshotPath           = rbdExamplePath + "snapshot.yaml"
 	defaultCloneCount      = 10
 
-	nbdMapOptions             = "debug-rbd=20"
+	nbdMapOptions             = "nbd:debug-rbd=20"
 	e2eDefaultCephLogStrategy = "preserve"
 )
 
@@ -271,7 +271,7 @@ var _ = Describe("RBD", func() {
 		}
 		// default io-timeout=0, needs kernel >= 5.4
 		if !util.CheckKernelSupport(kernelRelease, nbdZeroIOtimeoutSupport) {
-			nbdMapOptions = "debug-rbd=20,io-timeout=330"
+			nbdMapOptions = "nbd:debug-rbd=20,io-timeout=330"
 		}
 	})
 

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -53,14 +53,22 @@ parameters:
    # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
    # For nbd options refer
    # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
-   # mapOptions: lock_on_read,queue_depth=1024
+   # Format:
+   # mapOptions: "<mounter>:op1,op2;<mounter>:op1,op2"
+   # An empty mounter field is treated as krbd type for compatibility.
+   # eg:
+   # mapOptions: "krbd:lock_on_read,queue_depth=1024;nbd:try-netlink"
 
    # (optional) unmapOptions is a comma-separated list of unmap options.
    # For krbd options refer
    # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
    # For nbd options refer
    # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
-   # unmapOptions: force
+   # Format:
+   # unmapOptions: "<mounter>:op1,op2;<mounter>:op1,op2"
+   # An empty mounter field is treated as krbd type for compatibility.
+   # eg:
+   # unmapOptions: "krbd:force;nbd:force"
 
    # The secrets have to contain Ceph credentials with required access
    # to the 'pool'.

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -224,12 +224,14 @@ func populateRbdVol(
 			return nil, status.Errorf(codes.Internal, "unsupported krbd Feature")
 		}
 		// fallback to rbd-nbd,
-		// ignore the mapOptions and unmapOptions as they are meant for krbd use.
 		rv.Mounter = rbdNbdMounter
 	} else {
 		rv.Mounter = req.GetVolumeContext()["mounter"]
-		rv.MapOptions = req.GetVolumeContext()["mapOptions"]
-		rv.UnmapOptions = req.GetVolumeContext()["unmapOptions"]
+	}
+
+	err = getMapOptions(req, rv)
+	if err != nil {
+		return nil, err
 	}
 
 	rv.VolID = volID

--- a/internal/rbd/rbd_attach_test.go
+++ b/internal/rbd/rbd_attach_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMapOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		mapOption         string
+		expectKrbdOptions string
+		expectNbdOptions  string
+		expectErr         string
+	}{
+		{
+			name:              "with old format",
+			mapOption:         "kOp1,kOp2",
+			expectKrbdOptions: "kOp1,kOp2",
+			expectNbdOptions:  "",
+			expectErr:         "",
+		},
+		{
+			name:              "with new format",
+			mapOption:         "krbd:kOp1,kOp2;nbd:nOp1,nOp2",
+			expectKrbdOptions: "kOp1,kOp2",
+			expectNbdOptions:  "nOp1,nOp2",
+			expectErr:         "",
+		},
+		{
+			name:              "without krbd: label",
+			mapOption:         "kOp1,kOp2;nbd:nOp1,nOp2",
+			expectKrbdOptions: "kOp1,kOp2",
+			expectNbdOptions:  "nOp1,nOp2",
+			expectErr:         "",
+		},
+		{
+			name:              "with only nbd label",
+			mapOption:         "nbd:nOp1,nOp2",
+			expectKrbdOptions: "",
+			expectNbdOptions:  "nOp1,nOp2",
+			expectErr:         "",
+		},
+		{
+			name:              "unknown mounter used",
+			mapOption:         "xyz:xOp1,xOp2",
+			expectKrbdOptions: "",
+			expectNbdOptions:  "",
+			expectErr:         "unknown mounter type",
+		},
+		{
+			name:              "bad formatted options",
+			mapOption:         "nbd:nOp1:nOp2;",
+			expectKrbdOptions: "",
+			expectNbdOptions:  "",
+			expectErr:         "badly formatted map/unmap options",
+		},
+	}
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			krbdOpts, nbdOpts, err := parseMapOptions(tc.mapOption)
+			if err != nil && !strings.Contains(err.Error(), tc.expectErr) {
+				// returned error
+				t.Errorf("parseMapOptions(%s) returned error, expected: %v, got: %v",
+					tc.mapOption, tc.expectErr, err)
+			}
+			if krbdOpts != tc.expectKrbdOptions {
+				// unexpected krbd option error
+				t.Errorf("parseMapOptions(%s) returned unexpected krbd options, expected :%q, got: %q",
+					tc.mapOption, tc.expectKrbdOptions, krbdOpts)
+			}
+			if nbdOpts != tc.expectNbdOptions {
+				// unexpected nbd option error
+				t.Errorf("parseMapOptions(%s) returned unexpected nbd options, expected: %q, got: %q",
+					tc.mapOption, tc.expectNbdOptions, nbdOpts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Uses the below schema to supply mounter specific map/unmapOptions to the nodeplugin based on the discussion we all had at https://github.com/ceph/ceph-csi/pull/2636

This should specifically be really helpful with the `tryOthermonters` set to true, i.e with fallback mechanism settings turned ON.

```yaml
mapOption: "kbrd:v1,v2,v3;nbd:v1,v2,v3"
```

- By omitting `krbd:` or `nbd:`, the option(s) apply to rbdDefaultMounter which is krbd.
- A user can _override_ the options for a mounter by specifying `krbd:` or `nbd:`. 
  ```yaml
  mapOption: "v1,v2,v3;nbd:v1,v2,v3"
  ```
  is effectively the same as the 1st example.
- Sections are split by `;`.
- If users want to specify common options for both `krbd` and `nbd`, they should mention them twice.

Fixes: #2641

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
