### PR TITLE
CI: install arch specific go in Dockerfile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,10 +212,11 @@ else
 endif
 
 ifeq ($(USE_PULLED_IMAGE),no)
+.test-container-id: GOARCH ?= $(shell go env GOARCH 2>/dev/null)
 # create a (cached) container image with dependencies for testing cephcsi
 .test-container-id: .container-cmd build.env scripts/Dockerfile.test
 	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
-	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
+	$(CONTAINER_CMD) build $(CPUSET) --build-arg GOARCH=$(GOARCH) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 else
 # create the .test-container-id file based on the pulled image

--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,10 @@ containerized-test: .container-cmd .test-container-id
 
 ifeq ($(USE_PULLED_IMAGE),no)
 # create a (cached) container image with dependencies for building cephcsi
+.devel-container-id: GOARCH ?= $(shell go env GOARCH 2>/dev/null)
 .devel-container-id: .container-cmd scripts/Dockerfile.devel
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
-	$(CONTAINER_CMD) build $(CPUSET) --build-arg BASE_IMAGE=$(BASE_IMAGE) -t $(CSI_IMAGE_NAME):devel -f ./scripts/Dockerfile.devel .
+	$(CONTAINER_CMD) build $(CPUSET) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg GOARCH=$(GOARCH) -t $(CSI_IMAGE_NAME):devel -f ./scripts/Dockerfile.devel .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):devel > .devel-container-id
 else
 # create the .devel-container-id file based on pulled image

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -2,6 +2,7 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ARG GOROOT=/usr/local/go
+ARG GOARCH
 
 ENV GOPATH=/go \
  GOROOT=${GOROOT} \
@@ -11,8 +12,10 @@ ENV GOPATH=/go \
 COPY build.env /
 
 RUN source /build.env \
+    && \
+    ( test -n "${GOARCH}" && exit 0; echo -e "\n\nMissing GOARCH argument for building image, install Golang or run: make containerized-build GOARCH=amd64\n\n"; exit 1 ) \
     && mkdir -p /usr/local/go \
-    && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
+    && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
 RUN dnf -y install \
 	git \

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -12,6 +12,7 @@ FROM registry.fedoraproject.org/fedora:latest
 
 ARG GOPATH=/go
 ARG GOROOT=/usr/local/go
+ARG GOARCH
 
 ENV \
  GOPATH=${GOPATH} \
@@ -22,6 +23,8 @@ ENV \
 COPY build.env /
 
 RUN source /build.env \
+    && \
+    ( test -n "${GOARCH}" && exit 0; echo -e "\n\nMissing GOARCH argument for building image, install Golang or run: make containerized-test GOARCH=amd64\n\n"; exit 1 ) \
     && dnf -y install \
 	git \
 	make \
@@ -41,7 +44,7 @@ RUN source /build.env \
     && dnf -y clean all \
     && gem install mdl \
     && mkdir -p ${GOROOT} \
-    && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz  \
+    && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz  \
        | tar xzf - -C ${GOROOT} --strip-components=1 \
     && curl -sf "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" \
        | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \


### PR DESCRIPTION
Instead of installing the amd64 golang on all the platforms, install architecture specific go  version in dockerfile

closes #2707

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>