### PR TITLE
e2e: add e2e testcase of new image features

### DIFF
--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -40,6 +40,18 @@ var nbdResizeSupport = []util.KernelVersion{
 	}, // standard 5.3+ versions
 }
 
+// nolint:gomnd // numbers specify Kernel versions.
+var fastDiffSupport = []util.KernelVersion{
+	{
+		Version:      5,
+		PatchLevel:   3,
+		SubLevel:     0,
+		ExtraVersion: 0,
+		Distribution: "",
+		Backport:     false,
+	}, // standard 5.3+ versions
+}
+
 // To use `io-timeout=0` we need
 // www.mail-archive.com/linux-block@vger.kernel.org/msg38060.html
 // nolint:gomnd // numbers specify Kernel versions.


### PR DESCRIPTION
adding e2e test case to validate the workflow of pvc creation and attaching to pod works for new image features like fast-diff,obj-map,exclusive-lock, and layering.

fixes: #2695

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

