### PR TITLE
ci: update images for vault 1.8.5

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -162,11 +162,13 @@ node('cico-workspace') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
 
-			// vault:latest and nginx:latest are used by the e2e tests
+			// vault:latest,1.8.5 and nginx:latest are used by the e2e tests
 			podman_pull(ci_registry, "docker.io", "library/vault:latest")
 			ssh "./podman2minikube.sh docker.io/library/vault:latest"
 			podman_pull(ci_registry, "docker.io", "library/nginx:latest")
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
+			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
+			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
 		}
 		stage('deploy ceph-csi through helm') {
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -159,11 +159,13 @@ node('cico-workspace') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
 
-			// vault:latest and nginx:latest are used by the e2e tests
+			// vault:latest,1.8.5 and nginx:latest are used by the e2e tests
 			podman_pull(ci_registry, "docker.io", "library/vault:latest")
 			ssh "./podman2minikube.sh docker.io/library/vault:latest"
 			podman_pull(ci_registry, "docker.io", "library/nginx:latest")
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
+			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
+			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {

--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -18,3 +18,4 @@ docker.io/rook/ceph:v1.4.9	rook/ceph:v1.4.9
 docker.io/library/busybox:1.29	library/busybox:1.29
 docker.io/library/nginx:latest	library/nginx:latest
 docker.io/library/vault:latest	library/vault:latest
+docker.io/library/vault:1.8.5	library/vault:1.8.5

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -159,11 +159,13 @@ node('cico-workspace') {
 				ssh "./single-node-k8s.sh --k8s-version=${k8s_release}"
 			}
 
-			// vault:latest and nginx:latest are used by the e2e tests
+			// vault:latest,1.8.5 and nginx:latest are used by the e2e tests
 			podman_pull(ci_registry, "docker.io", "library/vault:latest")
 			ssh "./podman2minikube.sh docker.io/library/vault:latest"
 			podman_pull(ci_registry, "docker.io", "library/nginx:latest")
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
+			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
+			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
 		}
 		stage("run ${test_type} upgrade tests") {
 			timeout(time: 120, unit: 'MINUTES') {


### PR DESCRIPTION
updating ci scripts to pull the vault image from ci registry.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

