### PR TITLE
Revert "ci: have Mergify label PRs for `actions/` with `ci/skip/e2e`"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -316,12 +316,3 @@ pull_request_rules:
         add:
           - Repo activity
           - ci/skip/e2e
-  - name: label PR that only changes actions
-    conditions:
-      - -files~=^(!?actions/)
-    actions:
-      label:
-        add:
-          - component/build
-          - component/testing
-          - ci/skip/e2e


### PR DESCRIPTION
It seems that the matching condition on the modified files with

    -files~=^(!?actions/)

validates to 'true' when that is not intended. The example in the
Mergify documentation does not seem to be correct :-/

This reverts commit 411bf33a3d57e28640a52c6a071b59b4d167e6b0.

See-also: https://docs.mergify.com/examples/#merging-based-on-modified-files

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
