### PR TITLE
ci: strict rule for commit body length

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -19,7 +19,7 @@ rules:
   # Body shouldn't be empty
   body-min-length: [2, always, 1]
   # Wrap the lines to 80 characters.
-  body-max-line-length: [1, always, 80]
+  body-max-line-length: [2, always, 80]
 
   # always sign off the commit
   trailer-exists: [2, always, "Signed-off-by:"]


### PR DESCRIPTION
body-max-line-length is added as a warning even if the commit body is crossing the length limit of 80 it's considered as a warning, not an error. This commit moves the check from a warning to an error.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

