### PR TITLE
rbd: move driver component into the rbd-driver package

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/controller"
 	"github.com/ceph/ceph-csi/internal/controller/persistentvolume"
 	"github.com/ceph/ceph-csi/internal/liveness"
-	"github.com/ceph/ceph-csi/internal/rbd"
+	rbddriver "github.com/ceph/ceph-csi/internal/rbd/driver"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
@@ -222,7 +222,7 @@ func main() {
 	case rbdType:
 		validateCloneDepthFlag(&conf)
 		validateMaxSnaphostFlag(&conf)
-		driver := rbd.NewDriver()
+		driver := rbddriver.NewDriver()
 		driver.Run(&conf)
 
 	case cephFSType:

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -734,7 +734,7 @@ func checkContentSource(
 		if volID == "" {
 			return nil, nil, status.Errorf(codes.NotFound, "volume ID cannot be empty")
 		}
-		rbdvol, err := genVolFromVolID(ctx, volID, cr, req.GetSecrets())
+		rbdvol, err := GenVolFromVolID(ctx, volID, cr, req.GetSecrets())
 		if err != nil {
 			log.ErrorLog(ctx, "failed to get backend image for %s: %v", volID, err)
 			if !errors.Is(err, ErrImageNotFound) {
@@ -750,9 +750,9 @@ func checkContentSource(
 	return nil, nil, status.Errorf(codes.InvalidArgument, "not a proper volume source")
 }
 
-// checkErrAndUndoReserve work on error from genVolFromVolID() and undo omap reserve.
+// checkErrAndUndoReserve work on error from GenVolFromVolID() and undo omap reserve.
 // Even-though volumeID is part of rbdVolume struct we take it as an arg here, the main reason
-// being, the volume id is getting filled from `genVolFromVolID->generateVolumeFromVolumeID` call path,
+// being, the volume id is getting filled from `GenVolFromVolID->generateVolumeFromVolumeID` call path,
 // and this function is operating on the error case/scenario of above call chain, so we can not rely
 // on the 'rbdvol->rbdimage->voldID' field.
 
@@ -865,7 +865,7 @@ func (cs *ControllerServer) DeleteVolume(
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 
-	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, secrets)
+	rbdVol, err := GenVolFromVolID(ctx, volumeID, cr, secrets)
 	defer rbdVol.Destroy()
 	if err != nil {
 		return cs.checkErrAndUndoReserve(ctx, err, volumeID, rbdVol, cr)
@@ -1016,7 +1016,7 @@ func (cs *ControllerServer) CreateSnapshot(
 	defer cr.DeleteCredentials()
 
 	// Fetch source volume information
-	rbdVol, err := genVolFromVolID(ctx, req.GetSourceVolumeId(), cr, req.GetSecrets())
+	rbdVol, err := GenVolFromVolID(ctx, req.GetSourceVolumeId(), cr, req.GetSecrets())
 	defer rbdVol.Destroy()
 	if err != nil {
 		switch {
@@ -1462,7 +1462,7 @@ func (cs *ControllerServer) ControllerExpandVolume(
 	}
 	defer cr.DeleteCredentials()
 
-	rbdVol, err := genVolFromVolID(ctx, volID, cr, req.GetSecrets())
+	rbdVol, err := GenVolFromVolID(ctx, volID, cr, req.GetSecrets())
 	defer rbdVol.Destroy()
 	if err != nil {
 		switch {

--- a/internal/rbd/driver/driver_test.go
+++ b/internal/rbd/driver/driver_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rbd
+package rbddriver
 
 import (
 	"os"

--- a/internal/rbd/globals.go
+++ b/internal/rbd/globals.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"fmt"
+
+	"github.com/ceph/ceph-csi/internal/journal"
+)
+
+const (
+	// volIDVersion is the version number of volume ID encoding scheme.
+	volIDVersion uint16 = 1
+)
+
+var (
+	// CSIInstanceID is the instance ID that is unique to an instance of CSI, used when sharing
+	// ceph clusters across CSI instances, to differentiate omap names per CSI instance.
+	CSIInstanceID = "default"
+
+	// volJournal and snapJournal are used to maintain RADOS based journals for CO generated
+	// VolumeName to backing RBD images.
+	volJournal  *journal.Config
+	snapJournal *journal.Config
+	// rbdHardMaxCloneDepth is the hard limit for maximum number of nested volume clones that are taken before flatten
+	// occurs.
+	rbdHardMaxCloneDepth uint
+
+	// rbdSoftMaxCloneDepth is the soft limit for maximum number of nested volume clones that are taken before flatten
+	// occurs.
+	rbdSoftMaxCloneDepth              uint
+	maxSnapshotsOnImage               uint
+	minSnapshotsOnImageToStartFlatten uint
+	skipForceFlatten                  bool
+
+	// krbd features supported by the loaded driver.
+	krbdFeatures uint
+)
+
+// SetGlobalInt provides a way for the rbd-driver to configure global variables
+// in the rbd package.
+//
+// TODO: these global variables should be set in the ControllerService and
+// NodeService where appropriate. Using global variables limits the ability to
+// configure these options based on the Ceph cluster or StorageClass.
+func SetGlobalInt(name string, value uint) {
+	switch name {
+	case "rbdHardMaxCloneDepth":
+		rbdHardMaxCloneDepth = value
+	case "rbdSoftMaxCloneDepth":
+		rbdSoftMaxCloneDepth = value
+	case "maxSnapshotsOnImage":
+		maxSnapshotsOnImage = value
+	case "minSnapshotsOnImageToStartFlatten":
+		minSnapshotsOnImageToStartFlatten = value
+	case "krbdFeatures":
+		krbdFeatures = value
+	default:
+		panic(fmt.Sprintf("BUG: can not set unknown variable %q", name))
+	}
+}
+
+// SetGlobalBool provides a way for the rbd-driver to configure global
+// variables in the rbd package.
+//
+// TODO: these global variables should be set in the ControllerService and
+// NodeService where appropriate. Using global variables limits the ability to
+// configure these options based on the Ceph cluster or StorageClass.
+func SetGlobalBool(name string, value bool) {
+	switch name {
+	case "skipForceFlatten":
+		skipForceFlatten = value
+	default:
+		panic(fmt.Sprintf("BUG: can not set unknown variable %q", name))
+	}
+}
+
+// InitJournals initializes the global journals that are used by the rbd
+// package. This is called from the rbd-driver on startup.
+//
+// TODO: these global journals should be set in the ControllerService and
+// NodeService where appropriate. Using global journals limits the ability to
+// configure these options based on the Ceph cluster or StorageClass.
+func InitJournals(instance string) {
+	// Use passed in instance ID, if provided for omap suffix naming
+	if instance != "" {
+		CSIInstanceID = instance
+	}
+
+	volJournal = journal.NewCSIVolumeJournal(CSIInstanceID)
+	snapJournal = journal.NewCSISnapshotJournal(CSIInstanceID)
+}

--- a/internal/rbd/rbd_healer.go
+++ b/internal/rbd/rbd_healer.go
@@ -127,8 +127,8 @@ func callNodeStageVolume(ns *NodeServer, c *k8s.Clientset, pv *v1.PersistentVolu
 	return nil
 }
 
-// runVolumeHealer heal the volumes attached on a node.
-func runVolumeHealer(ns *NodeServer, conf *util.Config) error {
+// RunVolumeHealer heal the volumes attached on a node.
+func RunVolumeHealer(ns *NodeServer, conf *util.Config) error {
 	c, err := kubeclient.NewK8sClient()
 	if err != nil {
 		log.ErrorLogMsg("failed to connect to Kubernetes: %v", err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -250,8 +250,8 @@ func GetKrbdSupportedFeatures() (string, error) {
 	return strings.TrimSuffix(string(val), "\n"), nil
 }
 
-// hexStringToInteger convert hex value to uint.
-func hexStringToInteger(hexString string) (uint64, error) {
+// HexStringToInteger convert hex value to uint.
+func HexStringToInteger(hexString string) (uint, error) {
 	// trim 0x prefix
 	numberStr := strings.TrimPrefix(strings.ToLower(hexString), "0x")
 
@@ -262,7 +262,7 @@ func hexStringToInteger(hexString string) (uint64, error) {
 		return 0, err
 	}
 
-	return output, nil
+	return uint(output), nil
 }
 
 // isKrbdFeatureSupported checks if a given Image Feature is supported by krbd
@@ -274,7 +274,7 @@ func isKrbdFeatureSupported(ctx context.Context, imageFeatures string) bool {
 
 	supported := true
 	for _, featureName := range imageFeatureSet.Names() {
-		if (uint64(librbd.FeatureSetFromNames(strings.Split(featureName, " "))) & krbdFeatures) == 0 {
+		if (uint(librbd.FeatureSetFromNames(strings.Split(featureName, " "))) & krbdFeatures) == 0 {
 			supported = false
 			log.ErrorLog(ctx, "krbd feature %q not supported", featureName)
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1145,9 +1145,11 @@ func generateVolumeFromVolumeID(
 	return rbdVol, err
 }
 
-// genVolFromVolID generates a rbdVolume structure from the provided identifier, updating
+// GenVolFromVolID generates a rbdVolume structure from the provided identifier, updating
 // the structure with elements from on-disk image metadata as well.
-func genVolFromVolID(
+//
+// nolint // returns non-exported *rbdVolume, which is fine
+func GenVolFromVolID(
 	ctx context.Context,
 	volumeID string,
 	cr *util.Credentials,

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -200,34 +200,30 @@ type migrationVolID struct {
 	clusterID string
 }
 
-var (
-	supportedFeatures = map[string]imageFeature{
-		librbd.FeatureNameLayering: {
-			needRbdNbd: false,
-		},
-		librbd.FeatureNameExclusiveLock: {
-			needRbdNbd: false,
-		},
-		librbd.FeatureNameObjectMap: {
-			needRbdNbd: false,
-			dependsOn:  []string{librbd.FeatureNameExclusiveLock},
-		},
-		librbd.FeatureNameFastDiff: {
-			needRbdNbd: false,
-			dependsOn:  []string{librbd.FeatureNameObjectMap},
-		},
-		librbd.FeatureNameJournaling: {
-			needRbdNbd: true,
-			dependsOn:  []string{librbd.FeatureNameExclusiveLock},
-		},
-	}
+var supportedFeatures = map[string]imageFeature{
+	librbd.FeatureNameLayering: {
+		needRbdNbd: false,
+	},
+	librbd.FeatureNameExclusiveLock: {
+		needRbdNbd: false,
+	},
+	librbd.FeatureNameObjectMap: {
+		needRbdNbd: false,
+		dependsOn:  []string{librbd.FeatureNameExclusiveLock},
+	},
+	librbd.FeatureNameFastDiff: {
+		needRbdNbd: false,
+		dependsOn:  []string{librbd.FeatureNameObjectMap},
+	},
+	librbd.FeatureNameJournaling: {
+		needRbdNbd: true,
+		dependsOn:  []string{librbd.FeatureNameExclusiveLock},
+	},
+}
 
-	krbdFeatures uint64 // krbd features supported by the loaded driver.
-)
-
-// getKrbdSupportedFeatures load the module if needed and return supported
+// GetKrbdSupportedFeatures load the module if needed and return supported
 // features attribute as a string.
-func getKrbdSupportedFeatures() (string, error) {
+func GetKrbdSupportedFeatures() (string, error) {
 	// check if the module is loaded or compiled in
 	_, err := os.Stat(krbdSupportedFeaturesFile)
 	if err != nil {

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -334,9 +334,9 @@ func TestIsKrbdFeatureSupported(t *testing.T) {
 			t.Parallel()
 			var err error
 			krbdSupportedFeaturesAttr := "0x1"
-			krbdFeatures, err = hexStringToInteger(krbdSupportedFeaturesAttr) // initialize krbdFeatures
+			krbdFeatures, err = HexStringToInteger(krbdSupportedFeaturesAttr) // initialize krbdFeatures
 			if err != nil {
-				t.Errorf("hexStringToInteger(%s) failed", krbdSupportedFeaturesAttr)
+				t.Errorf("HexStringToInteger(%s) failed", krbdSupportedFeaturesAttr)
 			}
 			supported := isKrbdFeatureSupported(ctx, tc.featureName)
 			if supported != tc.isSupported {

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -235,7 +235,7 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	rbdVol, err := GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
 	defer rbdVol.Destroy()
 	if err != nil {
 		switch {
@@ -410,7 +410,7 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	rbdVol, err := GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
 	defer rbdVol.Destroy()
 	if err != nil {
 		switch {
@@ -522,7 +522,7 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	rbdVol, err := GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
 	defer rbdVol.Destroy()
 	if err != nil {
 		switch {
@@ -658,7 +658,7 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	rbdVol, err := GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
 	defer rbdVol.Destroy()
 	if err != nil {
 		switch {
@@ -745,7 +745,7 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer rs.VolumeLocks.Release(volumeID)
-	rbdVol, err := genVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
+	rbdVol, err := GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
 	defer rbdVol.Destroy()
 	if err != nil {
 		switch {


### PR DESCRIPTION
The rbd package contains several functions that can be used by
CSI-Addons Service implementations. Unfortunately it is not possible to
do this, as the rbd-driver needs to import the csi-addons/rbd package to
provide the CSI-Addons server. This causes a circular import when
services use the rbd package:

 - rbd/driver.go import csi-addons/rbd
 - csi-addons/rbd import rbd (including the driver)

By moving rbd/driver.go into its own package, the circular import can be
prevented.

Updates: #2672 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
