### PR TITLE
ci: request CentOS Stream 8 bare-metal machines

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -71,7 +71,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"

--- a/commitlint.groovy
+++ b/commitlint.groovy
@@ -20,7 +20,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -71,7 +71,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -96,7 +96,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -98,7 +98,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -95,7 +95,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -95,7 +95,7 @@ node('cico-workspace') {
 			}
 			firstAttempt = false
 			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8 --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
 				returnStdout: true
 			).trim().tokenize(' ')
 			env.CICO_NODE = "${cico[0]}.ci.centos.org"


### PR DESCRIPTION
CentOS 8 is EOL since the beginning of the year. CentOS Stream 8
installations should be used instead.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
