### PR TITLE
rbd: log stderror when running modprobe

### DIFF
--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -199,14 +199,15 @@ func waitForPath(ctx context.Context, pool, namespace, image string, maxRetries 
 
 // set features available with rbd-nbd, and NBD module loaded status.
 func setRbdNbdToolFeatures() {
+	var stderr string
 	// check if the module is loaded or compiled in
 	_, err := os.Stat(fmt.Sprintf("/sys/module/%s", moduleNbd))
 	if os.IsNotExist(err) {
 		// try to load the module
-		_, _, err = util.ExecCommand(context.TODO(), "modprobe", moduleNbd)
+		_, stderr, err = util.ExecCommand(context.TODO(), "modprobe", moduleNbd)
 		if err != nil {
 			hasNBD = false
-			log.WarningLogMsg("rbd-nbd: nbd modprobe failed with error %v", err)
+			log.WarningLogMsg("rbd-nbd: nbd modprobe failed (%v): %q", err, stderr)
 		}
 	}
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -214,6 +214,7 @@ var supportedFeatures = map[string]imageFeature{
 // GetKrbdSupportedFeatures load the module if needed and return supported
 // features attribute as a string.
 func GetKrbdSupportedFeatures() (string, error) {
+	var stderr string
 	// check if the module is loaded or compiled in
 	_, err := os.Stat(krbdSupportedFeaturesFile)
 	if err != nil {
@@ -223,9 +224,9 @@ func GetKrbdSupportedFeatures() (string, error) {
 			return "", err
 		}
 		// try to load the module
-		_, _, err = util.ExecCommand(context.TODO(), "modprobe", rbdDefaultMounter)
+		_, stderr, err = util.ExecCommand(context.TODO(), "modprobe", rbdDefaultMounter)
 		if err != nil {
-			log.ErrorLogMsg("modprobe failed: %v", err)
+			log.ErrorLogMsg("modprobe failed (%v): %q", err, stderr)
 
 			return "", err
 		}


### PR DESCRIPTION
logging the error is not user-friendly and it contains the system error message. Log the stderr which is the user-friendly error message for identifying the problem.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
