### PR TITLE
build: pull ceph base image from quay.io

### DIFF
--- a/build.env
+++ b/build.env
@@ -12,7 +12,7 @@
 CSI_IMAGE_VERSION=canary
 
 # Ceph version to use
-BASE_IMAGE=docker.io/ceph/ceph:v16
+BASE_IMAGE=quay.io/ceph/ceph:v16
 CEPH_VERSION=pacific
 
 # standard Golang options
@@ -45,7 +45,7 @@ CHANGE_MINIKUBE_NONE_USER=true
 # Rook options
 ROOK_VERSION=v1.6.2
 # Provide ceph image path
-ROOK_CEPH_CLUSTER_IMAGE=docker.io/ceph/ceph:v16
+ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v16
 
 # CSI sidecar version
 CSI_ATTACHER_VERSION=v3.4.0


### PR DESCRIPTION
pull the ceph image from quay.io instead of docker hub.
From ceph doc, the images are available in both quay and dockerhub https://docs.ceph.com/en/latest/install/
containers/#official-releases but the latest images are not updated in the docker hub.

closes #2796 

depends on:  https://github.com/ceph/ceph-csi/pull/2797

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

