### PR TITLE
rbd: enable expand operation for intree volumes

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1447,9 +1447,7 @@ func (cs *ControllerServer) ControllerExpandVolume(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	defer cr.DeleteCredentials()
-
-	rbdVol, err := GenVolFromVolID(ctx, volID, cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	rbdVol, err := genVolFromVolIDWithMigration(ctx, volID, cr, req.GetSecrets())
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrImageNotFound):
@@ -1463,6 +1461,7 @@ func (cs *ControllerServer) ControllerExpandVolume(
 
 		return nil, err
 	}
+	defer rbdVol.Destroy()
 
 	// NodeExpansion is needed for PersistentVolumes with,
 	// 1. Filesystem VolumeMode with & without Encryption and

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2071,3 +2071,22 @@ func strategicActionOnLogFile(ctx context.Context, logStrategy, logFile string) 
 		log.ErrorLog(ctx, "unknown cephLogStrategy option %q: hint: 'remove'|'compress'|'preserve'", logStrategy)
 	}
 }
+
+// genVolFromVolIDWithMigration populate a rbdVol structure based on the volID format.
+func genVolFromVolIDWithMigration(
+	ctx context.Context, volID string, cr *util.Credentials, secrets map[string]string) (*rbdVolume, error) {
+	if isMigrationVolID(volID) {
+		pmVolID, pErr := parseMigrationVolID(volID)
+		if pErr != nil {
+			return nil, pErr
+		}
+
+		return genVolFromMigVolID(ctx, pmVolID, cr)
+	}
+	rv, err := GenVolFromVolID(ctx, volID, cr, secrets)
+	if err != nil {
+		rv.Destroy()
+	}
+
+	return rv, err
+}


### PR DESCRIPTION
This commit enable the resize operation [1] for in-tree volumes.
new helper has been introduced here to aid the enablement or to
make it clean with existing code base.

[1] https://github.com/ceph/ceph-csi/blob/devel/docs/design/proposals/intree-migrate.md?plain=1#L66

Updates #2509

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

Additional Info:
- [x] no unit test added for the helper newVolFromVolIDWithMigration() as it contains cr format as in other left out helpers.
- [x] no e2e as it need support from sidecar..etc.
- [x] I have tested this manually and the resize has worked as expected and also for other operations.

Here is the log: 
```
I1222 06:34:26.791024 1000552 utils.go:177] ID: 26 Req-ID: mig_mons-b7f67366bb43f32e07d8a261a7840da9_image-773226a6-dbc3-47b5-b47c-bfa8d64b1e2e_7265706c696361706f6f6c GRPC call: /csi.v1./ExpandVolume
I1222 06:34:26.791314 1000552 utils.go:181] ID: 26 Req-ID: mig_mons-b7f67366bb43f32e07d8a261a7840da9_image-773226a6-dbc3-47b5-b47c-bfa8d64b1e2e_7265706c696361706f6f6c GRPC request: {"capacity_range":{"required_bytes":4294967296},....
I1222 06:34:26.828325 1000552 mount_linux.go:487] Attempting to determine if disk "/dev/rbd0" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/rbd0])
I1222 06:34:26.830157 1000552 mount_linux.go:490] Output: "DEVNAME=/dev/rbd0\nTYPE=ext4\n"
I1222 06:34:26.830187 1000552 resizefs_linux.go:56] ResizeFS.Resize - Expanding mounted volume /dev/rbd0
I1222 06:34:26.832030 1000552 resizefs_linux.go:71] Device /dev/rbd0 resized successfully
I1222 06:34:26.832140 1000552 utils.go:188] ID: 26 Req-ID: mig_mons-b7f67366bb43f32e07d8a261a7840da9_image-773226a6-dbc3-47b5-b47c-bfa8d64b1e2e_7265706c696361706f6f6c GRPC response: {}
...


[hchiramm@hchiramm ]$ mount |grep rbd
/dev/rbd0 on /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-c827c204-94e7-4ed9-87e9-fce212fe61a0/globalmount/mig_mons-b7f67366bb43f32e07d8a261a7840da9_image-773226a6-dbc3-47b5-b47c-bfa8d64b1e2e_7265706c696361706f6f6c type ext4 (rw,relatime,stripe=16,_netdev)
/dev/rbd0 on /var/lib/kubelet/pods/80dc68c4-049d-49cb-8933-abf64c35bb65/volumes/kubernetes.io~csi/pvc-c827c204-94e7-4ed9-87e9-fce212fe61a0/mount type ext4 (rw,relatime,stripe=16,_netdev)
[hchiramm@hchiramm ]$ kubectl exec -ti in-task-pv-pod -- df -kh|grep nginx
/dev/rbd0                                4.0G  4.0M  3.9G   1% /usr/share/nginx/html
[hchiramm@hchiramm ]$ 
```
