### PR TITLE
util: remove kubernetes csi prefixed parameters

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -27,6 +27,7 @@ import (
 	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -267,7 +268,8 @@ func (cs *ControllerServer) CreateVolume(
 			}
 		}
 
-		volumeContext := req.GetParameters()
+		// remove kubernetes csi prefixed parameters.
+		volumeContext := k8s.RemoveCSIPrefixedParameters(req.GetParameters())
 		volumeContext["subvolumeName"] = vID.FsSubvolName
 		volumeContext["subvolumePath"] = volOptions.RootPath
 		volume := &csi.Volume{
@@ -340,7 +342,8 @@ func (cs *ControllerServer) CreateVolume(
 
 	log.DebugLog(ctx, "cephfs: successfully created backing volume named %s for request name %s",
 		vID.FsSubvolName, requestName)
-	volumeContext := req.GetParameters()
+	// remove kubernetes csi prefixed parameters.
+	volumeContext := k8s.RemoveCSIPrefixedParameters(req.GetParameters())
 	volumeContext["subvolumeName"] = vID.FsSubvolName
 	volumeContext["subvolumePath"] = volOptions.RootPath
 	volume := &csi.Volume{

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -22,6 +22,7 @@ import (
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	librbd "github.com/ceph/go-ceph/rbd"
@@ -159,7 +160,8 @@ func (cs *ControllerServer) parseVolCreateRequest(
 }
 
 func buildCreateVolumeResponse(req *csi.CreateVolumeRequest, rbdVol *rbdVolume) *csi.CreateVolumeResponse {
-	volumeContext := req.GetParameters()
+	// remove kubernetes csi prefixed parameters.
+	volumeContext := k8s.RemoveCSIPrefixedParameters(req.GetParameters())
 	volumeContext["pool"] = rbdVol.Pool
 	volumeContext["journalPool"] = rbdVol.JournalPool
 	volumeContext["imageName"] = rbdVol.RbdImageName

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -265,22 +265,14 @@ func (ri *rbdImage) initKMS(ctx context.Context, volOptions, credentials map[str
 }
 
 // ParseEncryptionOpts returns kmsID and sets Owner attribute.
-func (ri *rbdImage) ParseEncryptionOpts(ctx context.Context, volOptions map[string]string) (string, error) {
+func (ri *rbdImage) ParseEncryptionOpts(
+	ctx context.Context,
+	volOptions map[string]string) (string, error) {
 	var (
 		err              error
 		ok               bool
 		encrypted, kmsID string
 	)
-
-	// if the KMS is of type VaultToken, additional metadata is needed
-	// depending on the tenant, the KMS can be configured with other
-	// options
-	// FIXME: this works only on Kubernetes, how do other CO supply metadata?
-	ri.Owner, ok = volOptions["csi.storage.k8s.io/pvc/namespace"]
-	if !ok {
-		log.DebugLog(ctx, "could not detect owner for %s", ri)
-	}
-
 	encrypted, ok = volOptions["encrypted"]
 	if !ok {
 		return "", nil

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -531,7 +531,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 // which are not same across clusters.
 func RegenerateJournal(
 	volumeAttributes map[string]string,
-	volumeID, requestName string,
+	volumeID, requestName, owner string,
 	cr *util.Credentials) (string, error) {
 	ctx := context.Background()
 	var (
@@ -550,6 +550,8 @@ func RegenerateJournal(
 		return "", fmt.Errorf("%w: error decoding volume ID (%s) (%s)",
 			ErrInvalidVolID, err, rbdVol.VolID)
 	}
+
+	rbdVol.Owner = owner
 
 	kmsID, err = rbdVol.ParseEncryptionOpts(ctx, volumeAttributes)
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1142,7 +1142,7 @@ func generateVolumeFromMapping(
 
 func genVolFromVolumeOptions(
 	ctx context.Context,
-	volOptions, credentials map[string]string,
+	volOptions map[string]string,
 	disableInUseChecks, checkClusterIDMapping bool) (*rbdVolume, error) {
 	var (
 		ok         bool
@@ -1194,11 +1194,6 @@ func genVolFromVolumeOptions(
 		rbdVol.ImageFeatureSet.Names(),
 		rbdVol.Mounter)
 	rbdVol.DisableInUseChecks = disableInUseChecks
-
-	err = rbdVol.initKMS(ctx, volOptions, credentials)
-	if err != nil {
-		return nil, err
-	}
 
 	return rbdVol, nil
 }

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -23,6 +23,7 @@ import (
 // to the driver on CreateVolumeRequest/CreateSnapshotRequest calls.
 const (
 	csiParameterPrefix = "csi.storage.k8s.io/"
+	pvcNamespaceKey    = "csi.storage.k8s.io/pvc/namespace"
 )
 
 // RemoveCSIPrefixedParameters removes parameters prefixed with csiParameterPrefix.
@@ -36,4 +37,9 @@ func RemoveCSIPrefixedParameters(param map[string]string) map[string]string {
 	}
 
 	return newParam
+}
+
+// GetOwner returns the pvc namespace name from the parameter.
+func GetOwner(param map[string]string) string {
+	return param[pvcNamespaceKey]
 }

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package k8s
+
+import (
+	"strings"
+)
+
+// CSI Parameters prefixed with csiParameterPrefix are passed through
+// to the driver on CreateVolumeRequest/CreateSnapshotRequest calls.
+const (
+	csiParameterPrefix = "csi.storage.k8s.io/"
+)
+
+// RemoveCSIPrefixedParameters removes parameters prefixed with csiParameterPrefix.
+func RemoveCSIPrefixedParameters(param map[string]string) map[string]string {
+	newParam := map[string]string{}
+	for k, v := range param {
+		if !strings.HasPrefix(k, csiParameterPrefix) {
+			// add the parameter to the new map if its not having the prefix
+			newParam[k] = v
+		}
+	}
+
+	return newParam
+}

--- a/internal/util/k8s/parameters_test.go
+++ b/internal/util/k8s/parameters_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package k8s
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveCSIPrefixedParameters(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		param map[string]string
+		want  map[string]string
+	}{
+		{
+			name: "without csi.storage.k8s.io prefix",
+			param: map[string]string{
+				"foo": "bar",
+			},
+			want: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "with csi.storage.k8s.io prefix",
+			param: map[string]string{
+				"foo":                              "bar",
+				"csi.storage.k8s.io/pvc/name":      "foo",
+				"csi.storage.k8s.io/pvc/namespace": "bar",
+				"csi.storage.k8s.io/pv/name":       "baz",
+			},
+			want: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
+			got := RemoveCSIPrefixedParameters(ts.param)
+			if !reflect.DeepEqual(got, ts.want) {
+				t.Errorf("RemoveCSIPrefixedParameters() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}

--- a/internal/util/k8s/parameters_test.go
+++ b/internal/util/k8s/parameters_test.go
@@ -60,3 +60,36 @@ func TestRemoveCSIPrefixedParameters(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOwner(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]string
+		want string
+	}{
+		{
+			name: "namespace is not present in the parameters",
+			args: map[string]string{
+				"foo": "bar",
+			},
+			want: "",
+		},
+		{
+			name: "namespace is present in the parameters",
+			args: map[string]string{
+				"csi.storage.k8s.io/pvc/namespace": "bar",
+			},
+			want: "bar",
+		},
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
+			if got := GetOwner(ts.args); got != ts.want {
+				t.Errorf("GetOwner() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
remove kubernetes csi prefixed parameters from the volumeContext as we dont want to store it in the PV VolumeAttributes.
    
updates: #2835 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

