### PR TITLE
build: new csi-addons tool for testing CSI-Addons operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ cephcsi: check-env
 e2e.test: check-env
 	go test $(GO_TAGS) -mod=vendor -c ./e2e
 
+.PHONY: csi-addons
+csi-addons: check-env
+	$(MAKE) -C tools csi-addons
+
 #
 # Update the generated deploy/ files when the template changed. This requires
 # running 'go mod vendor' so update the API files under the vendor/ directory.

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -44,8 +44,8 @@ WORKDIR ${SRC_DIR}
 # Copy source directories
 COPY . ${SRC_DIR}
 
-# Build executable
-RUN make cephcsi
+# Build executables
+RUN make cephcsi csi-addons
 
 #-- Final container
 FROM ${BASE_IMAGE}
@@ -58,6 +58,7 @@ LABEL maintainers="Ceph-CSI Authors" \
     description="Ceph-CSI Plugin"
 
 COPY --from=builder ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi
+COPY --from=builder ${SRC_DIR}/_output/csi-addons /usr/local/bin/csi-addons
 
 # verify that all dynamically linked libraries are available
 RUN [ $(ldd /usr/local/bin/cephcsi | grep -c '=> not found') = '0' ]

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,3 +15,7 @@
 .PHONY: generate-deploy
 generate-deploy: yamlgen/main.go
 	go run yamlgen/main.go
+
+.PHONY: csi-addons
+csi-addons: csi-addons/*.go
+	go build -o ../_output/csi-addons ./csi-addons

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,4 +1,11 @@
-# Assorted Tools for maintaining and building Ceph-CSI
+# Assorted Tools for developing, testing, maintaining and building Ceph-CSI
+
+## `csi-addons`
+
+`csi-addons` can be used inside the Ceph-CSI container images for testing the
+CSI-Addons operations. This makes it possible to develop new operations, even
+when there is no CSI-Addons Controller/Sidecar with support for the operation
+yet.
 
 ## `yamlgen`
 

--- a/tools/csi-addons/identity.go
+++ b/tools/csi-addons/identity.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/csi-addons/spec/lib/go/identity"
+)
+
+// GetIdentity executes the GetIdentity operation.
+type GetIdentity struct {
+	// inherit Connect() and Close() from type grpcClient
+	grpcClient
+}
+
+var _ = registerOperation("GetIdentity", &GetIdentity{})
+
+func (gi *GetIdentity) Init(c *command) error {
+	return nil
+}
+
+func (gi *GetIdentity) Execute() error {
+	service := identity.NewIdentityClient(gi.Client)
+	res, err := service.GetIdentity(context.TODO(), &identity.GetIdentityRequest{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("identity: %+v\n", res)
+
+	return nil
+}
+
+// Probe executes the Probe operation.
+type Probe struct {
+	// inherit Connect() and Close() from type grpcClient
+	grpcClient
+}
+
+var _ = registerOperation("Probe", &Probe{})
+
+func (p *Probe) Init(c *command) error {
+	return nil
+}
+
+func (p *Probe) Execute() error {
+	service := identity.NewIdentityClient(p.Client)
+	res, err := service.Probe(context.TODO(), &identity.ProbeRequest{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("probe succeeded: %+v\n", res)
+
+	return nil
+}

--- a/tools/csi-addons/main.go
+++ b/tools/csi-addons/main.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	endpoint    = "unix:///tmp/csi-addons.sock"
+	stagingPath = "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+)
+
+// command contains the parsed arguments that were passed while running the
+// executable.
+type command struct {
+	endpoint         string
+	stagingPath      string
+	operation        string
+	persistentVolume string
+}
+
+// cmd is the single instance of the command struct, used inside main().
+var cmd = &command{}
+
+func init() {
+	flag.StringVar(&cmd.endpoint, "endpoint", endpoint, "CSI-Addons endpoint")
+	flag.StringVar(&cmd.stagingPath, "stagingpath", stagingPath, "staging path")
+	flag.StringVar(&cmd.operation, "operation", "", "csi-addons operation")
+	flag.StringVar(&cmd.persistentVolume, "persistentvolume", "", "name of the PersistentVolume")
+
+	// output to show when --help is passed
+	flag.Usage = func() {
+		flag.PrintDefaults()
+		fmt.Fprintln(flag.CommandLine.Output())
+		fmt.Fprintln(flag.CommandLine.Output(), "The following operations are supported:")
+		for op := range operations {
+			fmt.Fprintln(flag.CommandLine.Output(), " - "+op)
+		}
+		os.Exit(0)
+	}
+
+	flag.Parse()
+}
+
+func main() {
+	op, found := operations[cmd.operation]
+	if !found {
+		fmt.Printf("ERROR: operation %q not found\n", cmd.operation)
+		os.Exit(1)
+	}
+
+	op.Connect(cmd.endpoint)
+
+	err := op.Init(cmd)
+	if err != nil {
+		err = fmt.Errorf("failed to initialize %q: %w", cmd.operation, err)
+	} else {
+		err = op.Execute()
+		if err != nil {
+			err = fmt.Errorf("failed to execute %q: %w", cmd.operation, err)
+		}
+	}
+
+	op.Close()
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// getKubernetesClient returns a Clientset so that the Kubernetes API can be
+// used. In case the Clientset can not be created, this function will panic as
+// there will be no use of running the tool.
+func getKubernetesClient() *kubernetes.Clientset {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return clientset
+}
+
+// getSecret get the secret details by name.
+func getSecret(c *kubernetes.Clientset, ns, name string) (map[string]string, error) {
+	secrets := make(map[string]string)
+
+	secret, err := c.CoreV1().Secrets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range secret.Data {
+		secrets[k] = string(v)
+	}
+
+	return secrets, nil
+}
+
+// operations contain a list of all available operations. Each operation should
+// be added by calling registerOperation().
+var operations = make(map[string]operation)
+
+// operation is the interface that all operations should implement. The
+// Connect() and Close() functions can be inherited from the grpcClient struct.
+type operation interface {
+	Connect(endpoint string)
+	Close()
+
+	Init(c *command) error
+	Execute() error
+}
+
+// grpcClient provides standard Connect() and Close() functions that an
+// operation needs to provide.
+type grpcClient struct {
+	Client *grpc.ClientConn
+}
+
+// Connect to the endpoint, or panic in case it fails.
+func (g *grpcClient) Connect(endpoint string) {
+	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+	if err != nil {
+		panic(fmt.Sprintf("failed to connect to %q: %v", endpoint, err))
+	}
+
+	g.Client = conn
+}
+
+// Close the connected grpc.ClientConn.
+func (g *grpcClient) Close() {
+	g.Client.Close()
+}
+
+// registerOperation adds a new operation struct to the operations map.
+func registerOperation(name string, op operation) error {
+	if _, ok := operations[name]; ok {
+		return fmt.Errorf("operation %q is already registered", name)
+	}
+
+	operations[name] = op
+
+	return nil
+}

--- a/tools/csi-addons/reclaimspace.go
+++ b/tools/csi-addons/reclaimspace.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/csi-addons/spec/lib/go/reclaimspace"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ControllerReclaimSpace executes the ControllerReclaimSpace operation.
+type ControllerReclaimSpace struct {
+	// inherit Connect() and Close() from type grpcClient
+	grpcClient
+
+	persistentVolume string
+}
+
+var _ = registerOperation("ControllerReclaimSpace", &ControllerReclaimSpace{})
+
+func (crs *ControllerReclaimSpace) Init(c *command) error {
+	crs.persistentVolume = c.persistentVolume
+
+	if crs.persistentVolume == "" {
+		return fmt.Errorf("persistentvolume name is not set")
+	}
+
+	return nil
+}
+
+func (crs *ControllerReclaimSpace) Execute() error {
+	c := getKubernetesClient()
+
+	pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), crs.persistentVolume, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	volID := pv.Spec.CSI.VolumeHandle
+	volattributes := pv.Spec.CSI.VolumeAttributes
+
+	deviceSecret, err := getSecret(c,
+		pv.Spec.CSI.NodeStageSecretRef.Namespace,
+		pv.Spec.CSI.NodeStageSecretRef.Name)
+	if err != nil {
+		return err
+	}
+
+	csiReq := &reclaimspace.ControllerReclaimSpaceRequest{
+		VolumeId:   volID,
+		Parameters: volattributes,
+		Secrets:    deviceSecret,
+	}
+
+	service := reclaimspace.NewReclaimSpaceControllerClient(crs.Client)
+	res, err := service.ControllerReclaimSpace(context.TODO(), csiReq)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("space reclaimed for %q: %+v\n", crs.persistentVolume, res)
+
+	return nil
+}
+
+// NodeReclaimSpace executes the NodeReclaimSpace operation.
+type NodeReclaimSpace struct {
+	// inherit Connect() and Close() from type grpcClient
+	grpcClient
+
+	persistentVolume  string
+	stagingTargetPath string
+}
+
+var _ = registerOperation("NodeReclaimSpace", &NodeReclaimSpace{})
+
+func (nrs *NodeReclaimSpace) Init(c *command) error {
+	nrs.persistentVolume = c.persistentVolume
+	if nrs.persistentVolume == "" {
+		return fmt.Errorf("persistentvolume name is not set")
+	}
+
+	if c.stagingPath == "" {
+		return fmt.Errorf("stagingpath is not set")
+	}
+	nrs.stagingTargetPath = fmt.Sprintf("%s/%s/globalmount", c.stagingPath, c.persistentVolume)
+
+	return nil
+}
+
+func (nrs *NodeReclaimSpace) Execute() error {
+	c := getKubernetesClient()
+
+	pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), nrs.persistentVolume, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	volID := pv.Spec.CSI.VolumeHandle
+
+	deviceSecret, err := getSecret(c,
+		pv.Spec.CSI.NodeStageSecretRef.Namespace,
+		pv.Spec.CSI.NodeStageSecretRef.Name)
+	if err != nil {
+		return err
+	}
+
+	csiReq := &reclaimspace.NodeReclaimSpaceRequest{
+		VolumeId:          volID,
+		VolumeCapability:  nil,
+		StagingTargetPath: nrs.stagingTargetPath,
+		Secrets:           deviceSecret,
+	}
+
+	service := reclaimspace.NewReclaimSpaceNodeClient(nrs.Client)
+	res, err := service.NodeReclaimSpace(context.TODO(), csiReq)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("space reclaimed for %q: %+v\n", nrs.persistentVolume, res)
+
+	return nil
+}


### PR DESCRIPTION
# Describe what this PR does #

`csi-addons` is a simple commandline tool that can be used to test, or execute CSI-Addons operations. This tool runs inside the Ceph-CSI containers, so that it can connect to the local UNIX Domain Socket where the CSI-Addons services are handled.

Example running on an OpenShift cluster, rsh'ing into one of the provisioner containers:
```console
$ oc -n openshift-storage -c csi-rbdplugin rsh csi-rbdplugin-provisioner-cd4f5f4f9-6s5xj
sh-4.4# csi-addons -h
  -endpoint string
    	CSI-Addons endpoint (default "unix:///tmp/csi-addons.sock")
  -operation string
    	csi-addons operation
  -persistentvolume string
    	name of the PersistentVolume
  -stagingpath string
    	staging path (default "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/")

The following operations are supported:
 - GetIdentity
 - Probe
 - ControllerReclaimSpace
 - NodeReclaimSpace
```

CSI-Addons `Probe` and `GetIdentity` call
```console
sh-4.4# csi-addons --endpoint=unix:///csi/csi-addons.sock --operation=Probe                  
probe succeeded: ready:{value:true}
sh-4.4# csi-addons --endpoint=unix:///csi/csi-addons.sock --operation=GetIdentity
identity: name:"openshift-storage.rbd.csi.ceph.com" vendor_version:"canary"
```

Running `ControllerReclaimSpace` on one of the PVs that are available:
```console
sh-4.4# csi-addons --endpoint=unix:///csi/csi-addons.sock --operation=ControllerReclaimSpace --persistentvolume=pvc-720d76c5-d994-4eb8-b8c0-d2bc5f493c17
space reclaimed for "pvc-720d76c5-d994-4eb8-b8c0-d2bc5f493c17": 
```

Running `NodeReclaimSpace` on a provisioner is not supported, it need to run on a Nodeplugin:
```console
sh-4.4# csi-addons --endpoint=unix:///csi/csi-addons.sock --operation=NodeReclaimSpace --persistentvolume=pvc-720d76c5-d994-4eb8-b8c0-d2bc5f493c17
ERROR: failed to execute "NodeReclaimSpace": rpc error: code = Unimplemented desc = unknown service reclaimspace.ReclaimSpaceNode
```

## Related issues ##

Depends-on: #2724 (based on that PR, so that the tool can build reclaimspace parts)

## Future concerns ##

This tool is currently included in the ceph-csi container image so that e2e testing can use it easily. It may also be beneficial for users/admins if they can execute csi-addons commands in running provisioner/nodeplugin containers withough having to go through the csi-addons/kubernetes-csi-addons project.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
