### PR TITLE
helm: fix kube version semver check for CSI cephfs resizer component.

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
@@ -48,12 +48,10 @@ rules:
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
 {{- end -}}
-{{- if semverCompare ">=1.15" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.provisioner.resizer.enabled }}
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["update", "patch"]
-{{- end -}}
 {{- end -}}
 {{- if .Values.topology.enabled }}
   - apiGroups: [""]

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -107,7 +107,6 @@ spec:
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}
 {{- end }}
-{{- if semverCompare ">=1.15" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.provisioner.resizer.enabled }}
         - name: csi-resizer
           image: "{{ .Values.provisioner.resizer.image.repository }}:{{ .Values.provisioner.resizer.image.tag }}"
@@ -127,7 +126,6 @@ spec:
               mountPath: /csi
           resources:
 {{ toYaml .Values.provisioner.resizer.resources | indent 12 }}
-{{- end }}
 {{- end }}
         - name: csi-cephfsplugin
           image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"


### PR DESCRIPTION
# Describe what this PR does #

This fix allows for the deployment of the CephFS resizer component when
using the helm chart on non vanilla kubernetes clusters whose API server
version are in the form of `1.x.y-abc+def-ghi`.

Following the same principle as #2039.

## Related issues ##

Fixes: #2905 
