### PR TITLE
rbd: increase force promote timeout to 2 minutes

### DIFF
--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -88,8 +88,8 @@ func (ri *rbdImage) promoteImage(force bool) error {
 	return nil
 }
 
-// forcePromoteImage promotes image to primary with force option with 1 minute
-// timeout. If there is no response within 1 minute,the rbd CLI process will be
+// forcePromoteImage promotes image to primary with force option with 2 minutes
+// timeout. If there is no response within 2 minutes,the rbd CLI process will be
 // killed and an error is returned.
 func (rv *rbdVolume) forcePromoteImage(cr *util.Credentials) error {
 	promoteArgs := []string{
@@ -102,7 +102,8 @@ func (rv *rbdVolume) forcePromoteImage(cr *util.Credentials) error {
 	}
 	_, stderr, err := util.ExecCommandWithTimeout(
 		context.TODO(),
-		time.Minute,
+		// 2 minutes timeout as the Replication RPC timeout is 2.5 minutes.
+		2*time.Minute,
 		"rbd",
 		promoteArgs...,
 	)


### PR DESCRIPTION
Increase the timeout to 2 minutes to give enough time for rollback to complete.
As rollback is performed by the force-promote command it, at times, may take more than a minute (based on dirty blocks that need to be rolled back approximately) to rollback.

The added extra 1 minute is useful though to avoid multiple calls to complete the rollback and in extreme corner cases to avoid failures in the first instance of the call when the mirror watcher is not yet removed (post scaling down the RBD mirror instance)

More context at https://bugzilla.redhat.com/show_bug.cgi?id=2009735#c33. 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
