### PR TITLE
csi-common: remove unimplemented controller expand,snapshot RPCs

### DIFF
--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -45,13 +45,6 @@ func (cs *DefaultControllerServer) ControllerUnpublishVolume(
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ControllerExpandVolume expand volume.
-func (cs *DefaultControllerServer) ControllerExpandVolume(
-	ctx context.Context,
-	req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
-}
-
 // ListVolumes lists volumes.
 func (cs *DefaultControllerServer) ListVolumes(
 	ctx context.Context,
@@ -79,20 +72,6 @@ func (cs *DefaultControllerServer) ControllerGetCapabilities(
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: cs.Driver.capabilities,
 	}, nil
-}
-
-// CreateSnapshot creates snapshot.
-func (cs *DefaultControllerServer) CreateSnapshot(
-	ctx context.Context,
-	req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
-}
-
-// DeleteSnapshot deletes snapshot.
-func (cs *DefaultControllerServer) DeleteSnapshot(
-	ctx context.Context,
-	req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ListSnapshots lists snapshots.

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -32,20 +32,6 @@ type DefaultNodeServer struct {
 	Type   string
 }
 
-// NodeStageVolume returns unimplemented response.
-func (ns *DefaultNodeServer) NodeStageVolume(
-	ctx context.Context,
-	req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
-}
-
-// NodeUnstageVolume returns unimplemented response.
-func (ns *DefaultNodeServer) NodeUnstageVolume(
-	ctx context.Context,
-	req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
-}
-
 // NodeExpandVolume returns unimplemented response.
 func (ns *DefaultNodeServer) NodeExpandVolume(
 	ctx context.Context,
@@ -86,13 +72,6 @@ func (ns *DefaultNodeServer) NodeGetCapabilities(
 			},
 		},
 	}, nil
-}
-
-// NodeGetVolumeStats returns volume stats.
-func (ns *DefaultNodeServer) NodeGetVolumeStats(
-	ctx context.Context,
-	req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ConstructMountOptions returns only unique mount options in slice.


### PR DESCRIPTION
These RPCs ( controller expand, create and delete snapshots) are
no longer unimplemented and we dont have to declare these as with
`unimplemented` states. This commit remove the same.

This PR also remove the implmented Node server RPCs like Stage/Unstage and VolumeStats.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

