### PR TITLE
rbd: implement CSI-Addons Identity Service

### DIFF
--- a/internal/rbd/driver.go
+++ b/internal/rbd/driver.go
@@ -132,7 +132,7 @@ func (r *Driver) Run(conf *util.Config) {
 	snapJournal = journal.NewCSISnapshotJournal(CSIInstanceID)
 
 	// configre CSI-Addons server and components
-	err = r.setupCSIAddonsServer(conf.CSIAddonsEndpoint)
+	err = r.setupCSIAddonsServer(conf)
 	if err != nil {
 		log.FatalLogMsg(err.Error())
 	}
@@ -232,16 +232,17 @@ func (r *Driver) Run(conf *util.Config) {
 // setupCSIAddonsServer creates a new CSI-Addons Server on the given (URL)
 // endpoint. The supported CSI-Addons operations get registered as their own
 // services.
-func (r *Driver) setupCSIAddonsServer(endpoint string) error {
+func (r *Driver) setupCSIAddonsServer(conf *util.Config) error {
 	var err error
 
-	r.cas, err = csiaddons.NewCSIAddonsServer(endpoint)
+	r.cas, err = csiaddons.NewCSIAddonsServer(conf.CSIAddonsEndpoint)
 	if err != nil {
 		return fmt.Errorf("failed to create CSI-Addons server: %w", err)
 	}
 
 	// register services
-	r.cas.RegisterService(&casrbd.IdentityServer{})
+	is := casrbd.NewIdentityServer(conf)
+	r.cas.RegisterService(is)
 
 	// start the server, this does not block, it runs a new go-routine
 	err = r.cas.Start()

--- a/internal/rbd/driver_test.go
+++ b/internal/rbd/driver_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 func TestSetupCSIAddonsServer(t *testing.T) {
@@ -31,8 +33,12 @@ func TestSetupCSIAddonsServer(t *testing.T) {
 	tmpDir := t.TempDir()
 	endpoint := "unix://" + tmpDir + "/csi-addons.sock"
 
+	config := &util.Config{
+		CSIAddonsEndpoint: endpoint,
+	}
+
 	drv := &Driver{}
-	err := drv.setupCSIAddonsServer(endpoint)
+	err := drv.setupCSIAddonsServer(config)
 	require.NoError(t, err)
 	require.NotNil(t, drv.cas)
 


### PR DESCRIPTION
Depending on the way Ceph-CSI is deployed, the capabilities will be
configured for the GetCapabilities procedure. The other procedures are
more straight-forward.

Closes: #2671

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
