### PR TITLE
rbd: update volume/snapshot-volume details on the image as metadata

### DIFF
--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -102,6 +102,7 @@ spec:
             - "--v={{ .Values.logLevel }}"
             - "--timeout={{ .Values.provisioner.timeout }}"
             - "--leader-election=true"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -73,6 +73,7 @@ spec:
             - "--v=5"
             - "--timeout=150s"
             - "--leader-election=true"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/ginkgo" // nolint
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -89,6 +90,12 @@ var (
 
 	nbdMapOptions             = "nbd:debug-rbd=20"
 	e2eDefaultCephLogStrategy = "preserve"
+
+	// PV and PVC metadata keys used by external provisioner as part of
+	// create requests as parameters, when `extra-create-metadata` is true.
+	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
+	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
+	pvNameKey       = "csi.storage.k8s.io/pv/name"
 )
 
 func deployRBDPlugin() {
@@ -394,6 +401,187 @@ var _ = Describe("RBD", func() {
 					}
 				})
 			}
+
+			By("create a PVC and check PVC/PV metadata on RBD image", func() {
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					e2elog.Failf("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create PVC: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				imageList, err := listRBDImages(f, defaultRBDPool)
+				if err != nil {
+					e2elog.Failf("failed to list rbd images: %v", err)
+				}
+
+				pvcName, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s/%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get PVC name %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey, err, stdErr)
+				}
+				pvcName = strings.TrimSuffix(pvcName, "\n")
+				if pvcName != pvc.Name {
+					e2elog.Failf("expected pvcName %q got %q", pvc.Name, pvcName)
+				}
+
+				pvcNamespace, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s/%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNamespaceKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get PVC namespace %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNamespaceKey, err, stdErr)
+				}
+				pvcNamespace = strings.TrimSuffix(pvcNamespace, "\n")
+				if pvcNamespace != pvc.Namespace {
+					e2elog.Failf("expected pvcNamespace %q got %q", pvc.Namespace, pvcNamespace)
+				}
+
+				pvcObj, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(
+					context.TODO(),
+					pvc.Name,
+					metav1.GetOptions{})
+				if err != nil {
+					e2elog.Logf("error getting pvc %q in namespace %q: %v", pvc.Name, pvc.Namespace, err)
+				}
+				if pvcObj.Spec.VolumeName == "" {
+					e2elog.Logf("pv name is empty %q in namespace %q: %v", pvc.Name, pvc.Namespace, err)
+				}
+				pvName, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s/%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], pvNameKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get PV name %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], pvNameKey, err, stdErr)
+				}
+				pvName = strings.TrimSuffix(pvName, "\n")
+				if pvName != pvcObj.Spec.VolumeName {
+					e2elog.Failf("expected pvName %q got %q", pvcObj.Spec.VolumeName, pvName)
+				}
+
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete pvc: %v", err)
+				}
+				validateRBDImageCount(f, 0, defaultRBDPool)
+			})
+
+			By("reattach the old PV to a new PVC and check if PVC metadata is updated on RBD image", func() {
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					e2elog.Failf("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create PVC: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				imageList, err := listRBDImages(f, defaultRBDPool)
+				if err != nil {
+					e2elog.Failf("failed to list rbd images: %v", err)
+				}
+
+				pvcName, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s/%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get PVC name %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey, err, stdErr)
+				}
+				pvcName = strings.TrimSuffix(pvcName, "\n")
+				if pvcName != pvc.Name {
+					e2elog.Failf("expected pvcName %q got %q", pvc.Name, pvcName)
+				}
+
+				pvcObj, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(
+					context.TODO(),
+					pvc.Name,
+					metav1.GetOptions{})
+				if err != nil {
+					e2elog.Logf("error getting pvc %q in namespace %q: %v", pvc.Name, pvc.Namespace, err)
+				}
+				if pvcObj.Spec.VolumeName == "" {
+					e2elog.Logf("pv name is empty %q in namespace %q: %v", pvc.Name, pvc.Namespace, err)
+				}
+
+				patchBytes := []byte(`{"spec":{"persistentVolumeReclaimPolicy": "Retain", "claimRef": null}}`)
+				_, err = c.CoreV1().PersistentVolumes().Patch(
+					context.TODO(),
+					pvcObj.Spec.VolumeName,
+					types.StrategicMergePatchType,
+					patchBytes,
+					metav1.PatchOptions{})
+				if err != nil {
+					e2elog.Logf("error Patching PV %q for persistentVolumeReclaimPolicy and claimRef: %v",
+						pvcObj.Spec.VolumeName, err)
+				}
+
+				err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(
+					context.TODO(),
+					pvc.Name,
+					metav1.DeleteOptions{})
+				if err != nil {
+					e2elog.Logf("failed to delete pvc: %w", err)
+				}
+
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				pvc.Name = "rbd-pvc-new"
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create new PVC: %v", err)
+				}
+
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				pvcName, stdErr, err = execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s/%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get PVC name %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey, err, stdErr)
+				}
+				pvcName = strings.TrimSuffix(pvcName, "\n")
+				if pvcName != pvc.Name {
+					e2elog.Failf("expected pvcName %q got %q", pvc.Name, pvcName)
+				}
+
+				patchBytes = []byte(`{"spec":{"persistentVolumeReclaimPolicy": "Delete"}}`)
+				_, err = c.CoreV1().PersistentVolumes().Patch(
+					context.TODO(),
+					pvcObj.Spec.VolumeName,
+					types.StrategicMergePatchType,
+					patchBytes,
+					metav1.PatchOptions{})
+				if err != nil {
+					e2elog.Logf("error Patching PV %q for persistentVolumeReclaimPolicy: %v", pvcObj.Spec.VolumeName, err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete pvc: %v", err)
+				}
+				validateRBDImageCount(f, 0, defaultRBDPool)
+			})
+
 			By("verify generic ephemeral volume support", func() {
 				// generic ephemeral volume support is supported from 1.21
 				if k8sVersionGreaterEquals(f.ClientSet, 1, 21) {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -96,6 +96,11 @@ var (
 	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
+
+	// snapshot metadata keys.
+	volSnapNameKey        = "csi.storage.k8s.io/volumesnapshot/name"
+	volSnapNamespaceKey   = "csi.storage.k8s.io/volumesnapshot/namespace"
+	volSnapContentNameKey = "csi.storage.k8s.io/volumesnapshotcontent/name"
 )
 
 func deployRBDPlugin() {
@@ -422,7 +427,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				pvcName, stdErr, err := execCommandInToolBoxPod(f,
-					fmt.Sprintf("rbd image-meta get %s/%s %s",
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
 						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey),
 					rookNamespace)
 				if err != nil || stdErr != "" {
@@ -435,7 +440,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				pvcNamespace, stdErr, err := execCommandInToolBoxPod(f,
-					fmt.Sprintf("rbd image-meta get %s/%s %s",
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
 						rbdOptions(defaultRBDPool), imageList[0], pvcNamespaceKey),
 					rookNamespace)
 				if err != nil || stdErr != "" {
@@ -458,7 +463,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Logf("pv name is empty %q in namespace %q: %v", pvc.Name, pvc.Namespace, err)
 				}
 				pvName, stdErr, err := execCommandInToolBoxPod(f,
-					fmt.Sprintf("rbd image-meta get %s/%s %s",
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
 						rbdOptions(defaultRBDPool), imageList[0], pvNameKey),
 					rookNamespace)
 				if err != nil || stdErr != "" {
@@ -497,7 +502,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				pvcName, stdErr, err := execCommandInToolBoxPod(f,
-					fmt.Sprintf("rbd image-meta get %s/%s %s",
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
 						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey),
 					rookNamespace)
 				if err != nil || stdErr != "" {
@@ -543,8 +548,10 @@ var _ = Describe("RBD", func() {
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
 
-				pvc.Name = "rbd-pvc-new"
-				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				pvcObj.Name = "rbd-pvc-new"
+				// unset the resource version as should not be set on objects to be created
+				pvcObj.ResourceVersion = ""
+				err = createPVCAndvalidatePV(f.ClientSet, pvcObj, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create new PVC: %v", err)
 				}
@@ -553,7 +560,7 @@ var _ = Describe("RBD", func() {
 				validateRBDImageCount(f, 1, defaultRBDPool)
 
 				pvcName, stdErr, err = execCommandInToolBoxPod(f,
-					fmt.Sprintf("rbd image-meta get %s/%s %s",
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
 						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey),
 					rookNamespace)
 				if err != nil || stdErr != "" {
@@ -561,8 +568,8 @@ var _ = Describe("RBD", func() {
 						rbdOptions(defaultRBDPool), imageList[0], pvcNameKey, err, stdErr)
 				}
 				pvcName = strings.TrimSuffix(pvcName, "\n")
-				if pvcName != pvc.Name {
-					e2elog.Failf("expected pvcName %q got %q", pvc.Name, pvcName)
+				if pvcName != pvcObj.Name {
+					e2elog.Failf("expected pvcName %q got %q", pvcObj.Name, pvcName)
 				}
 
 				patchBytes = []byte(`{"spec":{"persistentVolumeReclaimPolicy": "Delete"}}`)
@@ -574,6 +581,103 @@ var _ = Describe("RBD", func() {
 					metav1.PatchOptions{})
 				if err != nil {
 					e2elog.Logf("error Patching PV %q for persistentVolumeReclaimPolicy: %v", pvcObj.Spec.VolumeName, err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvcObj, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete pvc: %v", err)
+				}
+				validateRBDImageCount(f, 0, defaultRBDPool)
+			})
+
+			By("create a snapshot and check metadata on RBD snapshot image", func() {
+				err := createRBDSnapshotClass(f)
+				if err != nil {
+					e2elog.Failf("failed to create storageclass: %v", err)
+				}
+				defer func() {
+					err = deleteRBDSnapshotClass()
+					if err != nil {
+						e2elog.Failf("failed to delete VolumeSnapshotClass: %v", err)
+					}
+				}()
+
+				pvc, app, err := createPVCAndAppBinding(pvcPath, appPath, f, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create pvc and application binding: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+				// delete pod as we should not create snapshot for in-use pvc
+				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete application: %v", err)
+				}
+
+				snap := getSnapshot(snapshotPath)
+				snap.Namespace = f.UniqueName
+				snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+
+				err = createSnapshot(&snap, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create snapshot: %v", err)
+				}
+				// validate created backend rbd images
+				// parent PVC + snapshot
+				totalImages := 2
+				validateRBDImageCount(f, totalImages, defaultRBDPool)
+
+				imageList, err := listRBDImages(f, defaultRBDPool)
+				if err != nil {
+					e2elog.Failf("failed to list rbd images: %v", err)
+				}
+
+				volSnapName, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], volSnapNameKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get volume snapshot name %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], volSnapNameKey, err, stdErr)
+				}
+				volSnapName = strings.TrimSuffix(volSnapName, "\n")
+				if volSnapName != snap.Name {
+					e2elog.Failf("expected volSnapName %q got %q", snap.Name, volSnapName)
+				}
+
+				volSnapNamespace, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], volSnapNamespaceKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get volume snapshot namespace %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], volSnapNamespaceKey, err, stdErr)
+				}
+				volSnapNamespace = strings.TrimSuffix(volSnapNamespace, "\n")
+				if volSnapNamespace != snap.Namespace {
+					e2elog.Failf("expected volSnapNamespace %q got %q", snap.Namespace, volSnapNamespace)
+				}
+
+				content, err := getVolumeSnapshotContent(snap.Namespace, snap.Name)
+				if err != nil {
+					e2elog.Failf("failed to get snapshotcontent for %s in namespace %s: %v",
+						snap.Name, snap.Namespace, err)
+				}
+				volSnapContentName, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rbd image-meta get %s --image=%s %s",
+						rbdOptions(defaultRBDPool), imageList[0], volSnapContentNameKey),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					e2elog.Failf("failed to get snapshotcontent name %s/%s %s: err=%v stdErr=%q",
+						rbdOptions(defaultRBDPool), imageList[0], volSnapContentNameKey, err, stdErr)
+				}
+				volSnapContentName = strings.TrimSuffix(volSnapContentName, "\n")
+				if volSnapContentName != content.Name {
+					e2elog.Failf("expected volSnapContentName %q got %q", content.Name, volSnapContentName)
+				}
+
+				err = deleteSnapshot(&snap, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete snapshot: %v", err)
 				}
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -177,7 +177,13 @@ func (r ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime.
 	}
 	defer cr.DeleteCredentials()
 
-	rbdVolID, err := rbd.RegenerateJournal(pv.Spec.CSI.VolumeAttributes, volumeHandler, requestName, pvcNamespace, cr)
+	rbdVolID, err := rbd.RegenerateJournal(
+		pv.Spec.CSI.VolumeAttributes,
+		pv.Spec.ClaimRef.Name,
+		volumeHandler,
+		requestName,
+		pvcNamespace,
+		cr)
 	if err != nil {
 		log.ErrorLogMsg("failed to regenerate journal %s", err)
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -329,6 +329,12 @@ func (cs *ControllerServer) CreateVolume(
 		return nil, err
 	}
 
+	// Set Metadata on PV Create
+	err = rbdVol.setVolumeMetadata(req.GetParameters())
+	if err != nil {
+		return nil, err
+	}
+
 	return buildCreateVolumeResponse(req, rbdVol), nil
 }
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -452,6 +452,12 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 		}
 	}
 
+	// Set metadata on restart of provisioner pod when image exist
+	err := rbdVol.setVolumeMetadata(req.GetParameters())
+	if err != nil {
+		return nil, err
+	}
+
 	return buildCreateVolumeResponse(req, rbdVol), nil
 }
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1933,3 +1933,16 @@ func (rv *rbdVolume) setVolumeMetadata(parameters map[string]string) error {
 
 	return nil
 }
+
+// setSnapshotMetadata Set snapshot-name/snapshot-namespace/snapshotcontent-name metadata
+// on RBD image.
+func (rv *rbdVolume) setSnapshotMetadata(parameters map[string]string) error {
+	for k, v := range k8s.GetSnapshotMetadata(parameters) {
+		err := rv.SetMetadata(k, v)
+		if err != nil {
+			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w", k, v, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/ceph/go-ceph/rados"
@@ -1919,4 +1920,16 @@ func genVolFromVolIDWithMigration(
 	}
 
 	return rv, err
+}
+
+// setVolumeMetadata set PV/PVC/PVCNamespace metadata on RBD image.
+func (rv *rbdVolume) setVolumeMetadata(parameters map[string]string) error {
+	for k, v := range k8s.GetVolumeMetadata(parameters) {
+		err := rv.SetMetadata(k, v)
+		if err != nil {
+			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w", k, v, err)
+		}
+	}
+
+	return nil
 }

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -29,6 +29,11 @@ const (
 	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
+
+	// snapshot metadata keys.
+	volSnapNameKey        = "csi.storage.k8s.io/volumesnapshot/name"
+	volSnapNamespaceKey   = "csi.storage.k8s.io/volumesnapshot/namespace"
+	volSnapContentNameKey = "csi.storage.k8s.io/volumesnapshotcontent/name"
 )
 
 // RemoveCSIPrefixedParameters removes parameters prefixed with csiParameterPrefix.
@@ -75,6 +80,22 @@ func PrepareVolumeMetadata(pvcName, pvcNamespace, pvName string) map[string]stri
 	}
 	if pvName != "" {
 		newParam[pvNameKey] = pvName
+	}
+
+	return newParam
+}
+
+// GetSnapshotMetadata filter parameters, only return
+// snapshot-name/snapshot-namespace/snapshotcontent-name metadata.
+func GetSnapshotMetadata(parameters map[string]string) map[string]string {
+	keys := []string{volSnapNameKey, volSnapNamespaceKey, volSnapContentNameKey}
+	newParam := map[string]string{}
+	for k, v := range parameters {
+		for _, key := range keys {
+			if strings.Contains(k, key) {
+				newParam[k] = v
+			}
+		}
 	}
 
 	return newParam

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -23,7 +23,12 @@ import (
 // to the driver on CreateVolumeRequest/CreateSnapshotRequest calls.
 const (
 	csiParameterPrefix = "csi.storage.k8s.io/"
-	pvcNamespaceKey    = "csi.storage.k8s.io/pvc/namespace"
+
+	// PV and PVC metadata keys used by external provisioner as part of
+	// create requests as parameters, when `extra-create-metadata` is true.
+	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
+	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
+	pvNameKey       = "csi.storage.k8s.io/pv/name"
 )
 
 // RemoveCSIPrefixedParameters removes parameters prefixed with csiParameterPrefix.
@@ -42,4 +47,19 @@ func RemoveCSIPrefixedParameters(param map[string]string) map[string]string {
 // GetOwner returns the pvc namespace name from the parameter.
 func GetOwner(param map[string]string) string {
 	return param[pvcNamespaceKey]
+}
+
+// GetVolumeMetadata filter parameters, only return PV/PVC/PVCNamespace metadata.
+func GetVolumeMetadata(parameters map[string]string) map[string]string {
+	keys := []string{pvcNameKey, pvcNamespaceKey, pvNameKey}
+	newParam := map[string]string{}
+	for k, v := range parameters {
+		for _, key := range keys {
+			if strings.Contains(k, key) {
+				newParam[k] = v
+			}
+		}
+	}
+
+	return newParam
 }

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -63,3 +63,19 @@ func GetVolumeMetadata(parameters map[string]string) map[string]string {
 
 	return newParam
 }
+
+// PrepareVolumeMetadata return PV/PVC/PVCNamespace metadata based on inputs.
+func PrepareVolumeMetadata(pvcName, pvcNamespace, pvName string) map[string]string {
+	newParam := map[string]string{}
+	if pvcName != "" {
+		newParam[pvcNameKey] = pvcName
+	}
+	if pvcNamespace != "" {
+		newParam[pvcNamespaceKey] = pvcNamespace
+	}
+	if pvName != "" {
+		newParam[pvNameKey] = pvName
+	}
+
+	return newParam
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

 This helps Monitoring solutions without access to Kubernetes clusters to display the details of the PV/PVC/PVCNameSpace and snapshot-name/snapshot-namespace/snapshotcontent-name in their dashboard.

## Is there anything that requires special attention ##

Scenarios covered:
* Validate metadata is present after Create of a PV
* Validate metadata is set after Provisioner pod is restarted
* Validate metadata is updated after a PVC is deleted and PV is reattached to a new PVC
* Validate metadata is updated after a PVC is deleted and PV is reattached to a new PVC on a different namespace
* Validate metadata is set on snapshot create


## Related issues ##
Fixes: #2874

## Other details ##
Currently, this PR uses K8s CO specific keywords
```
// PV metadata keys
pvcNameKey      = "csi.storage.k8s.io/pvc/name"
pcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
pvNameKey       = "csi.storage.k8s.io/pv/name"

// snapshot metadata keys                                              
volSnapNameKey        = "csi.storage.k8s.io/volumesnapshot/name"       
volSnapNamespaceKey   = "csi.storage.k8s.io/volumesnapshot/namespace"  
volSnapContentNameKey = "csi.storage.k8s.io/volumesnapshotcontent/name"

```
we might want to use generalized naming for keywords, let's discuss it on this PR.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
