### PR TITLE
e2e: loadAppDeployment now sets ImagePullPolicy to PullIfNotPresent

### DIFF
--- a/e2e/deployment.go
+++ b/e2e/deployment.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -60,6 +61,10 @@ func loadAppDeployment(path string) (*appsv1.Deployment, error) {
 	deploy := appsv1.Deployment{}
 	if err := unmarshal(path, &deploy); err != nil {
 		return nil, err
+	}
+
+	for i := range deploy.Spec.Template.Spec.Containers {
+		deploy.Spec.Template.Spec.Containers[i].ImagePullPolicy = v1.PullIfNotPresent
 	}
 
 	return &deploy, nil


### PR DESCRIPTION
# Describe what this PR does #

This PR sets `imagePullPolicy` for deployment containers in e2e's `loadAppDeployment()` to `PullIfNotPresent`.

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #2889

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
