### PR TITLE
helm: remove namespace from storageclass yaml

### DIFF
--- a/charts/ceph-csi-cephfs/templates/storageclass.yaml
+++ b/charts/ceph-csi-cephfs/templates/storageclass.yaml
@@ -3,7 +3,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.storageClass.name }}
-  namespace: {{ .Release.Namespace }}
 {{- if .Values.storageClass.annotations }}
   annotations:
 {{ toYaml .Values.storageClass.annotations | indent 4 }}

--- a/charts/ceph-csi-rbd/templates/storageclass.yaml
+++ b/charts/ceph-csi-rbd/templates/storageclass.yaml
@@ -3,7 +3,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.storageClass.name }}
-  namespace: {{ .Release.Namespace }}
 {{- if .Values.storageClass.annotations }}
   annotations:
 {{ toYaml .Values.storageClass.annotations | indent 4 }}


### PR DESCRIPTION
removes namespace from non-namespaced storageclass object.

fixes: #2714

Replacement for #2715 as we didn't receive any update and PR is already closed.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
