### PR TITLE
ci: remove queue actions from non-merge rules in Mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -67,8 +67,6 @@ pull_request_rules:
     conditions:
       - base~=^(devel)|(release-.+)$
     actions:
-      queue:
-        name: default
       dismiss_reviews:
         approved: true
         changes_requested: false
@@ -77,8 +75,6 @@ pull_request_rules:
       - conflict
       - author!=dependabot[bot]
     actions:
-      queue:
-        name: default
       comment:
         # yamllint disable-line rule:truthy
         message: "This pull request now has conflicts with the target branch.


### PR DESCRIPTION
By the addition of the queue rules in the Mrgify configuration, all PRs
that require changes, or have been updated and review should be dropped,
are now added to the queue for merging. This is obviously not what we
want.

Fixes: 43fc945 ("ci: move from merge action to queue action")