### PR TITLE
doc: add kernel version recommendation for rbd-nbd

### DIFF
--- a/docs/rbd-nbd.md
+++ b/docs/rbd-nbd.md
@@ -29,6 +29,9 @@ client-side, which is inside the `csi-rbdplugin` node plugin.
 To use the rbd-nbd mounter for RBD-backed PVs, set `mounter` to `rbd-nbd`
 in the StorageClass.
 
+Please note that the minimum recommended kernel version to use rbd-nbd is
+5.4 or higher.
+
 ### Configuring logging path
 
 If you are using the default rbd nodePlugin DaemonSet and StorageClass


### PR DESCRIPTION
Without commit [1] Kernel doesn't handle io-timeout=0 correctly
Hence we recommend Kernel version 5.4 or higher that has commit [1]

[1] https://bit.ly/34CFh06

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

