### PR TITLE
cephfs: log error message if clone fails

### DIFF
--- a/internal/cephfs/core/fsjournal.go
+++ b/internal/cephfs/core/fsjournal.go
@@ -124,6 +124,11 @@ func CheckVolExists(ctx context.Context,
 			return nil, cerrors.ErrClonePending
 		}
 		if cloneState == cephFSCloneFailed {
+			log.ErrorLog(ctx,
+				"clone failed, deleting subvolume clone. vol=%s, subvol=%s subvolgroup=%s",
+				volOptions.FsName,
+				vid.FsSubvolName,
+				volOptions.SubvolumeGroup)
 			err = volOptions.PurgeVolume(ctx, fsutil.VolumeID(vid.FsSubvolName), true)
 			if err != nil {
 				log.ErrorLog(ctx, "failed to delete volume %s: %v", vid.FsSubvolName, err)


### PR DESCRIPTION
During CreateVolume from snapshot/volume, it's difficult to identify if the clone is failed and a new clone is created. In case
of clone failure logging the error message for better debugging.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
