### PR TITLE
ci: Fix build issue for retest action

### DIFF
--- a/.github/workflows/test-retest-action.yaml
+++ b/.github/workflows/test-retest-action.yaml
@@ -3,7 +3,7 @@ name: test-retest-action
 # yamllint disable-line rule:truthy
 on:
   pull_request:
-    branches: [main]
+    branches: [devel]
 
 jobs:
   build:

--- a/.github/workflows/test-retest-action.yaml
+++ b/.github/workflows/test-retest-action.yaml
@@ -11,13 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-
-      - name: Enter retest directory
-        run: cd actions/retest
-
-      - name: Build
-        run: go build -v ./...
+      - name: Docker build
+        # Run cd to avoid loading complete cephcsi directory in docker context
+        # while building retest image.
+        run: cd actions/retest && docker build -t retest .

--- a/actions/retest/Dockerfile
+++ b/actions/retest/Dockerfile
@@ -3,12 +3,16 @@ ARG BASE_IMAGE="golang:1.16"
 
 FROM ${BASE_IMAGE} as builder
 
+ARG WORK_DIR
+
 COPY . /home/src
 WORKDIR ${WORK_DIR}
 
 RUN go build -mod=vendor -o retest ./main.go
 
 FROM scratch
+
+ARG WORK_DIR
 
 COPY --from=builder ${WORK_DIR}/retest /usr/local/bin/retest
 


### PR DESCRIPTION
Currently retest action is failing with docker build error ` cannot normalize nothing` more details at https://github.com/ceph/ceph-csi/runs/4226095839?check_suite_focus=true

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>