### PR TITLE
ci: run tests on kubernetes 1.23

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -2,12 +2,12 @@
 - project:
     name: k8s-e2e-external-storage
     k8s_version:
-      - '1.20':
-          only_run_on_request: true
       - '1.21':
           only_run_on_request: false
       - '1.22':
           only_run_on_request: false
+      - '1.23':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,14 +2,14 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.19':
-          only_run_on_request: true
       - '1.20':
           only_run_on_request: false
       - '1.21':
           only_run_on_request: false
       - '1.22':
           only_run_on_request: false
+      - '1.23':
+          only_run_on_request: true
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
This commits removes the older version (1.19 and 1.20 from external tests only) from testing and adds the Kubernetes 1.23 to run on request for now.

Note:- Once the kubernetes 1.23 job is stable will run it by default

updates #2698

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
