### PR TITLE
ci: add release 3.5 image details to the mirror image list

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -9,18 +9,12 @@
 # ceph-csi devel
 docker.io/rook/ceph:v1.8.2	rook/ceph:v1.8.2
 
-
 # ceph-csi v3.5
-docker.io/ceph/ceph:v16		ceph/ceph:v16
-docker.io/rook/ceph:v1.6.2	rook/ceph:v1.6.2
-
-
-# ceph-csi v3.4
-docker.io/ceph/ceph:v16		ceph/ceph:v16
+quay.io/ceph/ceph:v16		ceph/ceph:v16
 docker.io/rook/ceph:v1.6.2	rook/ceph:v1.6.2
 
 # ceph-csi v3.3
-docker.io/ceph/ceph:v15		ceph/ceph:v15
+quay.io/ceph/ceph:v15		ceph/ceph:v15
 docker.io/rook/ceph:v1.4.9	rook/ceph:v1.4.9
 
 # e2e testing

--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -8,6 +8,7 @@
 
 # ceph-csi devel
 docker.io/rook/ceph:v1.8.2	rook/ceph:v1.8.2
+quay.io/ceph/ceph:v17		ceph/ceph:v17
 
 # ceph-csi v3.5
 quay.io/ceph/ceph:v16		ceph/ceph:v16

--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -9,6 +9,12 @@
 # ceph-csi devel
 docker.io/rook/ceph:v1.8.2	rook/ceph:v1.8.2
 
+
+# ceph-csi v3.5
+docker.io/ceph/ceph:v16		ceph/ceph:v16
+docker.io/rook/ceph:v1.6.2	rook/ceph:v1.6.2
+
+
 # ceph-csi v3.4
 docker.io/ceph/ceph:v16		ceph/ceph:v16
 docker.io/rook/ceph:v1.6.2	rook/ceph:v1.6.2


### PR DESCRIPTION
The release 3.5 image details were missing and this commit add the
same.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

