### PR TITLE
helm: use "version: 3-canary" for helm charts on "devel"

### DIFF
--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
-version: 1.3.0-canary
+version: 3-canary
 keywords:
   - ceph
   - cephfs

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: canary
 description: "Container Storage Interface (CSI) driver,
 provisioner, snapshotter, and attacher for Ceph RBD"
 name: ceph-csi-rbd
-version: 1.3.0-canary
+version: 3-canary
 keywords:
   - ceph
   - rbd


### PR DESCRIPTION
Version field for helm Chart.yaml needs to have SemVer 2
compatible value, therefore use "MAJOR-VERSION"+"-canary"
on "devel" branch.

Refer: https://helm.sh/docs/topics/charts/#the-chartyaml-file

Signed-off-by: Rakshith R <rar@redhat.com>
