### PR TITLE
rbd: modify oidc token file path according to FHS 3.0

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -134,7 +134,7 @@ spec:
             - name: ceph-logdir
               mountPath: /var/log/ceph
             - name: oidc-token
-              mountPath: /var/run/secrets/tokens
+              mountPath: /run/secrets/tokens
               readOnly: true
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -184,7 +184,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
             - name: oidc-token
-              mountPath: /var/run/secrets/tokens
+              mountPath: /run/secrets/tokens
               readOnly: true
           resources:
 {{ toYaml .Values.nodeplugin.plugin.resources | indent 12 }}

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -164,7 +164,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
             - name: oidc-token
-              mountPath: /var/run/secrets/tokens
+              mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-rbdplugin-controller
           # for stable functionality replace canary with latest release version

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -119,7 +119,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
             - name: oidc-token
-              mountPath: /var/run/secrets/tokens
+              mountPath: /run/secrets/tokens
               readOnly: true
         - name: liveness-prometheus
           securityContext:

--- a/internal/kms/aws_sts_metadata.go
+++ b/internal/kms/aws_sts_metadata.go
@@ -60,7 +60,7 @@ const (
 	// tokenFilePath is the path to the file containing the OIDC token.
 	//
 	// #nosec:G101, value not credential, just path to the token.
-	tokenFilePath = "/var/run/secrets/tokens/oidc-token"
+	tokenFilePath = "/run/secrets/tokens/oidc-token"
 )
 
 var _ = RegisterProvider(Provider{


### PR DESCRIPTION
OIDC token file path has been modified from
`/var/run/secrets/token` to `/run/secrets/tokens`.
This has been done to ensure compliance with
FHS 3.0.

refer:
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s13.html

Signed-off-by: Rakshith R <rar@redhat.com>
