### PR TITLE
rbd: add support for bigger size restore/clone PVC

### DIFF
--- a/e2e/ceph_user.go
+++ b/e2e/ceph_user.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/clone.go
+++ b/e2e/clone.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+)
+
+func validateBiggerCloneFromPVC(f *framework.Framework,
+	pvcPath,
+	appPath,
+	pvcClonePath,
+	appClonePath string) error {
+	const (
+		size    = "1Gi"
+		newSize = "2Gi"
+	)
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC: %w", err)
+	}
+	label := make(map[string]string)
+	pvc.Namespace = f.UniqueName
+	pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(size)
+	app, err := loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app: %w", err)
+	}
+	label[appKey] = appLabel
+	app.Namespace = f.UniqueName
+	app.Labels = label
+	opt := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
+	}
+	err = createPVCAndApp("", f, pvc, app, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create pvc and application: %w", err)
+	}
+
+	pvcClone, err := loadPVC(pvcClonePath)
+	if err != nil {
+		e2elog.Failf("failed to load PVC: %v", err)
+	}
+	pvcClone.Namespace = f.UniqueName
+	pvcClone.Spec.DataSource.Name = pvc.Name
+	pvcClone.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(newSize)
+	appClone, err := loadApp(appClonePath)
+	if err != nil {
+		e2elog.Failf("failed to load application: %v", err)
+	}
+	appClone.Namespace = f.UniqueName
+	appClone.Labels = label
+	err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create pvc clone and application: %w", err)
+	}
+	err = deletePVCAndApp("", f, pvc, app)
+	if err != nil {
+		return fmt.Errorf("failed to delete pvc and application: %w", err)
+	}
+	if pvcClone.Spec.VolumeMode == nil || *pvcClone.Spec.VolumeMode == v1.PersistentVolumeFilesystem {
+		err = checkDirSize(appClone, f, &opt, newSize)
+		if err != nil {
+			return err
+		}
+	}
+
+	if pvcClone.Spec.VolumeMode != nil && *pvcClone.Spec.VolumeMode == v1.PersistentVolumeBlock {
+		err = checkDeviceSize(appClone, f, &opt, newSize)
+		if err != nil {
+			return err
+		}
+	}
+	err = deletePVCAndApp("", f, pvcClone, appClone)
+	if err != nil {
+		return fmt.Errorf("failed to delete pvc and application: %w", err)
+	}
+
+	return nil
+}

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/kms.go
+++ b/e2e/kms.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/migration.go
+++ b/e2e/migration.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/namespace.go
+++ b/e2e/namespace.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/node.go
+++ b/e2e/node.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/upgrade.go
+++ b/e2e/upgrade.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/examples/rbd/pod-block-restore.yaml
+++ b/examples/rbd/pod-block-restore.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-block-volume-restore
+spec:
+  containers:
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      volumeDevices:
+        - name: data
+          devicePath: /dev/xvda
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: rbd-block-pvc-restore

--- a/examples/rbd/pvc-block-restore.yaml
+++ b/examples/rbd/pvc-block-restore.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rbd-block-pvc-restore
+spec:
+  storageClassName: csi-rbd-sc
+  dataSource:
+    name: rbd-pvc-snapshot
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 1Gi

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -181,6 +181,14 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 		return err
 	}
 
+	// expand the image if the requested size is greater than the current size
+	err = rv.expand()
+	if err != nil {
+		log.ErrorLog(ctx, "failed to resize volume %s: %v", rv, err)
+
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -128,7 +128,7 @@ func (rv *rbdVolume) generateTempClone() *rbdVolume {
 	tempClone.conn = rv.conn.Copy()
 	// The temp clone image need to have deep flatten feature
 	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
-	tempClone.imageFeatureSet = librbd.FeatureSetFromNames(f)
+	tempClone.ImageFeatureSet = librbd.FeatureSetFromNames(f)
 	tempClone.ClusterID = rv.ClusterID
 	tempClone.Monitors = rv.Monitors
 	tempClone.Pool = rv.Pool

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -389,6 +389,14 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 			return nil, err
 		}
 
+		// expand the image if the requested size is greater than the current size
+		err = rbdVol.expand()
+		if err != nil {
+			log.ErrorLog(ctx, "failed to resize volume %s: %v", rbdVol, err)
+
+			return nil, err
+		}
+
 	// rbdVol is a clone from parentVol
 	case vcs.GetVolume() != nil:
 		// When cloning into a thick-provisioned volume was happening,
@@ -589,6 +597,15 @@ func (cs *ControllerServer) createVolumeFromSnapshot(
 	}
 
 	log.DebugLog(ctx, "create volume %s from snapshot %s", rbdVol.RequestName, rbdSnap.RbdSnapName)
+
+	// resize the volume if the size is different
+	// expand the image if the requested size is greater than the current size
+	err = rbdVol.expand()
+	if err != nil {
+		log.ErrorLog(ctx, "failed to resize volume %s: %v", rbdVol, err)
+
+		return err
+	}
 
 	return nil
 }

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1001,7 +1001,7 @@ func (cs *ControllerServer) CreateSnapshot(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	rbdSnap.RbdImageName = rbdVol.RbdImageName
-	rbdSnap.SizeBytes = rbdVol.VolSize
+	rbdSnap.VolSize = rbdVol.VolSize
 	rbdSnap.SourceVolumeID = req.GetSourceVolumeId()
 	rbdSnap.RequestName = req.GetName()
 
@@ -1134,7 +1134,7 @@ func cloneFromSnapshot(
 
 	return &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{
-			SizeBytes:      rbdSnap.SizeBytes,
+			SizeBytes:      rbdSnap.VolSize,
 			SnapshotId:     rbdSnap.VolID,
 			SourceVolumeId: rbdSnap.SourceVolumeID,
 			CreationTime:   rbdSnap.CreatedAt,

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -637,7 +637,6 @@ func (cs *ControllerServer) createBackingImage(
 		if err != nil {
 			return err
 		}
-		log.DebugLog(ctx, "created volume %s from snapshot %s", rbdVol.RequestName, rbdSnap.RbdSnapName)
 	case parentVol != nil:
 		if err = cs.OperationLocks.GetCloneLock(parentVol.VolID); err != nil {
 			log.ErrorLog(ctx, err.Error())

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -655,7 +655,7 @@ func (cs *ControllerServer) createBackingImage(
 		}
 	}
 
-	log.DebugLog(ctx, "created volume %s backed by image %s", rbdVol.RequestName, rbdVol.RbdImageName)
+	log.DebugLog(ctx, "created image %s backed for request name %s", rbdVol, rbdVol.RequestName)
 
 	defer func() {
 		if err != nil {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -192,48 +192,8 @@ func getGRPCErrorForCreateVolume(err error) error {
 	return status.Error(codes.Internal, err.Error())
 }
 
-// validateRequestedVolumeSize validates the request volume size with the
-// source snapshot or volume size, if there is a size mismatches it returns an error.
-func validateRequestedVolumeSize(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSnapshot, cr *util.Credentials) error {
-	if rbdSnap != nil {
-		vol := generateVolFromSnap(rbdSnap)
-		err := vol.Connect(cr)
-		if err != nil {
-			return status.Error(codes.Internal, err.Error())
-		}
-		defer vol.Destroy()
-
-		err = vol.getImageInfo()
-		if err != nil {
-			return status.Error(codes.Internal, err.Error())
-		}
-		if rbdVol.VolSize != vol.VolSize {
-			return status.Errorf(
-				codes.InvalidArgument,
-				"size mismatches, requested volume size %d and source snapshot size %d",
-				rbdVol.VolSize,
-				vol.VolSize)
-		}
-	}
-	if parentVol != nil {
-		if rbdVol.VolSize != parentVol.VolSize {
-			return status.Errorf(
-				codes.InvalidArgument,
-				"size mismatches, requested volume size %d and source volume size %d",
-				rbdVol.VolSize,
-				parentVol.VolSize)
-		}
-	}
-
-	return nil
-}
-
-func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSnapshot, cr *util.Credentials) error {
-	err := validateRequestedVolumeSize(rbdVol, parentVol, rbdSnap, cr)
-	if err != nil {
-		return err
-	}
-
+func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSnapshot) error {
+	var err error
 	switch {
 	case rbdSnap != nil:
 		err = rbdSnap.isCompatibleEncryption(&rbdVol.rbdImage)
@@ -309,7 +269,7 @@ func (cs *ControllerServer) CreateVolume(
 		return cs.repairExistingVolume(ctx, req, cr, rbdVol, parentVol, rbdSnap)
 	}
 
-	err = checkValidCreateVolumeRequest(rbdVol, parentVol, rbdSnap, cr)
+	err = checkValidCreateVolumeRequest(rbdVol, parentVol, rbdSnap)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -596,7 +596,7 @@ func (cs *ControllerServer) createVolumeFromSnapshot(
 		}
 	}
 
-	log.DebugLog(ctx, "create volume %s from snapshot %s", rbdVol.RequestName, rbdSnap.RbdSnapName)
+	log.DebugLog(ctx, "create volume %s from snapshot %s", rbdVol, rbdSnap)
 
 	// resize the volume if the size is different
 	// expand the image if the requested size is greater than the current size

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1204,7 +1204,7 @@ func (cs *ControllerServer) doSnapshotClone(
 	defer cloneRbd.Destroy()
 	// add image feature for cloneRbd
 	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
-	cloneRbd.imageFeatureSet = librbd.FeatureSetFromNames(f)
+	cloneRbd.ImageFeatureSet = librbd.FeatureSetFromNames(f)
 
 	err := cloneRbd.Connect(cr)
 	if err != nil {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -408,6 +408,13 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 				return nil, cleanupThickClone(ctx, parentVol, rbdVol, rbdSnap, cr)
 			}
 		}
+		// expand the image if the requested size is greater than the current size
+		err := rbdVol.expand()
+		if err != nil {
+			log.ErrorLog(ctx, "failed to resize volume %s: %v", rbdVol, err)
+
+			return nil, err
+		}
 	}
 
 	return buildCreateVolumeResponse(req, rbdVol), nil

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -136,6 +136,8 @@ func (cs *ControllerServer) parseVolCreateRequest(
 
 	// always round up the request size in bytes to the nearest MiB/GiB
 	rbdVol.VolSize = util.RoundOffBytes(volSizeBytes)
+	// RequestedVolSize has the size of the volume requested by the user.
+	rbdVol.RequestedVolSize = rbdVol.VolSize
 
 	// start with pool the same as journal pool, in case there is a topology
 	// based split, pool for the image will be updated subsequently

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -176,7 +176,7 @@ func checkSnapCloneExists(
 	// Code from here on, rolls the transaction forward.
 
 	rbdSnap.CreatedAt = vol.CreatedAt
-	rbdSnap.SizeBytes = vol.VolSize
+	rbdSnap.VolSize = vol.VolSize
 	// found a snapshot already available, process and return its information
 	rbdSnap.VolID, err = util.GenerateVolID(ctx, rbdSnap.Monitors, cr, snapData.ImagePoolID, rbdSnap.Pool,
 		rbdSnap.ClusterID, snapUUID, volIDVersion)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -164,7 +164,10 @@ type rbdVolume struct {
 	VolName            string `json:"volName"`
 	MonValueFromSecret string `json:"monValueFromSecret"`
 	VolSize            int64  `json:"volSize"`
-	DisableInUseChecks bool   `json:"disableInUseChecks"`
+	// RequestedVolSize has the size of the volume requested by the user and
+	// this value will not be updated when doing getImageInfo() on rbdVolume.
+	RequestedVolSize   int64
+	DisableInUseChecks bool `json:"disableInUseChecks"`
 	readOnly           bool
 	Primary            bool
 	ThickProvision     bool

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1703,6 +1703,16 @@ func cleanupRBDImageMetadataStash(metaDataPath string) error {
 	return nil
 }
 
+// expand checks if the requestedVolume size and the existing image size both
+// are same. If they are same, it returns nil else it resizes the image.
+func (rv *rbdVolume) expand() error {
+	if rv.RequestedVolSize == rv.VolSize {
+		return nil
+	}
+
+	return rv.resize(rv.RequestedVolSize)
+}
+
 // resize the given volume to new size.
 // updates Volsize of rbdVolume object to newSize in case of success.
 func (rv *rbdVolume) resize(newSize int64) error {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -107,6 +107,9 @@ type rbdImage struct {
 	// identifying this rbd image
 	VolID string `json:"volID"`
 
+	// VolSize is the size of the RBD image backing this rbdImage.
+	VolSize int64
+
 	Monitors string
 	// JournalPool is the ceph pool in which the CSI Journal/CSI snapshot Journal is
 	// stored
@@ -163,7 +166,6 @@ type rbdVolume struct {
 	LogStrategy        string
 	VolName            string
 	MonValueFromSecret string
-	VolSize            int64
 	// RequestedVolSize has the size of the volume requested by the user and
 	// this value will not be updated when doing getImageInfo() on rbdVolume.
 	RequestedVolSize   int64

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1055,7 +1055,31 @@ func genSnapFromSnapID(
 		}
 	}
 
+	err = updateSnapshotDetails(rbdSnap)
+	if err != nil {
+		return fmt.Errorf("failed to update snapshot details for %q: %w", rbdSnap, err)
+	}
+
 	return err
+}
+
+// updateSnapshotDetails will copies the details from the rbdVolume to the
+// rbdSnapshot. example copying size from rbdVolume to rbdSnapshot.
+func updateSnapshotDetails(rbdSnap *rbdSnapshot) error {
+	vol := generateVolFromSnap(rbdSnap)
+	err := vol.Connect(rbdSnap.conn.Creds)
+	if err != nil {
+		return err
+	}
+	defer vol.Destroy()
+
+	err = vol.getImageInfo()
+	if err != nil {
+		return err
+	}
+	rbdSnap.VolSize = vol.VolSize
+
+	return nil
 }
 
 // generateVolumeFromVolumeID generates a rbdVolume structure from the provided identifier.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -153,21 +153,21 @@ type rbdVolume struct {
 	// Parent Pool is the pool that contains the parent image.
 	ParentPool         string
 	imageFeatureSet    librbd.FeatureSet
-	AdminID            string `json:"adminId"`
-	UserID             string `json:"userId"`
-	Mounter            string `json:"mounter"`
+	AdminID            string
+	UserID             string
+	Mounter            string
 	ReservedID         string
 	MapOptions         string
 	UnmapOptions       string
 	LogDir             string
 	LogStrategy        string
-	VolName            string `json:"volName"`
-	MonValueFromSecret string `json:"monValueFromSecret"`
-	VolSize            int64  `json:"volSize"`
+	VolName            string
+	MonValueFromSecret string
+	VolSize            int64
 	// RequestedVolSize has the size of the volume requested by the user and
 	// this value will not be updated when doing getImageInfo() on rbdVolume.
 	RequestedVolSize   int64
-	DisableInUseChecks bool `json:"disableInUseChecks"`
+	DisableInUseChecks bool
 	readOnly           bool
 	Primary            bool
 	ThickProvision     bool

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -184,7 +184,6 @@ type rbdSnapshot struct {
 	SourceVolumeID string
 	ReservedID     string
 	RbdSnapName    string
-	SizeBytes      int64
 }
 
 // imageFeature represents required image features and value.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1503,6 +1503,12 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(
 		}
 	}
 
+	// get image latest information
+	err = rv.getImageInfo()
+	if err != nil {
+		return fmt.Errorf("failed to get image info of %s: %w", rv, err)
+	}
+
 	// Success! Do not delete the cloned image now :)
 	deleteClone = false
 

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -41,7 +41,7 @@ func TestHasSnapshotFeature(t *testing.T) {
 	rv := rbdVolume{}
 
 	for _, test := range tests {
-		rv.imageFeatureSet = librbd.FeatureSetFromNames(strings.Split(test.features, ","))
+		rv.ImageFeatureSet = librbd.FeatureSetFromNames(strings.Split(test.features, ","))
 		if got := rv.hasSnapshotFeature(); got != test.hasFeature {
 			t.Errorf("hasSnapshotFeature(%s) = %t, want %t", test.features, got, test.hasFeature)
 		}

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -324,7 +324,7 @@ func createDummyImage(ctx context.Context, rbdVol *rbdVolume) error {
 			librbd.FeatureNameFastDiff,
 		}
 		features := librbd.FeatureSetFromNames(f)
-		dummyVol.imageFeatureSet = features
+		dummyVol.ImageFeatureSet = features
 		// create 1MiB dummy image. 1MiB=1048576 bytes
 		dummyVol.VolSize = 1048576
 		err = createImage(ctx, &dummyVol, dummyVol.conn.Creds)

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -64,17 +64,6 @@ func createRBDClone(
 		return err
 	}
 
-	err = cloneRbdVol.getImageInfo()
-	if err != nil {
-		log.ErrorLog(ctx, "failed to get rbd image: %s details with error: %v", cloneRbdVol, err)
-		delErr := deleteImage(ctx, cloneRbdVol, cr)
-		if delErr != nil {
-			log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", cloneRbdVol, delErr)
-		}
-
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR allows the user to create the bigger PVC from the PVC and restore a snapshot to a bigger size PVC. and did require refactoring to avoid linter issues.


fixes: #1566
fixes: #1438

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>