### PR TITLE
build: use golang:1.16 as runtime container for retest action

### DIFF
--- a/actions/retest/Dockerfile
+++ b/actions/retest/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${WORK_DIR}
 
 RUN go build -mod=vendor -o retest ./main.go
 
-FROM scratch
+FROM ${BASE_IMAGE}
 
 ARG WORK_DIR
 


### PR DESCRIPTION
It seems that building the `retest` action makes it consume shared
libraries that are not part of the `scratch` base container layer. By
using the golang:1.16 container image as a base, all required shared
libraries are available.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
