### PR TITLE
ci: use install.sh from golangci-lint repo

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -46,7 +46,7 @@ RUN source /build.env \
     && mkdir -p ${GOROOT} \
     && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz  \
        | tar xzf - -C ${GOROOT} --strip-components=1 \
-    && curl -sf "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" \
+    && curl -sf "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_VERSION}/install.sh" \
        | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
     && curl -L https://git.io/get_helm.sh | bash -s -- --version "${HELM_VERSION}" \
     && mkdir /opt/commitlint && pushd /opt/commitlint \


### PR DESCRIPTION
The golangci-lint install script at goreleaser.com is deprecated. Docs now advise to install from a GitHub link:

goreleaser/godownloader#207

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

