### PR TITLE
build: remove cache while building container image

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -33,6 +33,8 @@ RUN dnf -y install \
 	/usr/bin/cc \
 	make \
 	git \
+	&& dnf clean all \
+	&& rm -rf /var/cache/yum \
     && true
 
 ENV GOROOT=${GOROOT} \

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -29,6 +29,8 @@ RUN dnf -y install \
 	librados-devel \
 	librbd-devel \
     && dnf -y update \
+    && dnf clean all \
+    && rm -rf /var/cache/yum \
     && true
 
 WORKDIR "/go/src/github.com/ceph/ceph-csi"


### PR DESCRIPTION

    Reduce size of the container image by removing the cache in deploy
    and devel container.

Additional Note: Noticed around 120MB size reduction

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


