### PR TITLE
deploy: update deployment templates to point to 3.6-canary images

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.6.0
+CSI_IMAGE_VERSION=v3.6-canary
 
 # Ceph version to use
 BASE_IMAGE=quay.io/ceph/ceph:v17

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -87,7 +87,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.6.0
+      tag: v3.6-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -109,7 +109,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.6.0
+      tag: v3.6-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -105,7 +105,7 @@ spec:
               mountPath: /csi
         - name: csi-cephfsplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -144,7 +144,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -47,7 +47,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -105,7 +105,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -112,7 +112,7 @@ spec:
               mountPath: /csi
         - name: csi-rbdplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -168,7 +168,7 @@ spec:
               readOnly: true
         - name: csi-rbdplugin-controller
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -188,7 +188,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,7 +50,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -124,7 +124,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.6.0
+          image: quay.io/cephcsi/cephcsi:v3.6-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -177,7 +177,7 @@ else
 fi
 
 # configure csi image version
-CSI_IMAGE_VERSION=${CSI_IMAGE_VERSION:-"v3.6.0"}
+CSI_IMAGE_VERSION=${CSI_IMAGE_VERSION:-"v3.6-canary"}
 
 #feature-gates for kube
 K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-""}


### PR DESCRIPTION
This commit revert the deployment templates in release 3.6 branch
to canary.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

