### PR TITLE
e2e: add retry for regular CephFS testing failures

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -51,21 +51,12 @@ var (
 func deployCephfsPlugin() {
 	// delete objects deployed by rook
 
-	data, err := replaceNamespaceInTemplate(cephFSDirPath + cephFSProvisionerRBAC)
-	if err != nil {
-		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSProvisionerRBAC, err)
-	}
-	_, err = framework.RunKubectlInput(cephCSINamespace, data, "--ignore-not-found=true", ns, "delete", "-f", "-")
+	err := deleteResource(cephFSDirPath + cephFSProvisionerRBAC)
 	if err != nil {
 		e2elog.Failf("failed to delete provisioner rbac %s: %v", cephFSDirPath+cephFSProvisionerRBAC, err)
 	}
 
-	data, err = replaceNamespaceInTemplate(cephFSDirPath + cephFSNodePluginRBAC)
-	if err != nil {
-		e2elog.Failf("failed to read content from %s: %v", cephFSDirPath+cephFSNodePluginRBAC, err)
-	}
-	_, err = framework.RunKubectlInput(cephCSINamespace, data, "delete", "--ignore-not-found=true", ns, "-f", "-")
-
+	err = deleteResource(cephFSDirPath + cephFSNodePluginRBAC)
 	if err != nil {
 		e2elog.Failf("failed to delete nodeplugin rbac %s: %v", cephFSDirPath+cephFSNodePluginRBAC, err)
 	}

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -105,6 +105,7 @@ func createCephfsStorageClass(
 	sc.Namespace = cephCSINamespace
 
 	timeout := time.Duration(deployTimeout) * time.Minute
+
 	return wait.PollImmediate(poll, timeout, func() (bool, error) {
 		_, err = c.StorageV1().StorageClasses().Create(context.TODO(), &sc, metav1.CreateOptions{})
 		if err != nil {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -72,5 +72,4 @@ func handleFlags() {
 	framework.RegisterClusterFlags(flag.CommandLine)
 	testing.Init()
 	flag.Parse()
-	initResources()
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -77,13 +77,8 @@ var (
 	cephCSINamespace string
 	rookNamespace    string
 	radosNamespace   string
-	ns               string
 	poll             = 2 * time.Second
 )
-
-func initResources() {
-	ns = fmt.Sprintf("--namespace=%v", cephCSINamespace)
-}
 
 func getMons(ns string, c kubernetes.Interface) ([]string, error) {
 	opt := metav1.ListOptions{

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -146,7 +146,7 @@ func deleteResource(scPath string) error {
 	if err != nil {
 		e2elog.Logf("failed to read content from %s %v", scPath, err)
 	}
-	err = retryKubectlInput(cephCSINamespace, kubectlDelete, data, deployTimeout)
+	err = retryKubectlInput(cephCSINamespace, kubectlDelete, data, deployTimeout, "--ignore-not-found=true")
 	if err != nil {
 		e2elog.Logf("failed to delete %s %v", scPath, err)
 	}


### PR DESCRIPTION
On occasion deploying CephFS components fail due to errors like these:

    Feb 14 12:44:43.192: FAIL: failed to delete provisioner rbac ../deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml: error running /usr/bin/kubectl --server=https://192.168.39.26:8443 --kubeconfig=/root/.kube/config --namespace=cephcsi-e2e-271835d0 --ignore-not-found=true --namespace=cephcsi-e2e-271835d0 delete -f -:
    Command stdout:

    stderr:
    warning: deleting cluster-scoped resources, not scoped to the provided namespace
    Error from server: error when deleting "STDIN": etcdserver: request timed out
    Error from server: error when deleting "STDIN": etcdserver: request timed out
    Error from server: error when deleting "STDIN": etcdserver: request timed out

    error:
    exit status 1

By using the deleteResource() helper, an retry is done in case of a
failure.

There have been errors while CephFS tests were running, like:

    Feb  9 12:58:53.130: FAIL: failed to create storageclass: etcdserver: request timed out

When retrying to create the StorageClass, the e2e tests are expected to
continue and (hopefully) succeed.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
