### PR TITLE
build: disable removed Apache Arrow repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ ifeq ($(USE_PULLED_IMAGE),no)
 .devel-container-id: GOARCH ?= $(shell go env GOARCH 2>/dev/null)
 .devel-container-id: .container-cmd scripts/Dockerfile.devel
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
+	$(RM) .devel-container-id
 	$(CONTAINER_CMD) build $(CPUSET) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg GOARCH=$(GOARCH) -t $(CSI_IMAGE_NAME):devel -f ./scripts/Dockerfile.devel .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):devel > .devel-container-id
 else
@@ -216,6 +217,7 @@ ifeq ($(USE_PULLED_IMAGE),no)
 # create a (cached) container image with dependencies for testing cephcsi
 .test-container-id: .container-cmd build.env scripts/Dockerfile.test
 	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
+	$(RM) .test-container-id
 	$(CONTAINER_CMD) build $(CPUSET) --build-arg GOARCH=$(GOARCH) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 else

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -23,6 +23,11 @@ RUN source /build.env && \
 # test if the downloaded version of Golang works (different arch?)
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 
+# FIXME: Ceph does not need Apache Arrow anymore, some container images may
+# still have the repository enabled. Disabling the repository can be removed in
+# the future, see https://github.com/ceph/ceph-container/pull/1990 .
+RUN dnf config-manager --disable apache-arrow-centos || true
+
 RUN dnf -y install \
 	librados-devel librbd-devel \
 	/usr/bin/cc \

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -17,6 +17,11 @@ RUN source /build.env \
     && mkdir -p /usr/local/go \
     && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
+# FIXME: Ceph does not need Apache Arrow anymore, some container images may
+# still have the repository enabled. Disabling the repository can be removed in
+# the future, see https://github.com/ceph/ceph-container/pull/1990 .
+RUN dnf config-manager --disable apache-arrow-centos || true
+
 RUN dnf -y install \
 	git \
 	make \


### PR DESCRIPTION
The CentOS 8 repository for Apache Arrow has been removed. This causes
container-image builds fail with the following error:

    Errors during downloading metadata for repository 'apache-arrow-centos':
      - Status code: 404 for https://apache.jfrog.io/artifactory/arrow/centos/8/x86_64/repodata/repomd.xml (IP: 54.190.66.70)
    Error: Failed to download metadata for repo 'apache-arrow-centos': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried

The Ceph base image has `arrow/centos/8` configured, maybe Apache Arrow
offers a CentOS Stream 8 repository now? Once the Ceph container-image
has been updated, the repository can be enabled again.

Ceph-CSI does not depend on Apache Arrow, so there is no functional
change by disabling the repository.

See-also: ceph/ceph-container#1990

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
