### PR TITLE
e2e: reformat error message with consistent formatting

### DIFF
--- a/e2e/ceph_user.go
+++ b/e2e/ceph_user.go
@@ -87,7 +87,7 @@ func createCephUser(f *framework.Framework, user string, caps []string) (string,
 		return "", err
 	}
 	if stdErr != "" {
-		return "", fmt.Errorf("failed to create user %s with error %v", cmd, stdErr)
+		return "", fmt.Errorf("failed to create user %s: %v", cmd, stdErr)
 	}
 
 	return strings.TrimSpace(stdOut), nil

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -38,21 +38,21 @@ func deployCephfsPlugin() {
 
 	data, err := replaceNamespaceInTemplate(cephFSDirPath + cephFSProvisionerRBAC)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSProvisionerRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSProvisionerRBAC, err)
 	}
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, "--ignore-not-found=true", ns, "delete", "-f", "-")
 	if err != nil {
-		e2elog.Failf("failed to delete provisioner rbac %s with error %v", cephFSDirPath+cephFSProvisionerRBAC, err)
+		e2elog.Failf("failed to delete provisioner rbac %s: %v", cephFSDirPath+cephFSProvisionerRBAC, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(cephFSDirPath + cephFSNodePluginRBAC)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSNodePluginRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSNodePluginRBAC, err)
 	}
 	_, err = framework.RunKubectlInput(cephCSINamespace, data, "delete", "--ignore-not-found=true", ns, "-f", "-")
 
 	if err != nil {
-		e2elog.Failf("failed to delete nodeplugin rbac %s with error %v", cephFSDirPath+cephFSNodePluginRBAC, err)
+		e2elog.Failf("failed to delete nodeplugin rbac %s: %v", cephFSDirPath+cephFSNodePluginRBAC, err)
 	}
 
 	createORDeleteCephfsResources(kubectlCreate)
@@ -68,12 +68,12 @@ func createORDeleteCephfsResources(action kubectlAction) {
 		// createORDeleteRbdResources is used for upgrade testing as csidriverObject is
 		// newly added, discarding file not found error.
 		if !os.IsNotExist(err) {
-			e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+csiDriverObject, err)
+			e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+csiDriverObject, err)
 		}
 	} else {
 		err = retryKubectlInput(cephCSINamespace, action, string(csiDriver), deployTimeout)
 		if err != nil {
-			e2elog.Failf("failed to %s CSIDriver object with error %v", action, err)
+			e2elog.Failf("failed to %s CSIDriver object: %v", action, err)
 		}
 	}
 	cephConf, err := ioutil.ReadFile(examplePath + cephConfconfigMap)
@@ -81,74 +81,74 @@ func createORDeleteCephfsResources(action kubectlAction) {
 		// createORDeleteCephfsResources is used for upgrade testing as cephConfConfigmap is
 		// newly added, discarding file not found error.
 		if !os.IsNotExist(err) {
-			e2elog.Failf("failed to read content from %s with error %v", examplePath+cephConfconfigMap, err)
+			e2elog.Failf("failed to read content from %s: %v", examplePath+cephConfconfigMap, err)
 		}
 	} else {
 		err = retryKubectlInput(cephCSINamespace, action, string(cephConf), deployTimeout)
 		if err != nil {
-			e2elog.Failf("failed to %s ceph-conf configmap object with error %v", action, err)
+			e2elog.Failf("failed to %s ceph-conf configmap object: %v", action, err)
 		}
 	}
 	data, err := replaceNamespaceInTemplate(cephFSDirPath + cephFSProvisioner)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSProvisioner, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSProvisioner, err)
 	}
 	data = oneReplicaDeployYaml(data)
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s CephFS provisioner with error %v", action, err)
+		e2elog.Failf("failed to %s CephFS provisioner: %v", action, err)
 	}
 	data, err = replaceNamespaceInTemplate(cephFSDirPath + cephFSProvisionerRBAC)
 
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSProvisionerRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSProvisionerRBAC, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s CephFS provisioner rbac with error %v", action, err)
+		e2elog.Failf("failed to %s CephFS provisioner rbac: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(cephFSDirPath + cephFSProvisionerPSP)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSProvisionerPSP, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSProvisionerPSP, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s CephFS provisioner psp with error %v", action, err)
+		e2elog.Failf("failed to %s CephFS provisioner psp: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(cephFSDirPath + cephFSNodePlugin)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSNodePlugin, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSNodePlugin, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s CephFS nodeplugin with error %v", action, err)
+		e2elog.Failf("failed to %s CephFS nodeplugin: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(cephFSDirPath + cephFSNodePluginRBAC)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSNodePluginRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSNodePluginRBAC, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s CephFS nodeplugin rbac with error %v", action, err)
+		e2elog.Failf("failed to %s CephFS nodeplugin rbac: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(cephFSDirPath + cephFSNodePluginPSP)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", cephFSDirPath+cephFSNodePluginPSP, err)
+		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSNodePluginPSP, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s CephFS nodeplugin psp with error %v", action, err)
+		e2elog.Failf("failed to %s CephFS nodeplugin psp: %v", action, err)
 	}
 }
 
 func validateSubvolumeCount(f *framework.Framework, count int, fileSystemName, subvolumegroup string) {
 	subVol, err := listCephFSSubVolumes(f, fileSystemName, subvolumegroup)
 	if err != nil {
-		e2elog.Failf("failed to list CephFS subvolumes with error %v", err)
+		e2elog.Failf("failed to list CephFS subvolumes: %v", err)
 	}
 	if len(subVol) != count {
 		e2elog.Failf("subvolumes [%v]. subvolume count %d not matching expected count %v", subVol, len(subVol), count)
@@ -158,7 +158,7 @@ func validateSubvolumeCount(f *framework.Framework, count int, fileSystemName, s
 func validateSubvolumePath(f *framework.Framework, pvcName, pvcNamespace, fileSystemName, subvolumegroup string) error {
 	_, pv, err := getPVCAndPV(f.ClientSet, pvcName, pvcNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to get PVC %s in namespace %s with error %w", pvcName, pvcNamespace, err)
+		return fmt.Errorf("failed to get PVC %s in namespace %s: %w", pvcName, pvcNamespace, err)
 	}
 	subVolumePathInPV := pv.Spec.CSI.VolumeAttributes["subvolumePath"]
 	subVolume := pv.Spec.CSI.VolumeAttributes["subvolumeName"]
@@ -195,32 +195,32 @@ var _ = Describe("cephfs", func() {
 			if cephCSINamespace != defaultNs {
 				err := createNamespace(c, cephCSINamespace)
 				if err != nil {
-					e2elog.Failf("failed to create namespace %s with error %v", cephCSINamespace, err)
+					e2elog.Failf("failed to create namespace %s: %v", cephCSINamespace, err)
 				}
 			}
 			deployCephfsPlugin()
 		}
 		err := createConfigMap(cephFSDirPath, f.ClientSet, f)
 		if err != nil {
-			e2elog.Failf("failed to create configmap with error %v", err)
+			e2elog.Failf("failed to create configmap: %v", err)
 		}
 		// create cephFS provisioner secret
 		key, err := createCephUser(f, keyringCephFSProvisionerUsername, cephFSProvisionerCaps())
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringCephFSProvisionerUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringCephFSProvisionerUsername, err)
 		}
 		err = createCephfsSecret(f, cephFSProvisionerSecretName, keyringCephFSProvisionerUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create provisioner secret with error %v", err)
+			e2elog.Failf("failed to create provisioner secret: %v", err)
 		}
 		// create cephFS plugin secret
 		key, err = createCephUser(f, keyringCephFSNodePluginUsername, cephFSNodePluginCaps())
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringCephFSNodePluginUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringCephFSNodePluginUsername, err)
 		}
 		err = createCephfsSecret(f, cephFSNodePluginSecretName, keyringCephFSNodePluginUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create node secret with error %v", err)
+			e2elog.Failf("failed to create node secret: %v", err)
 		}
 	})
 
@@ -241,30 +241,30 @@ var _ = Describe("cephfs", func() {
 		}
 		err := deleteConfigMap(cephFSDirPath)
 		if err != nil {
-			e2elog.Failf("failed to delete configmap with error %v", err)
+			e2elog.Failf("failed to delete configmap: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), cephFSProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete provisioner secret with error %v", err)
+			e2elog.Failf("failed to delete provisioner secret: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), cephFSNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete node secret with error %v", err)
+			e2elog.Failf("failed to delete node secret: %v", err)
 		}
 		err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 		if err != nil {
-			e2elog.Failf("failed to delete storageclass with error %v", err)
+			e2elog.Failf("failed to delete storageclass: %v", err)
 		}
 		if deployCephFS {
 			deleteCephfsPlugin()
 			if cephCSINamespace != defaultNs {
 				err := deleteNamespace(c, cephCSINamespace)
 				if err != nil {
-					e2elog.Failf("failed to delete namespace %s with error %v", cephCSINamespace, err)
+					e2elog.Failf("failed to delete namespace %s: %v", cephCSINamespace, err)
 				}
 			}
 		}
@@ -284,14 +284,14 @@ var _ = Describe("cephfs", func() {
 			By("checking provisioner deployment is running", func() {
 				err := waitForDeploymentComplete(cephFSDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for deployment %s with error %v", cephFSDeploymentName, err)
+					e2elog.Failf("timeout waiting for deployment %s: %v", cephFSDeploymentName, err)
 				}
 			})
 
 			By("checking nodeplugin deamonset pods are running", func() {
 				err := waitForDaemonSets(cephFSDeamonSetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for daemonset %s with error %v", cephFSDeamonSetName, err)
+					e2elog.Failf("timeout waiting for daemonset %s: %v", cephFSDeamonSetName, err)
 				}
 			})
 
@@ -300,16 +300,16 @@ var _ = Describe("cephfs", func() {
 				By("verify PVC and app binding on helm installation", func() {
 					err := validatePVCAndAppBinding(pvcPath, appPath, f)
 					if err != nil {
-						e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+						e2elog.Failf("failed to validate CephFS pvc and application binding: %v", err)
 					}
 					//  Deleting the storageclass and secret created by helm
 					err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+						e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 					}
 					err = deleteResource(cephFSExamplePath + "secret.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+						e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 					}
 				})
 			}
@@ -349,22 +349,22 @@ var _ = Describe("cephfs", func() {
 				scPath := cephFSExamplePath + "secret.yaml"
 				err := validateCephFsStaticPV(f, appPath, scPath)
 				if err != nil {
-					e2elog.Failf("failed to validate CephFS static pv with error %v", err)
+					e2elog.Failf("failed to validate CephFS static pv: %v", err)
 				}
 			})
 
 			By("create a storageclass with pool and a PVC then bind it to an app", func() {
 				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
 				if err != nil {
-					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate CephFS pvc and application binding: %v", err)
 				}
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 				}
 			})
 
@@ -376,17 +376,17 @@ var _ = Describe("cephfs", func() {
 					false,
 					map[string]string{"volumeNamePrefix": volumeNamePrefix})
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				// set up PVC
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 
 				validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
@@ -394,7 +394,7 @@ var _ = Describe("cephfs", func() {
 				foundIt := false
 				subvolumes, err := listCephFSSubVolumes(f, fileSystemName, subvolumegroup)
 				if err != nil {
-					e2elog.Failf("failed to list subvolumes with error %v", err)
+					e2elog.Failf("failed to list subvolumes: %v", err)
 				}
 				for _, subVol := range subvolumes {
 					fmt.Printf("Checking prefix on %s\n", subVol)
@@ -407,12 +407,12 @@ var _ = Describe("cephfs", func() {
 				// clean up after ourselves
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to  delete PVC with error %v", err)
+					e2elog.Failf("failed to  delete PVC: %v", err)
 				}
 				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				if !foundIt {
 					e2elog.Failf("could not find subvolume with prefix %s", volumeNamePrefix)
@@ -425,15 +425,15 @@ var _ = Describe("cephfs", func() {
 				}
 				err := createCephfsStorageClass(f.ClientSet, f, true, params)
 				if err != nil {
-					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate CephFS pvc and application binding: %v", err)
 				}
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 				}
 			})
 
@@ -444,33 +444,33 @@ var _ = Describe("cephfs", func() {
 				}
 				err := createCephfsStorageClass(f.ClientSet, f, true, params)
 				if err != nil {
-					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate CephFS pvc and application binding: %v", err)
 				}
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and bind it to an app", func() {
 				err := createCephfsStorageClass(f.ClientSet, f, false, nil)
 				if err != nil {
-					e2elog.Failf("failed to create CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate CephFS pvc and application  binding with error %v", err)
+					e2elog.Failf("failed to validate CephFS pvc and application  binding: %v", err)
 				}
 			})
 
 			By("create a PVC and bind it to an app with normal user", func() {
 				err := validateNormalUserPVCAccess(pvcPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate normal user CephFS pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate normal user CephFS pvc and application binding: %v", err)
 				}
 			})
 
@@ -478,13 +478,13 @@ var _ = Describe("cephfs", func() {
 				totalCount := 2
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				// create PVC and app
@@ -492,11 +492,11 @@ var _ = Describe("cephfs", func() {
 					name := fmt.Sprintf("%s%d", f.UniqueName, i)
 					err = createPVCAndApp(name, f, pvc, app, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create PVC or application with error %v", err)
+						e2elog.Failf("failed to create PVC or application: %v", err)
 					}
 					err = validateSubvolumePath(f, pvc.Name, pvc.Namespace, fileSystemName, subvolumegroup)
 					if err != nil {
-						e2elog.Failf("failed to validate subvolumePath with error %v", err)
+						e2elog.Failf("failed to validate subvolumePath: %v", err)
 					}
 				}
 
@@ -506,7 +506,7 @@ var _ = Describe("cephfs", func() {
 					name := fmt.Sprintf("%s%d", f.UniqueName, i)
 					err = deletePVCAndApp(name, f, pvc, app)
 					if err != nil {
-						e2elog.Failf("failed to delete PVC or application with error %v", err)
+						e2elog.Failf("failed to delete PVC or application: %v", err)
 					}
 
 				}
@@ -516,54 +516,54 @@ var _ = Describe("cephfs", func() {
 			By("check data persist after recreating pod", func() {
 				err := checkDataPersist(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to check data persist in pvc with error %v", err)
+					e2elog.Failf("failed to check data persist in pvc: %v", err)
 				}
 			})
 
 			By("Create PVC, bind it to an app, unmount volume and check app deletion", func() {
 				pvc, app, err := createPVCAndAppBinding(pvcPath, appPath, f, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC or application with error %v", err)
+					e2elog.Failf("failed to create PVC or application: %v", err)
 				}
 
 				err = unmountCephFSVolume(f, app.Name, pvc.Name)
 				if err != nil {
-					e2elog.Failf("failed to unmount volume with error %v", err)
+					e2elog.Failf("failed to unmount volume: %v", err)
 				}
 
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC or application with error %v", err)
+					e2elog.Failf("failed to delete PVC or application: %v", err)
 				}
 			})
 
 			By("create PVC, delete backing subvolume and check pv deletion", func() {
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 
 				err = deleteBackingCephFSVolume(f, pvc)
 				if err != nil {
-					e2elog.Failf("failed to delete CephFS subvolume with error %v", err)
+					e2elog.Failf("failed to delete CephFS subvolume: %v", err)
 				}
 
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 			})
 
 			By("validate multiple subvolumegroup creation", func() {
 				err := deleteResource(cephFSExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 
 				// re-define configmap with information of multiple clusters.
@@ -577,27 +577,27 @@ var _ = Describe("cephfs", func() {
 
 				err = createCustomConfigMap(f.ClientSet, cephFSDirPath, clusterInfo)
 				if err != nil {
-					e2elog.Failf("failed to create configmap with error %v", err)
+					e2elog.Failf("failed to create configmap: %v", err)
 				}
 				params := map[string]string{
 					"clusterID": "clusterID-1",
 				}
 				err = createCephfsStorageClass(f.ClientSet, f, false, params)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application with error %v", err)
+					e2elog.Failf("failed to validate pvc and application: %v", err)
 				}
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				// verify subvolume group creation.
 				err = validateSubvolumegroup(f, "subvolgrp1")
 				if err != nil {
-					e2elog.Failf("failed to validate subvolume group with error %v", err)
+					e2elog.Failf("failed to validate subvolume group: %v", err)
 				}
 
 				// create resources and verify subvolume group creation
@@ -605,38 +605,38 @@ var _ = Describe("cephfs", func() {
 				params["clusterID"] = "clusterID-2"
 				err = createCephfsStorageClass(f.ClientSet, f, false, params)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application with error %v", err)
+					e2elog.Failf("failed to validate pvc and application: %v", err)
 				}
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = validateSubvolumegroup(f, "subvolgrp2")
 				if err != nil {
-					e2elog.Failf("failed to validate subvolume group with error %v", err)
+					e2elog.Failf("failed to validate subvolume group: %v", err)
 				}
 				err = deleteConfigMap(cephFSDirPath)
 				if err != nil {
-					e2elog.Failf("failed to delete configmap with error %v", err)
+					e2elog.Failf("failed to delete configmap: %v", err)
 				}
 				err = createConfigMap(cephFSDirPath, f.ClientSet, f)
 				if err != nil {
-					e2elog.Failf("failed to create configmap with error %v", err)
+					e2elog.Failf("failed to create configmap: %v", err)
 				}
 				err = createCephfsStorageClass(f.ClientSet, f, false, nil)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("Resize PVC and check application directory size", func() {
 				err := resizePVCAndValidateSize(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to resize PVC with error %v", err)
+					e2elog.Failf("failed to resize PVC: %v", err)
 				}
 			})
 
@@ -644,13 +644,13 @@ var _ = Describe("cephfs", func() {
 				// create PVC and bind it to an app
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 
 				app.Namespace = f.UniqueName
@@ -662,7 +662,7 @@ var _ = Describe("cephfs", func() {
 				app.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly = true
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC or application with error %v", err)
+					e2elog.Failf("failed to create PVC or application: %v", err)
 				}
 
 				opt := metav1.ListOptions{
@@ -683,24 +683,24 @@ var _ = Describe("cephfs", func() {
 				// delete PVC and app
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC or application with error %v", err)
+					e2elog.Failf("failed to delete PVC or application: %v", err)
 				}
 			})
 
 			By("Delete snapshot after deleting subvolume and snapshot from backend", func() {
 				err := createCephFSSnapshotClass(f)
 				if err != nil {
-					e2elog.Failf("failed to create CephFS snapshotclass with error %v", err)
+					e2elog.Failf("failed to create CephFS snapshotclass: %v", err)
 				}
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 
 				snap := getSnapshot(snapshotPath)
@@ -715,7 +715,7 @@ var _ = Describe("cephfs", func() {
 
 				err = deleteBackingCephFSSubvolumeSnapshot(f, pvc, &snap)
 				if err != nil {
-					e2elog.Failf("failed to delete backing snapshot for snapname with error=%s", err)
+					e2elog.Failf("failed to delete backing snapshot for snapname:=%s", err)
 				}
 
 				err = deleteBackingCephFSVolume(f, pvc)
@@ -725,19 +725,19 @@ var _ = Describe("cephfs", func() {
 
 				err = deleteSnapshot(&snap, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete snapshot with error=%s", err)
+					e2elog.Failf("failed to delete snapshot:=%s", err)
 				} else {
 					e2elog.Logf("successfully deleted snapshot")
 				}
 
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 
 				err = deleteResource(cephFSExamplePath + "snapshotclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete CephFS snapshotclass with error %v", err)
+					e2elog.Failf("failed to delete CephFS snapshotclass: %v", err)
 				}
 			})
 
@@ -749,17 +749,17 @@ var _ = Describe("cephfs", func() {
 
 				err := createCephFSSnapshotClass(f)
 				if err != nil {
-					e2elog.Failf("failed to create CephFS snapshotclass with error %v", err)
+					e2elog.Failf("failed to create CephFS snapshotclass: %v", err)
 				}
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 
 				snap := getSnapshot(snapshotPath)
@@ -776,17 +776,17 @@ var _ = Describe("cephfs", func() {
 				// another one from snapshot.
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 
 				pvcClone, err := loadPVC(pvcClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				appClone, err := loadApp(appClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 
 				pvcClone.Namespace = f.UniqueName
@@ -814,7 +814,7 @@ var _ = Describe("cephfs", func() {
 
 				err = deleteResource(cephFSExamplePath + "snapshotclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete CephFS snapshotclass with error %v", err)
+					e2elog.Failf("failed to delete CephFS snapshotclass: %v", err)
 				}
 			})
 
@@ -828,22 +828,22 @@ var _ = Describe("cephfs", func() {
 				wg.Add(totalCount)
 				err := createCephFSSnapshotClass(f)
 				if err != nil {
-					e2elog.Failf("failed to delete CephFS storageclass with error %v", err)
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 				}
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 
 				app.Namespace = f.UniqueName
@@ -856,7 +856,7 @@ var _ = Describe("cephfs", func() {
 				}
 				wErr := writeDataInPod(app, &opt, f)
 				if wErr != nil {
-					e2elog.Failf("failed to  write data  with error %v", wErr)
+					e2elog.Failf("failed to  write data : %v", wErr)
 				}
 
 				snap := getSnapshot(snapshotPath)
@@ -886,11 +886,11 @@ var _ = Describe("cephfs", func() {
 
 				pvcClone, err := loadPVC(pvcClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				appClone, err := loadApp(appClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				pvcClone.Namespace = f.UniqueName
 				appClone.Namespace = f.UniqueName
@@ -1032,7 +1032,7 @@ var _ = Describe("cephfs", func() {
 				// delete parent pvc
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC or application with error %v", err)
+					e2elog.Failf("failed to delete PVC or application: %v", err)
 				}
 
 				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
@@ -1047,17 +1047,17 @@ var _ = Describe("cephfs", func() {
 				totalSubvolumes := totalCount + 1
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
@@ -1074,13 +1074,13 @@ var _ = Describe("cephfs", func() {
 
 				pvcClone, err := loadPVC(pvcSmartClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvcClone.Spec.DataSource.Name = pvc.Name
 				pvcClone.Namespace = f.UniqueName
 				appClone, err := loadApp(appSmartClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				appClone.Namespace = f.UniqueName
 				wg.Add(totalCount)
@@ -1111,7 +1111,7 @@ var _ = Describe("cephfs", func() {
 				// delete parent pvc
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC or application with error %v", err)
+					e2elog.Failf("failed to delete PVC or application: %v", err)
 				}
 
 				wg.Add(totalCount)
@@ -1144,25 +1144,25 @@ var _ = Describe("cephfs", func() {
 				// create PVC and bind it to an app
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 
 				pvcClone, err := loadPVC(pvcSmartClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvcClone.Namespace = f.UniqueName
 				pvcClone.Spec.DataSource.Name = pvc.Name
 				pvcClone.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 
 				app.Namespace = f.UniqueName
@@ -1173,7 +1173,7 @@ var _ = Describe("cephfs", func() {
 				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 				err = createPVCAndApp("", f, pvcClone, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC or application with error %v", err)
+					e2elog.Failf("failed to create PVC or application: %v", err)
 				}
 
 				opt := metav1.ListOptions{
@@ -1194,13 +1194,13 @@ var _ = Describe("cephfs", func() {
 				// delete cloned ROX pvc and app
 				err = deletePVCAndApp("", f, pvcClone, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC or application with error %v", err)
+					e2elog.Failf("failed to delete PVC or application: %v", err)
 				}
 
 				// delete parent pvc
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 			})
 			// Make sure this should be last testcase in this file, because
@@ -1208,18 +1208,18 @@ var _ = Describe("cephfs", func() {
 			By("Create a PVC and delete PVC when backend pool deleted", func() {
 				err := pvcDeleteWhenPoolNotFound(pvcPath, true, f)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 			})
 			// delete cephFS provisioner secret
 			err := deleteCephUser(f, keyringCephFSProvisionerUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringCephFSProvisionerUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringCephFSProvisionerUsername, err)
 			}
 			// delete cephFS plugin secret
 			err = deleteCephUser(f, keyringCephFSNodePluginUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringCephFSNodePluginUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringCephFSNodePluginUsername, err)
 			}
 		})
 	})

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -27,7 +27,7 @@ func validateSubvolumegroup(f *framework.Framework, subvolgrp string) error {
 		return fmt.Errorf("failed to exec command in toolbox: %w", err)
 	}
 	if stdErr != "" {
-		return fmt.Errorf("failed to getpath for subvolumegroup %s with error %v", subvolgrp, stdErr)
+		return fmt.Errorf("failed to getpath for subvolumegroup %s : %v", subvolgrp, stdErr)
 	}
 	expectedGrpPath := "/volumes/" + subvolgrp
 	stdOut = strings.TrimSpace(stdOut)
@@ -193,7 +193,7 @@ func getSubvolumePath(f *framework.Framework, filesystem, subvolgrp, subvolume s
 		return "", err
 	}
 	if stdErr != "" {
-		return "", fmt.Errorf("failed to getpath for subvolume %s with error %s", subvolume, stdErr)
+		return "", fmt.Errorf("failed to getpath for subvolume %s : %s", subvolume, stdErr)
 	}
 
 	return strings.TrimSpace(stdOut), nil

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -69,20 +69,20 @@ func deployRBDPlugin() {
 	// delete objects deployed by rook
 	data, err := replaceNamespaceInTemplate(rbdDirPath + rbdProvisionerRBAC)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisionerRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdProvisionerRBAC, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, kubectlDelete, data, deployTimeout, "--ignore-not-found=true")
 	if err != nil {
-		e2elog.Failf("failed to delete provisioner rbac %s with error %v", rbdDirPath+rbdProvisionerRBAC, err)
+		e2elog.Failf("failed to delete provisioner rbac %s: %v", rbdDirPath+rbdProvisionerRBAC, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdNodePluginRBAC)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdNodePluginRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdNodePluginRBAC, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, kubectlDelete, data, deployTimeout, "--ignore-not-found=true")
 	if err != nil {
-		e2elog.Failf("failed to delete nodeplugin rbac %s with error %v", rbdDirPath+rbdNodePluginRBAC, err)
+		e2elog.Failf("failed to delete nodeplugin rbac %s: %v", rbdDirPath+rbdNodePluginRBAC, err)
 	}
 
 	createORDeleteRbdResources(kubectlCreate)
@@ -98,12 +98,12 @@ func createORDeleteRbdResources(action kubectlAction) {
 		// createORDeleteRbdResources is used for upgrade testing as csidriverObject is
 		// newly added, discarding file not found error.
 		if !os.IsNotExist(err) {
-			e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+csiDriverObject, err)
+			e2elog.Failf("failed to read content from %s: %v", rbdDirPath+csiDriverObject, err)
 		}
 	} else {
 		err = retryKubectlInput(cephCSINamespace, action, string(csiDriver), deployTimeout)
 		if err != nil {
-			e2elog.Failf("failed to %s CSIDriver object with error %v", action, err)
+			e2elog.Failf("failed to %s CSIDriver object: %v", action, err)
 		}
 	}
 	cephConf, err := ioutil.ReadFile(examplePath + cephConfconfigMap)
@@ -111,78 +111,78 @@ func createORDeleteRbdResources(action kubectlAction) {
 		// createORDeleteRbdResources is used for upgrade testing as cephConf Configmap is
 		// newly added, discarding file not found error.
 		if !os.IsNotExist(err) {
-			e2elog.Failf("failed to read content from %s with error %v", examplePath+cephConfconfigMap, err)
+			e2elog.Failf("failed to read content from %s: %v", examplePath+cephConfconfigMap, err)
 		}
 	} else {
 		err = retryKubectlInput(cephCSINamespace, action, string(cephConf), deployTimeout)
 		if err != nil {
-			e2elog.Failf("failed to %s ceph-conf configmap object with error %v", action, err)
+			e2elog.Failf("failed to %s ceph-conf configmap object: %v", action, err)
 		}
 	}
 	data, err := replaceNamespaceInTemplate(rbdDirPath + rbdProvisioner)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisioner, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdProvisioner, err)
 	}
 	data = oneReplicaDeployYaml(data)
 	data = enableTopologyInTemplate(data)
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s rbd provisioner with error %v", action, err)
+		e2elog.Failf("failed to %s rbd provisioner: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdProvisionerRBAC)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisionerRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdProvisionerRBAC, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s provisioner rbac with error %v", action, err)
+		e2elog.Failf("failed to %s provisioner rbac: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdProvisionerPSP)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdProvisionerPSP, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdProvisionerPSP, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s provisioner psp with error %v", action, err)
+		e2elog.Failf("failed to %s provisioner psp: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdNodePlugin)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdNodePlugin, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdNodePlugin, err)
 	}
 
 	domainLabel := nodeRegionLabel + "," + nodeZoneLabel
 	data = addTopologyDomainsToDSYaml(data, domainLabel)
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s nodeplugin with error %v", action, err)
+		e2elog.Failf("failed to %s nodeplugin: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdNodePluginRBAC)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdNodePluginRBAC, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdNodePluginRBAC, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s nodeplugin rbac with error %v", action, err)
+		e2elog.Failf("failed to %s nodeplugin rbac: %v", action, err)
 	}
 
 	data, err = replaceNamespaceInTemplate(rbdDirPath + rbdNodePluginPSP)
 	if err != nil {
-		e2elog.Failf("failed to read content from %s with error %v", rbdDirPath+rbdNodePluginPSP, err)
+		e2elog.Failf("failed to read content from %s: %v", rbdDirPath+rbdNodePluginPSP, err)
 	}
 	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to %s nodeplugin psp with error %v", action, err)
+		e2elog.Failf("failed to %s nodeplugin psp: %v", action, err)
 	}
 }
 
 func validateRBDImageCount(f *framework.Framework, count int, pool string) {
 	imageList, err := listRBDImages(f, pool)
 	if err != nil {
-		e2elog.Failf("failed to list rbd images with error %v", err)
+		e2elog.Failf("failed to list rbd images: %v", err)
 	}
 	if len(imageList) != count {
 		e2elog.Failf(
@@ -207,67 +207,67 @@ var _ = Describe("RBD", func() {
 		if deployRBD {
 			err := createNodeLabel(f, nodeRegionLabel, regionValue)
 			if err != nil {
-				e2elog.Failf("failed to create node label with error %v", err)
+				e2elog.Failf("failed to create node label: %v", err)
 			}
 			err = createNodeLabel(f, nodeZoneLabel, zoneValue)
 			if err != nil {
-				e2elog.Failf("failed to create node label with error %v", err)
+				e2elog.Failf("failed to create node label: %v", err)
 			}
 			if cephCSINamespace != defaultNs {
 				err = createNamespace(c, cephCSINamespace)
 				if err != nil {
-					e2elog.Failf("failed to create namespace with error %v", err)
+					e2elog.Failf("failed to create namespace: %v", err)
 				}
 			}
 			deployRBDPlugin()
 		}
 		err := createConfigMap(rbdDirPath, f.ClientSet, f)
 		if err != nil {
-			e2elog.Failf("failed to create configmap with error %v", err)
+			e2elog.Failf("failed to create configmap: %v", err)
 		}
 		// Since helm deploys storageclass, skip storageclass creation if
 		// ceph-csi is deployed via helm.
 		if !helmTest {
 			err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 			if err != nil {
-				e2elog.Failf("failed to create storageclass with error %v", err)
+				e2elog.Failf("failed to create storageclass: %v", err)
 			}
 		}
 		// create rbd provisioner secret
 		key, err := createCephUser(f, keyringRBDProvisionerUsername, rbdProvisionerCaps("", ""))
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringRBDProvisionerUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringRBDProvisionerUsername, err)
 		}
 		err = createRBDSecret(f, rbdProvisionerSecretName, keyringRBDProvisionerUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create provisioner secret with error %v", err)
+			e2elog.Failf("failed to create provisioner secret: %v", err)
 		}
 		// create rbd plugin secret
 		key, err = createCephUser(f, keyringRBDNodePluginUsername, rbdNodePluginCaps("", ""))
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringRBDNodePluginUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringRBDNodePluginUsername, err)
 		}
 		err = createRBDSecret(f, rbdNodePluginSecretName, keyringRBDNodePluginUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create node secret with error %v", err)
+			e2elog.Failf("failed to create node secret: %v", err)
 		}
 		deployVault(f.ClientSet, deployTimeout)
 
 		// wait for provisioner deployment
 		err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 		if err != nil {
-			e2elog.Failf("timeout waiting for deployment %s with error %v", rbdDeploymentName, err)
+			e2elog.Failf("timeout waiting for deployment %s: %v", rbdDeploymentName, err)
 		}
 
 		// wait for nodeplugin deamonset pods
 		err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
 		if err != nil {
-			e2elog.Failf("timeout waiting for daemonset %s with error %v", rbdDaemonsetName, err)
+			e2elog.Failf("timeout waiting for daemonset %s: %v", rbdDaemonsetName, err)
 		}
 
 		kernelRelease, err = getKernelVersionFromDaemonset(f, cephCSINamespace, rbdDaemonsetName, "csi-rbdplugin")
 		if err != nil {
-			e2elog.Failf("failed to get the kernel version with error %v", err)
+			e2elog.Failf("failed to get the kernel version: %v", err)
 		}
 		// default io-timeout=0, needs kernel >= 5.4
 		if !util.CheckKernelSupport(kernelRelease, nbdZeroIOtimeoutSupport) {
@@ -293,23 +293,23 @@ var _ = Describe("RBD", func() {
 
 		err := deleteConfigMap(rbdDirPath)
 		if err != nil {
-			e2elog.Failf("failed to delete configmap with error %v", err)
+			e2elog.Failf("failed to delete configmap: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), rbdProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete provisioner secret with error %v", err)
+			e2elog.Failf("failed to delete provisioner secret: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), rbdNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete node secret with error %v", err)
+			e2elog.Failf("failed to delete node secret: %v", err)
 		}
 		err = deleteResource(rbdExamplePath + "storageclass.yaml")
 		if err != nil {
-			e2elog.Failf("failed to delete storageclass with error %v", err)
+			e2elog.Failf("failed to delete storageclass: %v", err)
 		}
 		// deleteResource(rbdExamplePath + "snapshotclass.yaml")
 		deleteVault()
@@ -318,26 +318,26 @@ var _ = Describe("RBD", func() {
 			if cephCSINamespace != defaultNs {
 				err = deleteNamespace(c, cephCSINamespace)
 				if err != nil {
-					e2elog.Failf("failed to delete namespace with error %v", err)
+					e2elog.Failf("failed to delete namespace: %v", err)
 				}
 			}
 		}
 		err = deleteNodeLabel(c, nodeRegionLabel)
 		if err != nil {
-			e2elog.Failf("failed to delete node label with error %v", err)
+			e2elog.Failf("failed to delete node label: %v", err)
 		}
 		err = deleteNodeLabel(c, nodeZoneLabel)
 		if err != nil {
-			e2elog.Failf("failed to delete node label with error %v", err)
+			e2elog.Failf("failed to delete node label: %v", err)
 		}
 		// Remove the CSI labels that get added
 		err = deleteNodeLabel(c, nodeCSIRegionLabel)
 		if err != nil {
-			e2elog.Failf("failed to delete node label with error %v", err)
+			e2elog.Failf("failed to delete node label: %v", err)
 		}
 		err = deleteNodeLabel(c, nodeCSIZoneLabel)
 		if err != nil {
-			e2elog.Failf("failed to delete node label with error %v", err)
+			e2elog.Failf("failed to delete node label: %v", err)
 		}
 	})
 
@@ -348,23 +348,23 @@ var _ = Describe("RBD", func() {
 				By("verify PVC and app binding on helm installation", func() {
 					err := validatePVCAndAppBinding(pvcPath, appPath, f)
 					if err != nil {
-						e2elog.Failf("failed to validate CephFS pvc and application binding with error %v", err)
+						e2elog.Failf("failed to validate CephFS pvc and application binding: %v", err)
 					}
 					// validate created backend rbd images
 					validateRBDImageCount(f, 0, defaultRBDPool)
 					//  Deleting the storageclass and secret created by helm
 					err = deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 					err = deleteResource(rbdExamplePath + "secret.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete secret with error %v", err)
+						e2elog.Failf("failed to delete secret: %v", err)
 					}
 					// Re-create the RBD storageclass
 					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 				})
 			}
@@ -403,43 +403,43 @@ var _ = Describe("RBD", func() {
 			By("validate RBD migration+static Block PVC Deletion", func() {
 				err := generateClusterIDConfigMapForMigration(f, c)
 				if err != nil {
-					e2elog.Failf("failed to generate clusterID configmap with error %v", err)
+					e2elog.Failf("failed to generate clusterID configmap: %v", err)
 				}
 
 				// create a sc with different migration secret
 				err = createMigrationUserSecretAndSC(f, "migrationsc")
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validateRBDStaticMigrationPVDeletion(f, rawAppPath, "migrationsc", true)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd migrated static block pv with error %v", err)
+					e2elog.Failf("failed to validate rbd migrated static block pv: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteConfigMap(rbdDirPath)
 				if err != nil {
-					e2elog.Failf("failed to delete configmap with error %v", err)
+					e2elog.Failf("failed to delete configmap: %v", err)
 				}
 				err = createConfigMap(rbdDirPath, f.ClientSet, f)
 				if err != nil {
-					e2elog.Failf("failed to create configmap with error %v", err)
+					e2elog.Failf("failed to create configmap: %v", err)
 				}
 
 				err = deleteProvNodeMigrationSecret(f, true, true)
 				if err != nil {
-					e2elog.Failf("failed to delete migration users and Secrets associated with error %v", err)
+					e2elog.Failf("failed to delete migration users and Secrets associated: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and validate owner", func() {
 				err := validateImageOwner(pvcPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate owner of pvc with error %v", err)
+					e2elog.Failf("failed to validate owner of pvc: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -448,7 +448,7 @@ var _ = Describe("RBD", func() {
 			By("create a PVC and bind it to an app", func() {
 				err := validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate pvc and application binding: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -457,7 +457,7 @@ var _ = Describe("RBD", func() {
 			By("create a PVC and bind it to an app with normal user", func() {
 				err := validateNormalUserPVCAccess(pvcPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate normal user pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate normal user pvc and application binding: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -466,7 +466,7 @@ var _ = Describe("RBD", func() {
 			By("create a PVC and bind it to an app with ext4 as the FS ", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(
 					f.ClientSet,
@@ -476,28 +476,28 @@ var _ = Describe("RBD", func() {
 					map[string]string{"csi.storage.k8s.io/fstype": "ext4"},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate pvc and application binding: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and bind it to an app using rbd-nbd mounter", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(
 					f.ClientSet,
@@ -511,21 +511,21 @@ var _ = Describe("RBD", func() {
 					},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate pvc and application binding: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
@@ -533,7 +533,7 @@ var _ = Describe("RBD", func() {
 				if util.CheckKernelSupport(kernelRelease, nbdResizeSupport) {
 					err := deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 					// Storage class with rbd-nbd mounter
 					err = createRBDStorageClass(
@@ -548,12 +548,12 @@ var _ = Describe("RBD", func() {
 						},
 						deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 					// Block PVC resize
 					err = resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
 					if err != nil {
-						e2elog.Failf("failed to resize block PVC with error %v", err)
+						e2elog.Failf("failed to resize block PVC: %v", err)
 					}
 					// validate created backend rbd images
 					validateRBDImageCount(f, 0, defaultRBDPool)
@@ -561,17 +561,17 @@ var _ = Describe("RBD", func() {
 					// FileSystem PVC resize
 					err = resizePVCAndValidateSize(pvcPath, appPath, f)
 					if err != nil {
-						e2elog.Failf("failed to resize filesystem PVC with error %v", err)
+						e2elog.Failf("failed to resize filesystem PVC: %v", err)
 					}
 					// validate created backend rbd images
 					validateRBDImageCount(f, 0, defaultRBDPool)
 					err = deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 				}
 			})
@@ -579,7 +579,7 @@ var _ = Describe("RBD", func() {
 			By("perform IO on rbd-nbd volume after nodeplugin restart", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				// Storage class with rbd-nbd mounter
 				err = createRBDStorageClass(
@@ -594,17 +594,17 @@ var _ = Describe("RBD", func() {
 					},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 
 				app.Namespace = f.UniqueName
@@ -615,7 +615,7 @@ var _ = Describe("RBD", func() {
 				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
+					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
 
 				appOpt := metav1.ListOptions{
@@ -638,18 +638,18 @@ var _ = Describe("RBD", func() {
 
 				selector, err := getDaemonSetLabelSelector(f, cephCSINamespace, rbdDaemonsetName)
 				if err != nil {
-					e2elog.Failf("failed to get the labels with error %v", err)
+					e2elog.Failf("failed to get the labels: %v", err)
 				}
 				// delete rbd nodeplugin pods
 				err = deletePodWithLabel(selector, cephCSINamespace, false)
 				if err != nil {
-					e2elog.Failf("fail to delete pod with error %v", err)
+					e2elog.Failf("fail to delete pod: %v", err)
 				}
 
 				// wait for nodeplugin pods to come up
 				err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for daemonset pods with error %v", err)
+					e2elog.Failf("timeout waiting for daemonset pods: %v", err)
 				}
 
 				opt := metav1.ListOptions{
@@ -724,24 +724,24 @@ var _ = Describe("RBD", func() {
 
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC and application with error %v", err)
+					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and bind it to an app using rbd-nbd mounter with encryption", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				// Storage class with rbd-nbd mounter
 				err = createRBDStorageClass(
@@ -757,28 +757,28 @@ var _ = Describe("RBD", func() {
 					},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, noKMS, f)
 				if err != nil {
-					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
+					e2elog.Failf("failed to validate encrypted pvc: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and bind it to an app with encrypted RBD volume", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(
 					f.ClientSet,
@@ -788,28 +788,28 @@ var _ = Describe("RBD", func() {
 					map[string]string{"encrypted": "true"},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, noKMS, f)
 				if err != nil {
-					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
+					e2elog.Failf("failed to validate encrypted pvc: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("Resize Encrypted Block PVC and check Device size", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(
 					f.ClientSet,
@@ -819,13 +819,13 @@ var _ = Describe("RBD", func() {
 					map[string]string{"encrypted": "true"},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				// FileSystem PVC resize
 				err = resizePVCAndValidateSize(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to resize filesystem PVC with error %v", err)
+					e2elog.Failf("failed to resize filesystem PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -833,25 +833,25 @@ var _ = Describe("RBD", func() {
 				// Block PVC resize
 				err = resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
 				if err != nil {
-					e2elog.Failf("failed to resize block PVC with error %v", err)
+					e2elog.Failf("failed to resize block PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and bind it to an app with encrypted RBD volume with VaultKMS", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				scOpts := map[string]string{
 					"encrypted":       "true",
@@ -859,28 +859,28 @@ var _ = Describe("RBD", func() {
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, vaultKMS, f)
 				if err != nil {
-					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
+					e2elog.Failf("failed to validate encrypted pvc: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and bind it to an app with encrypted RBD volume with VaultTokensKMS", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				scOpts := map[string]string{
 					"encrypted":       "true",
@@ -888,7 +888,7 @@ var _ = Describe("RBD", func() {
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				// name(space) of the Tenant
@@ -906,7 +906,7 @@ var _ = Describe("RBD", func() {
 
 				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, vaultTokensKMS, f)
 				if err != nil {
-					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
+					e2elog.Failf("failed to validate encrypted pvc: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -919,11 +919,11 @@ var _ = Describe("RBD", func() {
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
@@ -966,7 +966,7 @@ var _ = Describe("RBD", func() {
 			By("create a PVC and bind it to an app with encrypted RBD volume with SecretsMetadataKMS", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				scOpts := map[string]string{
 					"encrypted":       "true",
@@ -974,21 +974,21 @@ var _ = Describe("RBD", func() {
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validateEncryptedPVCAndAppBinding(pvcPath, appPath, noKMS, f)
 				if err != nil {
-					e2elog.Failf("failed to validate encrypted pvc with error %v", err)
+					e2elog.Failf("failed to validate encrypted pvc: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
@@ -1100,7 +1100,7 @@ var _ = Describe("RBD", func() {
 				func() {
 					err := deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 					err = createRBDStorageClass(
 						f.ClientSet,
@@ -1115,19 +1115,19 @@ var _ = Describe("RBD", func() {
 						},
 						deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 					err = validatePVCAndAppBinding(pvcPath, appPath, f)
 					if err != nil {
-						e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+						e2elog.Failf("failed to validate pvc and application binding: %v", err)
 					}
 					err = deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 				},
 			)
@@ -1160,31 +1160,31 @@ var _ = Describe("RBD", func() {
 			By("create a thick-provisioned PVC-PVC clone and bind it to an app", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
 					"thickProvision": "true",
 				}, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, noKMS, isThickPVC, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create an encrypted PVC snapshot and restore it for an app with VaultKMS", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				scOpts := map[string]string{
 					"encrypted":       "true",
@@ -1192,7 +1192,7 @@ var _ = Describe("RBD", func() {
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				validatePVCSnapshot(1,
@@ -1203,11 +1203,11 @@ var _ = Describe("RBD", func() {
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
@@ -1337,7 +1337,7 @@ var _ = Describe("RBD", func() {
 			By("create an encrypted PVC-PVC clone and bind it to an app", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				scOpts := map[string]string{
 					"encrypted":       "true",
@@ -1345,25 +1345,25 @@ var _ = Describe("RBD", func() {
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, secretsMetadataKMS, isEncryptedPVC, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create an encrypted PVC-PVC clone and bind it to an app with VaultKMS", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				scOpts := map[string]string{
 					"encrypted":       "true",
@@ -1371,31 +1371,31 @@ var _ = Describe("RBD", func() {
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				validatePVCClone(1, pvcPath, appPath, pvcSmartClonePath, appSmartClonePath, vaultKMS, isEncryptedPVC, f)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a block type PVC and bind it to an app", func() {
 				err := validatePVCAndAppBinding(rawPvcPath, rawAppPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate pvc and application binding: %v", err)
 				}
 			})
 			By("create a Block mode PVC-PVC clone and bind it to an app", func() {
 				_, err := f.ClientSet.Discovery().ServerVersion()
 				if err != nil {
-					e2elog.Failf("failed to get server version with error %v", err)
+					e2elog.Failf("failed to get server version: %v", err)
 				}
 				validatePVCClone(
 					defaultCloneCount,
@@ -1411,13 +1411,13 @@ var _ = Describe("RBD", func() {
 				totalCount := 2
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				// create PVC and app
@@ -1425,7 +1425,7 @@ var _ = Describe("RBD", func() {
 					name := fmt.Sprintf("%s%d", f.UniqueName, i)
 					err := createPVCAndApp(name, f, pvc, app, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create PVC and application with error %v", err)
+						e2elog.Failf("failed to create PVC and application: %v", err)
 					}
 
 				}
@@ -1436,7 +1436,7 @@ var _ = Describe("RBD", func() {
 					name := fmt.Sprintf("%s%d", f.UniqueName, i)
 					err := deletePVCAndApp(name, f, pvc, app)
 					if err != nil {
-						e2elog.Failf("failed to delete PVC and application with error %v", err)
+						e2elog.Failf("failed to delete PVC and application: %v", err)
 					}
 
 				}
@@ -1448,7 +1448,7 @@ var _ = Describe("RBD", func() {
 			By("check data persist after recreating pod", func() {
 				err := checkDataPersist(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to check data persist with error %v", err)
+					e2elog.Failf("failed to check data persist: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -1462,7 +1462,7 @@ var _ = Describe("RBD", func() {
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(
 					f.ClientSet,
@@ -1472,11 +1472,11 @@ var _ = Describe("RBD", func() {
 					map[string]string{"csi.storage.k8s.io/fstype": "xfs"},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = resizePVCAndValidateSize(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to resize filesystem PVC with error %v", err)
+					e2elog.Failf("failed to resize filesystem PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -1485,7 +1485,7 @@ var _ = Describe("RBD", func() {
 			By("Resize Block PVC and check Device size", func() {
 				err := resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
 				if err != nil {
-					e2elog.Failf("failed to resize block PVC with error %v", err)
+					e2elog.Failf("failed to resize block PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -1494,18 +1494,18 @@ var _ = Describe("RBD", func() {
 			By("Test unmount after nodeplugin restart", func() {
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to  load application with error %v", err)
+					e2elog.Failf("failed to  load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
+					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
 
 				// validate created backend rbd images
@@ -1513,17 +1513,17 @@ var _ = Describe("RBD", func() {
 				// delete rbd nodeplugin pods
 				err = deletePodWithLabel("app=csi-rbdplugin", cephCSINamespace, false)
 				if err != nil {
-					e2elog.Failf("fail to delete pod with error %v", err)
+					e2elog.Failf("fail to delete pod: %v", err)
 				}
 				// wait for nodeplugin pods to come up
 				err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for daemonset pods with error %v", err)
+					e2elog.Failf("timeout waiting for daemonset pods: %v", err)
 				}
 
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC and application with error %v", err)
+					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -1533,7 +1533,7 @@ var _ = Describe("RBD", func() {
 				volumeNamePrefix := "foo-bar-"
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(
 					f.ClientSet,
@@ -1543,17 +1543,17 @@ var _ = Describe("RBD", func() {
 					map[string]string{"volumeNamePrefix": volumeNamePrefix},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				// set up PVC
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 
 				// validate created backend rbd images
@@ -1562,7 +1562,7 @@ var _ = Describe("RBD", func() {
 				foundIt := false
 				images, err := listRBDImages(f, defaultRBDPool)
 				if err != nil {
-					e2elog.Failf("failed to list rbd images with error %v", err)
+					e2elog.Failf("failed to list rbd images: %v", err)
 				}
 				for _, imgName := range images {
 					fmt.Printf("Checking prefix on %s\n", imgName)
@@ -1576,18 +1576,18 @@ var _ = Describe("RBD", func() {
 				// clean up after ourselves
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to  delete PVC with error %v", err)
+					e2elog.Failf("failed to  delete PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				if !foundIt {
 					e2elog.Failf("could not find image with prefix %s", volumeNamePrefix)
@@ -1597,7 +1597,7 @@ var _ = Describe("RBD", func() {
 			By("validate RBD static FileSystem PVC", func() {
 				err := validateRBDStaticPV(f, appPath, false, false)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd static pv with error %v", err)
+					e2elog.Failf("failed to validate rbd static pv: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -1606,7 +1606,7 @@ var _ = Describe("RBD", func() {
 			By("validate RBD static Block PVC", func() {
 				err := validateRBDStaticPV(f, rawAppPath, true, false)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd block pv with error %v", err)
+					e2elog.Failf("failed to validate rbd block pv: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -1615,66 +1615,66 @@ var _ = Describe("RBD", func() {
 			By("validate RBD migration+static FileSystem PVC", func() {
 				err := generateClusterIDConfigMapForMigration(f, c)
 				if err != nil {
-					e2elog.Failf("failed to generate clusterID configmap with error %v", err)
+					e2elog.Failf("failed to generate clusterID configmap: %v", err)
 				}
 				// create node user and migration secret.
 				err = createProvNodeCephUserAndSecret(f, false, true)
 				if err != nil {
-					e2elog.Failf("failed to create users and secret with error %v", err)
+					e2elog.Failf("failed to create users and secret: %v", err)
 				}
 
 				err = validateRBDStaticMigrationPV(f, appPath, rbdMigrationNodePluginSecretName, false)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd migrated static pv with error %v", err)
+					e2elog.Failf("failed to validate rbd migrated static pv: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = deleteProvNodeMigrationSecret(f, false, true)
 				if err != nil {
-					e2elog.Failf("failed to delete users and secret with error %v", err)
+					e2elog.Failf("failed to delete users and secret: %v", err)
 				}
 
 				err = deleteConfigMap(rbdDirPath)
 				if err != nil {
-					e2elog.Failf("failed to delete configmap with error %v", err)
+					e2elog.Failf("failed to delete configmap: %v", err)
 				}
 				err = createConfigMap(rbdDirPath, f.ClientSet, f)
 				if err != nil {
-					e2elog.Failf("failed to create configmap with error %v", err)
+					e2elog.Failf("failed to create configmap: %v", err)
 				}
 			})
 
 			By("validate RBD migration+static Block PVC", func() {
 				err := generateClusterIDConfigMapForMigration(f, c)
 				if err != nil {
-					e2elog.Failf("failed to generate clusterID configmap with error %v", err)
+					e2elog.Failf("failed to generate clusterID configmap: %v", err)
 				}
 				// create node user and migration secret.
 				err = createProvNodeCephUserAndSecret(f, false, true)
 				if err != nil {
-					e2elog.Failf("failed to create users and secret with error %v", err)
+					e2elog.Failf("failed to create users and secret: %v", err)
 				}
 
 				err = validateRBDStaticMigrationPV(f, rawAppPath, rbdMigrationNodePluginSecretName, true)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd migrated static block pv with error %v", err)
+					e2elog.Failf("failed to validate rbd migrated static block pv: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = deleteProvNodeMigrationSecret(f, false, true)
 				if err != nil {
-					e2elog.Failf("failed to delete users and secret with error %v", err)
+					e2elog.Failf("failed to delete users and secret: %v", err)
 				}
 
 				err = deleteConfigMap(rbdDirPath)
 				if err != nil {
-					e2elog.Failf("failed to delete configmap with error %v", err)
+					e2elog.Failf("failed to delete configmap: %v", err)
 				}
 				err = createConfigMap(rbdDirPath, f.ClientSet, f)
 				if err != nil {
-					e2elog.Failf("failed to create configmap with error %v", err)
+					e2elog.Failf("failed to create configmap: %v", err)
 				}
 			})
 
@@ -1691,7 +1691,7 @@ var _ = Describe("RBD", func() {
 				mountFlags := []string{"discard"}
 				err := checkMountOptions(pvcPath, appPath, f, mountFlags)
 				if err != nil {
-					e2elog.Failf("failed to check mount options with error %v", err)
+					e2elog.Failf("failed to check mount options: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -1701,18 +1701,18 @@ var _ = Describe("RBD", func() {
 				By("checking node has required CSI topology labels set", func() {
 					err := checkNodeHasLabel(f.ClientSet, nodeCSIRegionLabel, regionValue)
 					if err != nil {
-						e2elog.Failf("failed to check node label with error %v", err)
+						e2elog.Failf("failed to check node label: %v", err)
 					}
 					err = checkNodeHasLabel(f.ClientSet, nodeCSIZoneLabel, zoneValue)
 					if err != nil {
-						e2elog.Failf("failed to check node label with error %v", err)
+						e2elog.Failf("failed to check node label: %v", err)
 					}
 				})
 
 				By("creating a StorageClass with delayed binding mode and CSI topology parameter")
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				topologyConstraint := "[{\"poolName\":\"" + rbdTopologyPool + "\",\"domainSegments\":" +
 					"[{\"domainLabel\":\"region\",\"value\":\"" + regionValue + "\"}," +
@@ -1721,46 +1721,46 @@ var _ = Describe("RBD", func() {
 					map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 					map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				By("creating an app using a PV from the delayed binding mode StorageClass")
 				pvc, app, err := createPVCAndAppBinding(pvcPath, appPath, f, 0)
 				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
+					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
 				By("ensuring created PV has required node selector values populated")
 				err = checkPVSelectorValuesForPVC(f, pvc)
 				if err != nil {
-					e2elog.Failf("failed to check pv selector values with error %v", err)
+					e2elog.Failf("failed to check pv selector values: %v", err)
 				}
 				By("ensuring created PV has its image in the topology specific pool")
 				err = checkPVCImageInPool(f, pvc, rbdTopologyPool)
 				if err != nil {
-					e2elog.Failf("failed to check image in pool with error %v", err)
+					e2elog.Failf("failed to check image in pool: %v", err)
 				}
 
 				By("ensuring created PV has its image journal in the topology specific pool")
 				err = checkPVCImageJournalInPool(f, pvc, rbdTopologyPool)
 				if err != nil {
-					e2elog.Failf("failed to check image journal with error %v", err)
+					e2elog.Failf("failed to check image journal: %v", err)
 				}
 
 				By("ensuring created PV has its CSI journal in the CSI journal specific pool")
 				err = checkPVCCSIJournalInPool(f, pvc, "replicapool")
 				if err != nil {
-					e2elog.Failf("failed to check csi journal in pool with error %v", err)
+					e2elog.Failf("failed to check csi journal in pool: %v", err)
 				}
 
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC and application with error %v", err)
+					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
 
 				By("checking if data pool parameter is honored", func() {
 					err = deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 					topologyConstraint := "[{\"poolName\":\"" + rbdTopologyPool + "\",\"dataPool\":\"" + rbdTopologyDataPool +
 						"\",\"domainSegments\":" +
@@ -1770,41 +1770,41 @@ var _ = Describe("RBD", func() {
 						map[string]string{"volumeBindingMode": "WaitForFirstConsumer"},
 						map[string]string{"topologyConstrainedPools": topologyConstraint}, deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 					By("creating an app using a PV from the delayed binding mode StorageClass with a data pool")
 					pvc, app, err = createPVCAndAppBinding(pvcPath, appPath, f, 0)
 					if err != nil {
-						e2elog.Failf("failed to create PVC and application with error %v", err)
+						e2elog.Failf("failed to create PVC and application: %v", err)
 					}
 
 					By("ensuring created PV has its image in the topology specific pool")
 					err = checkPVCImageInPool(f, pvc, rbdTopologyPool)
 					if err != nil {
-						e2elog.Failf("failed to check  pvc image in pool with error %v", err)
+						e2elog.Failf("failed to check  pvc image in pool: %v", err)
 					}
 
 					By("ensuring created image has the right data pool parameter set")
 					err = checkPVCDataPoolForImageInPool(f, pvc, rbdTopologyPool, rbdTopologyDataPool)
 					if err != nil {
-						e2elog.Failf("failed to check data pool for image with error %v", err)
+						e2elog.Failf("failed to check data pool for image: %v", err)
 					}
 
 					// cleanup and undo changes made by the test
 					err = deletePVCAndApp("", f, pvc, app)
 					if err != nil {
-						e2elog.Failf("failed to delete PVC and application with error %v", err)
+						e2elog.Failf("failed to delete PVC and application: %v", err)
 					}
 				})
 
 				// cleanup and undo changes made by the test
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
@@ -1813,7 +1813,7 @@ var _ = Describe("RBD", func() {
 			By("Mount pvc to pod with invalid mount option", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(
 					f.ClientSet,
@@ -1823,22 +1823,22 @@ var _ = Describe("RBD", func() {
 					nil,
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to  load PVC with error %v", err)
+					e2elog.Failf("failed to  load PVC: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
@@ -1850,18 +1850,18 @@ var _ = Describe("RBD", func() {
 				}
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC and application with error %v", err)
+					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
 
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
@@ -1870,11 +1870,11 @@ var _ = Describe("RBD", func() {
 				// create pool for clones
 				err := createPool(f, clonePool)
 				if err != nil {
-					e2elog.Failf("failed to create pool %s with error %v", clonePool, err)
+					e2elog.Failf("failed to create pool %s: %v", clonePool, err)
 				}
 				err = createRBDSnapshotClass(f)
 				if err != nil {
-					e2elog.Failf("failed to create snapshotclass with error %v", err)
+					e2elog.Failf("failed to create snapshotclass: %v", err)
 				}
 				cloneSC := "clone-storageclass"
 				param := map[string]string{
@@ -1883,11 +1883,11 @@ var _ = Describe("RBD", func() {
 				// create new storageclass with new pool
 				err = createRBDStorageClass(f.ClientSet, f, cloneSC, nil, param, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validateCloneInDifferentPool(f, defaultRBDPool, cloneSC, clonePool)
 				if err != nil {
-					e2elog.Failf("failed to validate clones in different pool with error %v", err)
+					e2elog.Failf("failed to validate clones in different pool: %v", err)
 				}
 
 				err = retryKubectlArgs(
@@ -1898,33 +1898,33 @@ var _ = Describe("RBD", func() {
 					cloneSC,
 					"--ignore-not-found=true")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass %s with error %v", cloneSC, err)
+					e2elog.Failf("failed to delete storageclass %s: %v", cloneSC, err)
 				}
 
 				err = deleteResource(rbdExamplePath + "snapshotclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete snapshotclass with error %v", err)
+					e2elog.Failf("failed to delete snapshotclass: %v", err)
 				}
 				// validate images in trash
 				err = waitToRemoveImagesFromTrash(f, clonePool, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd images in pool %s trash with error %v", clonePool, err)
+					e2elog.Failf("failed to validate rbd images in pool %s trash: %v", clonePool, err)
 				}
 				err = waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd images in pool %s trash with error %v", defaultRBDPool, err)
+					e2elog.Failf("failed to validate rbd images in pool %s trash: %v", defaultRBDPool, err)
 				}
 
 				err = deletePool(clonePool, false, f)
 				if err != nil {
-					e2elog.Failf("failed to delete pool %s with error %v", clonePool, err)
+					e2elog.Failf("failed to delete pool %s: %v", clonePool, err)
 				}
 			})
 
 			By("create ROX PVC clone and mount it to multiple pods", func() {
 				err := createRBDSnapshotClass(f)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				defer func() {
 					err = deleteRBDSnapshotClass()
@@ -1936,25 +1936,25 @@ var _ = Describe("RBD", func() {
 				// create PVC and bind it to an app
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
+					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
 				// delete pod as we should not create snapshot for in-use pvc
 				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete application with error %v", err)
+					e2elog.Failf("failed to delete application: %v", err)
 				}
 
 				snap := getSnapshot(snapshotPath)
@@ -1963,7 +1963,7 @@ var _ = Describe("RBD", func() {
 
 				err = createSnapshot(&snap, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create snapshot with error %v", err)
+					e2elog.Failf("failed to create snapshot: %v", err)
 				}
 				// validate created backend rbd images
 				// parent PVC + snapshot
@@ -1971,7 +1971,7 @@ var _ = Describe("RBD", func() {
 				validateRBDImageCount(f, totalImages, defaultRBDPool)
 				pvcClone, err := loadPVC(pvcClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				// create clone PVC as ROX
@@ -1979,7 +1979,7 @@ var _ = Describe("RBD", func() {
 				pvcClone.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}
 				err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 				// validate created backend rbd images
 				// parent pvc+ snapshot + clone
@@ -1988,7 +1988,7 @@ var _ = Describe("RBD", func() {
 
 				appClone, err := loadApp(appClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 
 				totalCount := 2
@@ -2005,7 +2005,7 @@ var _ = Describe("RBD", func() {
 					appClone.Name = name
 					err = createApp(f.ClientSet, appClone, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create application with error %v", err)
+						e2elog.Failf("failed to create application: %v", err)
 					}
 				}
 
@@ -2033,23 +2033,23 @@ var _ = Describe("RBD", func() {
 					appClone.Name = name
 					err = deletePod(appClone.Name, appClone.Namespace, f.ClientSet, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to delete application with error %v", err)
+						e2elog.Failf("failed to delete application: %v", err)
 					}
 				}
 				// delete PVC clone
 				err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 				// delete snapshot
 				err = deleteSnapshot(&snap, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete snapshot with error %v", err)
+					e2elog.Failf("failed to delete snapshot: %v", err)
 				}
 				// delete parent pvc
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -2058,7 +2058,7 @@ var _ = Describe("RBD", func() {
 			By("validate PVC mounting if snapshot and parent PVC are deleted", func() {
 				err := createRBDSnapshotClass(f)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				defer func() {
 					err = deleteRBDSnapshotClass()
@@ -2070,18 +2070,18 @@ var _ = Describe("RBD", func() {
 				// create PVC and bind it to an app
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
+					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
@@ -2092,7 +2092,7 @@ var _ = Describe("RBD", func() {
 
 				err = createSnapshot(&snap, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create snapshot with error %v", err)
+					e2elog.Failf("failed to create snapshot: %v", err)
 				}
 				// validate created backend rbd images
 				// parent PVC + snapshot
@@ -2100,13 +2100,13 @@ var _ = Describe("RBD", func() {
 				validateRBDImageCount(f, totalImages, defaultRBDPool)
 				pvcClone, err := loadPVC(pvcClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				// delete parent PVC
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC and application with error %v", err)
+					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
@@ -2115,7 +2115,7 @@ var _ = Describe("RBD", func() {
 				pvcClone.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 				// validate created backend rbd images = snapshot + clone
 				totalImages = 2
@@ -2124,7 +2124,7 @@ var _ = Describe("RBD", func() {
 				// delete snapshot
 				err = deleteSnapshot(&snap, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete snapshot with error %v", err)
+					e2elog.Failf("failed to delete snapshot: %v", err)
 				}
 
 				// validate created backend rbd images = clone
@@ -2133,7 +2133,7 @@ var _ = Describe("RBD", func() {
 
 				appClone, err := loadApp(appClonePath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				appClone.Namespace = f.UniqueName
 				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
@@ -2141,17 +2141,17 @@ var _ = Describe("RBD", func() {
 				// create application
 				err = createApp(f.ClientSet, appClone, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create application with error %v", err)
+					e2elog.Failf("failed to create application: %v", err)
 				}
 
 				err = deletePod(appClone.Name, appClone.Namespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete application with error %v", err)
+					e2elog.Failf("failed to delete application: %v", err)
 				}
 				// delete PVC clone
 				err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -2164,7 +2164,7 @@ var _ = Describe("RBD", func() {
 
 					err := deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 
 					err = createRBDStorageClass(
@@ -2178,12 +2178,12 @@ var _ = Describe("RBD", func() {
 						},
 						deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 
 					err = createRBDSnapshotClass(f)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 
 					defer func() {
@@ -2193,29 +2193,29 @@ var _ = Describe("RBD", func() {
 						}
 						err = deleteResource(rbdExamplePath + "storageclass.yaml")
 						if err != nil {
-							e2elog.Failf("failed to delete storageclass with error %v", err)
+							e2elog.Failf("failed to delete storageclass: %v", err)
 						}
 						err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 						if err != nil {
-							e2elog.Failf("failed to create storageclass with error %v", err)
+							e2elog.Failf("failed to create storageclass: %v", err)
 						}
 					}()
 
 					// create PVC and bind it to an app
 					pvc, err := loadPVC(pvcPath)
 					if err != nil {
-						e2elog.Failf("failed to load PVC with error %v", err)
+						e2elog.Failf("failed to load PVC: %v", err)
 					}
 
 					pvc.Namespace = f.UniqueName
 					app, err := loadApp(appPath)
 					if err != nil {
-						e2elog.Failf("failed to load application with error %v", err)
+						e2elog.Failf("failed to load application: %v", err)
 					}
 					app.Namespace = f.UniqueName
 					err = createPVCAndApp("", f, pvc, app, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create PVC and application with error %v", err)
+						e2elog.Failf("failed to create PVC and application: %v", err)
 					}
 					// validate created backend rbd images
 					validateRBDImageCount(f, 1, defaultRBDPool)
@@ -2228,7 +2228,7 @@ var _ = Describe("RBD", func() {
 
 						err = createSnapshot(&snap, deployTimeout)
 						if err != nil {
-							e2elog.Failf("failed to create snapshot with error %v", err)
+							e2elog.Failf("failed to create snapshot: %v", err)
 						}
 						// validate created backend rbd images
 						// parent PVC + snapshot
@@ -2236,13 +2236,13 @@ var _ = Describe("RBD", func() {
 						validateRBDImageCount(f, totalImages, defaultRBDPool)
 						pvcClone, err = loadPVC(pvcClonePath)
 						if err != nil {
-							e2elog.Failf("failed to load PVC with error %v", err)
+							e2elog.Failf("failed to load PVC: %v", err)
 						}
 
 						// delete parent PVC
 						err = deletePVCAndApp("", f, pvc, app)
 						if err != nil {
-							e2elog.Failf("failed to delete PVC and application with error %v", err)
+							e2elog.Failf("failed to delete PVC and application: %v", err)
 						}
 						// validate created backend rbd images
 						validateRBDImageCount(f, 1, defaultRBDPool)
@@ -2253,7 +2253,7 @@ var _ = Describe("RBD", func() {
 						pvcClone.Spec.DataSource.Name = snap.Name
 						err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
 						if err != nil {
-							e2elog.Failf("failed to create PVC with error %v", err)
+							e2elog.Failf("failed to create PVC: %v", err)
 						}
 						// validate created backend rbd images = snapshot + clone
 						totalImages = 2
@@ -2262,7 +2262,7 @@ var _ = Describe("RBD", func() {
 						// delete snapshot
 						err = deleteSnapshot(&snap, deployTimeout)
 						if err != nil {
-							e2elog.Failf("failed to delete snapshot with error %v", err)
+							e2elog.Failf("failed to delete snapshot: %v", err)
 						}
 
 						// validate created backend rbd images = clone
@@ -2273,7 +2273,7 @@ var _ = Describe("RBD", func() {
 						// create application
 						err = createApp(f.ClientSet, app, deployTimeout)
 						if err != nil {
-							e2elog.Failf("failed to create application with error %v", err)
+							e2elog.Failf("failed to create application: %v", err)
 						}
 
 						pvc = pvcClone
@@ -2281,12 +2281,12 @@ var _ = Describe("RBD", func() {
 
 					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to delete application with error %v", err)
+						e2elog.Failf("failed to delete application: %v", err)
 					}
 					// delete PVC clone
 					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to delete PVC with error %v", err)
+						e2elog.Failf("failed to delete PVC: %v", err)
 					}
 					// validate created backend rbd images
 					validateRBDImageCount(f, 0, defaultRBDPool)
@@ -2297,7 +2297,7 @@ var _ = Describe("RBD", func() {
 
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 
 				err = createRBDStorageClass(
@@ -2311,34 +2311,34 @@ var _ = Describe("RBD", func() {
 					},
 					deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				defer func() {
 					err = deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
-						e2elog.Failf("failed to delete storageclass with error %v", err)
+						e2elog.Failf("failed to delete storageclass: %v", err)
 					}
 					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 					if err != nil {
-						e2elog.Failf("failed to create storageclass with error %v", err)
+						e2elog.Failf("failed to create storageclass: %v", err)
 					}
 				}()
 
 				// create PVC and bind it to an app
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
+					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
@@ -2347,7 +2347,7 @@ var _ = Describe("RBD", func() {
 					var pvcClone *v1.PersistentVolumeClaim
 					pvcClone, err = loadPVC(pvcSmartClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load PVC with error %v", err)
+						e2elog.Failf("failed to load PVC: %v", err)
 					}
 
 					// create clone PVC
@@ -2356,20 +2356,20 @@ var _ = Describe("RBD", func() {
 					pvcClone.Spec.DataSource.Name = pvc.Name
 					err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create PVC with error %v", err)
+						e2elog.Failf("failed to create PVC: %v", err)
 					}
 
 					// delete parent PVC
 					err = deletePVCAndApp("", f, pvc, app)
 					if err != nil {
-						e2elog.Failf("failed to delete PVC and application with error %v", err)
+						e2elog.Failf("failed to delete PVC and application: %v", err)
 					}
 
 					app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 					// create application
 					err = createApp(f.ClientSet, app, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create application with error %v", err)
+						e2elog.Failf("failed to create application: %v", err)
 					}
 
 					pvc = pvcClone
@@ -2377,12 +2377,12 @@ var _ = Describe("RBD", func() {
 
 				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete application with error %v", err)
+					e2elog.Failf("failed to delete application: %v", err)
 				}
 				// delete PVC clone
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -2393,30 +2393,30 @@ var _ = Describe("RBD", func() {
 					radosNamespace = radosNS
 					err := deleteConfigMap(rbdDirPath)
 					if err != nil {
-						e2elog.Failf("failed to delete configmap with Error: %v", err)
+						e2elog.Failf("failed to delete configmap:: %v", err)
 					}
 					err = createConfigMap(rbdDirPath, f.ClientSet, f)
 					if err != nil {
-						e2elog.Failf("failed to create configmap with error %v", err)
+						e2elog.Failf("failed to create configmap: %v", err)
 					}
 					err = createRadosNamespace(f)
 					if err != nil {
-						e2elog.Failf("failed to create rados namespace with error %v", err)
+						e2elog.Failf("failed to create rados namespace: %v", err)
 					}
 					// delete csi pods
 					err = deletePodWithLabel("app in (ceph-csi-rbd, csi-rbdplugin, csi-rbdplugin-provisioner)",
 						cephCSINamespace, false)
 					if err != nil {
-						e2elog.Failf("failed to delete pods with labels with error %v", err)
+						e2elog.Failf("failed to delete pods with labels: %v", err)
 					}
 					// wait for csi pods to come up
 					err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
 					if err != nil {
-						e2elog.Failf("timeout waiting for daemonset pods with error %v", err)
+						e2elog.Failf("timeout waiting for daemonset pods: %v", err)
 					}
 					err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 					if err != nil {
-						e2elog.Failf("timeout waiting for deployment to be in running state with error %v", err)
+						e2elog.Failf("timeout waiting for deployment to be in running state: %v", err)
 					}
 				}
 
@@ -2428,11 +2428,11 @@ var _ = Describe("RBD", func() {
 					rbdProvisionerCaps(defaultRBDPool, radosNamespace),
 				)
 				if err != nil {
-					e2elog.Failf("failed to create user %s with error %v", keyringRBDNamespaceProvisionerUsername, err)
+					e2elog.Failf("failed to create user %s: %v", keyringRBDNamespaceProvisionerUsername, err)
 				}
 				err = createRBDSecret(f, rbdNamespaceProvisionerSecretName, keyringRBDNamespaceProvisionerUsername, key)
 				if err != nil {
-					e2elog.Failf("failed to create provisioner secret with error %v", err)
+					e2elog.Failf("failed to create provisioner secret: %v", err)
 				}
 				// create rbd plugin secret
 				key, err = createCephUser(
@@ -2440,16 +2440,16 @@ var _ = Describe("RBD", func() {
 					keyringRBDNamespaceNodePluginUsername,
 					rbdNodePluginCaps(defaultRBDPool, radosNamespace))
 				if err != nil {
-					e2elog.Failf("failed to create user %s with error %v", keyringRBDNamespaceNodePluginUsername, err)
+					e2elog.Failf("failed to create user %s: %v", keyringRBDNamespaceNodePluginUsername, err)
 				}
 				err = createRBDSecret(f, rbdNamespaceNodePluginSecretName, keyringRBDNamespaceNodePluginUsername, key)
 				if err != nil {
-					e2elog.Failf("failed to create node secret with error %v", err)
+					e2elog.Failf("failed to create node secret: %v", err)
 				}
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				param := make(map[string]string)
 				// override existing secrets
@@ -2462,12 +2462,12 @@ var _ = Describe("RBD", func() {
 
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, param, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				err = validateImageOwner(pvcPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate owner of pvc with error %v", err)
+					e2elog.Failf("failed to validate owner of pvc: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -2475,13 +2475,13 @@ var _ = Describe("RBD", func() {
 				// Create a PVC and bind it to an app within the namesapce
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate pvc and application binding: %v", err)
 				}
 
 				// Resize Block PVC and check Device size within the namespace
 				err = resizePVCAndValidateSize(rawPvcPath, rawAppPath, f)
 				if err != nil {
-					e2elog.Failf("failed to resize block PVC with error %v", err)
+					e2elog.Failf("failed to resize block PVC: %v", err)
 				}
 
 				// Resize Filesystem PVC and check application directory size
@@ -2493,7 +2493,7 @@ var _ = Describe("RBD", func() {
 				// Create a PVC clone and bind it to an app within the namespace
 				err = createRBDSnapshotClass(f)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				defer func() {
 					err = deleteRBDSnapshotClass()
@@ -2504,13 +2504,13 @@ var _ = Describe("RBD", func() {
 
 				pvc, pvcErr := loadPVC(pvcPath)
 				if pvcErr != nil {
-					e2elog.Failf("failed to load PVC with error %v", pvcErr)
+					e2elog.Failf("failed to load PVC: %v", pvcErr)
 				}
 
 				pvc.Namespace = f.UniqueName
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC with error %v", err)
+					e2elog.Failf("failed to create PVC: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
@@ -2520,61 +2520,61 @@ var _ = Describe("RBD", func() {
 				snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
 				err = createSnapshot(&snap, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create snapshot with error %v", err)
+					e2elog.Failf("failed to create snapshot: %v", err)
 				}
 				validateRBDImageCount(f, 2, defaultRBDPool)
 
 				err = validatePVCAndAppBinding(pvcClonePath, appClonePath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate pvc and application binding: %v", err)
 				}
 				err = deleteSnapshot(&snap, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete snapshot with error %v", err)
+					e2elog.Failf("failed to delete snapshot: %v", err)
 				}
 				// as snapshot is deleted the image count should be one
 				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC with error %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 				validateRBDImageCount(f, 0, defaultRBDPool)
 
 				err = waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd images in pool %s trash with error %v", rbdOptions(defaultRBDPool), err)
+					e2elog.Failf("failed to validate rbd images in pool %s trash: %v", rbdOptions(defaultRBDPool), err)
 				}
 
 				// delete RBD provisioner secret
 				err = deleteCephUser(f, keyringRBDNamespaceProvisionerUsername)
 				if err != nil {
-					e2elog.Failf("failed to delete user %s with error %v", keyringRBDNamespaceProvisionerUsername, err)
+					e2elog.Failf("failed to delete user %s: %v", keyringRBDNamespaceProvisionerUsername, err)
 				}
 				err = c.CoreV1().
 					Secrets(cephCSINamespace).
 					Delete(context.TODO(), rbdNamespaceProvisionerSecretName, metav1.DeleteOptions{})
 				if err != nil {
-					e2elog.Failf("failed to delete provisioner secret with error %v", err)
+					e2elog.Failf("failed to delete provisioner secret: %v", err)
 				}
 				// delete RBD plugin secret
 				err = deleteCephUser(f, keyringRBDNamespaceNodePluginUsername)
 				if err != nil {
-					e2elog.Failf("failed to delete user %s with error %v", keyringRBDNamespaceNodePluginUsername, err)
+					e2elog.Failf("failed to delete user %s: %v", keyringRBDNamespaceNodePluginUsername, err)
 				}
 				err = c.CoreV1().
 					Secrets(cephCSINamespace).
 					Delete(context.TODO(), rbdNamespaceNodePluginSecretName, metav1.DeleteOptions{})
 				if err != nil {
-					e2elog.Failf("failed to delete node secret with error %v", err)
+					e2elog.Failf("failed to delete node secret: %v", err)
 				}
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				updateConfigMap("")
 			})
@@ -2583,14 +2583,14 @@ var _ = Describe("RBD", func() {
 				// create PVC and bind it to an app
 				pvc, err := loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error %v", err)
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
 
 				pvc.Namespace = f.UniqueName
 
 				app, err := loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 
 				app.Namespace = f.UniqueName
@@ -2602,7 +2602,7 @@ var _ = Describe("RBD", func() {
 				app.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly = true
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create PVC and application with error %v", err)
+					e2elog.Failf("failed to create PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
@@ -2625,7 +2625,7 @@ var _ = Describe("RBD", func() {
 				// delete PVC and app
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC and application with error %v", err)
+					e2elog.Failf("failed to delete PVC and application: %v", err)
 				}
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
@@ -2634,18 +2634,18 @@ var _ = Describe("RBD", func() {
 			By("create a thick-provisioned PVC", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
 					"thickProvision": "true",
 				}, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 
 				pvc, err := loadPVC(rawPvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load PVC with error: %v", err)
+					e2elog.Failf("failed to load PVC:: %v", err)
 				}
 
 				pvcSizes := []string{
@@ -2664,37 +2664,37 @@ var _ = Describe("RBD", func() {
 
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
 			By("create a PVC and Bind it to an app for mapped rbd image with options", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
 					"mapOptions":   "lock_on_read,queue_depth=1024",
 					"unmapOptions": "force",
 				}, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
-					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
+					e2elog.Failf("failed to validate pvc and application binding: %v", err)
 				}
 				err = deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
-					e2elog.Failf("failed to delete storageclass with error %v", err)
+					e2elog.Failf("failed to delete storageclass: %v", err)
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 				if err != nil {
-					e2elog.Failf("failed to create storageclass with error %v", err)
+					e2elog.Failf("failed to create storageclass: %v", err)
 				}
 			})
 
@@ -2874,7 +2874,7 @@ var _ = Describe("RBD", func() {
 			By("validate stale images in trash", func() {
 				err := waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to validate rbd images in pool %s trash with error %v", defaultRBDPool, err)
+					e2elog.Failf("failed to validate rbd images in pool %s trash: %v", defaultRBDPool, err)
 				}
 			})
 
@@ -2883,18 +2883,18 @@ var _ = Describe("RBD", func() {
 			By("Create a PVC and delete PVC when backend pool deleted", func() {
 				err := pvcDeleteWhenPoolNotFound(pvcPath, false, f)
 				if err != nil {
-					e2elog.Failf("failed to delete PVC when pool not found with error %v", err)
+					e2elog.Failf("failed to delete PVC when pool not found: %v", err)
 				}
 			})
 			// delete RBD provisioner secret
 			err := deleteCephUser(f, keyringRBDProvisionerUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringRBDProvisionerUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringRBDProvisionerUsername, err)
 			}
 			// delete RBD plugin secret
 			err = deleteCephUser(f, keyringRBDNodePluginUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringRBDNodePluginUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringRBDNodePluginUsername, err)
 			}
 		})
 	})

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -315,13 +315,13 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	wgErrs := make([]error, totalCount)
 	pvc, err := loadPVC(pvcPath)
 	if err != nil {
-		return fmt.Errorf("failed to load PVC with error %w", err)
+		return fmt.Errorf("failed to load PVC: %w", err)
 	}
 
 	pvc.Namespace = f.UniqueName
 	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to create PVC with error %w", err)
+		return fmt.Errorf("failed to create PVC: %w", err)
 	}
 	validateRBDImageCount(f, 1, defaultRBDPool)
 	snap := getSnapshot(snapshotPath)
@@ -345,7 +345,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to delete PVC with error %w", err)
+		return fmt.Errorf("failed to delete PVC: %w", err)
 	}
 
 	// validate the rbd images created for snapshots
@@ -353,11 +353,11 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 
 	pvcClone, err := loadPVC(pvcClonePath)
 	if err != nil {
-		return fmt.Errorf("failed to load PVC with error %w", err)
+		return fmt.Errorf("failed to load PVC: %w", err)
 	}
 	appClone, err := loadApp(appClonePath)
 	if err != nil {
-		return fmt.Errorf("failed to load application with error %w", err)
+		return fmt.Errorf("failed to load application: %w", err)
 	}
 	pvcClone.Namespace = f.UniqueName
 	// if request is to create clone with different storage class
@@ -839,7 +839,7 @@ func deletePVCImageJournalInPool(f *framework.Framework, pvc *v1.PersistentVolum
 	}
 	if stdErr != "" {
 		return fmt.Errorf(
-			"failed to remove omap %s csi.volume.%s with error %v",
+			"failed to remove omap %s csi.volume.%s: %v",
 			rbdOptions(pool),
 			imageData.imageID,
 			stdErr)
@@ -866,7 +866,7 @@ func deletePVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeC
 	}
 	if stdErr != "" {
 		return fmt.Errorf(
-			"failed to remove %s csi.volumes.default csi.volume.%s with error %v",
+			"failed to remove %s csi.volumes.default csi.volume.%s: %v",
 			rbdOptions(pool),
 			imageData.imageID,
 			stdErr)
@@ -881,7 +881,7 @@ func validateThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, siz
 
 	err := createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to create PVC with error %w", err)
+		return fmt.Errorf("failed to create PVC: %w", err)
 	}
 	validateRBDImageCount(f, 1, defaultRBDPool)
 
@@ -929,7 +929,7 @@ func validateThickPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, siz
 
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to delete PVC with error: %w", err)
+		return fmt.Errorf("failed to delete PVC:: %w", err)
 	}
 	validateRBDImageCount(f, 0, defaultRBDPool)
 
@@ -990,16 +990,16 @@ func recreateCSIRBDPods(f *framework.Framework) error {
 	err := deletePodWithLabel("app in (ceph-csi-rbd, csi-rbdplugin, csi-rbdplugin-provisioner)",
 		cephCSINamespace, false)
 	if err != nil {
-		return fmt.Errorf("failed to delete pods with labels with error %w", err)
+		return fmt.Errorf("failed to delete pods with labels: %w", err)
 	}
 	// wait for csi pods to come up
 	err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("timeout waiting for daemonset pods with error %w", err)
+		return fmt.Errorf("timeout waiting for daemonset pods: %w", err)
 	}
 	err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 	if err != nil {
-		return fmt.Errorf("timeout waiting for deployment to be in running state with error %w", err)
+		return fmt.Errorf("timeout waiting for deployment to be in running state: %w", err)
 	}
 
 	return nil

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -124,7 +124,7 @@ func deleteSnapshot(snap *snapapi.VolumeSnapshot, t int) error {
 		}
 		if !apierrs.IsNotFound(err) {
 			return false, fmt.Errorf(
-				"get on deleted snapshot %v failed with error other than \"not found\": %w",
+				"get on deleted snapshot %v failed : other than \"not found\": %w",
 				name,
 				err)
 		}

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -46,7 +46,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		if cephCSINamespace != defaultNs {
 			err = createNamespace(c, cephCSINamespace)
 			if err != nil {
-				e2elog.Failf("failed to create namespace with error %v", err)
+				e2elog.Failf("failed to create namespace: %v", err)
 			}
 		}
 
@@ -54,43 +54,43 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		// when we are done upgrading.
 		cwd, err = os.Getwd()
 		if err != nil {
-			e2elog.Failf("failed to getwd with error %v", err)
+			e2elog.Failf("failed to getwd: %v", err)
 		}
 		err = upgradeAndDeployCSI(upgradeVersion, "cephfs")
 		if err != nil {
-			e2elog.Failf("failed to upgrade csi with error %v", err)
+			e2elog.Failf("failed to upgrade csi: %v", err)
 		}
 		err = createConfigMap(cephFSDirPath, f.ClientSet, f)
 		if err != nil {
-			e2elog.Failf("failed to create configmap with error %v", err)
+			e2elog.Failf("failed to create configmap: %v", err)
 		}
 		var key string
 		// create cephFS provisioner secret
 		key, err = createCephUser(f, keyringCephFSProvisionerUsername, cephFSProvisionerCaps())
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringCephFSProvisionerUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringCephFSProvisionerUsername, err)
 		}
 		err = createCephfsSecret(f, cephFSProvisionerSecretName, keyringCephFSProvisionerUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create provisioner secret with error %v", err)
+			e2elog.Failf("failed to create provisioner secret: %v", err)
 		}
 		// create cephFS plugin secret
 		key, err = createCephUser(f, keyringCephFSNodePluginUsername, cephFSNodePluginCaps())
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringCephFSNodePluginUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringCephFSNodePluginUsername, err)
 		}
 		err = createCephfsSecret(f, cephFSNodePluginSecretName, keyringCephFSNodePluginUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create node secret with error %v", err)
+			e2elog.Failf("failed to create node secret: %v", err)
 		}
 
 		err = createCephFSSnapshotClass(f)
 		if err != nil {
-			e2elog.Failf("failed to create snapshotclass with error %v", err)
+			e2elog.Failf("failed to create snapshotclass: %v", err)
 		}
 		err = createCephfsStorageClass(f.ClientSet, f, true, nil)
 		if err != nil {
-			e2elog.Failf("failed to create storageclass with error %v", err)
+			e2elog.Failf("failed to create storageclass: %v", err)
 		}
 	})
 	AfterEach(func() {
@@ -110,27 +110,27 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		}
 		err = deleteConfigMap(cephFSDirPath)
 		if err != nil {
-			e2elog.Failf("failed to delete configmap with error %v", err)
+			e2elog.Failf("failed to delete configmap: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), cephFSProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete provisioner secret with error %v", err)
+			e2elog.Failf("failed to delete provisioner secret: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), cephFSNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete node secret with error %v", err)
+			e2elog.Failf("failed to delete node secret: %v", err)
 		}
 		err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 		if err != nil {
-			e2elog.Failf("failed to delete storageclass with error %v", err)
+			e2elog.Failf("failed to delete storageclass: %v", err)
 		}
 		err = deleteResource(cephFSExamplePath + "snapshotclass.yaml")
 		if err != nil {
-			e2elog.Failf("failed to delete storageclass with error %v", err)
+			e2elog.Failf("failed to delete storageclass: %v", err)
 		}
 		if deployCephFS {
 			deleteCephfsPlugin()
@@ -138,7 +138,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				err = deleteNamespace(c, cephCSINamespace)
 				if err != nil {
 					if err != nil {
-						e2elog.Failf("failed to delete namespace with error %v", err)
+						e2elog.Failf("failed to delete namespace: %v", err)
 					}
 				}
 			}
@@ -150,13 +150,13 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 			By("checking provisioner deployment is running", func() {
 				err = waitForDeploymentComplete(cephFSDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for deployment %s with error %v", cephFSDeploymentName, err)
+					e2elog.Failf("timeout waiting for deployment %s: %v", cephFSDeploymentName, err)
 				}
 			})
 			By("checking nodeplugin deamonset pods are running", func() {
 				err = waitForDaemonSets(cephFSDeamonSetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for daemonset %s with error%v", cephFSDeamonSetName, err)
+					e2elog.Failf("timeout waiting for daemonset %s: %v", cephFSDeamonSetName, err)
 				}
 			})
 
@@ -169,13 +169,13 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 
 				pvc, err = loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load pvc with error %v", err)
+					e2elog.Failf("failed to load pvc: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err = loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				label[appKey] = appLabel
 				app.Namespace = f.UniqueName
@@ -184,7 +184,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(pvcSize)
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create pvc and application with error %v", err)
+					e2elog.Failf("failed to create pvc and application: %v", err)
 				}
 				opt := metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
@@ -212,7 +212,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				e2elog.Logf("Calculating checksum of %s", filePath)
 				checkSum, err = calculateSHA512sum(f, app, filePath, &opt)
 				if err != nil {
-					e2elog.Failf("failed to calculate checksum with error %v", err)
+					e2elog.Failf("failed to calculate checksum: %v", err)
 				}
 
 				// pvc clone is only supported from v1.16+
@@ -230,25 +230,25 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				}
 				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete application with error %v", err)
+					e2elog.Failf("failed to delete application: %v", err)
 				}
 				deleteCephfsPlugin()
 
 				// switch back to current changes.
 				err = os.Chdir(cwd)
 				if err != nil {
-					e2elog.Failf("failed to d chdir with error %v", err)
+					e2elog.Failf("failed to d chdir: %v", err)
 				}
 				deployCephfsPlugin()
 
 				err = waitForDeploymentComplete(cephFSDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for upgraded deployment %s with error %v", cephFSDeploymentName, err)
+					e2elog.Failf("timeout waiting for upgraded deployment %s: %v", cephFSDeploymentName, err)
 				}
 
 				err = waitForDaemonSets(cephFSDeamonSetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for upgraded daemonset %s with error %v", cephFSDeamonSetName, err)
+					e2elog.Failf("timeout waiting for upgraded daemonset %s: %v", cephFSDeamonSetName, err)
 				}
 
 				app.Labels = label
@@ -256,7 +256,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				// an earlier release.
 				err = createApp(f.ClientSet, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create application with error %v", err)
+					e2elog.Failf("failed to create application: %v", err)
 				}
 			})
 
@@ -269,13 +269,13 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 17) {
 					pvcClone, err = loadPVC(pvcClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load pvc with error %v", err)
+						e2elog.Failf("failed to load pvc: %v", err)
 					}
 					pvcClone.Namespace = f.UniqueName
 					pvcClone.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(pvcSize)
 					appClone, err = loadApp(appClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load application with error %v", err)
+						e2elog.Failf("failed to load application: %v", err)
 					}
 					label[appKey] = "validate-snap-cephfs"
 					appClone.Namespace = f.UniqueName
@@ -283,7 +283,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					appClone.Labels = label
 					err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create pvc and application with error %v", err)
+						e2elog.Failf("failed to create pvc and application: %v", err)
 					}
 					opt := metav1.ListOptions{
 						LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
@@ -292,7 +292,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					testFilePath := filepath.Join(mountPath, "testClone")
 					newCheckSum, err = calculateSHA512sum(f, appClone, testFilePath, &opt)
 					if err != nil {
-						e2elog.Failf("failed to calculate checksum with error %v", err)
+						e2elog.Failf("failed to calculate checksum: %v", err)
 					}
 
 					if strings.Compare(newCheckSum, checkSum) != 0 {
@@ -332,14 +332,14 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					pvcClone, err = loadPVC(pvcSmartClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load pvc with error %v", err)
+						e2elog.Failf("failed to load pvc: %v", err)
 					}
 					pvcClone.Spec.DataSource.Name = pvc.Name
 					pvcClone.Namespace = f.UniqueName
 					pvcClone.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(pvcSize)
 					appClone, err = loadApp(appSmartClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load application with error %v", err)
+						e2elog.Failf("failed to load application: %v", err)
 					}
 					label[appKey] = "validate-snap-cephfs"
 					appClone.Namespace = f.UniqueName
@@ -347,7 +347,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					appClone.Labels = label
 					err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create pvc and application with error %v", err)
+						e2elog.Failf("failed to create pvc and application: %v", err)
 					}
 					opt := metav1.ListOptions{
 						LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
@@ -356,7 +356,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					testFilePath := filepath.Join(mountPath, "testClone")
 					newCheckSum, err = calculateSHA512sum(f, appClone, testFilePath, &opt)
 					if err != nil {
-						e2elog.Failf("failed to calculate checksum with error %v", err)
+						e2elog.Failf("failed to calculate checksum: %v", err)
 					}
 
 					if strings.Compare(newCheckSum, checkSum) != 0 {
@@ -370,7 +370,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 					// delete cloned pvc and pod
 					err = deletePVCAndApp("", f, pvcClone, appClone)
 					if err != nil {
-						e2elog.Failf("failed to delete pvc and application with error %v", err)
+						e2elog.Failf("failed to delete pvc and application: %v", err)
 					}
 
 				}
@@ -390,23 +390,23 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 						PersistentVolumeClaims(pvc.Namespace).
 						Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 					if err != nil {
-						e2elog.Failf("failed to get pvc with error %v", err)
+						e2elog.Failf("failed to get pvc: %v", err)
 					}
 
 					// resize PVC
 					err = expandPVCSize(f.ClientSet, pvc, pvcExpandSize, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to expand pvc with error %v", err)
+						e2elog.Failf("failed to expand pvc: %v", err)
 					}
 					// wait for application pod to come up after resize
 					err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout, noError)
 					if err != nil {
-						e2elog.Failf("timeout waiting for pod to be in running state with error %v", err)
+						e2elog.Failf("timeout waiting for pod to be in running state: %v", err)
 					}
 					// validate if resize is successful.
 					err = checkDirSize(app, f, &opt, pvcExpandSize)
 					if err != nil {
-						e2elog.Failf("failed to check directory size with error %v", err)
+						e2elog.Failf("failed to check directory size: %v", err)
 					}
 				}
 			})
@@ -414,17 +414,17 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 			By("delete pvc and app")
 			err = deletePVCAndApp("", f, pvc, app)
 			if err != nil {
-				e2elog.Failf("failed to delete pvc and application with error %v", err)
+				e2elog.Failf("failed to delete pvc and application: %v", err)
 			}
 			// delete cephFS provisioner secret
 			err = deleteCephUser(f, keyringCephFSProvisionerUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringCephFSProvisionerUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringCephFSProvisionerUsername, err)
 			}
 			// delete cephFS plugin secret
 			err = deleteCephUser(f, keyringCephFSNodePluginUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringCephFSNodePluginUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringCephFSNodePluginUsername, err)
 			}
 		})
 	})

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -42,7 +42,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if cephCSINamespace != defaultNs {
 			err := createNamespace(c, cephCSINamespace)
 			if err != nil {
-				e2elog.Failf("failed to create namespace with error %v", err)
+				e2elog.Failf("failed to create namespace: %v", err)
 			}
 		}
 
@@ -51,52 +51,52 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		var err error
 		cwd, err = os.Getwd()
 		if err != nil {
-			e2elog.Failf("failed to do  getwd with error %v", err)
+			e2elog.Failf("failed to do  getwd: %v", err)
 		}
 
 		deployVault(f.ClientSet, deployTimeout)
 		err = upgradeAndDeployCSI(upgradeVersion, "rbd")
 		if err != nil {
-			e2elog.Failf("failed to upgrade and deploy CSI with error %v", err)
+			e2elog.Failf("failed to upgrade and deploy CSI: %v", err)
 		}
 		err = createConfigMap(rbdDirPath, f.ClientSet, f)
 		if err != nil {
-			e2elog.Failf("failed to create configmap with error %v", err)
+			e2elog.Failf("failed to create configmap: %v", err)
 		}
 		err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
 		if err != nil {
-			e2elog.Failf("failed to create storageclass with error %v", err)
+			e2elog.Failf("failed to create storageclass: %v", err)
 		}
 		// create rbd provisioner secret
 		key, err := createCephUser(f, keyringRBDProvisionerUsername, rbdProvisionerCaps("", ""))
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringRBDProvisionerUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringRBDProvisionerUsername, err)
 		}
 		err = createRBDSecret(f, rbdProvisionerSecretName, keyringRBDProvisionerUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create provisioner secret with error %v", err)
+			e2elog.Failf("failed to create provisioner secret: %v", err)
 		}
 		// create rbd plugin secret
 		key, err = createCephUser(f, keyringRBDNodePluginUsername, rbdNodePluginCaps("", ""))
 		if err != nil {
-			e2elog.Failf("failed to create user %s with error %v", keyringRBDNodePluginUsername, err)
+			e2elog.Failf("failed to create user %s: %v", keyringRBDNodePluginUsername, err)
 		}
 		err = createRBDSecret(f, rbdNodePluginSecretName, keyringRBDNodePluginUsername, key)
 		if err != nil {
-			e2elog.Failf("failed to create node secret with error %v", err)
+			e2elog.Failf("failed to create node secret: %v", err)
 		}
 		err = createRBDSnapshotClass(f)
 		if err != nil {
-			e2elog.Failf("failed to create snapshotclass with error %v", err)
+			e2elog.Failf("failed to create snapshotclass: %v", err)
 		}
 
 		err = createNodeLabel(f, nodeRegionLabel, regionValue)
 		if err != nil {
-			e2elog.Failf("failed to create node label with error %v", err)
+			e2elog.Failf("failed to create node label: %v", err)
 		}
 		err = createNodeLabel(f, nodeZoneLabel, zoneValue)
 		if err != nil {
-			e2elog.Failf("failed to create node label with error %v", err)
+			e2elog.Failf("failed to create node label: %v", err)
 		}
 	})
 	AfterEach(func() {
@@ -117,27 +117,27 @@ var _ = Describe("RBD Upgrade Testing", func() {
 
 		err := deleteConfigMap(rbdDirPath)
 		if err != nil {
-			e2elog.Failf("failed to delete configmap with error %v", err)
+			e2elog.Failf("failed to delete configmap: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), rbdProvisionerSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete provisioner secret with error %v", err)
+			e2elog.Failf("failed to delete provisioner secret: %v", err)
 		}
 		err = c.CoreV1().
 			Secrets(cephCSINamespace).
 			Delete(context.TODO(), rbdNodePluginSecretName, metav1.DeleteOptions{})
 		if err != nil {
-			e2elog.Failf("failed to delete node secret with error %v", err)
+			e2elog.Failf("failed to delete node secret: %v", err)
 		}
 		err = deleteResource(rbdExamplePath + "storageclass.yaml")
 		if err != nil {
-			e2elog.Failf("failed to delete storageclass with error %v", err)
+			e2elog.Failf("failed to delete storageclass: %v", err)
 		}
 		err = deleteResource(rbdExamplePath + "snapshotclass.yaml")
 		if err != nil {
-			e2elog.Failf("failed to delete snapshotclass with error %v", err)
+			e2elog.Failf("failed to delete snapshotclass: %v", err)
 		}
 		deleteVault()
 		if deployRBD {
@@ -145,17 +145,17 @@ var _ = Describe("RBD Upgrade Testing", func() {
 			if cephCSINamespace != defaultNs {
 				err = deleteNamespace(c, cephCSINamespace)
 				if err != nil {
-					e2elog.Failf("failed to delete namespace with error %v", err)
+					e2elog.Failf("failed to delete namespace: %v", err)
 				}
 			}
 		}
 		err = deleteNodeLabel(c, nodeRegionLabel)
 		if err != nil {
-			e2elog.Failf("failed to delete node label with error %v", err)
+			e2elog.Failf("failed to delete node label: %v", err)
 		}
 		err = deleteNodeLabel(c, nodeZoneLabel)
 		if err != nil {
-			e2elog.Failf("failed to delete node label with error %v", err)
+			e2elog.Failf("failed to delete node label: %v", err)
 		}
 	})
 
@@ -167,14 +167,14 @@ var _ = Describe("RBD Upgrade Testing", func() {
 			By("checking provisioner deployment is running", func() {
 				err := waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for deployment %s with error %v", rbdDeploymentName, err)
+					e2elog.Failf("timeout waiting for deployment %s: %v", rbdDeploymentName, err)
 				}
 			})
 
 			By("checking nodeplugin deamonset pods are running", func() {
 				err := waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for daemonset %s with error %v", rbdDaemonsetName, err)
+					e2elog.Failf("timeout waiting for daemonset %s: %v", rbdDaemonsetName, err)
 				}
 			})
 
@@ -186,13 +186,13 @@ var _ = Describe("RBD Upgrade Testing", func() {
 
 				pvc, err = loadPVC(pvcPath)
 				if err != nil {
-					e2elog.Failf("failed to load pvc with error %v", err)
+					e2elog.Failf("failed to load pvc: %v", err)
 				}
 				pvc.Namespace = f.UniqueName
 
 				app, err = loadApp(appPath)
 				if err != nil {
-					e2elog.Failf("failed to load application with error %v", err)
+					e2elog.Failf("failed to load application: %v", err)
 				}
 				label[appKey] = appLabel
 				app.Namespace = f.UniqueName
@@ -200,7 +200,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(pvcSize)
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create pvc with error %v", err)
+					e2elog.Failf("failed to create pvc: %v", err)
 				}
 				opt := metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
@@ -231,7 +231,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				e2elog.Logf("Calculating checksum of %s", filePath)
 				checkSum, err = calculateSHA512sum(f, app, filePath, &opt)
 				if err != nil {
-					e2elog.Failf("failed to calculate checksum with error %v", err)
+					e2elog.Failf("failed to calculate checksum: %v", err)
 				}
 
 				// pvc clone is only supported from v1.16+
@@ -249,25 +249,25 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				}
 				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to delete application with error %v", err)
+					e2elog.Failf("failed to delete application: %v", err)
 				}
 				deleteRBDPlugin()
 
 				err = os.Chdir(cwd)
 				if err != nil {
-					e2elog.Failf("failed to change directory with error %v", err)
+					e2elog.Failf("failed to change directory: %v", err)
 				}
 
 				deployRBDPlugin()
 
 				err = waitForDeploymentComplete(rbdDeploymentName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for upgraded deployment %s with error %v", rbdDeploymentName, err)
+					e2elog.Failf("timeout waiting for upgraded deployment %s: %v", rbdDeploymentName, err)
 				}
 
 				err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
-					e2elog.Failf("timeout waiting for upgraded daemonset %s with error %v", rbdDaemonsetName, err)
+					e2elog.Failf("timeout waiting for upgraded daemonset %s: %v", rbdDaemonsetName, err)
 				}
 
 				// validate if the app gets bound to a pvc created by
@@ -275,7 +275,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				app.Labels = label
 				err = createApp(f.ClientSet, app, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to create application with error %v", err)
+					e2elog.Failf("failed to create application: %v", err)
 				}
 			})
 
@@ -288,14 +288,14 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					pvcClone, err := loadPVC(pvcClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load pvc with error %v", err)
+						e2elog.Failf("failed to load pvc: %v", err)
 					}
 					pvcClone.Namespace = f.UniqueName
 					pvcClone.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(pvcSize)
 					pvcClone.Spec.DataSource.Name = "rbd-pvc-snapshot"
 					appClone, err := loadApp(appClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load application with error %v", err)
+						e2elog.Failf("failed to load application: %v", err)
 					}
 					label[appKey] = "validate-snap-clone"
 					appClone.Namespace = f.UniqueName
@@ -303,7 +303,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 					appClone.Labels = label
 					err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create pvc with error %v", err)
+						e2elog.Failf("failed to create pvc: %v", err)
 					}
 					opt := metav1.ListOptions{
 						LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
@@ -312,7 +312,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 					testFilePath := filepath.Join(mountPath, "testClone")
 					newCheckSum, err := calculateSHA512sum(f, appClone, testFilePath, &opt)
 					if err != nil {
-						e2elog.Failf("failed to calculate checksum with error %v", err)
+						e2elog.Failf("failed to calculate checksum: %v", err)
 					}
 					if strings.Compare(newCheckSum, checkSum) != 0 {
 						e2elog.Failf(
@@ -325,7 +325,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 					// delete cloned pvc and pod
 					err = deletePVCAndApp("", f, pvcClone, appClone)
 					if err != nil {
-						e2elog.Failf("failed to delete pvc and application with error %v", err)
+						e2elog.Failf("failed to delete pvc and application: %v", err)
 					}
 
 				}
@@ -340,14 +340,14 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 16) {
 					pvcClone, err := loadPVC(pvcSmartClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load pvc with error %v", err)
+						e2elog.Failf("failed to load pvc: %v", err)
 					}
 					pvcClone.Spec.DataSource.Name = pvc.Name
 					pvcClone.Namespace = f.UniqueName
 					pvcClone.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(pvcSize)
 					appClone, err := loadApp(appSmartClonePath)
 					if err != nil {
-						e2elog.Failf("failed to load application with error %v", err)
+						e2elog.Failf("failed to load application: %v", err)
 					}
 					label[appKey] = "validate-clone"
 					appClone.Namespace = f.UniqueName
@@ -355,7 +355,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 					appClone.Labels = label
 					err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to create pvc with error %v", err)
+						e2elog.Failf("failed to create pvc: %v", err)
 					}
 					opt := metav1.ListOptions{
 						LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
@@ -364,7 +364,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 					testFilePath := filepath.Join(mountPath, "testClone")
 					newCheckSum, err := calculateSHA512sum(f, appClone, testFilePath, &opt)
 					if err != nil {
-						e2elog.Failf("failed to calculate checksum with error %v", err)
+						e2elog.Failf("failed to calculate checksum: %v", err)
 					}
 					if strings.Compare(newCheckSum, checkSum) != 0 {
 						e2elog.Failf(
@@ -377,7 +377,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 					// delete cloned pvc and pod
 					err = deletePVCAndApp("", f, pvcClone, appClone)
 					if err != nil {
-						e2elog.Failf("failed to delete pvc and application with error %v", err)
+						e2elog.Failf("failed to delete pvc and application: %v", err)
 					}
 
 				}
@@ -398,23 +398,23 @@ var _ = Describe("RBD Upgrade Testing", func() {
 						PersistentVolumeClaims(pvc.Namespace).
 						Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 					if err != nil {
-						e2elog.Failf("failed to get pvc with error %v", err)
+						e2elog.Failf("failed to get pvc: %v", err)
 					}
 
 					// resize PVC
 					err = expandPVCSize(f.ClientSet, pvc, pvcExpandSize, deployTimeout)
 					if err != nil {
-						e2elog.Failf("failed to expand pvc with error %v", err)
+						e2elog.Failf("failed to expand pvc: %v", err)
 					}
 					// wait for application pod to come up after resize
 					err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout, noError)
 					if err != nil {
-						e2elog.Failf("timeout waiting for pod to be in running state with error %v", err)
+						e2elog.Failf("timeout waiting for pod to be in running state: %v", err)
 					}
 					// validate if resize is successful.
 					err = checkDirSize(app, f, &opt, pvcExpandSize)
 					if err != nil {
-						e2elog.Failf("failed to check directory size with error %v", err)
+						e2elog.Failf("failed to check directory size: %v", err)
 					}
 				}
 			})
@@ -422,18 +422,18 @@ var _ = Describe("RBD Upgrade Testing", func() {
 			By("delete pvc and app", func() {
 				err := deletePVCAndApp("", f, pvc, app)
 				if err != nil {
-					e2elog.Failf("failed to delete pvc and application with error %v", err)
+					e2elog.Failf("failed to delete pvc and application: %v", err)
 				}
 			})
 			// delete RBD provisioner secret
 			err := deleteCephUser(f, keyringRBDProvisionerUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringRBDProvisionerUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringRBDProvisionerUsername, err)
 			}
 			// delete RBD plugin secret
 			err = deleteCephUser(f, keyringRBDNodePluginUsername)
 			if err != nil {
-				e2elog.Failf("failed to delete user %s with error %v", keyringRBDNodePluginUsername, err)
+				e2elog.Failf("failed to delete user %s: %v", keyringRBDNodePluginUsername, err)
 			}
 		})
 	})

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -526,21 +526,21 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 	// write data in PVC
 	err := writeDataInPod(app, opt, f)
 	if err != nil {
-		e2elog.Logf("failed to write data in the pod with error %v", err)
+		e2elog.Logf("failed to write data in the pod: %v", err)
 
 		return "", err
 	}
 
 	checkSum, err := calculateSHA512sum(f, app, filePath, opt)
 	if err != nil {
-		e2elog.Logf("failed to calculate checksum with error %v", err)
+		e2elog.Logf("failed to calculate checksum: %v", err)
 
 		return checkSum, err
 	}
 
 	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to delete pod with error %v", err)
+		e2elog.Failf("failed to delete pod: %v", err)
 	}
 
 	return checkSum, nil
@@ -558,18 +558,18 @@ func validatePVCClone(
 	chErrs := make([]error, totalCount)
 	pvc, err := loadPVC(sourcePvcPath)
 	if err != nil {
-		e2elog.Failf("failed to load PVC with error %v", err)
+		e2elog.Failf("failed to load PVC: %v", err)
 	}
 
 	label := make(map[string]string)
 	pvc.Namespace = f.UniqueName
 	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to create PVC with error %v", err)
+		e2elog.Failf("failed to create PVC: %v", err)
 	}
 	app, err := loadApp(sourceAppPath)
 	if err != nil {
-		e2elog.Failf("failed to load app with error %v", err)
+		e2elog.Failf("failed to load app: %v", err)
 	}
 	label[appKey] = appLabel
 	app.Namespace = f.UniqueName
@@ -589,20 +589,20 @@ func validatePVCClone(
 	if *pvc.Spec.VolumeMode == v1.PersistentVolumeFilesystem {
 		checkSum, err = writeDataAndCalChecksum(app, &opt, f)
 		if err != nil {
-			e2elog.Failf("failed to calculate checksum with error %v", err)
+			e2elog.Failf("failed to calculate checksum: %v", err)
 		}
 	}
 	// validate created backend rbd images
 	validateRBDImageCount(f, 1, defaultRBDPool)
 	pvcClone, err := loadPVC(clonePvcPath)
 	if err != nil {
-		e2elog.Failf("failed to load PVC with error %v", err)
+		e2elog.Failf("failed to load PVC: %v", err)
 	}
 	pvcClone.Spec.DataSource.Name = pvc.Name
 	pvcClone.Namespace = f.UniqueName
 	appClone, err := loadApp(clonePvcAppPath)
 	if err != nil {
-		e2elog.Failf("failed to load application with error %v", err)
+		e2elog.Failf("failed to load application: %v", err)
 	}
 	appClone.Namespace = f.UniqueName
 	wg.Add(totalCount)
@@ -690,7 +690,7 @@ func validatePVCClone(
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to delete PVC with error %v", err)
+		e2elog.Failf("failed to delete PVC: %v", err)
 	}
 
 	totalCloneCount = totalCount + totalCount
@@ -765,7 +765,7 @@ func validatePVCSnapshot(
 	chErrs := make([]error, totalCount)
 	err := createRBDSnapshotClass(f)
 	if err != nil {
-		e2elog.Failf("failed to create storageclass with error %v", err)
+		e2elog.Failf("failed to create storageclass: %v", err)
 	}
 	defer func() {
 		err = deleteRBDSnapshotClass()
@@ -776,17 +776,17 @@ func validatePVCSnapshot(
 
 	pvc, err := loadPVC(pvcPath)
 	if err != nil {
-		e2elog.Failf("failed to load PVC with error %v", err)
+		e2elog.Failf("failed to load PVC: %v", err)
 	}
 	label := make(map[string]string)
 	pvc.Namespace = f.UniqueName
 	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to create PVC with error %v", err)
+		e2elog.Failf("failed to create PVC: %v", err)
 	}
 	app, err := loadApp(appPath)
 	if err != nil {
-		e2elog.Failf("failed to load app with error %v", err)
+		e2elog.Failf("failed to load app: %v", err)
 	}
 	// write data in PVC
 	label[appKey] = appLabel
@@ -798,7 +798,7 @@ func validatePVCSnapshot(
 	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 	checkSum, err := writeDataAndCalChecksum(app, &opt, f)
 	if err != nil {
-		e2elog.Failf("failed to calculate checksum with error %v", err)
+		e2elog.Failf("failed to calculate checksum: %v", err)
 	}
 	validateRBDImageCount(f, 1, defaultRBDPool)
 	snap := getSnapshot(snapshotPath)
@@ -816,7 +816,7 @@ func validatePVCSnapshot(
 					content, sErr := getVolumeSnapshotContent(s.Namespace, s.Name)
 					if sErr != nil {
 						wgErrs[n] = fmt.Errorf(
-							"failed to get snapshotcontent for %s in namespace %s with error: %w",
+							"failed to get snapshotcontent for %s in namespace %s: %w",
 							s.Name,
 							s.Namespace,
 							sErr)
@@ -850,11 +850,11 @@ func validatePVCSnapshot(
 	validateRBDImageCount(f, totalCount+1, defaultRBDPool)
 	pvcClone, err := loadPVC(pvcClonePath)
 	if err != nil {
-		e2elog.Failf("failed to load PVC with error %v", err)
+		e2elog.Failf("failed to load PVC: %v", err)
 	}
 	appClone, err := loadApp(appClonePath)
 	if err != nil {
-		e2elog.Failf("failed to load application with error %v", err)
+		e2elog.Failf("failed to load application: %v", err)
 	}
 	pvcClone.Namespace = f.UniqueName
 	appClone.Namespace = f.UniqueName
@@ -902,7 +902,7 @@ func validatePVCSnapshot(
 				checkSumClone, chErrs[n] = calculateSHA512sum(f, &a, filePath, &opt)
 				e2elog.Logf("checksum value for the clone is %s with pod name %s", checkSumClone, name)
 				if chErrs[n] != nil {
-					e2elog.Logf("failed to calculte checksum for clone with error %s", chErrs[n])
+					e2elog.Logf("failed to calculte checksum for clone: %s", chErrs[n])
 				}
 				if checkSumClone != checkSum {
 					e2elog.Logf(
@@ -998,7 +998,7 @@ func validatePVCSnapshot(
 	// delete parent pvc
 	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 	if err != nil {
-		e2elog.Failf("failed to delete PVC with error %v", err)
+		e2elog.Failf("failed to delete PVC: %v", err)
 	}
 
 	// total images in cluster is total snaps+ total clones
@@ -1016,7 +1016,7 @@ func validatePVCSnapshot(
 					content, err = getVolumeSnapshotContent(s.Namespace, s.Name)
 					if err != nil {
 						wgErrs[n] = fmt.Errorf(
-							"failed to get snapshotcontent for %s in namespace %s with error: %w",
+							"failed to get snapshotcontent for %s in namespace %s: %w",
 							s.Name,
 							s.Namespace,
 							err)
@@ -1221,7 +1221,7 @@ func validateController(
 func k8sVersionGreaterEquals(c kubernetes.Interface, major, minor int) bool {
 	v, err := c.Discovery().ServerVersion()
 	if err != nil {
-		e2elog.Failf("failed to get server version with error %v", err)
+		e2elog.Failf("failed to get server version: %v", err)
 		// Failf() marks the case as failure, and returns from the
 		// Go-routine that runs the case. This function will not have a
 		// return value.


### PR DESCRIPTION
To make the error return consistent across e2e tests we have decided
to remove `with error` presence from the logs and this commit
does that for cephfs tests.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
