### PR TITLE
rbd: reset dummy image id

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -314,6 +314,9 @@ func createDummyImage(ctx context.Context, rbdVol *rbdVolume) error {
 		}
 		dummyVol := *rbdVol
 		dummyVol.RbdImageName = imgName
+		// dummyVol holds rbdVol details, reset ImageID or else dummy image cannot be
+		// deleted from trash during repair operation.
+		dummyVol.ImageID = ""
 		f := []string{
 			librbd.FeatureNameLayering,
 			librbd.FeatureNameObjectMap,


### PR DESCRIPTION
dummy image rbdVolume struct is derived from the actual one rbdVolume of the volumeID sent in the EnableVolumeReplication request. and the dummy rbdVolume struct contains the image id of the actual volume because of that when we are repairing the dummy image the image is sent to trash but not deleted due to the wrong image ID. resetting
the image id will make sure the image id is fetching from the ceph cluster and the same image id will be used for manager operation.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
