### PR TITLE
revert: update templates to point to 3.5-canary

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.5.1
+CSI_IMAGE_VERSION=v3.5-canary
 
 # Ceph version to use
 BASE_IMAGE=quay.io/ceph/ceph:v16

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -87,7 +87,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.5.1
+      tag: v3.5-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -109,7 +109,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.5.1
+      tag: v3.5-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -105,7 +105,7 @@ spec:
               mountPath: /csi
         - name: csi-cephfsplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -144,7 +144,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -47,7 +47,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -103,7 +103,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -112,7 +112,7 @@ spec:
               mountPath: /csi
         - name: csi-rbdplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -165,7 +165,7 @@ spec:
               mountPath: /etc/ceph/
         - name: csi-rbdplugin-controller
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -185,7 +185,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,7 +50,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -121,7 +121,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.5.1
+          image: quay.io/cephcsi/cephcsi:v3.5-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -284,7 +284,7 @@ teardown-rook)
     ;;
 cephcsi)
     echo "copying the cephcsi image"
-    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.5.1 "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.5.1
+    copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.5-canary "${CEPHCSI_IMAGE_REPO}"/cephcsi:v3.5-canary
     ;;
 k8s-sidecar)
     echo "copying the kubernetes sidecar images"


### PR DESCRIPTION
updating deployment templates to point to the 3.5-canary images.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

