### PR TITLE
nfs: use go-ceph API for creating/deleting exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ GO_PROJECT=github.com/ceph/ceph-csi
 
 CEPH_VERSION ?= $(shell . $(CURDIR)/build.env ; echo $${CEPH_VERSION})
 # TODO: ceph_preview tag may be removed with go-ceph 0.16.0
-GO_TAGS_LIST ?= $(CEPH_VERSION) ceph_preview
+# TODO: ceph_ci_untested is added for NFS-export management (go-ceph#655)
+GO_TAGS_LIST ?= $(CEPH_VERSION) ceph_preview ceph_ci_untested
 
 # go build flags
 LDFLAGS ?=

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/aws/aws-sdk-go v1.43.32
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.3
 	github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000
-	github.com/ceph/go-ceph v0.14.0
+	// TODO: API for managing NFS-exports requires `ceph_ci_untested` build-tag
+	github.com/ceph/go-ceph v0.15.0
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/csi-addons/replication-lib-utils v0.2.0
 	github.com/csi-addons/spec v0.1.2-0.20211220115741-32fa508dadbe

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
-github.com/ceph/go-ceph v0.14.0 h1:sJoT0au7NT3TPmDWf5W9w6tZy0U/5xZrIXVVauZR+Xo=
-github.com/ceph/go-ceph v0.14.0/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
+github.com/ceph/go-ceph v0.15.0 h1:ILB3NaLWOtt4u/2d8I8HZTC4Ycm1PsOYVar3IFU1xlo=
+github.com/ceph/go-ceph v0.15.0/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	ca "github.com/ceph/go-ceph/cephfs/admin"
+	"github.com/ceph/go-ceph/common/admin/nfs"
 	"github.com/ceph/go-ceph/rados"
 	ra "github.com/ceph/go-ceph/rbd/admin"
 )
@@ -139,4 +140,14 @@ func (cc *ClusterConnection) GetTaskAdmin() (*ra.TaskAdmin, error) {
 	}
 
 	return rbdAdmin.Task(), nil
+}
+
+// GetNFSAdmin returns an Admin type that can be used to interact with the
+// NFS-cluster that is managed by Ceph.
+func (cc *ClusterConnection) GetNFSAdmin() (*nfs.Admin, error) {
+	if cc.conn == nil {
+		return nil, errors.New("cluster is not connected yet")
+	}
+
+	return nfs.NewFromConn(cc.conn), nil
 }

--- a/vendor/github.com/ceph/go-ceph/common/admin/nfs/admin.go
+++ b/vendor/github.com/ceph/go-ceph/common/admin/nfs/admin.go
@@ -1,0 +1,21 @@
+//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
+// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+
+package nfs
+
+import (
+	ccom "github.com/ceph/go-ceph/common/commands"
+)
+
+// Admin is used to administer ceph nfs features.
+type Admin struct {
+	conn ccom.RadosCommander
+}
+
+// NewFromConn creates an new management object from a preexisting
+// rados connection. The existing connection can be rados.Conn or any
+// type implementing the RadosCommander interface.
+//  PREVIEW
+func NewFromConn(conn ccom.RadosCommander) *Admin {
+	return &Admin{conn}
+}

--- a/vendor/github.com/ceph/go-ceph/common/admin/nfs/doc.go
+++ b/vendor/github.com/ceph/go-ceph/common/admin/nfs/doc.go
@@ -1,0 +1,5 @@
+/*
+Package nfs from common/admin contains a set of APIs used to interact
+with and administer NFS support for ceph clusters.
+*/
+package nfs

--- a/vendor/github.com/ceph/go-ceph/common/admin/nfs/export.go
+++ b/vendor/github.com/ceph/go-ceph/common/admin/nfs/export.go
@@ -1,0 +1,198 @@
+//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
+// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+
+package nfs
+
+import (
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+// SquashMode indicates the kind of user-id squashing performed on an export.
+type SquashMode string
+
+// src: https://github.com/nfs-ganesha/nfs-ganesha/blob/next/src/config_samples/export.txt
+const (
+	// NoneSquash performs no id squashing.
+	NoneSquash SquashMode = "None"
+	// RootSquash performs squashing of root user (with any gid).
+	RootSquash SquashMode = "Root"
+	// AllSquash performs squashing of all users.
+	AllSquash SquashMode = "All"
+	// RootIDSquash performs squashing of root uid/gid.
+	RootIDSquash SquashMode = "RootId"
+	// NoRootSquash is equivalent to NoneSquash
+	NoRootSquash = NoneSquash
+	// Unspecifiedquash
+	Unspecifiedquash SquashMode = ""
+)
+
+// CephFSExportSpec is used to specify the parameters used to create a new
+// CephFS based export.
+type CephFSExportSpec struct {
+	FileSystemName string     `json:"fsname"`
+	ClusterID      string     `json:"cluster_id"`
+	PseudoPath     string     `json:"pseudo_path"`
+	Path           string     `json:"path,omitempty"`
+	ReadOnly       bool       `json:"readonly"`
+	ClientAddr     []string   `json:"client_addr,omitempty"`
+	Squash         SquashMode `json:"squash,omitempty"`
+}
+
+// ExportResult is returned along with newly created exports.
+type ExportResult struct {
+	Bind           string `json:"bind"`
+	FileSystemName string `json:"fs"`
+	Path           string `json:"path"`
+	ClusterID      string `json:"cluster"`
+	Mode           string `json:"mode"`
+}
+
+type cephFSExportFields struct {
+	Prefix string `json:"prefix"`
+	Format string `json:"format"`
+
+	CephFSExportSpec
+}
+
+// FSALInfo describes NFS-Ganesha specific FSAL properties of an export.
+type FSALInfo struct {
+	Name           string `json:"name"`
+	UserID         string `json:"user_id"`
+	FileSystemName string `json:"fs_name"`
+}
+
+// ClientInfo describes per-client parameters of an export.
+type ClientInfo struct {
+	Addresses  []string   `json:"addresses"`
+	AccessType string     `json:"access_type"`
+	Squash     SquashMode `json:"squash"`
+}
+
+// ExportInfo describes an NFS export.
+type ExportInfo struct {
+	ExportID      int64        `json:"export_id"`
+	Path          string       `json:"path"`
+	ClusterID     string       `json:"cluster_id"`
+	PseudoPath    string       `json:"pseudo"`
+	AccessType    string       `json:"access_type"`
+	Squash        SquashMode   `json:"squash"`
+	SecurityLabel bool         `json:"security_label"`
+	Protocols     []int        `json:"protocols"`
+	Transports    []string     `json:"transports"`
+	FSAL          FSALInfo     `json:"fsal"`
+	Clients       []ClientInfo `json:"clients"`
+}
+
+func parseExportResult(res commands.Response) (*ExportResult, error) {
+	r := &ExportResult{}
+	if err := res.NoStatus().Unmarshal(r).End(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func parseExportsList(res commands.Response) ([]ExportInfo, error) {
+	l := []ExportInfo{}
+	if err := res.NoStatus().Unmarshal(&l).End(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func parseExportInfo(res commands.Response) (ExportInfo, error) {
+	i := ExportInfo{}
+	if err := res.NoStatus().Unmarshal(&i).End(); err != nil {
+		return i, err
+	}
+	return i, nil
+}
+
+// CreateCephFSExport will create a new NFS export for a CephFS file system.
+//  PREVIEW
+//
+// Similar To:
+//  ceph nfs export create cephfs
+func (nfsa *Admin) CreateCephFSExport(spec CephFSExportSpec) (
+	*ExportResult, error) {
+	// ---
+	f := &cephFSExportFields{
+		Prefix:           "nfs export create cephfs",
+		Format:           "json",
+		CephFSExportSpec: spec,
+	}
+	return parseExportResult(commands.MarshalMgrCommand(nfsa.conn, f))
+}
+
+const delSucc = "Successfully deleted export"
+
+// RemoveExport will remove an NFS export based on the pseudo-path of the export.
+//  PREVIEW
+//
+// Similar To:
+//  ceph nfs export rm
+func (nfsa *Admin) RemoveExport(clusterID, pseudoPath string) error {
+	m := map[string]string{
+		"prefix":      "nfs export rm",
+		"format":      "json",
+		"cluster_id":  clusterID,
+		"pseudo_path": pseudoPath,
+	}
+	return (commands.MarshalMgrCommand(nfsa.conn, m).
+		FilterBodyPrefix(delSucc).NoData().End())
+}
+
+// ListDetailedExports will return a list of exports with details.
+//  PREVIEW
+//
+// Similar To:
+//  ceph nfs export ls --detailed
+func (nfsa *Admin) ListDetailedExports(clusterID string) ([]ExportInfo, error) {
+	/*
+		NOTE: there is no simple list because based on a quick reading of the code
+		in ceph, the details fetching should not be significantly slower with
+		details than without, and since this is an API call not a CLI its easy
+		enough to ignore the details you don't care about. If I'm wrong, and
+		we discover a major perf. difference in the future we can always add a new
+		simpler list-without-details function.
+	*/
+	m := map[string]string{
+		"prefix":     "nfs export ls",
+		"detailed":   "true",
+		"format":     "json",
+		"cluster_id": clusterID,
+	}
+	return parseExportsList(commands.MarshalMgrCommand(nfsa.conn, m))
+}
+
+// ExportInfo will return a structure describing the export specified by it's
+// pseudo-path.
+//  PREVIEW
+//
+// Similar To:
+//  ceph nfs export info
+func (nfsa *Admin) ExportInfo(clusterID, pseudoPath string) (ExportInfo, error) {
+	m := map[string]string{
+		"prefix":      "nfs export info",
+		"format":      "json",
+		"cluster_id":  clusterID,
+		"pseudo_path": pseudoPath,
+	}
+	return parseExportInfo(commands.MarshalMgrCommand(nfsa.conn, m))
+}
+
+/*
+TODO?
+
+'nfs export apply': cluster_id: str, inbuf: str
+"""Create or update an export by `-i <json_or_ganesha_export_file>`"""
+
+
+'nfs export create rgw':
+	   bucket: str,
+	   cluster_id: str,
+	   pseudo_path: str,
+	   readonly: Optional[bool] = False,
+	   client_addr: Optional[List[str]] = None,
+	   squash: str = 'none',
+"""Create an RGW export"""
+*/

--- a/vendor/github.com/ceph/go-ceph/internal/commands/response.go
+++ b/vendor/github.com/ceph/go-ceph/internal/commands/response.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -152,6 +153,18 @@ func (r Response) FilterSuffix(s string) Response {
 	}
 	if strings.HasSuffix(r.status, s) {
 		return Response{r.body, "", r.err}
+	}
+	return r
+}
+
+// FilterBodyPrefix sets the body value equivalent to an empty string if the
+// body value contains the given prefix string.
+func (r Response) FilterBodyPrefix(p string) Response {
+	if !r.Ok() {
+		return r
+	}
+	if bytes.HasPrefix(r.body, []byte(p)) {
+		return Response{[]byte(""), r.status, r.err}
 	}
 	return r
 }

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/buffergroup.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/buffergroup.go
@@ -1,0 +1,89 @@
+package cutil
+
+// #include <stdlib.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// BufferGroup is a helper structure that holds Go-allocated slices of
+// C-allocated strings and their respective lengths. Useful for C functions
+// that consume byte buffers with explicit length instead of null-terminated
+// strings. When used as input arguments in C functions, caller must make sure
+// the C code will not hold any pointers to either of the struct's attributes
+// after that C function returns.
+type BufferGroup struct {
+	// C-allocated buffers.
+	Buffers []CharPtr
+	// Lengths of C buffers, where Lengths[i] = length(Buffers[i]).
+	Lengths []SizeT
+}
+
+// TODO: should BufferGroup implementation change and the slices would contain
+//       nested Go pointers, they must be pinned with PtrGuard.
+
+// NewBufferGroupStrings returns new BufferGroup constructed from strings.
+func NewBufferGroupStrings(strs []string) *BufferGroup {
+	s := &BufferGroup{
+		Buffers: make([]CharPtr, len(strs)),
+		Lengths: make([]SizeT, len(strs)),
+	}
+
+	for i, str := range strs {
+		bs := []byte(str)
+		s.Buffers[i] = CharPtr(C.CBytes(bs))
+		s.Lengths[i] = SizeT(len(bs))
+	}
+
+	return s
+}
+
+// NewBufferGroupBytes returns new BufferGroup constructed
+// from slice of byte slices.
+func NewBufferGroupBytes(bss [][]byte) *BufferGroup {
+	s := &BufferGroup{
+		Buffers: make([]CharPtr, len(bss)),
+		Lengths: make([]SizeT, len(bss)),
+	}
+
+	for i, bs := range bss {
+		s.Buffers[i] = CharPtr(C.CBytes(bs))
+		s.Lengths[i] = SizeT(len(bs))
+	}
+
+	return s
+}
+
+// Free free()s the C-allocated memory.
+func (s *BufferGroup) Free() {
+	for _, ptr := range s.Buffers {
+		C.free(unsafe.Pointer(ptr))
+	}
+
+	s.Buffers = nil
+	s.Lengths = nil
+}
+
+// BuffersPtr returns a pointer to the beginning of the Buffers slice.
+func (s *BufferGroup) BuffersPtr() CharPtrPtr {
+	if len(s.Buffers) == 0 {
+		return nil
+	}
+
+	return CharPtrPtr(&s.Buffers[0])
+}
+
+// LengthsPtr returns a pointer to the beginning of the Lengths slice.
+func (s *BufferGroup) LengthsPtr() SizeTPtr {
+	if len(s.Lengths) == 0 {
+		return nil
+	}
+
+	return SizeTPtr(&s.Lengths[0])
+}
+
+func testBufferGroupGet(s *BufferGroup, index int) (str string, length int) {
+	bs := C.GoBytes(unsafe.Pointer(s.Buffers[index]), C.int(s.Lengths[index]))
+	return string(bs), int(s.Lengths[index])
+}

--- a/vendor/github.com/ceph/go-ceph/internal/log/log.go
+++ b/vendor/github.com/ceph/go-ceph/internal/log/log.go
@@ -1,0 +1,14 @@
+// Package log is the internal package for go-ceph logging. This package is only
+// used from go-ceph code, not from consumers of go-ceph. go-ceph code uses the
+// functions in this package to log information that can't be returned as
+// errors. The functions default to no-ops and can be set with the external log
+// package common/log by the go-ceph consumers.
+package log
+
+func noop(string, ...interface{}) {}
+
+// These variables are set by the common log package.
+var (
+	Warnf  = noop
+	Debugf = noop
+)

--- a/vendor/github.com/ceph/go-ceph/rados/rados_set_locator.go
+++ b/vendor/github.com/ceph/go-ceph/rados/rados_set_locator.go
@@ -1,0 +1,31 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+import (
+	"unsafe"
+)
+
+// SetLocator sets the key for mapping objects to pgs within an io context.
+// Until a different locator key is set, all objects in this io context will be placed in the same pg.
+// To reset the locator, an empty string must be set.
+//  PREVIEW
+//
+// Implements:
+//  void rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key);
+func (ioctx *IOContext) SetLocator(locator string) {
+	if locator == "" {
+		C.rados_ioctx_locator_set_key(ioctx.ioctx, nil)
+	} else {
+		var cLoc *C.char = C.CString(locator)
+		defer C.free(unsafe.Pointer(cLoc))
+		C.rados_ioctx_locator_set_key(ioctx.ioctx, cLoc)
+	}
+}

--- a/vendor/github.com/ceph/go-ceph/rados/read_op.go
+++ b/vendor/github.com/ceph/go-ceph/rados/read_op.go
@@ -69,13 +69,19 @@ func (r *ReadOp) AssertExists() {
 // function. The GetOmapStep may be used to iterate over the key-value
 // pairs after the Operate call has been performed.
 func (r *ReadOp) GetOmapValues(startAfter, filterPrefix string, maxReturn uint64) *GetOmapStep {
-	gos := newGetOmapStep(startAfter, filterPrefix, maxReturn)
+	gos := newGetOmapStep()
 	r.steps = append(r.steps, gos)
+
+	cStartAfter := C.CString(startAfter)
+	cFilterPrefix := C.CString(filterPrefix)
+	defer C.free(unsafe.Pointer(cStartAfter))
+	defer C.free(unsafe.Pointer(cFilterPrefix))
+
 	C.rados_read_op_omap_get_vals2(
 		r.op,
-		gos.cStartAfter,
-		gos.cFilterPrefix,
-		C.uint64_t(gos.maxReturn),
+		cStartAfter,
+		cFilterPrefix,
+		C.uint64_t(maxReturn),
 		&gos.iter,
 		gos.more,
 		gos.rval,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -116,15 +116,17 @@ github.com/cenkalti/backoff/v3
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.14.0
+# github.com/ceph/go-ceph v0.15.0
 ## explicit; go 1.12
 github.com/ceph/go-ceph/cephfs/admin
 github.com/ceph/go-ceph/common/admin/manager
+github.com/ceph/go-ceph/common/admin/nfs
 github.com/ceph/go-ceph/common/commands
 github.com/ceph/go-ceph/internal/callbacks
 github.com/ceph/go-ceph/internal/commands
 github.com/ceph/go-ceph/internal/cutil
 github.com/ceph/go-ceph/internal/errutil
+github.com/ceph/go-ceph/internal/log
 github.com/ceph/go-ceph/internal/retry
 github.com/ceph/go-ceph/internal/timespec
 github.com/ceph/go-ceph/rados


### PR DESCRIPTION
Recent versions of Ceph allow calling the NFS-export management
functions over the go-ceph API.

This seems incompatible with older versions that have been tested with
the `ceph nfs` commands that this commit replaces.

Updates: #2913
Depends-on: ceph/go-ceph#655

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
