### PR TITLE
CI change for mergifyio `strict` mode deprecation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,22 +4,71 @@ defaults:
     # mergify.io has removed bot_account from its free open source plan.
     comment:
     # bot_account: ceph-csi-bot # mergify[bot] will be commenting.
-    merge:
+    queue:
       # merge_bot_account: ceph-csi-bot #mergify[bot] will be merging prs.
       # update_bot_account: ceph-csi-bot #mergify will randomly pick and use
       # credentials of users with write access to repo to rebase prs.
+      name: default
       method: rebase
       rebase_fallback: merge
-      strict: smart
-      strict_method: rebase
-    rebase:
-    # bot_account: ceph-csi-bot # same as update_bot_account.
+      update_method: rebase
+
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - or:
+          - and:
+              - base~=^(devel)|(release-.+)$
+              - "status-success=codespell"
+              - "status-success=multi-arch-build"
+              - "status-success=go-test"
+              - "status-success=golangci-lint"
+              - "status-success=mod-check"
+              - "status-success=lint-extras"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.21"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.22"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.23"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.21"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.22"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.23"
+              - "status-success=ci/centos/mini-e2e/k8s-1.21"
+              - "status-success=ci/centos/mini-e2e/k8s-1.22"
+              - "status-success=ci/centos/mini-e2e/k8s-1.23"
+              - "status-success=ci/centos/upgrade-tests-cephfs"
+              - "status-success=ci/centos/upgrade-tests-rbd"
+              - "status-success=DCO"
+          - and:
+              - base=release-v3.4
+              - "status-success=codespell"
+              - "status-success=multi-arch-build"
+              - "status-success=go-test"
+              - "status-success=commitlint"
+              - "status-success=golangci-lint"
+              - "status-success=mod-check"
+              - "status-success=lint-extras"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.21"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.22"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.23"
+              - "status-success=ci/centos/mini-e2e/k8s-1.21"
+              - "status-success=ci/centos/mini-e2e/k8s-1.22"
+              - "status-success=ci/centos/mini-e2e/k8s-1.23"
+              - "status-success=ci/centos/upgrade-tests-cephfs"
+              - "status-success=ci/centos/upgrade-tests-rbd"
+              - "status-success=DCO"
+          - and:
+              - base=ci/centos
+              - "status-success=ci/centos/job-validation"
+              - "status-success=ci/centos/jjb-validate"
+              - "status-success=DCO"
 
 pull_request_rules:
   - name: remove outdated approvals
     conditions:
       - base~=^(devel)|(release-.+)$
     actions:
+      queue:
+        name: default
       dismiss_reviews:
         approved: true
         changes_requested: false
@@ -28,6 +77,8 @@ pull_request_rules:
       - conflict
       - author!=dependabot[bot]
     actions:
+      queue:
+        name: default
       comment:
         # yamllint disable-line rule:truthy
         message: "This pull request now has conflicts with the target branch.
@@ -61,7 +112,8 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue:
+        name: default
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge
@@ -92,7 +144,8 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue:
+        name: default
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label
@@ -122,7 +175,8 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue:
+        name: default
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v3.4 branch
@@ -160,7 +214,8 @@ pull_request_rules:
       - "status-success=ci/centos/upgrade-tests-rbd"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue:
+        name: default
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: remove outdated approvals on ci/centos
@@ -182,7 +237,8 @@ pull_request_rules:
       - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue:
+        name: default
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label on ci/centos
@@ -196,7 +252,8 @@ pull_request_rules:
       - "status-success=ci/centos/jjb-validate"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue:
+        name: default
       dismiss_reviews: {}
       delete_head_branch: {}
   ##


### PR DESCRIPTION
    ci: move from merge action to queue action
    
    as mentioned in the below blog the support for strict mode
    and merge action will be done soon in mergify. This brings
    the change requested for the same.
    
    Ref# https://blog.mergify.com/strict-mode-deprecation/

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>