### PR TITLE
helm-charts: Add selinuxMount flag to enable/disable /etc/selinux host mount

### DIFF
--- a/charts/ceph-csi-cephfs/README.md
+++ b/charts/ceph-csi-cephfs/README.md
@@ -156,6 +156,7 @@ charts and their default values.
 | `secret.name`                                  | Specifies the cephFS secret name                                                                                                                     | `csi-cephfs-secret`                                |
 | `secret.adminID`                               | Specifies the admin ID of the cephFS secret                                                                                                          | `<plaintext ID>`                                   |
 | `secret.adminKey`                              | Specifies the key that corresponds to the adminID                                                                                                    | `<Ceph auth key corresponding to ID above>`        |
+| `selinuxMount`                                | Mount the host /etc/selinux inside pods to support selinux-enabled filesystems                                                                                                      | `true`                                            |
 
 ### Command Line
 

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -112,9 +112,11 @@ spec:
               name: host-mount
             - mountPath: /sys
               name: host-sys
+{{- if .Values.selinuxMount }}
             - mountPath: /etc/selinux
               name: etc-selinux
               readOnly: true
+{{- end }}
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
@@ -176,9 +178,11 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+{{- if .Values.selinuxMount }}
         - name: etc-selinux
           hostPath:
             path: /etc/selinux
+{{- end }}
         - name: host-mount
           hostPath:
             path: /run/mount

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
@@ -40,8 +40,10 @@ spec:
       readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
+{{- if .Values.selinuxMount }}
     - pathPrefix: '/etc/selinux'
       readOnly: true
+{{- end }}
     - pathPrefix: '/lib/modules'
       readOnly: true
     - pathPrefix: '{{ .Values.kubeletDir }}'

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -201,6 +201,10 @@ provisioner:
   podSecurityPolicy:
     enabled: false
 
+# Mount the host /etc/selinux inside pods to support
+# selinux-enabled filesystems
+selinuxMount: true
+
 topology:
   # Specifies whether topology based provisioning support should
   # be exposed by CSI

--- a/charts/ceph-csi-rbd/README.md
+++ b/charts/ceph-csi-rbd/README.md
@@ -175,6 +175,7 @@ charts and their default values.
 | `secret.userID`                                | Specifies the user ID of the rbd secret                                                                                                              | `<plaintext ID>`                                   |
 | `secret.userKey`                               | Specifies the key that corresponds to the userID                                                                                                     | `<Ceph auth key corresponding to ID above>`        |
 | `secret.encryptionPassphrase`                  | Specifies the encryption passphrase of the secret                                                                                                    | `test_passphrase`                                  |
+| `selinuxMount`                                | Mount the host /etc/selinux inside pods to support selinux-enabled filesystems                                                                                                      | `true`                                            |
 
 ### Command Line
 

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -109,9 +109,11 @@ spec:
               name: host-mount
             - mountPath: /sys
               name: host-sys
+{{- if .Values.selinuxMount }}
             - mountPath: /etc/selinux
               name: etc-selinux
               readOnly: true
+{{- end }}
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
@@ -193,9 +195,11 @@ spec:
         - name: host-sys
           hostPath:
             path: /sys
+{{- if .Values.selinuxMount }}
         - name: etc-selinux
           hostPath:
             path: /etc/selinux
+{{- end }}
         - name: lib-modules
           hostPath:
             path: /lib/modules

--- a/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
@@ -40,8 +40,10 @@ spec:
       readOnly: false
     - pathPrefix: '/sys'
       readOnly: false
+{{- if .Values.selinuxMount }}
     - pathPrefix: '/etc/selinux'
       readOnly: true
+{{- end }}
     - pathPrefix: '/lib/modules'
       readOnly: true
     - pathPrefix: '{{ .Values.cephLogDirHostPath }}'

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -399,6 +399,10 @@ storageClass:
   # mountOptions:
   #   - discard
 
+# Mount the host /etc/selinux inside pods to support
+# selinux-enabled filesystems
+selinuxMount: true
+
 secret:
   # Specifies whether the secret should be created
   create: false


### PR DESCRIPTION
# Describe what this PR does #

Add selinuxMount flag to enable/disable /etc/selinux host mount inside pods to support selinux-enabled filesystems

Is the change backward compatible?

Yes, selinuxMount default is true (the previous behaviour)

Are there concerns around backward compatibility?

None I'm aware of

## Related issues ##

Fixes: #2876

