### PR TITLE
build: migrate CentOS 8 container-images to CentOS Stream 8

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -4,6 +4,15 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE} as builder
 
+# FIXME: Ceph base containers should use CentOS Stream 8
+# Move the container to CentOS Stream 8. Do this as 1st step in the
+# container-image creation, so that the final container-image can use the
+# cached layer.
+RUN true \
+    && dnf -y swap --disablerepo='*' --repofrompath=c8-extras,http://mirror.centos.org/centos/8/extras/x86_64/os centos-linux-repos centos-stream-repos \
+    && dnf -y distro-sync \
+    && true
+
 LABEL stage="build"
 
 ARG CSI_IMAGE_NAME=quay.io/cephcsi/cephcsi
@@ -49,6 +58,13 @@ RUN make cephcsi
 
 #-- Final container
 FROM ${BASE_IMAGE}
+
+# FIXME: Ceph base containers should use CentOS Stream 8
+# Move the container to CentOS Stream 8
+RUN true \
+    && dnf -y swap --disablerepo='*' --repofrompath=c8-extras,http://mirror.centos.org/centos/8/extras/x86_64/os centos-linux-repos centos-stream-repos \
+    && dnf -y distro-sync \
+    && true
 
 ARG SRC_DIR
 

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -9,6 +9,13 @@ ENV GOPATH=/go \
  GO111MODULE=on \
  PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 
+# FIXME: Ceph base containers should use CentOS Stream 8
+# Move the container to CentOS Stream 8
+RUN true \
+    && dnf -y swap --disablerepo='*' --repofrompath=c8-extras,http://mirror.centos.org/centos/8/extras/x86_64/os centos-linux-repos centos-stream-repos \
+    && dnf -y distro-sync \
+    && true
+
 COPY build.env /
 
 RUN source /build.env \


### PR DESCRIPTION
Today the CentOS 8 repositories have been removed from the CentOS
mirroring network. CentOS 8 has been EOL since the beginning of the
year. Unfortunately Ceph has not moved its container-images to a
maintained version of CentOS, and installing dependencies now fails.

By migrating the CentOS 8 based container-images to CentOS Stream 8, it
is again possible to install the dependencies and tools for Ceph-CSI.

Updates: #2836

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
