### PR TITLE
rebase: update golang version to 1.17.5

### DIFF
--- a/build.env
+++ b/build.env
@@ -16,7 +16,7 @@ BASE_IMAGE=docker.io/ceph/ceph:v16
 CEPH_VERSION=octopus
 
 # standard Golang options
-GOLANG_VERSION=1.16.4
+GOLANG_VERSION=1.17.5
 GO111MODULE=on
 
 # commitlint version

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2
 	google.golang.org/grpc v1.42.0
+	google.golang.org/protobuf v1.26.0
 	k8s.io/api v0.22.4
 	k8s.io/apimachinery v0.22.4
 	k8s.io/client-go v12.0.0+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -543,6 +543,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # google.golang.org/protobuf v1.26.0
+## explicit
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire


### PR DESCRIPTION
This commit updates the golang to the latest available release i.e 1.17.5

Updating golang to 1.7.x will unblock https://github.com/ceph/ceph-csi/pull/2699

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

