### PR TITLE
build: ignore generated go-tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ deploy/cephcsi/image/cephcsi
 
 # generated golangci-lint configuration
 scripts/golangci.yml
+scripts/golangci.yml.buildtags.in


### PR DESCRIPTION
The `scripts/golangci.yml.buildtags.in` file is generated from the
`Makefile`, there is no need to include it in the repository. By adding
the file to the `.gitignore` list, the output of `git status` will not
show the file anymore.

Fixes: 8fb5739f2 "build: more flexible handling of go build tags; added ceph_preview"

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
