### PR TITLE
charts: add allowPrivilegeEscalation: true to containerSecurityContext to nodeplugin daemonset

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -42,6 +42,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: "{{ .Values.nodeplugin.registrar.image.repository }}:{{ .Values.nodeplugin.registrar.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.registrar.image.pullPolicy }}
           args:
@@ -135,6 +136,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           args:

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -42,6 +42,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: "{{ .Values.nodeplugin.registrar.image.repository }}:{{ .Values.nodeplugin.registrar.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.registrar.image.pullPolicy }}
           args:
@@ -142,6 +143,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           args:

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -26,6 +26,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0
           args:
             - "--v=5"
@@ -106,6 +107,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -28,6 +28,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0
           args:
             - "--v=5"
@@ -124,6 +125,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
           image: quay.io/cephcsi/cephcsi:canary
           args:
             - "--type=liveness"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

When running the kubernetes cluster with one single privileged PodSecurityPolicy which is allowing everything the nodeplugin daemonset can fail to start. To be precise the problem is the `defaultAllowPrivilegeEscalation: false` configuration in the PSP. Containers of the nodeplugin daemonset won't start when they have `privileged: true` but no `allowPrivilegeEscalation` in their container securityContext.

Kubernetes will not schedule if this mismatch exists `cannot set allowPrivilegeEscalation to false and privileged to true`:
```
[Warning  FailedCreate  7s (x3 over 14s)  daemonset-controller  (combined from similar events): Error creating: Pod "ceph-csi-nodeplugin-rbd-7qm9f" is invalid: [spec.containers[0].securityContext: Invalid value: core.SecurityContext{Capabilities:(*core.Capabilities)(nil), Privileged:(*bool)(0xc04f579a0c), SELinuxOptions:(*core.SELinuxOptions)(nil), WindowsOptions:(*core.WindowsSecurityContextOptions)(nil), RunAsUser:(*int64)(nil), RunAsGroup:(*int64)(nil), RunAsNonRoot:(*bool)(nil), ReadOnlyRootFilesystem:(*bool)(nil), AllowPrivilegeEscalation:(*bool)(0xc04d20ce50), ProcMount:(*core.ProcMountType)(nil), SeccompProfile:(*core.SeccompProfile)(nil)}: cannot set `allowPrivilegeEscalation` to false and `privileged` to true, spec.containers[2].securityContext: Invalid value: core.SecurityContext{Capabilities:(*core.Capabilities)(nil), Privileged:(*bool)(0xc04f579a0f), SELinuxOptions:(*core.SELinuxOptions)(nil), WindowsOptions:(*core.WindowsSecurityContextOptions)(nil), RunAsUser:(*int64)(nil), RunAsGroup:(*int64)(nil), RunAsNonRoot:(*bool)(nil), ReadOnlyRootFilesystem:(*bool)(nil), AllowPrivilegeEscalation:(*bool)(0xc04d20ce50), ProcMount:(*core.ProcMountType)(nil), SeccompProfile:(*core.SeccompProfile)(nil)}: cannot set `allowPrivilegeEscalation` to false and `privileged` to true]]()
``` 

The default PodSecurityPolicy for every workload in the k8s cluster is the following:
```yaml
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  annotations:
    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
  name: system-unrestricted-psp
spec:
  allowPrivilegeEscalation: true
  allowedCapabilities:
  - '*'
  defaultAllowPrivilegeEscalation: false
  fsGroup:
    rule: RunAsAny
  hostIPC: true
  hostNetwork: true
  hostPID: true
  hostPorts:
  - max: 65535
    min: 0
  privileged: true
  runAsUser:
    rule: RunAsAny
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    rule: RunAsAny
  volumes:
  - '*'
```

The daemonsets run when the `allowPrivilegeEscalation` parameter is added to the container securityContext config. In detail this is needed for the containers:
* driver-registrar
* liveness-prometheus

Updating the helm chart templates for `ceph-csi-rbd` and `ceph-csi-cephfs`solve the problem when using `defaultAllowPrivilegeEscalation: true` in global privileged PodSecurityPolicy. For example:

```yaml
{{- if .Values.nodeplugin.httpMetrics.enabled }}
        - name: liveness-prometheus
          securityContext:
            privileged: true
            allowPrivilegeEscalation: true
          image: "{{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}"
``` 


## Is there anything that requires special attention ##

Do you have any questions? No

Is the change backward compatible? Yes

Are there concerns around backward compatibility? No

Provide any external context for the change, if any.

For example:

https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

None

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

None

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
