### PR TITLE
ci: fix helm chart push for release branches

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -24,12 +24,9 @@ jobs:
           username: ${{ secrets.QUAY_IO_USERNAME }}
           password: ${{ secrets.QUAY_IO_PASSWORD }}
 
-      - name: Set build environment based on Git branch name
-        if: github.ref == 'refs/heads/devel'
-        run: echo "BRANCH_NAME=devel" >> $GITHUB_ENV
-
       - name: Set build environment variables
         run: |
+          echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
           echo "GITHUB_USER=${{ secrets.CEPH_CSI_BOT_NAME }}" >> $GITHUB_ENV
           echo "GITHUB_EMAIL=${{ secrets.CEPH_CSI_BOT_EMAIL }}" >> $GITHUB_ENV
           echo "GITHUB_TOKEN=${{ secrets.CEPH_CSI_BOT_TOKEN }}" >> $GITHUB_ENV


### PR DESCRIPTION
Currently BRANCH_NAME for release branches is not set causing
the source in helm chart to be set as
```
sources:
  - https://github.com/ceph/ceph-csi/tree//charts/ceph-csi-cephfs
```

Current change fixes it.

Refer: https://github.com/ceph/csi-charts/blob/master/docs/index.yaml#L29-L36

Signed-off-by: Rakshith R <rar@redhat.com>

The proposed change to obtain branch name is in use at https://github.com/rook/rook/blob/fcd0d90c3a2246f93211330526d71d04762b2c92/.github/workflows/push-build.yaml#L47