### PR TITLE
deploy: make the snapshotter version in parity

### DIFF
--- a/build.env
+++ b/build.env
@@ -27,7 +27,7 @@ GOLANGCI_VERSION=v1.43.0
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases
-SNAPSHOT_VERSION=v4.0.0
+SNAPSHOT_VERSION=v4.2.0
 
 # "go test" configuration
 # set to stdout or html to enable coverage reporting, disabled by default

--- a/docs/snap-clone.md
+++ b/docs/snap-clone.md
@@ -33,7 +33,7 @@
     `SNAPSHOT_VERSION` variable, for example:
 
     ```console
-    SNAPSHOT_VERSION="v4.0.0" ./scripts/install-snapshot.sh install
+    SNAPSHOT_VERSION="v4.2.0" ./scripts/install-snapshot.sh install
     ```
 
   - In the future, you can choose to cleanup by running

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(dirname "${0}")"
 # shellcheck source=build.env
 source "${SCRIPT_DIR}/../build.env"
 
-SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v4.0.0"}
+SNAPSHOT_VERSION=${SNAPSHOT_VERSION:-"v4.2.0"}
 
 TEMP_DIR="$(mktemp -d)"
 SNAPSHOTTER_URL="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOT_VERSION}"
@@ -24,7 +24,7 @@ VOLUME_SNAPSHOT="${SNAPSHOTTER_URL}/client/config/crd/snapshot.storage.k8s.io_vo
 function install_snapshot_controller() {
     local namespace=$1
     if [ -z "${namespace}" ]; then
-        namespace="default"
+        namespace="kube-system"
     fi
 
     create_or_delete_resource "create" ${namespace}
@@ -51,7 +51,7 @@ function install_snapshot_controller() {
 function cleanup_snapshot_controller() {
     local namespace=$1
     if [ -z "${namespace}" ]; then
-        namespace="default"
+        namespace="kube-system"
     fi
     create_or_delete_resource "delete" ${namespace}
 }
@@ -65,8 +65,8 @@ function create_or_delete_resource() {
     mkdir -p "${TEMP_DIR}"
     curl -o "${temp_rbac}" "${SNAPSHOT_RBAC}"
     curl -o "${temp_snap_controller}" "${SNAPSHOT_CONTROLLER}"
-    sed -i "s/namespace: default/namespace: ${namespace}/g" "${temp_rbac}"
-    sed -i "s/namespace: default/namespace: ${namespace}/g" "${snapshotter_psp}"
+    sed -i "s/namespace: kube-system/namespace: ${namespace}/g" "${temp_rbac}"
+    sed -i "s/namespace: kube-system/namespace: ${namespace}/g" "${snapshotter_psp}"
     sed -i "s/canary/${SNAPSHOT_VERSION}/g" "${temp_snap_controller}"
 
     kubectl "${operation}" -f "${temp_rbac}"

--- a/scripts/snapshot-controller-psp.yaml
+++ b/scripts/snapshot-controller-psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: csi-snapshotter-psp
+  namespace: kube-system
 spec:
   allowPrivilegeEscalation: true
   allowedCapabilities:
@@ -28,8 +29,8 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-snapshotter-psp
-  # replace with non-default namespace name
-  namespace: default
+  # replace with non-kube-system namespace name
+  namespace: kube-system
 rules:
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
@@ -41,13 +42,13 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-snapshotter-psp
-  # replace with non-default namespace name
-  namespace: default
+  # replace with non-kube-system namespace name
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: snapshot-controller
-    # replace with non-default namespace name
-    namespace: default
+    # replace with non-kube-system namespace name
+    namespace: kube-system
 roleRef:
   kind: Role
   name: csi-snapshotter-psp


### PR DESCRIPTION
The build.env versions are not matching with current version
we have in the deployment artifacts, this correct the same.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

