### PR TITLE
rbd: add a workaround to fix rbd snapshot scheduling

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2050,28 +2050,6 @@ func (ri *rbdImage) addSnapshotScheduling(
 		return err
 	}
 	adminConn := ra.MirrorSnashotSchedule()
-	// list all the snapshot scheduling and check at least one image scheduling
-	// exists with specified interval.
-	ssList, err := adminConn.List(ls)
-	if err != nil {
-		return err
-	}
-
-	for _, ss := range ssList {
-		// make sure we are matching image level scheduling. The
-		// `adminConn.List` lists the global level scheduling also.
-		if ss.Name == ri.String() {
-			for _, s := range ss.Schedule {
-				// TODO: Add support to check start time also.
-				// The start time is currently stored with different format
-				// in ceph. Comparison is not possible unless we know in
-				// which format ceph is storing it.
-				if s.Interval == interval {
-					return err
-				}
-			}
-		}
-	}
 	err = adminConn.Add(ls, interval, startTime)
 	if err != nil {
 		return err

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -114,6 +114,14 @@ func (cc *ClusterConnection) GetFSAdmin() (*ca.FSAdmin, error) {
 	return ca.NewFromConn(cc.conn), nil
 }
 
+func (cc *ClusterConnection) GetFSID() (string, error) {
+	if cc.conn == nil {
+		return "", errors.New("cluster is not connected yet")
+	}
+
+	return cc.conn.GetFSID()
+}
+
 // GetRBDAdmin get RBDAdmin to administrate rbd volumes.
 func (cc *ClusterConnection) GetRBDAdmin() (*ra.RBDAdmin, error) {
 	if cc.conn == nil {


### PR DESCRIPTION
currently, we have a bug in the rbd mirror scheduling module. After doing failover and failback the scheduling is not getting updated and the mirroring snapshots are not getting created periodically as per the scheduling interval. This PR workaround this one by doing the below operations

- Create a dummy (csi-vol-dummy-ceph fsID) image per cluster and this image should be easily identified.

- During Promote operation on any image enables the mirroring on the dummy image. when we enable the mirroring on the dummy image the pool will get updated and the scheduling will be reconfigured.

- During Demote operation on any image disables the mirroring on the dummy image. the disabled need to be done to enable the mirroring again when we get the promote request to make the image as the primary

- When the DR is no more needed, this image needs to be manually cleanup for now as we don't want to add a check in the existing DeleteVolume code path for deleting dummy images as it impacts the performance of the DeleteVolume workflow.

Moved to add scheduling to the promote operation as scheduling need to be added when the image is promoted and this is the correct method of adding the scheduling to make the scheduling take place.

More details at https://bugzilla.redhat.com/show_bug.cgi?id=2019161
Signed-off-by: Madhu Rajanna madhupr007@gmail.com
Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>