### PR TITLE
ci: use official CentOS container location

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM quay.io/centos/centos:latest
 
 RUN true \
  && yum -y install git make python3-pip \

--- a/mirror/Containerfile
+++ b/mirror/Containerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM quay.io/centos/centos:latest
 
 RUN true \
  && yum -y install skopeo \


### PR DESCRIPTION
registry.centos.org is not officially  maintained by the CentOS infrastructure team. The container images on quay.io are the official once and we should use those instead.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

openshift image builds are failing with below error

logs
```
Cloning "https://github.com/ceph/ceph-csi" ...
	Commit:	a07fb3bcfc7c36d951e1ae8fde8cfe80abe18ef6 (ci: update images for vault 1.8.5)
	Author:	Madhu Rajanna <madhupr007@gmail.com>
	Date:	Fri Nov 19 12:28:36 2021 +0530
Caching blobs under "/var/cache/blobs".

Pulling image centos:latest ...
Warning: Pull failed, retrying in 5s ...
Warning: Pull failed, retrying in 5s ...
Warning: Pull failed, retrying in 5s ...
error: build error: failed to pull image: After retrying 2 times, Pull image still failed due to error: Error determining manifest MIME type for docker://centos:latest: Error reading manifest sha256:a1801b843b1bfaf77c501e7a6d3f709401a1e0c83863037fa3aab063a7fdb9dc in docker.io/library/centos: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://w
```
