### PR TITLE
cleanup: add IsBlockMultiNode() helper

### DIFF
--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -290,3 +290,19 @@ func requirePositive(x int64) int64 {
 
 	return 0
 }
+
+// IsBlockMultiNode checks the volume capabilities for BlockMode and MultiNode.
+func IsBlockMultiNode(caps []*csi.VolumeCapability) (bool, bool) {
+	isMultiNode := false
+	isBlock := false
+	for _, capability := range caps {
+		if capability.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
+			isMultiNode = true
+		}
+		if capability.GetBlock() != nil {
+			isBlock = true
+		}
+	}
+
+	return isBlock, isMultiNode
+}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -99,17 +99,8 @@ func (cs *ControllerServer) parseVolCreateRequest(
 	req *csi.CreateVolumeRequest) (*rbdVolume, error) {
 	// TODO (sbezverk) Last check for not exceeding total storage capacity
 
-	isMultiNode := false
-	isBlock := false
-	for _, capability := range req.VolumeCapabilities {
-		// RO modes need to be handled independently (ie right now even if access mode is RO, they'll be RW upon attach)
-		if capability.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
-			isMultiNode = true
-		}
-		if capability.GetBlock() != nil {
-			isBlock = true
-		}
-	}
+	// RO modes need to be handled independently (ie right now even if access mode is RO, they'll be RW upon attach)
+	isBlock, isMultiNode := csicommon.IsBlockMultiNode(req.VolumeCapabilities)
 
 	// We want to fail early if the user is trying to create a RWX on a non-block type device
 	if isMultiNode && !isBlock {


### PR DESCRIPTION
IsBlockMultiNode() is a new helper that takes a slice of
VolumeCapability objects and checks if it includes multi-node access
and/or block-mode support.

This can then easily be used in other services that need checking for
these particular capabilities, and preventing multi-node block-mode
access.

Updates: #2672 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
