### PR TITLE
rbd: change the configmap of HPCS/KP key names to reflect the IBM string

### DIFF
--- a/docs/design/proposals/encryped-with-keyprotect.md
+++ b/docs/design/proposals/encryped-with-keyprotect.md
@@ -15,16 +15,16 @@ service from the CSI driver and to make use of the encryption operations:
 * KMS_SERVICE_NAME=[kms_service_name]
 A unique name for the key management service within the project.
 
-* KP_SERVICE_INSTANCE_ID=[service_instance_id]
+* IBM_KP_SERVICE_INSTANCE_ID=[service_instance_id]
 The Instance ID of the IBM HPCS service, ex:  crn:v1:bluemix:public:hs-crypto:us-south:a/5d19cf8b82874c2dab37e397426fbc42:e2ae65ff-954b-453f-b0d7-fc5064c203ce::
 
-* KP_SERVICE_API_KEY=[service_api_key]
+* IBM_KP_SERVICE_API_KEY=[service_api_key]
 Ex:  06x6DbTkVQ-qCRmq9cK-p9xOQpU2UwJMcdjnIDdr0g2R
 
-* KP_CUSTOMER_ROOT_KEY=[customer_root_key]
+* IBM_KP_CUSTOMER_ROOT_KEY=[customer_root_key]
 Ex: c7a9aa91-5cb5-48da-a821-e85c27b99d92
 
-* KP_REGION = [region of the key protect service]
+* IBM_KP_REGION = [region of the key protect service]
 Ex: us-south-2
 ```
 

--- a/examples/kms/vault/csi-kms-connection-details.yaml
+++ b/examples/kms/vault/csi-kms-connection-details.yaml
@@ -57,15 +57,15 @@ data:
   aws-metadata-test: |-
     {
       "KMS_PROVIDER": "aws-metadata",
-      "KMS_SECRET_NAME": "ceph-csi-aws-credentials",
+      "IBM_KP_SECRET_NAME": "ceph-csi-aws-credentials",
       "AWS_REGION": "us-west-2"
     }
   kp-metadata-test: |-
     {
       "KMS_PROVIDER": "kp-metadata",
-      "KMS_SECRET_NAME": "ceph-csi-kp-credentials",
-      "KP_SERVICE_INSTANCE_ID": "7abef064-01dd-4237-9ea5-8b3890970be3",
-      "KP_REGION": "us-south-2",
+      "IBM_KP_SECRET_NAME": "ceph-csi-kp-credentials",
+      "IBM_KP_SERVICE_INSTANCE_ID": "7abef064-01dd-4237-9ea5-8b3890970be3",
+      "IBM_KP_REGION": "us-south-2",
     }
 metadata:
   name: csi-kms-connection-details

--- a/examples/kms/vault/kp-credentials.yaml
+++ b/examples/kms/vault/kp-credentials.yaml
@@ -7,7 +7,7 @@ kind: Secret
 metadata:
   name: ceph-csi-kp-credentials
 stringData:
-  KP_SERVICE_API_KEY: "UhMN3Jko1pCpDPpFV65N8dYANBv5vF97QuNHqXVHmKa0"
-  KP_CUSTOMER_ROOT_KEY: "c7a9aa91-5cb5-48da-a821-e85c27b99d92"
-  KP_SESSION_TOKEN: ""
-  KP_CRK_ARN: ""
+  IBM_KP_SERVICE_API_KEY: "UhMN3Jko1pCpDPpFV65N8dYANBv5vF97QuNHqXVHmKa0"
+  IBM_KP_CUSTOMER_ROOT_KEY: "c7a9aa91-5cb5-48da-a821-e85c27b99d92"
+  IBM_KP_SESSION_TOKEN: ""
+  IBM_KP_CRK_ARN: ""

--- a/internal/kms/keyprotect.go
+++ b/internal/kms/keyprotect.go
@@ -33,7 +33,7 @@ const (
 
 	// keyProtectMetadataDefaultSecretsName is the default name of the Kubernetes Secret
 	// that contains the credentials to access the Key Protect KMS. The name of
-	// the Secret can be configured by setting the `KMS_SECRET_NAME`
+	// the Secret can be configured by setting the `IBM_KP_SECRET_NAME`
 	// option.
 	//
 	// #nosec:G101, value not credential, just references token.
@@ -43,17 +43,16 @@ const (
 	// the credentials to access the Key ProtectKMS.
 	//
 	// #nosec:G101, no hardcoded secret, this is a configuration key.
-	keyProtectSecretNameKey = "KMS_SECRET_NAME"
-	keyProtectRegionKey     = "KP_REGION"
+	keyProtectSecretNameKey = "IBM_KP_SECRET_NAME"
+	keyProtectRegionKey     = "IBM_KP_REGION"
 
-	keyProtectServiceInstanceID = "KP_SERVICE_INSTANCE_ID"
+	keyProtectServiceInstanceID = "IBM_KP_SERVICE_INSTANCE_ID"
 	// The following options are part of the Kubernetes Secrets.
 	// #nosec:G101, no hardcoded secrets, only configuration keys.
-	keyProtectServiceAPIKey   = "KP_SERVICE_API_KEY"
-	KeyProtectCustomerRootKey = "KP_CUSTOMER_ROOT_KEY"
-
-	keyProtectSessionToken = "KP_SESSION_TOKEN"
-	keyProtectCRK          = "KP_CRK_ARN"
+	keyProtectServiceAPIKey   = "IBM_KP_SERVICE_API_KEY"
+	KeyProtectCustomerRootKey = "IBM_KP_CUSTOMER_ROOT_KEY"
+	keyProtectSessionToken    = "IBM_KP_SESSION_TOKEN" //nolint:gosec // only configuration key
+	keyProtectCRK             = "IBM_KP_CRK_ARN"
 )
 
 var _ = RegisterProvider(Provider{


### PR DESCRIPTION
considering IBM has different crypto services (ex: SKLM) in place, its
good to keep the configmap key names with below format

`IBM_KP_...` instead of `KP_..`

so that in future, if we add more crypto services from IBM we can keep
similar schema specific to that specific service from IBM.

Ex: `IBM_SKLM_...`

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
