### PR TITLE
rbd: dont attempt explicit permission mod change from the RBD driver

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -333,6 +333,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 			},
 		},
 		Spec: v1.PodSpec{
+			SecurityContext: &v1.PodSecurityContext{FSGroup: &user},
 			Containers: []v1.Container{
 				{
 					Name:    "write-pod",

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -366,7 +366,6 @@ func (ns *NodeServer) stageTransaction(
 	transaction := &stageTransaction{}
 
 	var err error
-	var readOnly bool
 
 	// Allow image to be mounted on multiple nodes if it is ROX
 	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
@@ -421,7 +420,7 @@ func (ns *NodeServer) stageTransaction(
 	transaction.isStagePathCreated = true
 
 	// nodeStage Path
-	readOnly, err = ns.mountVolumeToStagePath(ctx, req, staticVol, stagingTargetPath, devicePath)
+	_, err = ns.mountVolumeToStagePath(ctx, req, staticVol, stagingTargetPath, devicePath)
 	if err != nil {
 		return transaction, err
 	}
@@ -434,11 +433,6 @@ func (ns *NodeServer) stageTransaction(
 	err = resizeNodeStagePath(ctx, isBlock, transaction, req.GetVolumeId(), stagingTargetPath)
 	if err != nil {
 		return transaction, err
-	}
-
-	if !readOnly {
-		// #nosec - allow anyone to write inside the target path
-		err = os.Chmod(stagingTargetPath, 0o777)
 	}
 
 	return transaction, err

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -420,7 +420,7 @@ func (ns *NodeServer) stageTransaction(
 	transaction.isStagePathCreated = true
 
 	// nodeStage Path
-	_, err = ns.mountVolumeToStagePath(ctx, req, staticVol, stagingTargetPath, devicePath)
+	err = ns.mountVolumeToStagePath(ctx, req, staticVol, stagingTargetPath, devicePath)
 	if err != nil {
 		return transaction, err
 	}
@@ -678,7 +678,7 @@ func (ns *NodeServer) mountVolumeToStagePath(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest,
 	staticVol bool,
-	stagingPath, devicePath string) (bool, error) {
+	stagingPath, devicePath string) error {
 	readOnly := false
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
 	diskMounter := &mount.SafeFormatAndMount{Interface: ns.Mounter, Exec: utilexec.New()}
@@ -696,7 +696,7 @@ func (ns *NodeServer) mountVolumeToStagePath(
 	if err != nil {
 		log.ErrorLog(ctx, "failed to get disk format for path %s, error: %v", devicePath, err)
 
-		return readOnly, err
+		return err
 	}
 
 	opt := []string{"_netdev"}
@@ -736,7 +736,7 @@ func (ns *NodeServer) mountVolumeToStagePath(
 			if cmdErr != nil {
 				log.ErrorLog(ctx, "failed to run mkfs error: %v, output: %v", cmdErr, string(cmdOut))
 
-				return readOnly, cmdErr
+				return cmdErr
 			}
 		}
 	}
@@ -757,7 +757,7 @@ func (ns *NodeServer) mountVolumeToStagePath(
 			err)
 	}
 
-	return readOnly, err
+	return err
 }
 
 func (ns *NodeServer) mountVolume(ctx context.Context, stagingPath string, req *csi.NodePublishVolumeRequest) error {


### PR DESCRIPTION
currently we are overriding the permission to `0o777` at time of node
stage which is not the correct action. That said, this permission
change causes an extra permission correction at time of nodestaging
by the CO while the FSGROUP change policy has been set to
`OnRootMismatch`.


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>