### PR TITLE
rbd: reject small size restore/clone from snapshot/volume

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -215,6 +215,12 @@ func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSna
 		if err != nil {
 			return status.Errorf(codes.InvalidArgument, "cannot restore from snapshot %s: %s", rbdSnap, err.Error())
 		}
+
+		err = rbdSnap.isCompabitableClone(&rbdVol.rbdImage)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "cannot restore from snapshot %s: %s", rbdSnap, err.Error())
+		}
+
 	case parentVol != nil:
 		err = parentVol.isCompatibleEncryption(&rbdVol.rbdImage)
 		if err != nil {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -231,6 +231,11 @@ func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSna
 		if err != nil {
 			return status.Errorf(codes.InvalidArgument, "cannot clone from volume %s: %s", parentVol, err.Error())
 		}
+
+		err = parentVol.isCompabitableClone(&rbdVol.rbdImage)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "cannot clone from volume %s: %s", parentVol, err.Error())
+		}
 	}
 
 	return nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1993,6 +1993,17 @@ func (ri *rbdImage) isCompatibleEncryption(dst *rbdImage) error {
 	return nil
 }
 
+func (ri *rbdImage) isCompabitableClone(dst *rbdImage) error {
+	if dst.VolSize < ri.VolSize {
+		return fmt.Errorf(
+			"volume size %d is smaller than source volume size %d",
+			dst.VolSize,
+			ri.VolSize)
+	}
+
+	return nil
+}
+
 func (ri *rbdImage) isCompatibleThickProvision(dst *rbdVolume) error {
 	thick, err := ri.isThickProvisioned()
 	if err != nil {


### PR DESCRIPTION
As per the CSI standard, the size is an optional parameter, as we are allowing the clone/restore to a bigger size today we need to block the clone/restore to a smaller size as its a have side effects like data corruption, etc.
    
Note:- Even though this check is present in the kubernetes sidecar as CSI is CO independent adding the check here.
    
updates: #2718
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
