### PR TITLE
doc: initial/partial instructions for using NFS examples

### DIFF
--- a/examples/nfs/README.md
+++ b/examples/nfs/README.md
@@ -1,0 +1,70 @@
+# Dynamic provisioning with NFS
+
+The easiest way to try out the examples for dynamic provisioning with NFS, is
+to use [Rook Ceph with CephNFS][rook_ceph]. Rook can be used to deploy a Ceph
+cluster. Ceph is able to maintain a NFS-Ganesha service with a few commands,
+making configuring the Ceph cluster a minimal effort.
+
+## Enabling the Ceph NFS-service
+
+Ceph does not enable the NFS-service by default. In order for Rook Ceph to be
+able to configure NFS-exports, the NFS-service needs to be configured first.
+
+In the [Rook Toolbox][rook_toolbox], run the following commands:
+
+```console
+ceph osd pool create nfs-ganesha
+ceph mgr module enable rook
+ceph mgr module enable nfs
+ceph orch set backend rook
+```
+
+## Create a NFS-cluster
+
+In the directory where this `README` is located, there is an example
+`rook-nfs.yaml` file. This file can be used to create a Ceph managed
+NFS-cluster with the name "my-nfs".
+
+```console
+$ kubectl create -f rook-nfs.yaml
+cephnfs.ceph.rook.io/my-nfs created
+```
+
+The CephNFS resource will create a NFS-Ganesha Pod and Service with label
+`app=rook-ceph-nfs`:
+
+```console
+$ kubectl get pods -l app=rook-ceph-nfs
+NAME                                      READY   STATUS    RESTARTS   AGE
+rook-ceph-nfs-my-nfs-a-5d47f66977-sc2rk   2/2     Running   0          61s
+$ kubectl get service -l app=rook-ceph-nfs
+NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+rook-ceph-nfs-my-nfs-a   ClusterIP   172.30.218.195   <none>        2049/TCP   2m58s
+```
+
+## Create a StorageClass
+
+The parameters of the StorageClass reflect mostly what CephFS requires to
+connect to the Ceph cluster. All required options are commented clearly in the
+`storageclass.yaml` file.
+
+In addition to the CephFS parameters, there are:
+
+- `nfsCluster`: name of the Ceph managed NFS-cluster (here `my-nfs`)
+- `server`: hostname/IP/service of the NFS-server (here `172.30.218.195`)
+
+Edit `storageclass.yaml`, and create the resource:
+
+```console
+$ kubectl create -f storageclass.yaml
+storageclass.storage.k8s.io/csi-nfs-sc created
+```
+
+## TODO: next steps
+
+- deploy the NFS-provisioner
+- deploy the kubernetes-csi/csi-driver-nfs
+- create the CSIDriver object
+
+[rook_ceph]: https://rook.io/docs/rook/latest/ceph-nfs-crd.html
+[rook_toolbox]: https://rook.io/docs/rook/latest/ceph-toolbox.html

--- a/examples/nfs/pod.yaml
+++ b/examples/nfs/pod.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cephcsi-nfs-demo-pod
+spec:
+  containers:
+    - name: web-server
+      image: docker.io/library/nginx:latest
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: cephcsi-nfs-pvc
+        readOnly: false

--- a/examples/nfs/pvc.yaml
+++ b/examples/nfs/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cephcsi-nfs-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-nfs-sc

--- a/examples/nfs/rook-nfs.yaml
+++ b/examples/nfs/rook-nfs.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephNFS
+metadata:
+  name: my-nfs
+  namespace: default
+spec:
+  # For Ceph v15, the rados block is required. It is ignored for Ceph v16.
+  rados:
+    # Ceph v16 always uses/expects "nfs-ganesha"
+    pool: nfs-ganesha
+    # RADOS namespace where NFS client recovery data is stored in the pool.
+    # fixed value for Ceph v16: the name of this CephNFS object
+    namespace: my-nfs
+
+  # Settings for the NFS server
+  server:
+    # the number of active NFS servers
+    active: 1

--- a/examples/nfs/storageclass.yaml
+++ b/examples/nfs/storageclass.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-nfs-sc
+provisioner: nfs.csi.ceph.com
+parameters:
+  # (required) Name of the NFS-cluster as managed by Ceph.
+  nfsCluster: <nfs-cluster>
+
+  # (required) Hostname, ip-address or service that points to the Ceph managed
+  # NFS-server that will be used for mounting the NFS-export.
+  server: <nfs-server>
+
+  #
+  # The parameters below are standard CephFS options, these are used for
+  # managing the underlying CephFS volume.
+  #
+
+  # (required) String representing a Ceph cluster to provision storage from.
+  # Should be unique across all Ceph clusters in use for provisioning,
+  # cannot be greater than 36 bytes in length, and should remain immutable for
+  # the lifetime of the StorageClass in use.
+  # Ensure to create an entry in the configmap named ceph-csi-config, based on
+  # csi-config-map-sample.yaml, to accompany the string chosen to
+  # represent the Ceph cluster in clusterID below
+  clusterID: <cluster-id>
+
+  # (required) CephFS filesystem name into which the volume shall be created
+  # eg: fsName: myfs
+  fsName: <cephfs-name>
+
+  # (optional) Ceph pool into which volume data shall be stored
+  # pool: <cephfs-data-pool>
+
+  # The secrets have to contain user and/or Ceph admin credentials.
+  csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-secret
+  csi.storage.k8s.io/controller-expand-secret-namespace: default
+  csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: default
+
+  # (optional) Prefix to use for naming subvolumes.
+  # If omitted, defaults to "csi-vol-".
+  volumeNamePrefix: nfs-export-
+
+reclaimPolicy: Delete
+allowVolumeExpansion: false


### PR DESCRIPTION
The README explains some of the requirements and basic configuration for
using the NFS-provisioner. When more deployment artifacts are added, the
README will get extended.

The Rook CephNFS example is included, as it is the easiest to get
started with dynamic provisioning of NFS-volumes.

Updates: #2913

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
