### PR TITLE
deploy: support rook deployment for v1.8+

### DIFF
--- a/build.env
+++ b/build.env
@@ -43,7 +43,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.6.2
+ROOK_VERSION=v1.8.2
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v16
 

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -75,7 +75,7 @@ func createCephfsStorageClass(
 	sc.Parameters["csi.storage.k8s.io/node-stage-secret-name"] = cephFSNodePluginSecretName
 
 	if enablePool {
-		sc.Parameters["pool"] = "myfs-data0"
+		sc.Parameters["pool"] = "myfs-replicated"
 	}
 
 	// overload any parameters that were passed

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -695,12 +695,12 @@ func deletePool(name string, cephFS bool, f *framework.Framework) error {
 		// ceph fs rm myfs --yes-i-really-mean-it
 		// ceph osd pool delete myfs-metadata myfs-metadata
 		// --yes-i-really-mean-it
-		// ceph osd pool delete myfs-data0 myfs-data0
+		// ceph osd pool delete myfs-replicated myfs-replicated
 		// --yes-i-really-mean-it
 		cmds = append(cmds, fmt.Sprintf("ceph fs fail %s", name),
 			fmt.Sprintf("ceph fs rm %s --yes-i-really-mean-it", name),
 			fmt.Sprintf("ceph osd pool delete %s-metadata %s-metadata --yes-i-really-really-mean-it", name, name),
-			fmt.Sprintf("ceph osd pool delete %s-data0 %s-data0 --yes-i-really-really-mean-it", name, name))
+			fmt.Sprintf("ceph osd pool delete %s-replicated %s-replicated --yes-i-really-really-mean-it", name, name))
 	} else {
 		// ceph osd pool delete replicapool replicapool
 		// --yes-i-really-mean-it

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -2,7 +2,8 @@
 
 ROOK_VERSION=${ROOK_VERSION:-"v1.6.2"}
 ROOK_DEPLOY_TIMEOUT=${ROOK_DEPLOY_TIMEOUT:-300}
-ROOK_URL="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/cluster/examples/kubernetes/ceph"
+ROOK_URL="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/"
+ROOK_DEPLOYMENT_PATH="cluster/examples/kubernetes/ceph"
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}
 ROOK_BLOCK_EC_POOL_NAME=${ROOK_BLOCK_EC_POOL_NAME:-"ec-pool"}
 
@@ -31,6 +32,17 @@ function log_errors() {
 
 rook_version() {
 	echo "${ROOK_VERSION#v}" | cut -d'.' -f"${1}"
+}
+
+function update_rook_url() {
+	ROOK_MAJOR=$(rook_version 1)
+	ROOK_MINOR=$(rook_version 2)
+
+	# If rook version is => 1.8 update deployment path.
+	if [ "${ROOK_MAJOR}" -eq 1 ] && [ "${ROOK_MINOR}" -ge 8 ]; then
+		ROOK_DEPLOYMENT_PATH="deploy/examples"
+	fi
+	ROOK_URL+=${ROOK_DEPLOYMENT_PATH}
 }
 
 function deploy_rook() {
@@ -208,6 +220,9 @@ function check_rbd_stat() {
 	fi
 	echo ""
 }
+
+# update rook URL before doing any operation.
+update_rook_url
 
 case "${1:-}" in
 deploy)

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -198,6 +198,12 @@ function check_rbd_stat() {
 		else
 			RBD_POOL_NAME=$1
 		fi
+		# Rook creates a detault pool with name device_health_metrics for
+		#  device-health-metrics CephBlockPool CR
+		if [[ "${RBD_POOL_NAME}" == "device-health-metrics" ]]; then
+			RBD_POOL_NAME="device_health_metrics"
+		fi
+
 		echo "Checking RBD ($RBD_POOL_NAME) stats... ${retry}s" && sleep 5
 
 		TOOLBOX_POD=$(kubectl_retry -n rook-ceph get pods -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -21,7 +21,7 @@ function log_errors() {
 	kubectl get nodes
 	kubectl -n rook-ceph get events
 	kubectl -n rook-ceph describe pods
-	kubectl -n rook-ceph logs -l app=rook-ceph-operator
+	kubectl -n rook-ceph logs -l app=rook-ceph-operator --tail=-1
 	kubectl -n rook-ceph get CephClusters -oyaml
 	kubectl -n rook-ceph get CephFilesystems -oyaml
 	kubectl -n rook-ceph get CephBlockPools -oyaml

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -130,6 +130,7 @@ function delete_block_pool() {
 function create_block_ec_pool() {
 	curl -o block-pool-ec.yaml "${ROOK_URL}/pool-ec.yaml"
 	sed -i "s/ec-pool/${ROOK_BLOCK_EC_POOL_NAME}/g" block-pool-ec.yaml
+	sed -i "s/failureDomain: host/failureDomain: osd/g" block-pool-ec.yaml
 	kubectl_retry create -f "./block-pool-ec.yaml"
 	rm -f "./block-pool-ec.yaml"
 

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -71,7 +71,7 @@ function deploy_rook() {
 		curl -o "${TEMP_DIR}"/cluster-test.yaml "${ROOK_URL}/cluster-test.yaml"
 		sed -i "s|image.*|${ROOK_CEPH_CLUSTER_VERSION_IMAGE_PATH}|g" "${TEMP_DIR}"/cluster-test.yaml
 		sed -i "s/config: |/config: |\n    \[mon\]\n    mon_warn_on_insecure_global_id_reclaim_allowed = false/g" "${TEMP_DIR}"/cluster-test.yaml
-		sed -i "s/healthCheck:/healthCheck:\n    livenessProbe:\n      mon:\n        disabled: true\n      mgr:\n        disabled: true\n      mds:\n        disabled: true/g" "${TEMP_DIR}"/cluster-test.yaml
+		sed -i "s/healthCheck:/healthCheck:\n    livenessProbe:\n      mon:\n        disabled: true\n      mgr:\n        disabled: true\n      mds:\n        disabled: true\n    startupProbe:\n      mon:\n        disabled: true\n      mgr:\n        disabled: true\n      mds:\n        disabled: true/g" "${TEMP_DIR}"/cluster-test.yaml
 		cat "${TEMP_DIR}"/cluster-test.yaml
 		kubectl_retry create -f "${TEMP_DIR}/cluster-test.yaml"
 	fi


### PR DESCRIPTION
In Rook v1.8+ the path for the deployment articafts  are changed from `"cluster/examples/kubernetes/ceph`  to `deploy/examples`.
    
Fixes: #2787

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>