### PR TITLE
doc: lift supported ceph version for snapshot/clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ for its support details.
 | CephFS | Dynamically provision, de-provision File mode RWO volume  | Beta           | >= v1.1.0          | >= v1.0.0        | Nautilus (>=14.2.2)  | >= v1.14.0         |
 |        | Dynamically provision, de-provision File mode RWX volume  | Beta           | >= v1.1.0          | >= v1.0.0        | Nautilus (>=v14.2.2) | >= v1.14.0         |
 |        | Dynamically provision, de-provision File mode ROX volume  | Alpha          | >= v3.0.0          | >= v1.0.0        | Nautilus (>=v14.2.2) | >= v1.14.0         |
-|        | Creating and deleting snapshot                            | Beta           | >= v3.1.0          | >= v1.0.0        | Octopus (>=v15.2.3)  | >= v1.17.0         |
-|        | Provision volume from snapshot                            | Beta           | >= v3.1.0          | >= v1.0.0        | Octopus (>=v15.2.3)  | >= v1.17.0         |
-|        | Provision volume from another volume                      | Beta           | >= v3.1.0          | >= v1.0.0        | Octopus (>=v15.2.3)  | >= v1.16.0         |
+|        | Creating and deleting snapshot                            | Beta           | >= v3.1.0          | >= v1.0.0        | Octopus (>=v15.2.4)  | >= v1.17.0         |
+|        | Provision volume from snapshot                            | Beta           | >= v3.1.0          | >= v1.0.0        | Octopus (>=v15.2.4)  | >= v1.17.0         |
+|        | Provision volume from another volume                      | Beta           | >= v3.1.0          | >= v1.0.0        | Octopus (>=v15.2.4)  | >= v1.16.0         |
 |        | Expand volume                                             | Beta           | >= v2.0.0          | >= v1.1.0        | Nautilus (>=v14.2.2) | >= v1.15.0         |
 |        | Volume/PV Metrics of File Mode Volume                     | Beta           | >= v1.2.0          | >= v1.1.0        | Nautilus (>=v14.2.2) | >= v1.15.0         |
 


### PR DESCRIPTION
snapshot and clone should be supported from octopus 15.2.4 instead of 15.2.3.

fixes #2731

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

