### PR TITLE
util: add support to run commands with nsenter

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -31,6 +31,7 @@ spec:
       priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
 {{- end }}
       hostNetwork: true
+      hostPID: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -27,6 +27,7 @@ serviceAccounts:
 #       - "<MONValue2>"
 #     cephFS:
 #       subvolumeGroup: "csi"
+#     netNamespaceFilePath: "{{ .kubeletDir }}/plugins/{{ .driverName }}/net"
 csiConfig: []
 
 # Set logging level for csi containers.

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -25,6 +25,7 @@ serviceAccounts:
 #     monitors:
 #       - "<MONValue1>"
 #       - "<MONValue2>"
+#     netNamespaceFilePath: "{{ .kubeletDir }}/plugins/{{ .driverName }}/net"
 csiConfig: []
 
 # Configuration details of clusterID,PoolID and FscID mapping

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -15,6 +15,7 @@ spec:
       serviceAccountName: cephfs-csi-nodeplugin
       priorityClassName: system-node-critical
       hostNetwork: true
+      hostPID: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/csi-config-map-sample.yaml
+++ b/examples/csi-config-map-sample.yaml
@@ -20,6 +20,12 @@ kind: ConfigMap
 # NOTE: Make sure you don't add radosNamespace option to a currently in use
 # configuration as it will cause issues.
 # The field "cephFS.subvolumeGroup" is optional and defaults to "csi".
+# The <netNamespaceFilePath#> fields are the various network namespace
+# path for the Ceph cluster identified by the <cluster-id>, This will be used
+# by the CSI plugin to execute the rbd map/unmap and mount -t commands in the
+# network namespace specified by the <netNamespaceFilePath#>.
+# If a CSI plugin is using more than one Ceph cluster, repeat the section for
+# each such cluster in use.
 # NOTE: Changes to the configmap is automatically updated in the running pods,
 # thus restarting existing pods using the configmap is NOT required on edits
 # to the configmap.
@@ -37,6 +43,7 @@ data:
       {
         "clusterID": "<cluster-id>",
         "radosNamespace": "<rados-namespace>",
+        "netNamespaceFilePath": "<kubeletRootPath>/plugins/rbd.csi.ceph.com/net",
         "monitors": [
           "<MONValue1>",
           "<MONValue2>",

--- a/internal/cephfs/mounter/kernel.go
+++ b/internal/cephfs/mounter/kernel.go
@@ -51,7 +51,16 @@ func mountKernel(ctx context.Context, mountPoint string, cr *util.Credentials, v
 
 	args = append(args, "-o", optionsStr)
 
-	_, stderr, err := util.ExecCommand(ctx, "mount", args[:]...)
+	var (
+		stderr string
+		err    error
+	)
+
+	if volOptions.NetNamespaceFilePath != "" {
+		_, stderr, err = util.ExecuteCommandWithNSEnter(ctx, volOptions.NetNamespaceFilePath, "mount", args[:]...)
+	} else {
+		_, stderr, err = util.ExecCommand(ctx, "mount", args[:]...)
+	}
 	if err != nil {
 		return fmt.Errorf("%w stderr: %s", err, stderr)
 	}

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -126,6 +126,11 @@ func (ns *NodeServer) NodeStageVolume(
 	}
 	defer volOptions.Destroy()
 
+	volOptions.NetNamespaceFilePath, err = util.GetNetNamespaceFilePath(util.CsiConfigFile, volOptions.ClusterID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	mnt, err := mounter.New(volOptions)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create mounter for volume %s: %v", volID, err)

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -50,6 +50,8 @@ type VolumeOptions struct {
 	ProvisionVolume    bool   `json:"provisionVolume"`
 	KernelMountOptions string `json:"kernelMountOptions"`
 	FuseMountOptions   string `json:"fuseMountOptions"`
+	// Network namespace file path to execute nsenter command
+	NetNamespaceFilePath string
 
 	// conn is a connection to the Ceph cluster obtained from a ConnPool
 	conn *util.ClusterConnection

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -332,6 +332,10 @@ func (ns *NodeServer) NodeStageVolume(
 	}
 	defer rv.Destroy()
 
+	rv.NetNamespaceFilePath, err = util.GetNetNamespaceFilePath(util.CsiConfigFile, rv.ClusterID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	if isHealer {
 		err = healerStageTransaction(ctx, cr, rv, stagingParentPath)
 		if err != nil {

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -457,8 +457,17 @@ func createPath(ctx context.Context, volOpt *rbdVolume, device string, cr *util.
 		mapArgs = append(mapArgs, "--read-only")
 	}
 
-	// Execute map
-	stdout, stderr, err := util.ExecCommand(ctx, cli, mapArgs...)
+	var (
+		stdout string
+		stderr string
+		err    error
+	)
+
+	if volOpt.NetNamespaceFilePath != "" {
+		stdout, stderr, err = util.ExecuteCommandWithNSEnter(ctx, volOpt.NetNamespaceFilePath, cli, mapArgs...)
+	} else {
+		stdout, stderr, err = util.ExecCommand(ctx, cli, mapArgs...)
+	}
 	if err != nil {
 		log.WarningLog(ctx, "rbd: map error %v, rbd output: %s", err, stderr)
 		// unmap rbd image if connection timeout

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -156,6 +156,8 @@ type rbdVolume struct {
 	LogStrategy        string
 	VolName            string
 	MonValueFromSecret string
+	// Network namespace file path to execute nsenter command
+	NetNamespaceFilePath string
 	// RequestedVolSize has the size of the volume requested by the user and
 	// this value will not be updated when doing getImageInfo() on rbdVolume.
 	RequestedVolSize   int64

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -49,6 +49,8 @@ type ClusterInfo struct {
 		// SubvolumeGroup contains the name of the SubvolumeGroup for CSI volumes
 		SubvolumeGroup string `json:"subvolumeGroup"`
 	} `json:"cephFS"`
+	// symlink filepath for the network namespace where we need to execute commands.
+	NetNamespaceFilePath string `json:"netNamespaceFilePath"`
 }
 
 // Expected JSON structure in the passed in config file is,
@@ -160,4 +162,13 @@ func GetClusterID(options map[string]string) (string, error) {
 	}
 
 	return clusterID, nil
+}
+
+func GetNetNamespaceFilePath(pathToConfig, clusterID string) (string, error) {
+	cluster, err := readClusterInfo(pathToConfig, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	return cluster.NetNamespaceFilePath, nil
 }


### PR DESCRIPTION
add support to run rbd map and mount -t commands with the nsenter.

The complete design of the pod/multus network is added here https://github.com/rook/rook/blob/master/design/ceph/multus-network.md#csi-pods

WIP Rook design PR https://github.com/rook/rook/pull/9903

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>


cc @leseb 