### PR TITLE
rbd: unexport existing KMS structs for vault, AWS and KeyProtect

### DIFF
--- a/internal/kms/aws_metadata.go
+++ b/internal/kms/aws_metadata.go
@@ -65,7 +65,7 @@ var _ = RegisterProvider(Provider{
 	Initializer: initAWSMetadataKMS,
 })
 
-type AWSMetadataKMS struct {
+type awsMetadataKMS struct {
 	// basic options to get the secret
 	namespace  string
 	secretName string
@@ -79,7 +79,7 @@ type AWSMetadataKMS struct {
 }
 
 func initAWSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
-	kms := &AWSMetadataKMS{
+	kms := &awsMetadataKMS{
 		namespace: args.Namespace,
 	}
 
@@ -124,7 +124,7 @@ func initAWSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 	return kms, nil
 }
 
-func (kms *AWSMetadataKMS) getSecrets() (map[string]interface{}, error) {
+func (kms *awsMetadataKMS) getSecrets() (map[string]interface{}, error) {
 	c, err := k8s.NewK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Kubernetes to "+
@@ -153,18 +153,18 @@ func (kms *AWSMetadataKMS) getSecrets() (map[string]interface{}, error) {
 	return config, nil
 }
 
-func (kms *AWSMetadataKMS) Destroy() {
+func (kms *awsMetadataKMS) Destroy() {
 	// Nothing to do.
 }
 
 // RequiresDEKStore indicates that the DEKs should get stored in the metadata
 // of the volumes. This Amazon KMS provider does not support storing DEKs in
 // AWS as that adds additional costs.
-func (kms *AWSMetadataKMS) RequiresDEKStore() DEKStoreType {
+func (kms *awsMetadataKMS) RequiresDEKStore() DEKStoreType {
 	return DEKStoreMetadata
 }
 
-func (kms *AWSMetadataKMS) getService() (*awsKMS.KMS, error) {
+func (kms *awsMetadataKMS) getService() (*awsKMS.KMS, error) {
 	creds := awsCreds.NewStaticCredentials(kms.accessKey,
 		kms.secretAccessKey, kms.sessionToken)
 
@@ -183,7 +183,7 @@ func (kms *AWSMetadataKMS) getService() (*awsKMS.KMS, error) {
 }
 
 // EncryptDEK uses the Amazon KMS and the configured CMK to encrypt the DEK.
-func (kms *AWSMetadataKMS) EncryptDEK(volumeID, plainDEK string) (string, error) {
+func (kms *awsMetadataKMS) EncryptDEK(volumeID, plainDEK string) (string, error) {
 	svc, err := kms.getService()
 	if err != nil {
 		return "", fmt.Errorf("could not get KMS service: %w", err)
@@ -206,7 +206,7 @@ func (kms *AWSMetadataKMS) EncryptDEK(volumeID, plainDEK string) (string, error)
 }
 
 // DecryptDEK uses the Amazon KMS and the configured CMK to decrypt the DEK.
-func (kms *AWSMetadataKMS) DecryptDEK(volumeID, encryptedDEK string) (string, error) {
+func (kms *awsMetadataKMS) DecryptDEK(volumeID, encryptedDEK string) (string, error) {
 	svc, err := kms.getService()
 	if err != nil {
 		return "", fmt.Errorf("could not get KMS service: %w", err)

--- a/internal/kms/keyprotect.go
+++ b/internal/kms/keyprotect.go
@@ -79,7 +79,7 @@ func initKeyProtectKMSOld(args ProviderInitArgs) (EncryptionKMS, error) {
 }
 
 // KeyProtectKMS store the KMS connection information retrieved from the kms configmap.
-type KeyProtectKMS struct {
+type keyProtectKMS struct {
 	// basic options to get the secret
 	namespace  string
 	secretName string
@@ -97,7 +97,7 @@ type KeyProtectKMS struct {
 }
 
 func initKeyProtectKMS(args ProviderInitArgs) (EncryptionKMS, error) {
-	kms := &KeyProtectKMS{
+	kms := &keyProtectKMS{
 		namespace: args.Namespace,
 	}
 	// required options for further configuration (getting secrets)
@@ -164,7 +164,7 @@ func initKeyProtectKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 	return kms, nil
 }
 
-func (kms *KeyProtectKMS) getSecrets() (map[string]interface{}, error) {
+func (kms *keyProtectKMS) getSecrets() (map[string]interface{}, error) {
 	c, err := k8s.NewK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Kubernetes to "+
@@ -193,16 +193,16 @@ func (kms *KeyProtectKMS) getSecrets() (map[string]interface{}, error) {
 	return config, nil
 }
 
-func (kms *KeyProtectKMS) Destroy() {
+func (kms *keyProtectKMS) Destroy() {
 	// Nothing to do.
 }
 
-func (kms *KeyProtectKMS) RequiresDEKStore() DEKStoreType {
+func (kms *keyProtectKMS) RequiresDEKStore() DEKStoreType {
 	return DEKStoreMetadata
 }
 
-func (kms *KeyProtectKMS) getService() error {
-	// Use Service API Key and KeyProtect Service Instance ID to create a ClientConfig
+func (kms *keyProtectKMS) getService() error {
+	// Use your Service API Key and your KeyProtect Service Instance ID to create a ClientConfig
 	cc := kp.ClientConfig{
 		BaseURL:    kms.baseURL,
 		TokenURL:   kms.tokenURL,
@@ -221,7 +221,7 @@ func (kms *KeyProtectKMS) getService() error {
 }
 
 // EncryptDEK uses the KeyProtect KMS and the configured CRK to encrypt the DEK.
-func (kms *KeyProtectKMS) EncryptDEK(volumeID, plainDEK string) (string, error) {
+func (kms *keyProtectKMS) EncryptDEK(volumeID, plainDEK string) (string, error) {
 	if err := kms.getService(); err != nil {
 		return "", fmt.Errorf("could not get KMS service: %w", err)
 	}
@@ -240,7 +240,7 @@ func (kms *KeyProtectKMS) EncryptDEK(volumeID, plainDEK string) (string, error) 
 }
 
 // DecryptDEK uses the Key protect KMS and the configured CRK to decrypt the DEK.
-func (kms *KeyProtectKMS) DecryptDEK(volumeID, encryptedDEK string) (string, error) {
+func (kms *keyProtectKMS) DecryptDEK(volumeID, encryptedDEK string) (string, error) {
 	if err := kms.getService(); err != nil {
 		return "", fmt.Errorf("could not get KMS service: %w", err)
 	}

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -359,20 +359,20 @@ type DEKStore interface {
 	RemoveDEK(volumeID string) error
 }
 
-// IntegratedDEK is a DEKStore that can not be configured. Either the KMS does
+// integratedDEK is a DEKStore that can not be configured. Either the KMS does
 // not use a DEK, or the DEK is stored in the KMS without additional
 // configuration options.
-type IntegratedDEK struct{}
+type integratedDEK struct{}
 
-func (i IntegratedDEK) RequiresDEKStore() DEKStoreType {
+func (i integratedDEK) RequiresDEKStore() DEKStoreType {
 	return DEKStoreIntegrated
 }
 
-func (i IntegratedDEK) EncryptDEK(volumeID, plainDEK string) (string, error) {
+func (i integratedDEK) EncryptDEK(volumeID, plainDEK string) (string, error) {
 	return plainDEK, nil
 }
 
-func (i IntegratedDEK) DecryptDEK(volumeID, encyptedDEK string) (string, error) {
+func (i integratedDEK) DecryptDEK(volumeID, encyptedDEK string) (string, error) {
 	return encyptedDEK, nil
 }
 

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -50,7 +50,7 @@ const (
 
 // SecretsKMS is default KMS implementation that means no KMS is in use.
 type SecretsKMS struct {
-	IntegratedDEK
+	integratedDEK
 
 	passphrase string
 }

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -87,9 +87,9 @@ type vaultConnection struct {
 	vaultDestroyKeys bool
 }
 
-type VaultKMS struct {
+type vaultKMS struct {
 	vaultConnection
-	IntegratedDEK
+	integratedDEK
 
 	// vaultPassphrasePath (VPP) used to be added before the "key" of the
 	// secret (like /v1/secret/data/<VPP>/key)
@@ -329,7 +329,7 @@ var _ = RegisterProvider(Provider{
 
 // InitVaultKMS returns an interface to HashiCorp Vault KMS.
 func initVaultKMS(args ProviderInitArgs) (EncryptionKMS, error) {
-	kms := &VaultKMS{}
+	kms := &vaultKMS{}
 	err := kms.initConnection(args.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
@@ -392,7 +392,7 @@ func initVaultKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 
 // FetchDEK returns passphrase from Vault. The passphrase is stored in a
 // data.data.passphrase structure.
-func (kms *VaultKMS) FetchDEK(key string) (string, error) {
+func (kms *vaultKMS) FetchDEK(key string) (string, error) {
 	s, err := kms.secrets.GetSecret(filepath.Join(kms.vaultPassphrasePath, key), kms.keyContext)
 	if err != nil {
 		return "", err
@@ -411,7 +411,7 @@ func (kms *VaultKMS) FetchDEK(key string) (string, error) {
 }
 
 // StoreDEK saves new passphrase in Vault.
-func (kms *VaultKMS) StoreDEK(key, value string) error {
+func (kms *vaultKMS) StoreDEK(key, value string) error {
 	data := map[string]interface{}{
 		"data": map[string]string{
 			"passphrase": value,
@@ -428,7 +428,7 @@ func (kms *VaultKMS) StoreDEK(key, value string) error {
 }
 
 // RemoveDEK deletes passphrase from Vault.
-func (kms *VaultKMS) RemoveDEK(key string) error {
+func (kms *vaultKMS) RemoveDEK(key string) error {
 	pathKey := filepath.Join(kms.vaultPassphrasePath, key)
 	err := kms.secrets.DeleteSecret(pathKey, kms.getDeleteKeyContext())
 	if err != nil {

--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -67,7 +67,7 @@ Example JSON structure in the KMS config is,
 	...
 }.
 */
-type VaultTenantSA struct {
+type vaultTenantSA struct {
 	vaultTenantConnection
 
 	// tenantSAName is the name of the ServiceAccount in the Tenants Kubernetes Namespace
@@ -97,7 +97,7 @@ func initVaultTenantSA(args ProviderInitArgs) (EncryptionKMS, error) {
 		}
 	}
 
-	kms := &VaultTenantSA{}
+	kms := &vaultTenantSA{}
 	kms.vaultTenantConnection.init()
 	kms.tenantConfigOptionFilter = isTenantSAConfigOption
 
@@ -150,7 +150,7 @@ func initVaultTenantSA(args ProviderInitArgs) (EncryptionKMS, error) {
 
 // Destroy removes the temporary stored token from the ServiceAccount and
 // destroys the vaultTenantConnection object.
-func (kms *VaultTenantSA) Destroy() {
+func (kms *vaultTenantSA) Destroy() {
 	if kms.saTokenDir != "" {
 		_ = os.RemoveAll(kms.saTokenDir)
 	}
@@ -158,7 +158,7 @@ func (kms *VaultTenantSA) Destroy() {
 	kms.vaultTenantConnection.Destroy()
 }
 
-func (kms *VaultTenantSA) configureTenant(config map[string]interface{}, tenant string) error {
+func (kms *vaultTenantSA) configureTenant(config map[string]interface{}, tenant string) error {
 	kms.Tenant = tenant
 	tenantConfig, found := fetchTenantConfig(config, tenant)
 	if found {
@@ -184,11 +184,11 @@ func (kms *VaultTenantSA) configureTenant(config map[string]interface{}, tenant 
 }
 
 // parseConfig calls vaultTenantConnection.parseConfig() and also set
-// additional config options specific to VaultTenantSA. This function is called
+// additional config options specific to vaultTenantSA. This function is called
 // multiple times, for the different nested configuration layers.
 // parseTenantConfig() calls this as well, with a reduced set of options,
 // filtered by isTenantConfigOption().
-func (kms *VaultTenantSA) parseConfig(config map[string]interface{}) error {
+func (kms *vaultTenantSA) parseConfig(config map[string]interface{}) error {
 	err := kms.vaultTenantConnection.parseConfig(config)
 	if err != nil {
 		return err
@@ -234,7 +234,7 @@ func isTenantSAConfigOption(opt string) bool {
 		return true
 	}
 
-	// additional options for VaultTenantSA
+	// additional options for vaultTenantSA
 	switch opt {
 	case "tenantSAName":
 	case "vaultAuthPath":
@@ -248,7 +248,7 @@ func isTenantSAConfigOption(opt string) bool {
 
 // setServiceAccountName stores the name of the ServiceAccount in the
 // configuration if it has been set in the options.
-func (kms *VaultTenantSA) setServiceAccountName(config map[string]interface{}) error {
+func (kms *vaultTenantSA) setServiceAccountName(config map[string]interface{}) error {
 	err := setConfigString(&kms.tenantSAName, config, "tenantSAName")
 	if errors.Is(err, errConfigOptionInvalid) {
 		return err
@@ -258,8 +258,8 @@ func (kms *VaultTenantSA) setServiceAccountName(config map[string]interface{}) e
 }
 
 // getServiceAccount returns the Tenants ServiceAccount with the name
-// configured in the VaultTenantSA.
-func (kms *VaultTenantSA) getServiceAccount() (*corev1.ServiceAccount, error) {
+// configured in the vaultTenantSA.
+func (kms *vaultTenantSA) getServiceAccount() (*corev1.ServiceAccount, error) {
 	c, err := kms.getK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("can not get ServiceAccount %s/%s, "+
@@ -278,7 +278,7 @@ func (kms *VaultTenantSA) getServiceAccount() (*corev1.ServiceAccount, error) {
 // getToken looks up the ServiceAccount and the Secrets linked from it. When it
 // finds the Secret that contains the `token` field, the contents is read and
 // returned.
-func (kms *VaultTenantSA) getToken() (string, error) {
+func (kms *vaultTenantSA) getToken() (string, error) {
 	sa, err := kms.getServiceAccount()
 	if err != nil {
 		return "", err
@@ -309,7 +309,7 @@ func (kms *VaultTenantSA) getToken() (string, error) {
 // getTokenPath creates a temporary directory structure that contains the token
 // linked from the ServiceAccount. This path can then be used in place of the
 // standard `/var/run/secrets/kubernetes.io/serviceaccount/token` location.
-func (kms *VaultTenantSA) getTokenPath() (string, error) {
+func (kms *vaultTenantSA) getTokenPath() (string, error) {
 	dir, err := ioutil.TempDir("", kms.tenantSAName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create directory for ServiceAccount %s/%s: %w", kms.tenantSAName, kms.Tenant, err)

--- a/internal/kms/vault_sa_test.go
+++ b/internal/kms/vault_sa_test.go
@@ -31,7 +31,7 @@ func TestVaultTenantSAKMSRegistered(t *testing.T) {
 
 func TestTenantSAParseConfig(t *testing.T) {
 	t.Parallel()
-	vts := VaultTenantSA{}
+	vts := vaultTenantSA{}
 
 	config := make(map[string]interface{})
 

--- a/internal/kms/vault_tokens.go
+++ b/internal/kms/vault_tokens.go
@@ -202,7 +202,7 @@ type vaultTenantConnection struct {
 	tenantConfigOptionFilter func(string) bool
 }
 
-type VaultTokensKMS struct {
+type vaultTokensKMS struct {
 	vaultTenantConnection
 
 	// TokenName is the name of the Secret in the Tenants Kubernetes Namespace
@@ -228,7 +228,7 @@ func initVaultTokensKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 		}
 	}
 
-	kms := &VaultTokensKMS{}
+	kms := &vaultTokensKMS{}
 	kms.vaultTenantConnection.init()
 	err = kms.initConnection(config)
 	if err != nil {
@@ -278,7 +278,7 @@ func initVaultTokensKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 	return kms, nil
 }
 
-func (kms *VaultTokensKMS) configureTenant(config map[string]interface{}, tenant string) error {
+func (kms *vaultTokensKMS) configureTenant(config map[string]interface{}, tenant string) error {
 	kms.Tenant = tenant
 	tenantConfig, found := fetchTenantConfig(config, tenant)
 	if found {
@@ -340,7 +340,7 @@ func (vtc *vaultTenantConnection) parseConfig(config map[string]interface{}) err
 // setTokenName updates the kms.TokenName with the options from config. This
 // method can be called multiple times, i.e. to override configuration options
 // from tenants.
-func (kms *VaultTokensKMS) setTokenName(config map[string]interface{}) error {
+func (kms *vaultTokensKMS) setTokenName(config map[string]interface{}) error {
 	err := setConfigString(&kms.TokenName, config, "tenantTokenName")
 	if errors.Is(err, errConfigOptionInvalid) {
 		return err
@@ -501,7 +501,7 @@ func (vtc *vaultTenantConnection) RemoveDEK(key string) error {
 	return nil
 }
 
-func (kms *VaultTokensKMS) getToken() (string, error) {
+func (kms *vaultTokensKMS) getToken() (string, error) {
 	c, err := kms.getK8sClient()
 	if err != nil {
 		return "", err

--- a/internal/kms/vault_tokens.go
+++ b/internal/kms/vault_tokens.go
@@ -186,7 +186,7 @@ Example JSON structure in the KMS config is,
 */
 type vaultTenantConnection struct {
 	vaultConnection
-	IntegratedDEK
+	integratedDEK
 
 	client *kubernetes.Clientset
 


### PR DESCRIPTION
At present the KMS structs are exported and ideally we should be
able to work without exporting the same.

Updates https://github.com/ceph/ceph-csi/issues/2725 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

