### PR TITLE
ci: run tests on kubernetes 1.23 by default

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -7,7 +7,7 @@
       - '1.22':
           only_run_on_request: false
       - '1.23':
-          only_run_on_request: true
+          only_run_on_request: false
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -9,7 +9,7 @@
       - '1.22':
           only_run_on_request: false
       - '1.23':
-          only_run_on_request: true
+          only_run_on_request: false
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
The e2e tests are running fine on kubernetes 1.23. This commit runs the tests on kubernetes 1.23 by default.

updates: https://github.com/ceph/ceph-csi/issues/2698

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

