### PR TITLE
ci: use 1.8.5 vault for e2e

### DIFF
--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: vault
-          image: docker.io/library/vault:latest
+          image: docker.io/library/vault:1.8.5
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 100
@@ -64,7 +64,7 @@ spec:
             - name: home
               mountPath: /home
         - name: monitor
-          image: docker.io/library/vault:latest
+          image: docker.io/library/vault:1.8.5
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 100
@@ -151,7 +151,7 @@ spec:
             name: init-scripts
       containers:
         - name: vault-init-job
-          image: docker.io/library/vault:latest
+          image: docker.io/library/vault:1.8.5
           securityContext:
             runAsUser: 100
           volumeMounts:


### PR DESCRIPTION
The current latest vault release is 1.9.0 but with the latest image, our E2E is broken. reverting back the vault version to 1.8.5 till we root cause the issue.

Note:- This is to unblock PR merging

updates: #2657

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

