### PR TITLE
 e2e: run generic ephemeral for kubernetes 1.21+

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -315,33 +315,32 @@ var _ = Describe("cephfs", func() {
 			}
 			By("verify generic ephemeral volume support", func() {
 				// generic ephemeral volume support is beta since v1.21.
-				if !k8sVersionGreaterEquals(f.ClientSet, 1, 21) {
-					Skip("generic ephemeral volume only supported from v1.21+")
-				}
-				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
-				if err != nil {
-					e2elog.Failf("failed to create CephFS storageclass: %v", err)
-				}
-				// create application
-				app, err := loadApp(appEphemeralPath)
-				if err != nil {
-					e2elog.Failf("failed to load application: %v", err)
-				}
-				app.Namespace = f.UniqueName
-				err = createApp(f.ClientSet, app, deployTimeout)
-				if err != nil {
-					e2elog.Failf("failed to create application: %v", err)
-				}
-				validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
-				// delete pod
-				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
-				if err != nil {
-					e2elog.Failf("failed to delete application: %v", err)
-				}
-				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
-				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
-				if err != nil {
-					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 21) {
+					err := createCephfsStorageClass(f.ClientSet, f, true, nil)
+					if err != nil {
+						e2elog.Failf("failed to create CephFS storageclass: %v", err)
+					}
+					// create application
+					app, err := loadApp(appEphemeralPath)
+					if err != nil {
+						e2elog.Failf("failed to load application: %v", err)
+					}
+					app.Namespace = f.UniqueName
+					err = createApp(f.ClientSet, app, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to create application: %v", err)
+					}
+					validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
+					// delete pod
+					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to delete application: %v", err)
+					}
+					validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+					err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+					if err != nil {
+						e2elog.Failf("failed to delete CephFS storageclass: %v", err)
+					}
 				}
 			})
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -373,31 +373,30 @@ var _ = Describe("RBD", func() {
 			}
 			By("verify generic ephemeral volume support", func() {
 				// generic ephemeral volume support is supported from 1.21
-				if !k8sVersionGreaterEquals(f.ClientSet, 1, 21) {
-					Skip("generic ephemeral volume only supported from v1.21+")
-				}
-				// create application
-				app, err := loadApp(appEphemeralPath)
-				if err != nil {
-					e2elog.Failf("failed to load application: %v", err)
-				}
-				app.Namespace = f.UniqueName
-				err = createApp(f.ClientSet, app, deployTimeout)
-				if err != nil {
-					e2elog.Failf("failed to create application: %v", err)
-				}
-				// validate created backend rbd images
-				validateRBDImageCount(f, 1, defaultRBDPool)
-				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
-				if err != nil {
-					e2elog.Failf("failed to delete application: %v", err)
-				}
-				// validate created backend rbd images
-				validateRBDImageCount(f, 0, defaultRBDPool)
-				// validate images in trash
-				err = waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
-				if err != nil {
-					e2elog.Failf("failed to validate rbd images in pool %s trash: %v", defaultRBDPool, err)
+				if k8sVersionGreaterEquals(f.ClientSet, 1, 21) {
+					// create application
+					app, err := loadApp(appEphemeralPath)
+					if err != nil {
+						e2elog.Failf("failed to load application: %v", err)
+					}
+					app.Namespace = f.UniqueName
+					err = createApp(f.ClientSet, app, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to create application: %v", err)
+					}
+					// validate created backend rbd images
+					validateRBDImageCount(f, 1, defaultRBDPool)
+					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to delete application: %v", err)
+					}
+					// validate created backend rbd images
+					validateRBDImageCount(f, 0, defaultRBDPool)
+					// validate images in trash
+					err = waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
+					if err != nil {
+						e2elog.Failf("failed to validate rbd images in pool %s trash: %v", defaultRBDPool, err)
+					}
 				}
 			})
 


### PR DESCRIPTION
Currently, we are skipping the generic ephemeral testing if the kubernetes version is less than 1.21 because of this one the who test suite is getting skipped and e2e is marked as success in 2 minutes. This commit runs the ephemeral tests if the kube=>1.21+. If we do this, for the lower version we can run other tests.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

* sample logs from CI

```log
S [SKIPPING] [39.739 seconds]

cephfs

/go/src/github.com/ceph/ceph-csi/e2e/cephfs.go:185

  Test CephFS CSI

  /go/src/github.com/ceph/ceph-csi/e2e/cephfs.go:273

    Test CephFS CSI [It]

    /go/src/github.com/ceph/ceph-csi/e2e/cephfs.go:274



    generic ephemeral volume only supported from v1.21+



    /go/src/github.com/ceph/ceph-csi/e2e/cephfs.go:319

------------------------------

RBD Upgrade Testing Test RBD CSI 

  Test RBD CSI

  /go/src/github.com/ceph/ceph-csi/e2e/upgrade-rbd.go:163

[BeforeEach] RBD Upgrade Testing

  /go/src/github.com/ceph/ceph-csi/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:185

STEP: Creating a kubernetes client

Nov 25 12:05:59.289: INFO: >>> kubeConfig: /root/.kube/config

STEP: Building a namespace api object, basename upgrade-test-rbd

STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in upgrade-test-rbd-3274

STEP: Waiting for a default service account to be provisioned in namespace

[BeforeEach] RBD Upgrade Testing

  /go/src/github.com/ceph/ceph-csi/e2e/upgrade-rbd.go:37

[AfterEach] RBD Upgrade Testing

  /go/src/github.com/ceph/ceph-csi/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:186

Nov 25 12:05:59.439: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready

STEP: Destroying namespace "upgrade-test-rbd-3274" for this suite.

[AfterEach] RBD Upgrade Testing

  /go/src/github.com/ceph/ceph-csi/e2e/upgrade-rbd.go:102



S [SKIPPING] in Spec Setup (BeforeEach) [0.158 seconds]

RBD Upgrade Testing

/go/src/github.com/ceph/ceph-csi/e2e/upgrade-rbd.go:19

  Test RBD CSI [BeforeEach]

  /go/src/github.com/ceph/ceph-csi/e2e/upgrade-rbd.go:162

    Test RBD CSI

    /go/src/github.com/ceph/ceph-csi/e2e/upgrade-rbd.go:163



    Skipping RBD Upgrade Testing



    /go/src/github.com/ceph/ceph-csi/e2e/upgrade-rbd.go:39

------------------------------



Ran 0 of 4 Specs in 147.860 seconds

SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 4 Skipped

--- PASS: TestE2E (147.87s)

PASS
```