### PR TITLE
ci(mergify): don't dismiss review if PR has not merged

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -110,8 +110,15 @@ pull_request_rules:
     actions:
       queue:
         name: default
-      dismiss_reviews: {}
       delete_head_branch: {}
+
+  - name: dismiss review of merged pull request
+    conditions:
+      - base~=^(devel)|(release-.+)$
+      - merged
+    actions:
+      dismiss_reviews: {}
+
   - name: automatic merge
     conditions:
       - label!=DNM
@@ -142,8 +149,8 @@ pull_request_rules:
     actions:
       queue:
         name: default
-      dismiss_reviews: {}
       delete_head_branch: {}
+
   - name: automatic merge PR having ready-to-merge label
     conditions:
       - label!=DNM
@@ -173,7 +180,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-      dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release-v3.5 branch
     conditions:
@@ -252,7 +258,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-      dismiss_reviews: {}
       delete_head_branch: {}
   - name: remove outdated approvals on ci/centos
     conditions:
@@ -275,7 +280,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-      dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label on ci/centos
     conditions:
@@ -290,7 +294,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-      dismiss_reviews: {}
       delete_head_branch: {}
   ##
   ## Automatically set/remove labels


### PR DESCRIPTION
Pull requests are not going to be queued if at the same time the pull request review are dismiss
