### PR TITLE
ci: queue rules update to handle prs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,13 @@ queue_rules:
   - name: default
     conditions:
       # Conditions to get out of the queue (= merged)
+      - label!=DNM
+      - -closed
+      - -draft
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - "approved-reviews-by=@ceph/ceph-csi-contributors"
+      - "approved-reviews-by=@ceph/ceph-csi-maintainers"
       - or:
           - and:
               - base~=^(devel)|(release-.+)$


### PR DESCRIPTION
This commit adds queue rules to prevent closed,draft
prs with DNM label from entering the queue.

Closes: https://github.com/ceph/ceph-csi/pull/2762
Signed-off-by: Rakshith R <rar@redhat.com>


