### PR TITLE
ci: remove kubernetes 1.20 from CI

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,6 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.20':
-          only_run_on_request: false
       - '1.21':
           only_run_on_request: false
       - '1.22':


### PR DESCRIPTION
removing kubernetes test run with 1.20 as with  #2705 we don't need 1.20 CI results to merge a PR and we have kubernetes 1.23
latest release.

depends on #2705 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

