### PR TITLE
rbd: add BaseURL and tokenURL configuration

### DIFF
--- a/docs/design/proposals/encryped-with-keyprotect.md
+++ b/docs/design/proposals/encryped-with-keyprotect.md
@@ -12,20 +12,26 @@ Below parameters/values can be used to establish the connection to the HPCS
 service from the CSI driver and to make use of the encryption operations:
 
 ```text
-* KMS_SERVICE_NAME=[kms_service_name]
+* IBM_KP_BASE_URL
+The Key Protect/HPCS connection URL.
+
+* IBM_KP_TOKEN_URL
+The Token Authenticaltion URL of KeyProtect/HPCS service.
+
+* KMS_SERVICE_NAME
 A unique name for the key management service within the project.
 
-* IBM_KP_SERVICE_INSTANCE_ID=[service_instance_id]
+* IBM_KP_SERVICE_INSTANCE_ID
 The Instance ID of the IBM HPCS service, ex:  crn:v1:bluemix:public:hs-crypto:us-south:a/5d19cf8b82874c2dab37e397426fbc42:e2ae65ff-954b-453f-b0d7-fc5064c203ce::
 
-* IBM_KP_SERVICE_API_KEY=[service_api_key]
+* IBM_KP_SERVICE_API_KEY
 Ex:  06x6DbTkVQ-qCRmq9cK-p9xOQpU2UwJMcdjnIDdr0g2R
 
-* IBM_KP_CUSTOMER_ROOT_KEY=[customer_root_key]
+* IBM_KP_CUSTOMER_ROOT_KEY
 Ex: c7a9aa91-5cb5-48da-a821-e85c27b99d92
 
-* IBM_KP_REGION = [region of the key protect service]
-Ex: us-south-2
+* IBM_KP_REGION
+Region of the key protect service, ex: us-south-2
 ```
 
 ### Values provided in the connection Secret

--- a/examples/kms/vault/csi-kms-connection-details.yaml
+++ b/examples/kms/vault/csi-kms-connection-details.yaml
@@ -65,6 +65,8 @@ data:
       "KMS_PROVIDER": "kp-metadata",
       "IBM_KP_SECRET_NAME": "ceph-csi-kp-credentials",
       "IBM_KP_SERVICE_INSTANCE_ID": "7abef064-01dd-4237-9ea5-8b3890970be3",
+      "IBM_KP_BASE_URL": "https://us-south.kms.cloud.ibm.com",
+      "IBM_KP_TOKEN_URL": ""https://iam.cloud.ibm.com/oidc/token",
       "IBM_KP_REGION": "us-south-2",
     }
 metadata:


### PR DESCRIPTION
This commit adds optional BaseURL and TokenURL configuration to
key protect/hpcs configuration and client connections, if not
provided default values are used.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
