### PR TITLE
ci: use refs/pull/<id>/merge in k8s external storage tests too

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -65,7 +65,7 @@ node('cico-workspace') {
 
 	stage('checkout PR') {
 		if (params.ghprbPullId != null) {
-			ref = "pull/${ghprbPullId}/head"
+			ref = "pull/${ghprbPullId}/merge"
 		}
 		if (params.ghprbTargetBranch != null) {
 			git_since = "${ghprbTargetBranch}"


### PR DESCRIPTION
This change was missed in
https://github.com/ceph/ceph-csi/pull/1617.

Signed-off-by: Rakshith R <rar@redhat.com>
