### PR TITLE
cephfs: go with default permissions while creating subvolumes

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -339,6 +339,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 		return err
 	}
 	var user int64 = 2000
+	onRootMismatch := v1.FSGroupChangeOnRootMismatch
 	app := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -352,7 +353,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 			},
 		},
 		Spec: v1.PodSpec{
-			SecurityContext: &v1.PodSecurityContext{FSGroup: &user},
+			SecurityContext: &v1.PodSecurityContext{FSGroup: &user, FSGroupChangePolicy: &(onRootMismatch)},
 			Containers: []v1.Container{
 				{
 					Name:    "write-pod",

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -39,12 +39,6 @@ import (
 // taken through this additional cluster information.
 var clusterAdditionalInfo = make(map[string]*localClusterState)
 
-const (
-	// modeAllRWX can be used for setting permissions to Read-Write-eXecute
-	// for User, Group and Other.
-	modeAllRWX = 0o777
-)
-
 // Subvolume holds subvolume information. This includes only the needed members
 // from fsAdmin.SubVolumeInfo.
 type Subvolume struct {
@@ -231,7 +225,6 @@ func (s *subVolumeClient) CreateVolume(ctx context.Context) error {
 
 	opts := fsAdmin.SubVolumeOptions{
 		Size: fsAdmin.ByteCount(s.Size),
-		Mode: modeAllRWX,
 	}
 	if s.Pool != "" {
 		opts.PoolLayout = s.Pool


### PR DESCRIPTION
While creating subvolumes, CephFS driver set the mode to `777`
and pass it along to go ceph apis which cause the subvolume
permission to be on 777, however if we create a subvolume
directly in the ceph cluster, the default permission bits are
set which is 755 for the subvolume. This commit try to stick
to the default behaviour even while creating the subvolume via
CSI driver.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

