### PR TITLE
doc: remove deprecated alpha1 reference of snapshot objects

### DIFF
--- a/docs/snap-clone.md
+++ b/docs/snap-clone.md
@@ -84,14 +84,16 @@ volumesnapshot.snapshot.storage.k8s.io/cephfs-pvc-snapshot created
 $ kubectl get volumesnapshot
 NAME                  READYTOUSE   SOURCEPVC       SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
 cephfs-pvc-snapshot   true         csi-cephfs-pvc                          1Gi           csi-cephfsplugin-snapclass   snapcontent-34476204-a14a-4d59-bfbc-2bbba695652c   3s             6s
+
 ```
 
 - Get details about the volumesnapshotcontent
 
 ```console
 $ kubectl get volumesnapshotcontent
-NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                VOLUMESNAPSHOTCLASS          VOLUMESNAPSHOT        AGE
-snapcontent-34476204-a14a-4d59-bfbc-2bbba695652c   true         1073741824    Delete           cephfs.csi.ceph.com   csi-cephfsplugin-snapclass   cephfs-pvc-snapshot   64s
+NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                                  VOLUMESNAPSHOTCLASS                         VOLUMESNAPSHOT            VOLUMESNAPSHOTNAMESPACE   AGE
+snapcontent-881cb74a-9dff-4989-a83d-eece5ed079af   true         1073741824    Delete           cephfs.csi.ceph.com                     csi-cephfsplugin-snapclass                  cephfs-pvc-snapshot       default                   12m
+
 ```
 
 ### Restore CephFS Snapshot
@@ -145,8 +147,9 @@ kubectl create -f snapshotclass.yaml
 
 ```console
 $ kubectl get volumesnapshotclass
-NAME                      AGE
-csi-rbdplugin-snapclass   4s
+NAME                                        DRIVER                                  DELETIONPOLICY   AGE
+csi-rbdplugin-snapclass                     rbd.csi.ceph.com                        Delete           30m
+
 ```
 
 ### Create RBD Snapshot
@@ -159,41 +162,8 @@ kubectl create -f snapshot.yaml
 
 ```console
 $ kubectl get volumesnapshot
-NAME               AGE
-rbd-pvc-snapshot   6s
-```
-
-### Check the status of the Snapshot
-
-```console
-$ kubectl describe volumesnapshot rbd-pvc-snapshot
-
-Name:         rbd-pvc-snapshot
-Namespace:    default
-Labels:       <none>
-Annotations:  <none>
-API Version:  snapshot.storage.k8s.io/v1alpha1
-Kind:         VolumeSnapshot
-Metadata:
-  Creation Timestamp:  2019-02-06T08:52:34Z
-  Finalizers:
-    snapshot.storage.kubernetes.io/volumesnapshot-protection
-  Generation:        5
-  Resource Version:  84239
-  Self Link:         /apis/snapshot.storage.k8s.io/v1alpha1/namespaces/default/volumesnapshots/rbd-pvc-snapshot
-  UID:               8b9b5740-29ec-11e9-8e0f-b8ca3aad030b
-Spec:
-  Snapshot Class Name:    csi-rbdplugin-snapclass
-  Snapshot Content Name:  snapcontent-8b9b5740-29ec-11e9-8e0f-b8ca3aad030b
-  Source:
-    API Group:  <nil>
-    Kind:       PersistentVolumeClaim
-    Name:       rbd-pvc
-Status:
-  Creation Time:  2019-02-06T08:52:34Z
-  Ready To Use:   true
-  Restore Size:   1Gi
-Events:           <none>
+NAME               READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                            SNAPSHOTCONTENT                                    CREATIONTIME   AGE
+rbd-pvc-snapshot   true         rbd-pvc                             1Gi           csi-rbdplugin-snapclass                  snapcontent-905e6015-2403-4302-8a4e-cd3bdf63507b   78s            79s
 ```
 
 ### Restore RBD Snapshot


### PR DESCRIPTION
alpha1 version is deprecated and this commit correct the
example doc and make it GAd version

Additional note: we have already moved the artifacts to `v1` version.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

