### PR TITLE
rbd: fix parsing mapOptions

### DIFF
--- a/internal/rbd/rbd_attach_test.go
+++ b/internal/rbd/rbd_attach_test.go
@@ -60,18 +60,25 @@ func TestParseMapOptions(t *testing.T) {
 			expectErr:         "",
 		},
 		{
-			name:              "unknown mounter used",
-			mapOption:         "xyz:xOp1,xOp2",
+			name:              "with `:` delimiter used with in the options",
+			mapOption:         "krbd:kOp1,kOp2=kOp21:kOp22;nbd:nOp1,nOp2=nOp21:nOp22",
+			expectKrbdOptions: "kOp1,kOp2=kOp21:kOp22",
+			expectNbdOptions:  "nOp1,nOp2=nOp21:nOp22",
+			expectErr:         "",
+		},
+		{
+			name:              "with `:` delimiter used with in the options, without mounter label",
+			mapOption:         "kOp1,kOp2=kOp21:kOp22;nbd:nOp1,nOp2",
 			expectKrbdOptions: "",
 			expectNbdOptions:  "",
 			expectErr:         "unknown mounter type",
 		},
 		{
-			name:              "bad formatted options",
-			mapOption:         "nbd:nOp1:nOp2;",
+			name:              "unknown mounter used",
+			mapOption:         "xyz:xOp1,xOp2",
 			expectKrbdOptions: "",
 			expectNbdOptions:  "",
-			expectErr:         "badly formatted map/unmap options",
+			expectErr:         "unknown mounter type",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Currently, we support

mapOption: "krbd:v1,v2,v3;nbd:v1,v2,v3"

- By omitting `krbd:` or `nbd:`, the option(s) apply to
  rbdDefaultMounter which is krbd.
- A user can _override_ the options for a mounter by specifying `krbd:`
  or `nbd:`.
  mapOption: "v1,v2,v3;nbd:v1,v2,v3"
  is effectively the same as the 1st example.
- Sections are split by `;`.
- If users want to specify common options for both `krbd` and `nbd`,
  they should mention them twice.

But in case if the krbd or nbd specifc options contian `:` within them,
then the parsing is failing now.

E0301 10:19:13.615111 7348 utils.go:200] ID: 63 Req-ID:
0001-0009-rook-ceph-0000000000000001-fd37c41b-9948-11ec-ad32-0242ac110004
GRPC error: badly formatted map/unmap options:
"krbd:read_from_replica=localize,crush_location=zone:zone1;"

This patch fix the above case where the options itself contain `:`
delimitor
ex: krbd:v1,v2,v3=v31:v32;nbd:v1,v2,v3"

## Is there anything that requires special attention ##

Please note, if you are using such options which contain `:` delimiter,
then it is mandatory to specify the mounter-type.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>



## Related issues ##

Fixes: #2910

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
