### PR TITLE
e2e: make recreateCSIRBDPods() function to a generic one

### DIFF
--- a/e2e/migration.go
+++ b/e2e/migration.go
@@ -62,7 +62,7 @@ func generateClusterIDConfigMapForMigration(f *framework.Framework, c kubernetes
 		return fmt.Errorf("failed to create configmap: %w", err)
 	}
 	// restart csi pods for the configmap to take effect.
-	err = recreateCSIRBDPods(f)
+	err = recreateCSIPods(f, rbdPodLabels, rbdDaemonsetName, rbdDeploymentName)
 	if err != nil {
 		return fmt.Errorf("failed to recreate rbd csi pods: %w", err)
 	}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1013,22 +1013,3 @@ func waitToRemoveImagesFromTrash(f *framework.Framework, poolName string, t int)
 
 	return err
 }
-
-func recreateCSIRBDPods(f *framework.Framework) error {
-	err := deletePodWithLabel("app in (ceph-csi-rbd, csi-rbdplugin, csi-rbdplugin-provisioner)",
-		cephCSINamespace, false)
-	if err != nil {
-		return fmt.Errorf("failed to delete pods with labels: %w", err)
-	}
-	// wait for csi pods to come up
-	err = waitForDaemonSets(rbdDaemonsetName, cephCSINamespace, f.ClientSet, deployTimeout)
-	if err != nil {
-		return fmt.Errorf("timeout waiting for daemonset pods: %w", err)
-	}
-	err = waitForDeploymentComplete(f.ClientSet, rbdDeploymentName, cephCSINamespace, deployTimeout)
-	if err != nil {
-		return fmt.Errorf("timeout waiting for deployment to be in running state: %w", err)
-	}
-
-	return nil
-}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -60,6 +60,8 @@ const (
 	appLabel = "write-data-in-pod"
 
 	noError = ""
+	// labels/selector used to list/delete rbd pods.
+	rbdPodLabels = "app in (ceph-csi-rbd, csi-rbdplugin, csi-rbdplugin-provisioner)"
 )
 
 var (


### PR DESCRIPTION
This commit make recreateCSIRBDPods function to be a general one
so that it can be consumed by more clients.

Updates https://github.com/ceph/ceph-csi/issues/2509

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>