### PR TITLE
cleanup: use interface in filesystem.go

### DIFF
--- a/internal/cephfs/core/filesystem.go
+++ b/internal/cephfs/core/filesystem.go
@@ -25,76 +25,102 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
-func (vo *VolumeOptions) getFscID(ctx context.Context) (int64, error) {
-	fsa, err := vo.conn.GetFSAdmin()
+// FileSystem is the interface that holds the signature of filesystem methods
+// that interacts with CephFS filesystem API's.
+type FileSystem interface {
+	// GetFscID returns the ID of the filesystem with the given name.
+	GetFscID(context.Context, string) (int64, error)
+	// GetMetadataPool returns the metadata pool name of the filesystem with the given name.
+	GetMetadataPool(context.Context, string) (string, error)
+	// GetFsName returns the name of the filesystem with the given ID.
+	GetFsName(context.Context, int64) (string, error)
+}
+
+// fileSystem is the implementation of FileSystem interface.
+type fileSystem struct {
+	conn *util.ClusterConnection
+}
+
+// NewFileSystem returns a new instance of fileSystem.
+func NewFileSystem(conn *util.ClusterConnection) FileSystem {
+	return &fileSystem{
+		conn: conn,
+	}
+}
+
+// GetFscID returns the ID of the filesystem with the given name.
+func (f *fileSystem) GetFscID(ctx context.Context, fsName string) (int64, error) {
+	fsa, err := f.conn.GetFSAdmin()
 	if err != nil {
-		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem ID for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem ID for %s:", fsName, err)
 
 		return 0, err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
-		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem ID for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem ID for %s:", fsName, err)
 
 		return 0, err
 	}
 
 	for _, vol := range volumes {
-		if vol.Name == vo.FsName {
+		if vol.Name == fsName {
 			return vol.ID, nil
 		}
 	}
 
-	log.ErrorLog(ctx, "failed to list volume %s", vo.FsName)
+	log.ErrorLog(ctx, "failed to list volume %s", fsName)
 
 	return 0, cerrors.ErrVolumeNotFound
 }
 
-func (vo *VolumeOptions) getMetadataPool(ctx context.Context) (string, error) {
-	fsa, err := vo.conn.GetFSAdmin()
+// GetMetadataPool returns the metadata pool name of the filesystem with the given name.
+func (f *fileSystem) GetMetadataPool(ctx context.Context, fsName string) (string, error) {
+	fsa, err := f.conn.GetFSAdmin()
 	if err != nil {
-		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s:", fsName, err)
 
 		return "", err
 	}
 
 	fsPoolInfos, err := fsa.ListFileSystems()
 	if err != nil {
-		log.ErrorLog(ctx, "could not list filesystems, can not fetch metadata pool for %s:", vo.FsName, err)
+		log.ErrorLog(ctx, "could not list filesystems, can not fetch metadata pool for %s:", fsName, err)
 
 		return "", err
 	}
 
 	for _, fspi := range fsPoolInfos {
-		if fspi.Name == vo.FsName {
+		if fspi.Name == fsName {
 			return fspi.MetadataPool, nil
 		}
 	}
 
-	return "", fmt.Errorf("%w: could not find metadata pool for %s", util.ErrPoolNotFound, vo.FsName)
+	return "", fmt.Errorf("%w: could not find metadata pool for %s", util.ErrPoolNotFound, fsName)
 }
 
-func (vo *VolumeOptions) getFsName(ctx context.Context) (string, error) {
-	fsa, err := vo.conn.GetFSAdmin()
+// GetFsName returns the name of the filesystem with the given ID.
+func (f *fileSystem) GetFsName(ctx context.Context, fscID int64) (string, error) {
+	fsa, err := f.conn.GetFSAdmin()
 	if err != nil {
-		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem name for ID %d:", vo.FscID, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem name for ID %d:", fscID, err)
 
 		return "", err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
-		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem name for ID %d:", vo.FscID, err)
+		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem name for ID %d:", fscID, err)
 
 		return "", err
 	}
 
 	for _, vol := range volumes {
-		if vol.ID == vo.FscID {
+		if vol.ID == fscID {
 			return vol.Name, nil
 		}
 	}
 
-	return "", fmt.Errorf("%w: fscID (%d) not found in Ceph cluster", util.ErrPoolNotFound, vo.FscID)
+	return "", fmt.Errorf("%w: fscID (%d) not found in Ceph cluster", util.ErrPoolNotFound, fscID)
 }

--- a/internal/cephfs/core/filesystem.go
+++ b/internal/cephfs/core/filesystem.go
@@ -52,14 +52,14 @@ func NewFileSystem(conn *util.ClusterConnection) FileSystem {
 func (f *fileSystem) GetFscID(ctx context.Context, fsName string) (int64, error) {
 	fsa, err := f.conn.GetFSAdmin()
 	if err != nil {
-		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem ID for %s:", fsName, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem ID for %s: %s", fsName, err)
 
 		return 0, err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
-		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem ID for %s:", fsName, err)
+		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem ID for %s: %s", fsName, err)
 
 		return 0, err
 	}
@@ -79,14 +79,14 @@ func (f *fileSystem) GetFscID(ctx context.Context, fsName string) (int64, error)
 func (f *fileSystem) GetMetadataPool(ctx context.Context, fsName string) (string, error) {
 	fsa, err := f.conn.GetFSAdmin()
 	if err != nil {
-		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s:", fsName, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch metadata pool for %s: %s", fsName, err)
 
 		return "", err
 	}
 
 	fsPoolInfos, err := fsa.ListFileSystems()
 	if err != nil {
-		log.ErrorLog(ctx, "could not list filesystems, can not fetch metadata pool for %s:", fsName, err)
+		log.ErrorLog(ctx, "could not list filesystems, can not fetch metadata pool for %s: %s", fsName, err)
 
 		return "", err
 	}
@@ -104,14 +104,14 @@ func (f *fileSystem) GetMetadataPool(ctx context.Context, fsName string) (string
 func (f *fileSystem) GetFsName(ctx context.Context, fscID int64) (string, error) {
 	fsa, err := f.conn.GetFSAdmin()
 	if err != nil {
-		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem name for ID %d:", fscID, err)
+		log.ErrorLog(ctx, "could not get FSAdmin, can not fetch filesystem name for ID %d: %s", fscID, err)
 
 		return "", err
 	}
 
 	volumes, err := fsa.EnumerateVolumes()
 	if err != nil {
-		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem name for ID %d:", fscID, err)
+		log.ErrorLog(ctx, "could not list volumes, can not fetch filesystem name for ID %d: %s", fscID, err)
 
 		return "", err
 	}

--- a/internal/cephfs/core/volumeoptions.go
+++ b/internal/cephfs/core/volumeoptions.go
@@ -230,12 +230,13 @@ func NewVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVo
 		return nil, err
 	}
 
-	opts.FscID, err = opts.getFscID(ctx)
+	fs := NewFileSystem(opts.conn)
+	opts.FscID, err = fs.GetFscID(ctx, opts.FsName)
 	if err != nil {
 		return nil, err
 	}
 
-	opts.MetadataPool, err = opts.getMetadataPool(ctx)
+	opts.MetadataPool, err = fs.GetMetadataPool(ctx, opts.FsName)
 	if err != nil {
 		return nil, err
 	}
@@ -308,12 +309,13 @@ func NewVolumeOptionsFromVolID(
 		}
 	}()
 
-	volOptions.FsName, err = volOptions.getFsName(ctx)
+	fs := NewFileSystem(volOptions.conn)
+	volOptions.FsName, err = fs.GetFsName(ctx, volOptions.FscID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx)
+	volOptions.MetadataPool, err = fs.GetMetadataPool(ctx, volOptions.FsName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -549,12 +551,13 @@ func NewSnapshotOptionsFromID(
 		}
 	}()
 
-	volOptions.FsName, err = volOptions.getFsName(ctx)
+	fs := NewFileSystem(volOptions.conn)
+	volOptions.FsName, err = fs.GetFsName(ctx, volOptions.FscID)
 	if err != nil {
 		return &volOptions, nil, &sid, err
 	}
 
-	volOptions.MetadataPool, err = volOptions.getMetadataPool(ctx)
+	volOptions.MetadataPool, err = fs.GetMetadataPool(ctx, volOptions.FsName)
 	if err != nil {
 		return &volOptions, nil, &sid, err
 	}


### PR DESCRIPTION
Currently, we are using methods and all the methods make a network call to fetch details from the ceph clusters, it's difficult to write test cases for these functions, if we move to the interfaces we can make use of mock to write unit testing for the caller functions.

updates https://github.com/ceph/ceph-csi/issues/852

Making an initial PR with only one file to get the review on the idea, the whole change to the internal core functions are available at https://github.com/Madhu-1/ceph-csi/commit/378a3a45196af019fcae794a33562888a9e9a9dc.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

