### PR TITLE
cephfs: resize cloned, restored volume if required

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -1261,6 +1261,34 @@ var _ = Describe("cephfs", func() {
 					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 			})
+
+			By("restore snapshot to a bigger size PVC", func() {
+				err := validateBiggerPVCFromSnapshot(f,
+					pvcPath,
+					appPath,
+					snapshotPath,
+					pvcClonePath,
+					appClonePath)
+				if err != nil {
+					e2elog.Failf("failed to validate restore bigger size clone: %v", err)
+				}
+
+				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+			})
+
+			By("clone PVC to a bigger size PVC", func() {
+				err := validateBiggerCloneFromPVC(f,
+					pvcPath,
+					appPath,
+					pvcSmartClonePath,
+					appSmartClonePath)
+				if err != nil {
+					e2elog.Failf("failed to validate bigger size clone: %v", err)
+				}
+
+				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+			})
+
 			// Make sure this should be last testcase in this file, because
 			// it deletes pool
 			By("Create a PVC and delete PVC when backend pool deleted", func() {

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -211,11 +211,7 @@ func (cs *ControllerServer) CreateVolume(
 
 	if vID != nil {
 		if sID != nil || pvID != nil {
-			// while cloning the volume the size is not populated properly to the new volume now.
-			// it will be fixed in cephfs soon with the parentvolume size. Till then by below
-			// resize we are making sure we return or satisfy the requested size by setting the size
-			// explicitly
-			err = volOptions.ResizeVolume(ctx, fsutil.VolumeID(vID.FsSubvolName), volOptions.Size)
+			err = volOptions.ExpandVolume(ctx, fsutil.VolumeID(vID.FsSubvolName), volOptions.Size)
 			if err != nil {
 				purgeErr := volOptions.PurgeVolume(ctx, fsutil.VolumeID(vID.FsSubvolName), false)
 				if purgeErr != nil {
@@ -235,6 +231,7 @@ func (cs *ControllerServer) CreateVolume(
 				return nil, status.Error(codes.Internal, err.Error())
 			}
 		}
+
 		volumeContext := req.GetParameters()
 		volumeContext["subvolumeName"] = vID.FsSubvolName
 		volumeContext["subvolumePath"] = volOptions.RootPath

--- a/internal/cephfs/core/clone.go
+++ b/internal/cephfs/core/clone.go
@@ -131,13 +131,14 @@ func CreateCloneFromSubvolume(
 
 		return cloneState.toError()
 	}
-	// This is a work around to fix sizing issue for cloned images
-	err = volOpt.ResizeVolume(ctx, cloneID, volOpt.Size)
+
+	err = volOpt.ExpandVolume(ctx, cloneID, volOpt.Size)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to expand volume %s: %v", cloneID, err)
 
 		return err
 	}
+
 	// As we completed clone, remove the intermediate snap
 	if err = parentvolOpt.UnprotectSnapshot(ctx, snapshotID, volID); err != nil {
 		// In case the snap is already unprotected we get ErrSnapProtectionExist error code
@@ -227,10 +228,8 @@ func CreateCloneFromSnapshot(
 	if cloneState != cephFSCloneComplete {
 		return cloneState.toError()
 	}
-	// The clonedvolume currently does not reflect the proper size due to an issue in cephfs
-	// however this is getting addressed in cephfs and the parentvolume size will be reflected
-	// in the new cloned volume too. Till then we are explicitly making the size set
-	err = volOptions.ResizeVolume(ctx, fsutil.VolumeID(vID.FsSubvolName), volOptions.Size)
+
+	err = volOptions.ExpandVolume(ctx, fsutil.VolumeID(vID.FsSubvolName), volOptions.Size)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to expand volume %s with error: %v", vID.FsSubvolName, err)
 

--- a/internal/cephfs/core/volumeoptions.go
+++ b/internal/cephfs/core/volumeoptions.go
@@ -361,6 +361,7 @@ func NewVolumeOptionsFromVolID(
 	if err == nil {
 		volOptions.RootPath = info.Path
 		volOptions.Features = info.Features
+		volOptions.Size = info.BytesQuota
 	}
 
 	if errors.Is(err, cerrors.ErrInvalidCommand) {
@@ -580,6 +581,7 @@ func NewSnapshotOptionsFromID(
 		return &volOptions, nil, &sid, err
 	}
 	volOptions.Features = subvolInfo.Features
+	volOptions.Size = subvolInfo.BytesQuota
 
 	info, err := volOptions.GetSnapshotInfo(ctx, fsutil.VolumeID(sid.FsSnapshotName), fsutil.VolumeID(sid.FsSubvolName))
 	if err != nil {


### PR DESCRIPTION
Currently, as a workaround, we are calling the resize volume on the cloned, restore volumes to adjust the cloned, restored volumes. With this fix, we are calling the resize volume only if there is a size mismatch with requested and the volume from which the new volume needs to be created.

fixes https://github.com/ceph/ceph-csi/issues/1439
fixes https://github.com/ceph/ceph-csi/issues/1254
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>