### PR TITLE
rbd: change the keyprotect metadata name to `ibmkeyprotect`

### DIFF
--- a/examples/kms/vault/csi-kms-connection-details.yaml
+++ b/examples/kms/vault/csi-kms-connection-details.yaml
@@ -60,9 +60,9 @@ data:
       "IBM_KP_SECRET_NAME": "ceph-csi-aws-credentials",
       "AWS_REGION": "us-west-2"
     }
-  kp-metadata-test: |-
+  ibmkeyprotect-test: |-
     {
-      "KMS_PROVIDER": "kp-metadata",
+      "KMS_PROVIDER": "ibmkeyprotect",
       "IBM_KP_SECRET_NAME": "ceph-csi-kp-credentials",
       "IBM_KP_SERVICE_INSTANCE_ID": "7abef064-01dd-4237-9ea5-8b3890970be3",
       "IBM_KP_BASE_URL": "https://us-south.kms.cloud.ibm.com",

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -91,8 +91,8 @@ data:
         "encryptionKMSType": "metadata",
         "secretName": "storage-encryption-secret"
       },
-      "kp-metadata-test": {
-        "encryptionKMSType": "kp-metadata",
+      "ibmkeyprotect-test": {
+        "encryptionKMSType": "ibmkeyprotect",
         "secretName": "ceph-csi-kp-credentials",
         "keyProtectRegionKey": "us-south-2",
         "keyProtectServiceInstanceID": "7abef064-01dd-4237-9ea5-8b3890970be3"

--- a/internal/kms/keyprotect.go
+++ b/internal/kms/keyprotect.go
@@ -23,14 +23,15 @@ import (
 	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/util/k8s"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	kp "github.com/IBM/keyprotect-go-client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	kmsTypeKeyProtectMetadata = "kp-metadata"
-
+	kmsTypeKeyProtectMetadata    = "ibmkeyprotect"
+	kmsTypeKeyProtectMetadataOld = "kp-metadata"
 	// keyProtectMetadataDefaultSecretsName is the default name of the Kubernetes Secret
 	// that contains the credentials to access the Key Protect KMS. The name of
 	// the Secret can be configured by setting the `IBM_KP_SECRET_NAME`
@@ -61,6 +62,21 @@ var _ = RegisterProvider(Provider{
 	UniqueID:    kmsTypeKeyProtectMetadata,
 	Initializer: initKeyProtectKMS,
 })
+
+// RegisterProvider for kmsTypeKeyProtectMetadataOld is kept here for backward compatibility.
+var _ = RegisterProvider(Provider{
+	UniqueID:    kmsTypeKeyProtectMetadataOld,
+	Initializer: initKeyProtectKMSOld,
+})
+
+// initKeyProtectKMSOld is the wrapper with a warning log.
+func initKeyProtectKMSOld(args ProviderInitArgs) (EncryptionKMS, error) {
+	log.WarningLogMsg("%q is deprecated provider for IBM key Protect,"+
+		"use new provider name %q in the configuration, proceeding with %q",
+		kmsTypeKeyProtectMetadataOld, kmsTypeKeyProtectMetadata, kmsTypeKeyProtectMetadata)
+
+	return initKeyProtectKMS(args)
+}
 
 // KeyProtectKMS store the KMS connection information retrieved from the kms configmap.
 type KeyProtectKMS struct {


### PR DESCRIPTION
To be consistent with other components and also to explictly
state it belong to `ibm keyprotect` service introducing this
change

https://github.com/rook/rook/pull/9615/files#diff-2f97d4e20aa3611cfe1fec4777fb663abcf866d94ed58d33220a82a7229e25f4R53

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

