### PR TITLE
ci: update golangci-lint to latest release

### DIFF
--- a/build.env
+++ b/build.env
@@ -23,7 +23,7 @@ GO111MODULE=on
 COMMITLINT_VERSION=latest
 
 # static checks and linters
-GOLANGCI_VERSION=v1.39.0
+GOLANGCI_VERSION=v1.43.0
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -79,7 +78,7 @@ func deleteCephfsPlugin() {
 }
 
 func createORDeleteCephfsResources(action kubectlAction) {
-	csiDriver, err := ioutil.ReadFile(cephFSDirPath + csiDriverObject)
+	csiDriver, err := os.ReadFile(cephFSDirPath + csiDriverObject)
 	if err != nil {
 		// createORDeleteRbdResources is used for upgrade testing as csidriverObject is
 		// newly added, discarding file not found error.
@@ -92,7 +91,7 @@ func createORDeleteCephfsResources(action kubectlAction) {
 			e2elog.Failf("failed to %s CSIDriver object: %v", action, err)
 		}
 	}
-	cephConf, err := ioutil.ReadFile(examplePath + cephConfconfigMap)
+	cephConf, err := os.ReadFile(examplePath + cephConfconfigMap)
 	if err != nil {
 		// createORDeleteCephfsResources is used for upgrade testing as cephConfConfigmap is
 		// newly added, discarding file not found error.

--- a/e2e/namespace.go
+++ b/e2e/namespace.go
@@ -19,7 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -87,7 +87,7 @@ func deleteNamespace(c kubernetes.Interface, name string) error {
 }
 
 func replaceNamespaceInTemplate(filePath string) (string, error) {
-	read, err := ioutil.ReadFile(filePath)
+	read, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", err
 	}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -120,7 +119,7 @@ func deleteRBDPlugin() {
 }
 
 func createORDeleteRbdResources(action kubectlAction) {
-	csiDriver, err := ioutil.ReadFile(rbdDirPath + csiDriverObject)
+	csiDriver, err := os.ReadFile(rbdDirPath + csiDriverObject)
 	if err != nil {
 		// createORDeleteRbdResources is used for upgrade testing as csidriverObject is
 		// newly added, discarding file not found error.
@@ -133,7 +132,7 @@ func createORDeleteRbdResources(action kubectlAction) {
 			e2elog.Failf("failed to %s CSIDriver object: %v", action, err)
 		}
 	}
-	cephConf, err := ioutil.ReadFile(examplePath + cephConfconfigMap)
+	cephConf, err := os.ReadFile(examplePath + cephConfconfigMap)
 	if err != nil {
 		// createORDeleteRbdResources is used for upgrade testing as cephConf Configmap is
 		// newly added, discarding file not found error.

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -160,7 +160,7 @@ func deleteResource(scPath string) error {
 }
 
 func unmarshal(fileName string, obj interface{}) error {
-	f, err := ioutil.ReadFile(fileName)
+	f, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -280,8 +280,8 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 		snapSource       bool
 		objUUID          string
 		savedImagePool   string
-		savedImagePoolID int64 = util.InvalidPoolID
-		cj                     = conn.config
+		savedImagePoolID = util.InvalidPoolID
+		cj               = conn.config
 	)
 
 	if snapParentName != "" {

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/ceph/ceph-csi/internal/util/k8s"
@@ -94,7 +93,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 func getKMSConfiguration() (map[string]interface{}, error) {
 	var config map[string]interface{}
 	// #nosec
-	content, err := ioutil.ReadFile(kmsConfigPath)
+	content, err := os.ReadFile(kmsConfigPath)
 	if err == nil {
 		// kmsConfigPath exists and was successfully read
 		err = json.Unmarshal(content, &config)

--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -320,7 +320,7 @@ func (kms *VaultTenantSA) getTokenPath() (string, error) {
 		return "", err
 	}
 
-	err = os.WriteFile(dir+"/token", []byte(token), 0600)
+	err = os.WriteFile(dir+"/token", []byte(token), 0o600)
 	if err != nil {
 		return "", fmt.Errorf("failed to write token for ServiceAccount %s/%s: %w", kms.tenantSAName, kms.Tenant, err)
 	}

--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -320,7 +320,7 @@ func (kms *VaultTenantSA) getTokenPath() (string, error) {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(dir+"/token", []byte(token), 0600)
+	err = os.WriteFile(dir+"/token", []byte(token), 0600)
 	if err != nil {
 		return "", fmt.Errorf("failed to write token for ServiceAccount %s/%s: %w", kms.tenantSAName, kms.Tenant, err)
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1625,7 +1625,7 @@ func stashRBDImageMetadata(volOptions *rbdVolume, metaDataPath string) error {
 	}
 
 	fPath := filepath.Join(metaDataPath, stashFileName)
-	err = ioutil.WriteFile(fPath, encodedBytes, 0o600)
+	err = os.WriteFile(fPath, encodedBytes, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to stash JSON image metadata for image (%s) at path (%s): %w", volOptions, fPath, err)
 	}
@@ -1673,7 +1673,7 @@ func updateRBDImageMetadataStash(metaDataPath, device string) error {
 	}
 
 	fPath := filepath.Join(metaDataPath, stashFileName)
-	err = ioutil.WriteFile(fPath, encodedBytes, 0600)
+	err = os.WriteFile(fPath, encodedBytes, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to stash JSON image metadata at path: (%s) for spec:(%s) : %w",
 			fPath, imgMeta.String(), err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -244,7 +243,7 @@ func GetKrbdSupportedFeatures() (string, error) {
 			return "", err
 		}
 	}
-	val, err := ioutil.ReadFile(krbdSupportedFeaturesFile)
+	val, err := os.ReadFile(krbdSupportedFeaturesFile)
 	if err != nil {
 		log.ErrorLogMsg("reading file %q failed: %v", krbdSupportedFeaturesFile, err)
 
@@ -1638,7 +1637,7 @@ func lookupRBDImageMetadataStash(metaDataPath string) (rbdImageMetadataStash, er
 	var imgMeta rbdImageMetadataStash
 
 	fPath := filepath.Join(metaDataPath, stashFileName)
-	encodedBytes, err := ioutil.ReadFile(fPath) // #nosec - intended reading from fPath
+	encodedBytes, err := os.ReadFile(fPath) // #nosec - intended reading from fPath
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return imgMeta, fmt.Errorf("failed to read stashed JSON image metadata from path (%s): %w", fPath, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1672,7 +1672,7 @@ func updateRBDImageMetadataStash(metaDataPath, device string) error {
 	}
 
 	fPath := filepath.Join(metaDataPath, stashFileName)
-	err = os.WriteFile(fPath, encodedBytes, 0600)
+	err = os.WriteFile(fPath, encodedBytes, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to stash JSON image metadata at path: (%s) for spec:(%s) : %w",
 			fPath, imgMeta.String(), err)

--- a/internal/util/cephconf.go
+++ b/internal/util/cephconf.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -57,7 +56,7 @@ func WriteCephConfig() error {
 
 	// create config file if it does not exist to support backward compatibility
 	if _, err = os.Stat(CephConfigPath); os.IsNotExist(err) {
-		err = ioutil.WriteFile(CephConfigPath, cephConfig, 0o600)
+		err = os.WriteFile(CephConfigPath, cephConfig, 0o600)
 	}
 
 	if err != nil {

--- a/internal/util/cluster_mapping.go
+++ b/internal/util/cluster_mapping.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -70,7 +69,7 @@ type ClusterMappingInfo struct {
 
 func readClusterMappingInfo(filename string) (*[]ClusterMappingInfo, error) {
 	var info []ClusterMappingInfo
-	content, err := ioutil.ReadFile(filename) // #nosec:G304, file inclusion via variable.
+	content, err := os.ReadFile(filename) // #nosec:G304, file inclusion via variable.
 	if err != nil {
 		err = fmt.Errorf("error fetching clusterID mapping %w", err)
 

--- a/internal/util/cluster_mapping_test.go
+++ b/internal/util/cluster_mapping_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -142,7 +142,7 @@ func TestGetClusterMappingInfo(t *testing.T) {
 			t.Parallel()
 			mappingConfigFile := fmt.Sprintf("%s/mapping-%d.json", mappingBasePath, currentI)
 			if len(currentTT.mappingFilecontent) != 0 {
-				err = ioutil.WriteFile(mappingConfigFile, currentTT.mappingFilecontent, 0o600)
+				err = os.WriteFile(mappingConfigFile, currentTT.mappingFilecontent, 0o600)
 				if err != nil {
 					t.Errorf("failed to write to %q, error = %v", mappingConfigFile, err)
 				}
@@ -158,7 +158,7 @@ func TestGetClusterMappingInfo(t *testing.T) {
 	}
 
 	clusterMappingConfigFile = fmt.Sprintf("%s/mapping.json", mappingBasePath)
-	err = ioutil.WriteFile(clusterMappingConfigFile, mappingFileContent, 0o600)
+	err = os.WriteFile(clusterMappingConfigFile, mappingFileContent, 0o600)
 	if err != nil {
 		t.Errorf("failed to write mapping content error = %v", err)
 	}
@@ -318,7 +318,7 @@ func TestFetchMappedClusterIDAndMons(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to marshal csi config info %v", err)
 	}
-	err = ioutil.WriteFile(csiConfigFile, csiConfigFileContent, 0o600)
+	err = os.WriteFile(csiConfigFile, csiConfigFileContent, 0o600)
 	if err != nil {
 		t.Errorf("failed to write %s file content: %v", CsiConfigFile, err)
 	}
@@ -351,7 +351,7 @@ func TestFetchMappedClusterIDAndMons(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to marshal mapping info %v", err)
 	}
-	err = ioutil.WriteFile(clusterMappingConfigFile, clusterMappingFileContent, 0o600)
+	err = os.WriteFile(clusterMappingConfigFile, clusterMappingFileContent, 0o600)
 	if err != nil {
 		t.Errorf("failed to write %s file content: %v", clusterMappingFileContent, err)
 	}

--- a/internal/util/conn_pool.go
+++ b/internal/util/conn_pool.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -96,7 +96,7 @@ func (cp *ConnPool) Destroy() {
 
 func (cp *ConnPool) generateUniqueKey(monitors, user, keyfile string) (string, error) {
 	// the keyfile can be unique for operations, contents will be the same
-	key, err := ioutil.ReadFile(keyfile) // #nosec:G304, file inclusion via variable.
+	key, err := os.ReadFile(keyfile) // #nosec:G304, file inclusion via variable.
 	if err != nil {
 		return "", fmt.Errorf("could not open keyfile %s: %w", keyfile, err)
 	}

--- a/internal/util/conn_pool_test.go
+++ b/internal/util/conn_pool_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -81,7 +80,7 @@ func TestConnPool(t *testing.T) {
 
 	// create a keyfile with some contents
 	keyfile := "/tmp/conn_utils.keyfile"
-	err := ioutil.WriteFile(keyfile, []byte("the-key"), 0o600)
+	err := os.WriteFile(keyfile, []byte("the-key"), 0o600)
 	if err != nil {
 		t.Errorf("failed to create keyfile: %v", err)
 

--- a/internal/util/credentials.go
+++ b/internal/util/credentials.go
@@ -54,7 +54,7 @@ func storeKey(key string) (string, error) {
 		}
 	}()
 
-	if _, err = tmpfile.Write([]byte(key)); err != nil {
+	if _, err = tmpfile.WriteString(key); err != nil {
 		return "", fmt.Errorf("error writing key to temporary keyfile: %w", err)
 	}
 

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -72,7 +72,7 @@ func readClusterInfo(pathToConfig, clusterID string) (*ClusterInfo, error) {
 	var config []ClusterInfo
 
 	// #nosec
-	content, err := ioutil.ReadFile(pathToConfig)
+	content, err := os.ReadFile(pathToConfig)
 	if err != nil {
 		err = fmt.Errorf("error fetching configuration for cluster ID %q: %w", clusterID, err)
 

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -54,7 +53,7 @@ func TestCSIConfig(t *testing.T) {
 	}
 
 	data = ""
-	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	err = os.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
 	if err != nil {
 		t.Errorf("Test setup error %s", err)
 	}
@@ -66,7 +65,7 @@ func TestCSIConfig(t *testing.T) {
 	}
 
 	data = "[{\"clusterIDBad\":\"" + clusterID2 + "\",\"monitors\":[\"mon1\",\"mon2\",\"mon3\"]}]"
-	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	err = os.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
 	if err != nil {
 		t.Errorf("Test setup error %s", err)
 	}
@@ -78,7 +77,7 @@ func TestCSIConfig(t *testing.T) {
 	}
 
 	data = "[{\"clusterID\":\"" + clusterID2 + "\",\"monitorsBad\":[\"mon1\",\"mon2\",\"mon3\"]}]"
-	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	err = os.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
 	if err != nil {
 		t.Errorf("Test setup error %s", err)
 	}
@@ -90,7 +89,7 @@ func TestCSIConfig(t *testing.T) {
 	}
 
 	data = "[{\"clusterID\":\"" + clusterID2 + "\",\"monitors\":[\"mon1\",2,\"mon3\"]}]"
-	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	err = os.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
 	if err != nil {
 		t.Errorf("Test setup error %s", err)
 	}
@@ -102,7 +101,7 @@ func TestCSIConfig(t *testing.T) {
 	}
 
 	data = "[{\"clusterID\":\"" + clusterID2 + "\",\"monitors\":[\"mon1\",\"mon2\",\"mon3\"]}]"
-	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	err = os.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
 	if err != nil {
 		t.Errorf("Test setup error %s", err)
 	}
@@ -121,7 +120,7 @@ func TestCSIConfig(t *testing.T) {
 
 	data = "[{\"clusterID\":\"" + clusterID2 + "\",\"monitors\":[\"mon1\",\"mon2\",\"mon3\"]}," +
 		"{\"clusterID\":\"" + clusterID1 + "\",\"monitors\":[\"mon4\",\"mon5\",\"mon6\"]}]"
-	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	err = os.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
 	if err != nil {
 		t.Errorf("Test setup error %s", err)
 	}
@@ -134,7 +133,7 @@ func TestCSIConfig(t *testing.T) {
 
 	data = "[{\"clusterID\":\"" + clusterID2 + "\",\"monitors\":[\"mon1\",\"mon2\",\"mon3\"]}," +
 		"{\"clusterID\":\"" + clusterID1 + "\",\"monitors\":[\"mon4\",\"mon5\",\"mon6\"]}]"
-	err = ioutil.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
+	err = os.WriteFile(basePath+"/"+csiClusters, []byte(data), 0o600)
 	if err != nil {
 		t.Errorf("Test setup error %s", err)
 	}

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -39,27 +39,27 @@ var (
 	ErrMissingConfigForMonitor = errors.New("missing configuration of cluster ID for monitor")
 )
 
-type errorPair struct {
+type pairError struct {
 	first  error
 	second error
 }
 
-func (e errorPair) Error() string {
+func (e pairError) Error() string {
 	return fmt.Sprintf("%v: %v", e.first, e.second)
 }
 
 // Is checks if target error is wrapped in the first error.
-func (e errorPair) Is(target error) bool {
+func (e pairError) Is(target error) bool {
 	return errors.Is(e.first, target)
 }
 
 // Unwrap returns the second error.
-func (e errorPair) Unwrap() error {
+func (e pairError) Unwrap() error {
 	return e.second
 }
 
 // JoinErrors combines two errors. Of the returned error, Is() follows the first
 // branch, Unwrap() follows the second branch.
 func JoinErrors(e1, e2 error) error {
-	return errorPair{e1, e2}
+	return pairError{e1, e2}
 }

--- a/internal/util/log/log_utils.go
+++ b/internal/util/log/log_utils.go
@@ -15,7 +15,6 @@ package log
 
 import (
 	"compress/gzip"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -24,7 +23,7 @@ import (
 // compressed format.
 func GzipLogFile(pathToFile string) error {
 	// Get all the bytes from the file.
-	content, err := ioutil.ReadFile(pathToFile) // #nosec:G304, file inclusion via variable.
+	content, err := os.ReadFile(pathToFile) // #nosec:G304, file inclusion via variable.
 	if err != nil {
 		return err
 	}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -274,7 +274,7 @@ func TestParseKernelRelease(t *testing.T) {
 	for i, release := range goodReleases {
 		version, patchlevel, sublevel, extraversion, err := parseKernelRelease(release)
 		if err != nil {
-			t.Errorf("parsing error for release %q: %w", release, err)
+			t.Errorf("parsing error for release %q: %s", release, err)
 		}
 		good := goodVersions[i]
 		if version != good[0] || patchlevel != good[1] || sublevel != good[2] || extraversion != good[3] {

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -179,3 +179,10 @@ linters:
     # TODO: enable wrapcheck linter
     # See: https://github.com/ceph/ceph-csi/pull/2268
     - wrapcheck
+    # TODO: enable linters added in golangci-lint 1.43
+    - contextcheck
+    - gomnd
+    - ireturn
+    - tagliatelle
+    - varnamelen
+    - nilnil


### PR DESCRIPTION
This PR updates the  CI tool to the latest release i.e 1.43.0 and fixes all failures which are found in older tools. New tools checks are marked for TODO.

updates #2595 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>


@ceph/ceph-csi-maintainers @ceph/contributors requesting a review on priority as rebasing this kind of PR becomes difficult.