### PR TITLE
ci: use CEPH_CSI_BOT token for retest action

### DIFF
--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -12,7 +12,7 @@ jobs:
       # path to the retest action
       - uses: ceph/ceph-csi/actions/retest@devel
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           required-label: "ci/retry/e2e"
           max-retry: "5"
           required-approve-count: "2"


### PR DESCRIPTION
For retest action's comment `@Mergifyio refresh`
to be accepted by mergifyio,
the bot should have write permissions to the repo.
Therefore, use Ceph-csi-bot instead of github actions
bot.

Signed-off-by: Rakshith R <rar@redhat.com>

ex: https://github.com/ceph/ceph-csi/pull/2900#issuecomment-1071069295

https://github.com/ceph/ceph-csi/blob/9fe38708745fb11f3f34234aa26645c1a27e83be/.github/workflows/publish-artifacts.yaml#L32 

(I am assuming ceph-csi-bot has write access to the repo.)