### PR TITLE
rbd: journal based mirroring for point-in-time and crash consistent images

### DIFF
--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rbd
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -73,6 +74,7 @@ func TestValidateSchedulingInterval(t *testing.T) {
 
 func TestValidateSchedulingDetails(t *testing.T) {
 	t.Parallel()
+	ctx := context.TODO()
 	tests := []struct {
 		name       string
 		parameters map[string]string
@@ -98,10 +100,10 @@ func TestValidateSchedulingDetails(t *testing.T) {
 		{
 			"when mirroring mode is journal",
 			map[string]string{
-				imageMirroringKey:     "journal",
+				imageMirroringKey:     string(imageMirrorModeJournal),
 				schedulingIntervalKey: "1h",
 			},
-			true,
+			false,
 		},
 		{
 			"when startTime is specified without interval",
@@ -136,7 +138,7 @@ func TestValidateSchedulingDetails(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateSchedulingDetails(tt.parameters)
+			err := validateSchedulingDetails(ctx, tt.parameters)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getSchedulingDetails() error = %v, wantErr %v", err, tt.wantErr)
 


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Journal-based RADOS block device mirroring ensures point-in-time
consistent replicas of all changes to an image, including reads and
writes, block device resizing, snapshots, clones, and flattening.

Journaling-based mirroring records all modifications to an image in the
order in which they occur. This ensures that a crash-consistent mirror
of an image is available.

Mirroring when configured in journal mode, mirroring will
utilize the RBD journaling image feature to replicate the image
contents. If the RBD journaling image feature is not yet enabled on the
image, it will be automatically enabled.

## Related issues ##

Fixes: #2018
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
