### PR TITLE
util: use `vaultNamespace` if `vaultAuthNamespace` is not set

### DIFF
--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -192,6 +192,11 @@ func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 	if errors.Is(err, errConfigOptionInvalid) {
 		return err
 	}
+	// set the option if the value was not invalid
+	if firstInit || !errors.Is(err, errConfigOptionMissing) {
+		keyContext[loss.KeyVaultNamespace] = vaultNamespace
+	}
+
 	vaultAuthNamespace := ""
 	err = setConfigString(&vaultAuthNamespace, config, "vaultAuthNamespace")
 	if errors.Is(err, errConfigOptionInvalid) {
@@ -205,7 +210,6 @@ func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 	// set the option if the value was not invalid
 	if firstInit || !errors.Is(err, errConfigOptionMissing) {
 		vaultConfig[api.EnvVaultNamespace] = vaultAuthNamespace
-		keyContext[loss.KeyVaultNamespace] = vaultNamespace
 	}
 
 	verifyCA := strconv.FormatBool(vaultDefaultCAVerify) // optional


### PR DESCRIPTION
When a tenant configures `vaultNamespace` in their own ConfigMap, it is
not applied to the Vault configuration, unless `vaultAuthNamespace` is
set as well. This is unexpected, as the `vaultAuthNamespace` usually is
something configured globally, and not per tenant.

The `vaultAuthNamespace` is an advanced option, that is often not needed
to be configured. Only when tenants have to configure their own
`vaultNamespace`, it is possible that they need to use a different
`vaultAuthNamespace`. The default for the `vaultAuthNamespace` is now
the `vaultNamespace` value from the global configuration. Tenants can
still set it to something else in their own ConfigMap if needed.

Note that Hashicorp Vault Namespaces are only functional in the
Enterprise version of the product. Therefor this can not be tested in
the Ceph-CSI e2e with the Open Source version of Vault.

Fixes: https://bugzilla.redhat.com/2050056

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
