### PR TITLE
cleanup: remove ceph.conf WA options which are already fixed

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -423,14 +423,6 @@ cephconf: |
     auth_service_required = cephx
     auth_client_required = cephx
 
-    # Workaround for http://tracker.ceph.com/issues/23446
-    fuse_set_user_groups = false
-
-    # ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
-    # adding 'fuse_big_writes = true' option by default to override this limit
-    # see https://github.com/ceph/ceph-csi/issues/1928
-    fuse_big_writes = true
-
 #########################################################
 # Variables for 'internal' use please use with caution! #
 #########################################################

--- a/examples/ceph-conf.yaml
+++ b/examples/ceph-conf.yaml
@@ -15,13 +15,6 @@ data:
     auth_service_required = cephx
     auth_client_required = cephx
 
-    # Workaround for http://tracker.ceph.com/issues/23446
-    fuse_set_user_groups = false
-
-    # ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
-    # adding 'fuse_big_writes = true' option by default to override this limit
-    # see https://github.com/ceph/ceph-csi/issues/1928
-    fuse_big_writes = true
   # keyring is a required key and its value should be empty
   keyring: |
 metadata:

--- a/internal/util/cephconf.go
+++ b/internal/util/cephconf.go
@@ -24,14 +24,6 @@ var cephConfig = []byte(`[global]
 auth_cluster_required = cephx
 auth_service_required = cephx
 auth_client_required = cephx
-
-# Workaround for http://tracker.ceph.com/issues/23446
-fuse_set_user_groups = false
-
-# ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
-# adding 'fuse_big_writes = true' option by default to override this limit
-# see https://github.com/ceph/ceph-csi/issues/1928
-fuse_big_writes = true
 `)
 
 const (


### PR DESCRIPTION
This commit removes ceph.conf WA options:
```
     # Workaround for http://tracker.ceph.com/issues/23446
     fuse_set_user_groups = false

     # ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
     # adding 'fuse_big_writes = true' option by default to override this limit
     # see https://github.com/ceph/ceph-csi/issues/1928
     fuse_big_writes = true
```
Since they are already fixed.

Refer: https://tracker.ceph.com/issues/44885
Refer: https://tracker.ceph.com/issues/23446
Closes: #2825

Signed-off-by: Rakshith R <rar@redhat.com>
