### PR TITLE
ci: queue rules update to handle prs 

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,9 @@ queue_rules:
   - name: default
     conditions:
       # Conditions to get out of the queue (= merged)
+      - label!=DNM
+      - -closed
+      - -draft
       - or:
           - and:
               - base~=^(devel)|(release-.+)$


### PR DESCRIPTION
This commit adds queue rules to prevent closed,draft
prs with DNM label from entering the queue.

Signed-off-by: Rakshith R <rar@redhat.com>