### PR TITLE
ci: pass GOARCH when building images in OpenShift

### DIFF
--- a/jobs/build-images.yaml
+++ b/jobs/build-images.yaml
@@ -28,11 +28,14 @@
                   ceph-csi-canary"
           },
           test: {
-            sh 'oc start-build --follow ceph-csi-test'
+            sh 'oc start-build --follow \
+                  --build-arg=GOARCH=amd64 \
+                  ceph-csi-test'
           },
           devel: {
             sh "oc start-build --follow \
                   --build-arg=BASE_IMAGE='${base_image}' \
+                  --build-arg=GOARCH=amd64 \
                   ceph-csi-devel"
           }
         }


### PR DESCRIPTION
It seems that regular jobs in the OpenShift environment fail with the
following error:

    Missing GOARCH argument for building image, install Golang or run: make containerized-test GOARCH=amd64

This happens for both the `devel` and `test` image builds since December
13 when installing Golang in the container-images was added.

Fixes: 8a3fe53e "ci: install arch specific go in Dockerfile.devel"

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
