### PR TITLE
build: install psproc-ng package

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -57,6 +57,8 @@ LABEL maintainers="Ceph-CSI Authors" \
     architecture=${GO_ARCH} \
     description="Ceph-CSI Plugin"
 
+RUN dnf -y install procps-ng
+
 COPY --from=builder ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi
 
 # verify that all dynamically linked libraries are available


### PR DESCRIPTION
# Describe what this PR does #

We depend on `ps` command in our e2e currently and also for debugging purpose
it is really helpful to have `ps` command in our container.

Thanks Rakshith R \<rar@redhat.com\>  for discovering this bug.

Fixes: #2850
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
