### PR TITLE
build: consume quincy release of Ceph

### DIFF
--- a/build.env
+++ b/build.env
@@ -12,8 +12,8 @@
 CSI_IMAGE_VERSION=canary
 
 # Ceph version to use
-BASE_IMAGE=quay.io/ceph/ceph:v16
-CEPH_VERSION=pacific
+BASE_IMAGE=quay.io/ceph/ceph:v17
+CEPH_VERSION=quincy
 
 # standard Golang options
 GOLANG_VERSION=1.17.5


### PR DESCRIPTION
This promotes the ceph release to Quincy

Depends On #2976 
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

