### PR TITLE
ci: have mergify label PRs for `actions/` with `ci/skip/e2e`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -310,7 +310,7 @@ pull_request_rules:
           - ci/skip/e2e
   - name: title contains Mergify
     conditions:
-      - "title~=mergify"
+      - "title~=(?i)mergify"
     actions:
       label:
         add:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -316,3 +316,12 @@ pull_request_rules:
         add:
           - Repo activity
           - ci/skip/e2e
+  - name: label PR that only changes actions
+    conditions:
+      - -files~=^(!?actions/)
+    actions:
+      label:
+        add:
+          - component/build
+          - component/testing
+          - ci/skip/e2e


### PR DESCRIPTION
The matching checks the list of modified files, and if it does not
contain anything outside the `actions/` directory, the labels are
applied.

Actions are not tested with e2e, so changes can be labelled to skip
these time and resource intensive tests.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
