### PR TITLE
ci: update rook image to mirror

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -6,6 +6,9 @@
 # format: <full-image-spec> <short-name>
 #
 
+# ceph-csi devel
+docker.io/rook/ceph:v1.8.2	rook/ceph:v1.8.2
+
 # ceph-csi v3.4
 docker.io/ceph/ceph:v16		ceph/ceph:v16
 docker.io/rook/ceph:v1.6.2	rook/ceph:v1.6.2


### PR DESCRIPTION
Update rook image tag to mirror latest version to the internal registry.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>


CI is failing at https://github.com/ceph/ceph-csi/pull/2806 as the image is not available in the internal registry.

```
+ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@n26.dusty.ci.centos.org 'podman pull --authfile=~/.podman-auth.json registry-ceph-csi.apps.ocp.ci.centos.org/rook/ceph:v1.8.2 && podman tag registry-ceph-csi.apps.ocp.ci.centos.org/rook/ceph:v1.8.2 rook/ceph:v1.8.2 docker.io/rook/ceph:v1.8.2'

Warning: Permanently added 'n26.dusty.ci.centos.org,172.19.2.90' (ECDSA) to the list of known hosts.

Trying to pull registry-ceph-csi.apps.ocp.ci.centos.org/rook/ceph:v1.8.2...

Error: initializing source docker://registry-ceph-csi.apps.ocp.ci.centos.org/rook/ceph:v1.8.2: reading manifest v1.8.2 in registry-ceph-csi.apps.ocp.ci.centos.org/rook/ceph: manifest unknown: manifest unknown

script returned exit code 125
```