### PR TITLE
rbd: execute rbd image promote with timeout 

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -557,7 +557,13 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 
 	// promote secondary to primary
 	if !mirroringInfo.Primary {
-		err = rbdVol.promoteImage(req.Force)
+		if req.GetForce() {
+			// workaround for https://github.com/ceph/ceph-csi/issues/2736
+			// TODO: remove this workaround when the issue is fixed
+			err = rbdVol.forcePromoteImage(cr)
+		} else {
+			err = rbdVol.promoteImage(req.GetForce())
+		}
 		if err != nil {
 			log.ErrorLog(ctx, err.Error())
 			// In case of the DR the image on the primary site cannot be

--- a/internal/util/cephcmds_test.go
+++ b/internal/util/cephcmds_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestExecCommandWithTimeout(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx     context.Context
+		program string
+		timeout time.Duration
+		args    []string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		stdout      string
+		expectedErr error
+		wantErr     bool
+	}{
+		{
+			name: "echo hello",
+			args: args{
+				ctx:     context.TODO(),
+				program: "echo",
+				timeout: time.Second,
+				args:    []string{"hello"},
+			},
+			stdout:      "hello\n",
+			expectedErr: nil,
+			wantErr:     false,
+		},
+		{
+			name: "sleep with timeout",
+			args: args{
+				ctx:     context.TODO(),
+				program: "sleep",
+				timeout: time.Second,
+				args:    []string{"3"},
+			},
+			stdout:      "",
+			expectedErr: context.DeadlineExceeded,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		newtt := tt
+		t.Run(newtt.name, func(t *testing.T) {
+			t.Parallel()
+			stdout, _, err := ExecCommandWithTimeout(newtt.args.ctx,
+				newtt.args.timeout,
+				newtt.args.program,
+				newtt.args.args...)
+			if (err != nil) != newtt.wantErr {
+				t.Errorf("ExecCommandWithTimeout() error = %v, wantErr %v", err, newtt.wantErr)
+
+				return
+			}
+
+			if newtt.wantErr && !errors.Is(err, newtt.expectedErr) {
+				t.Errorf("ExecCommandWithTimeout() error expected got = %v, want %v", err, newtt.expectedErr)
+			}
+
+			if stdout != newtt.stdout {
+				t.Errorf("ExecCommandWithTimeout() got = %v, want %v", stdout, newtt.stdout)
+			}
+		})
+	}
+}


### PR DESCRIPTION
added ExecCommandWithTimeout helper function to execute the commands with the timeout option, if the command does not return any response within the timeout time the process will be terminated and an error will be returned back to the user.

use ExecCommandWithTimeout with a timeout of 1 minute for the promote operation. If the command does not return an error/response in 1 minute the process will be killed  and the error will be returned to the user

updates https://github.com/ceph/ceph-csi/issues/2736
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>