### PR TITLE
e2e: use `pstree` instead of `ps` for checking rbd-nbd process

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1265,11 +1265,11 @@ var _ = Describe("RBD", func() {
 					var runningAttachCmd string
 					runningAttachCmd, stdErr, err = execCommandInContainer(
 						f,
-						"ps -eo 'cmd' | grep [r]bd-nbd",
+						"pstree --arguments | grep [r]bd-nbd",
 						cephCSINamespace,
 						"csi-rbdplugin",
 						&opt)
-					// if the rbd-nbd process is not running the ps | grep command
+					// if the rbd-nbd process is not running the 'grep' command
 					// will return with exit code 1
 					if err != nil {
 						if strings.Contains(err.Error(), "command terminated with exit code 1") {


### PR DESCRIPTION
The CentOS Stream 8 base container image does not have `ps` installed.
This causes CI jobs to fail, when checking for a restarted rbd-nbd
process.

Instead of using `ps`, the `pstree` command can be used. This will add
some ASCII-tree symbols in front of the command that is logged by the
e2e tests, but that is only used for manual reviewing and does not harm
the running test.

Fixes: #2850

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
