### PR TITLE
e2e: consider not found error in deployment check

### DIFF
--- a/e2e/deployment.go
+++ b/e2e/deployment.go
@@ -140,6 +140,9 @@ func waitForDeploymentComplete(clientSet kubernetes.Interface, name, ns string, 
 			if isRetryableAPIError(err) {
 				return false, nil
 			}
+			if apierrs.IsNotFound(err) {
+				return false, nil
+			}
 			e2elog.Logf("deployment error: %v", err)
 
 			return false, err


### PR DESCRIPTION
it might need some time for the deployment to get created, consider the NotFound as a valid error, and retry again.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
