### PR TITLE
remove namespace from storageclass helm chart template

### DIFF
--- a/charts/ceph-csi-cephfs/templates/storageclass.yaml
+++ b/charts/ceph-csi-cephfs/templates/storageclass.yaml
@@ -3,7 +3,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.storageClass.name }}
-  namespace: {{ .Release.Namespace }}
 {{- if .Values.storageClass.annotations }}
   annotations:
 {{ toYaml .Values.storageClass.annotations | indent 4 }}

--- a/charts/ceph-csi-rbd/templates/storageclass.yaml
+++ b/charts/ceph-csi-rbd/templates/storageclass.yaml
@@ -3,7 +3,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.storageClass.name }}
-  namespace: {{ .Release.Namespace }}
 {{- if .Values.storageClass.annotations }}
   annotations:
 {{ toYaml .Values.storageClass.annotations | indent 4 }}


### PR DESCRIPTION
# Describe what this PR does #

removes namespace from non-namespaced storageclass object

## Is there anything that requires special attention ##

nothing to mention

## Related issues ##

Fixes: #2714
(reported by me)

## Future concerns ##

nothing to mention
