### PR TITLE
rbd: recreate dummy image with new image features and 1MiB size

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -314,6 +314,14 @@ func createDummyImage(ctx context.Context, rbdVol *rbdVolume) error {
 		}
 		dummyVol := *rbdVol
 		dummyVol.RbdImageName = imgName
+		f := []string{
+			librbd.FeatureNameLayering,
+			librbd.FeatureNameObjectMap,
+			librbd.FeatureNameExclusiveLock,
+			librbd.FeatureNameFastDiff,
+		}
+		features := librbd.FeatureSetFromNames(f)
+		dummyVol.imageFeatureSet = features
 		// create 1MiB dummy image. 1MiB=1048576 bytes
 		dummyVol.VolSize = 1048576
 		err = createImage(ctx, &dummyVol, dummyVol.conn.Creds)
@@ -332,6 +340,10 @@ func createDummyImage(ctx context.Context, rbdVol *rbdVolume) error {
 
 // repairDummyImage deletes and recreates the dummy image.
 func repairDummyImage(ctx context.Context, dummyVol *rbdVolume) error {
+	// instead of checking the images features and than adding missing image
+	// features, updating the image size to 1Mib. We will delete the image
+	// and recreate it.
+
 	// deleting and recreating the dummy image will not impact anything as its
 	// a workaround to fix the scheduling problem.
 	err := deleteImage(ctx, dummyVol, dummyVol.conn.Creds)


### PR DESCRIPTION
we added a workaround for rbd scheduling by creating a dummy image in #2656. with the fix, we are creating a dummy image of the size of the first actual rbd image which is sent in EnableVolumeReplication request if the actual rbd image size is 1Tib we are creating a dummy image of 1TiB which is not good. even though it's a thin-provisioned rbd image this is causing issues for the transfer of the snapshot during the mirroring operation. The current changes include recreating the rbd image with 1Mib size which is the smaller supported size in rbd.

The dummy image will be created with a 1MiB size. during the snapshot transfer operation, the 1MiB will be transferred even if the dummy image does not contain any data. adding the new image features `fast-diff,layering,obj-map,exclusive-lock` on the dummy image will ensure that only the diff is transferred to the remote cluster.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>