### PR TITLE
rbd: make rbdImage as received for internal methods

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -237,7 +237,7 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 	}()
 
 	if rv.ThickProvision {
-		err = tempClone.DeepCopy(rv)
+		err = tempClone.DeepCopy(&rv.rbdImage)
 		if err != nil {
 			return fmt.Errorf("failed to deep copy %q into %q: %w", parentVol, rv, err)
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -593,7 +593,7 @@ func (cs *ControllerServer) createVolumeFromSnapshot(
 	parentVol.conn = rbdVol.conn.Copy()
 
 	if rbdVol.ThickProvision {
-		err = parentVol.DeepCopy(rbdVol)
+		err = parentVol.DeepCopy(&rbdVol.rbdImage)
 		if err != nil {
 			return status.Errorf(codes.Internal, "failed to deep copy %q into %q: %v", parentVol, rbdVol, err)
 		}


### PR DESCRIPTION
Currently, most of the internal methods have the rbdVolume as the received. As these methods are completely internal and require only the fields of the rbdImage, use rbdImage as the receiver instead of rbdVolume.

updates #2742

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

