### PR TITLE
[wip ]e2e: remove podUnknown state case condition in waitForPodInRunningState

### DIFF
--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -273,7 +273,6 @@ func createAppErr(c kubernetes.Interface, app *v1.Pod, timeout int, errString st
 
 func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, expectedError string) error {
 	timeout := time.Duration(t) * time.Minute
-	start := time.Now()
 	e2elog.Logf("Waiting up to %v to be in Running state", name)
 
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
@@ -304,12 +303,6 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, ex
 					return true, err
 				}
 			}
-		case v1.PodUnknown:
-			e2elog.Logf(
-				"%s app  is in %s phase expected to be in Running  state (%d seconds elapsed)",
-				name,
-				pod.Status.Phase,
-				int(time.Since(start).Seconds()))
 		}
 
 		return false, nil


### PR DESCRIPTION
podUnknown state is a long time deprecated value and we dont need it.

-- snip--
// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
// to an error in communicating with the host of the pod.
// Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)

--/snip--

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

