### PR TITLE
helm: Fix missing ClusterRoleBinding for nodeplugin ServiceAccount

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrolebinding.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.create -}}
-{{- if .Values.topology.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -18,5 +17,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "ceph-csi-rbd.nodeplugin.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end -}}


### PR DESCRIPTION
# Describe what this PR does #
Create nodeplugin-clusterrolebinding even when topology is disabled.
Otherwise the volume healer generates RBAC errors because it cannot access volumeattachments.

## Is there anything that requires special attention ##

Is the change backward compatible?
yes

Are there concerns around backward compatibility?
no

## Related issues ##

## Future concerns ##

---
