### PR TITLE
ci: add "component/nfs" label with Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -309,6 +309,13 @@ pull_request_rules:
       label:
         add:
           - component/cephfs
+  - name: title contains NFS
+    conditions:
+      - "title~=nfs: "
+    actions:
+      label:
+        add:
+          - component/nfs
   - name: title contains RBD
     conditions:
       - "title~=rbd: "


### PR DESCRIPTION
"component/nfs" has been added to the labels in the repository, and
Mergify should be able to add that to PRs.

Updates: #2913

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
