### PR TITLE
e2e: retry on "transport: missing content-type field" error

### DIFF
--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -46,6 +46,13 @@ func isRetryableAPIError(err error) bool {
 		return true
 	}
 
+	// "transport: missing content-type field" is an error that sometimes
+	// is returned while talking to the kubernetes-api-server. There does
+	// not seem to be a public error constant for this.
+	if strings.Contains(err.Error(), "transport: missing content-type field") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
The e2e sometimes fail getting objects like PVCs from the Kubernetes API
server, and log the following error:

    Error getting pvc "rbd-6940" in namespace "rbd-694": rpc error: code = Unknown desc = OK: HTTP status code 200; transport: missing content-type field

By checking the error message, and initiating a retry on this failure,
CI jobs should fail less regulary.

See-also: https://github.com/ceph/ceph-csi/pull/2622#issuecomment-972600735

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
