### PR TITLE
ci: add GOARCH to path for copying kubectl

### DIFF
--- a/single-node-k8s.sh
+++ b/single-node-k8s.sh
@@ -100,7 +100,13 @@ function install_minikube()
     MINIKUBE_VERSION="${MINIKUBE_VERSION}" KUBE_VERSION="${k8s_version}" ${GOPATH}/src/github.com/ceph/ceph-csi/scripts/minikube.sh up
 
     # copy kubectl from minikube to /usr/bin
-    cp ~/.minikube/cache/linux/"${k8s_version}"/kubectl /usr/bin/
+    if [ -x ~/.minikube/cache/linux/"${k8s_version}"/kubectl ]
+    then
+        cp ~/.minikube/cache/linux/"${k8s_version}"/kubectl /usr/bin/
+    else
+        # minikube 1.25.2 adds the GOARCH to the path ("amd64" in our CI)
+        cp ~/.minikube/cache/linux/amd64/"${k8s_version}"/kubectl /usr/bin/
+    fi
 
     # scan for extra disks
     minikube ssh 'echo 1 | sudo tee /sys/bus/pci/rescan > /dev/null ; dmesg | grep virtio_blk'


### PR DESCRIPTION
minikube 1.25.2 moved the downloaded kubectl and other binaries to a new
subdir; it now includes runtime.GOARCH as an extra component.

See-also: kubernetes/minikube#13539

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
