### PR TITLE
ci: add actions/retest to dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,13 @@ updates:
       - dependency-name: "k8s.io/mount-utils"
       - dependency-name: "k8s.io/pod-security-admission"
       - dependency-name: "k8s.io/sample-apiserver"
+  - package-ecosystem: "gomod"
+    directory: "/actions/retest"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    labels:
+      - rebase
+      - ci/skip/e2e
+    commit-message:
+      prefix: "rebase"


### PR DESCRIPTION
Adding actions/retest to the dependabot configuration makes sure all
vendored packages will get updated when new releases are available.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
