### PR TITLE
ci: replace docker.io ceph image with quay.io path

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -137,10 +137,10 @@ node('cico-workspace') {
 						script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 						returnStdout: true
 					).trim()
-					def d_io_regex = ~"^docker.io/"
+					def q_io_regex = ~"^quay.io/"
 
-					// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
-					podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
+					// base_image is like ceph/ceph:v15 or quay.io/ceph/ceph:v15, strip "quay.io/"
+					podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 				}
 			}
 		}

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -117,14 +117,14 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
-			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
-			podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
+			// base_image is like ceph/ceph:v15 or quay.io/ceph/ceph:v15, strip "quay.io/"
+			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 		}

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -119,14 +119,14 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
-			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
-			podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
+			// base_image is like ceph/ceph:v15 or quay.io/ceph/ceph:v15, strip "quay.io/"
+			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 		}

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -116,14 +116,14 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
 			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
-			podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
+			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 		}


### PR DESCRIPTION
The ceph images are served from quay.io and this commit adjust
the docker pull to quay.io pull for centos jobs

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

