### PR TITLE
rbd: update ControllerExpandVolume with migration secret support

### DIFF
--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -22,7 +22,6 @@ const (
 	intreeVolPrefix      = "kubernetes-dynamic-pvc-"
 )
 
-// nolint:unparam // currently name receive pvName, this can change in the future
 func getStaticPV(
 	name, volName, size, secretName, secretNS, sc, driverName string,
 	blockPV bool,
@@ -70,7 +69,6 @@ func getStaticPV(
 	return pv
 }
 
-// nolint:unparam // currently name receive same name, this can change in the future
 func getStaticPVC(name, pvName, size, ns, sc string, blockPVC bool) *v1.PersistentVolumeClaim {
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/util/credentials_test.go
+++ b/internal/util/credentials_test.go
@@ -42,7 +42,7 @@ func TestIsMigrationSecret(t *testing.T) {
 		newtt := tt
 		t.Run(newtt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := IsMigrationSecret(newtt.vc); got != newtt.want {
+			if got := isMigrationSecret(newtt.vc); got != newtt.want {
 				t.Errorf("isMigrationSecret() = %v, want %v", got, newtt.want)
 			}
 		})


### PR DESCRIPTION
This PR address below items from the tracker/todo: 
- [x] e2e: adjust migration e2e tests and introduce helper functions
    This commit adjust existing migration e2e tests to a couple of tests
    to cover the scenarios. The seperate filesystem and block tests have
    been shrinked to single one and also introduced a couple of helper
    functions to setup and teardown migraition specific secret,configmap
    and sc. The static pv function has been renamed to a general name
    while the tests were adjusted.
- [x]  rbd: add migration secret support to controllerserver functions
    This commit adds the migration secret request validation to expand,
    create controller functions.
- [x]  e2e: remove unparam linter escapes from getStaticPV and getStaticPVC
     This `unparam` linter escape is no longer needed and CI is failing
    if we keep there. This commit remove the same and make CI happy.
       
Updates #2509 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>