### PR TITLE
deploy: add erasure coded pool deployment 

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -179,6 +179,7 @@ EXTRA_CONFIG="${EXTRA_CONFIG} --extra-config=kubelet.resolv-conf=${RESOLV_CONF}"
 
 #extra Rook configuration
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}
+ROOK_BLOCK_EC_POOL_NAME=${ROOK_BLOCK_EC_POOL_NAME:-"ec-pool"}
 
 # enable read-only anonymous access to kubelet metrics
 EXTRA_CONFIG="${EXTRA_CONFIG} --extra-config=kubelet.read-only-port=10255"
@@ -241,6 +242,16 @@ delete-block-pool)
     DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
     "$DIR"/rook.sh delete-block-pool
     ;;
+create-block-ec-pool)
+    echo "creating a erasure coded block pool named $ROOK_BLOCK_EC_POOL_NAME"
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    "$DIR"/rook.sh create-block-ec-pool
+    ;;
+delete-block-ec-pool)
+    echo "deleting erasure coded block pool named $ROOK_BLOCK_EC_POOL_NAME"
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    "$DIR"/rook.sh delete-block-ec-pool
+    ;;
 cleanup-snapshotter)
     echo "cleanup snapshot controller"
     DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
@@ -281,6 +292,8 @@ Available Commands:
   install-snapshotter  Install snapshot controller
   create-block-pool    Creates a rook block pool (named $ROOK_BLOCK_POOL_NAME)
   delete-block-pool    Deletes a rook block pool (named $ROOK_BLOCK_POOL_NAME)
+  create-block-ec-pool Creates a rook erasure coded block pool (named $ROOK_BLOCK_EC_POOL_NAME)
+  delete-block-ec-pool Creates a rook erasure coded block pool (named $ROOK_BLOCK_EC_POOL_NAME)
   cleanup-snapshotter  Cleanup snapshot controller
   teardown-rook        Teardown rook from minikube
   cephcsi              Copy built docker images to kubernetes cluster

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -234,6 +234,8 @@ Available Commands:
   teardown           Teardown a rook
   create-block-pool  Create a rook block pool
   delete-block-pool  Delete a rook block pool
+  create-block-ec-pool Creates a rook erasure coded block pool
+  delete-block-ec-pool Deletes a rook erasure coded block pool
 " >&2
 	;;
 esac


### PR DESCRIPTION
Add support to deploy erasure-coded pools in minikube script

Blocks: https://github.com/ceph/ceph-csi/pull/2681
Updates: https://github.com/ceph/ceph-csi/pull/2654

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
