### PR TITLE
ci: use CentOS Stream 8 for infra containers

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,9 +1,9 @@
-FROM quay.io/centos/centos:latest
+FROM quay.io/centos/centos:stream8
 
 RUN true \
- && yum -y install git make python3-pip \
+ && dnf -y install git make python3-pip \
  && pip3 install jenkins-job-builder \
- && yum -y clean all \
+ && dnf -y clean all \
  && true
 
 ENV MAKE_TARGET=${MAKE_TARGET:-test}

--- a/mirror/Containerfile
+++ b/mirror/Containerfile
@@ -1,8 +1,8 @@
-FROM quay.io/centos/centos:latest
+FROM quay.io/centos/centos:stream8
 
 RUN true \
- && yum -y install skopeo \
- && yum -y clean all \
+ && dnf -y install skopeo \
+ && dnf -y clean all \
  && true
 
 ADD images.txt /opt/mirror/


### PR DESCRIPTION
The container images for Jenkins Job Builder and mirroring images were
still using the EOL CentOS 8 base image. Rebuilding those
container-images fails as the CentOS mirrors do not provide the
repositories for installing package anymore.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
