### PR TITLE
doc: move release 3.4.0 to unsupported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ in the Kubernetes documentation.
 | v3.6.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.6.0    |
 | v3.5.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.5.1    |
 | v3.5.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.5.0    |
-| v3.4.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.4.0    |
 
 | Deprecated Ceph CSI Release/Branch | Container image name | Image Tag |
 | ----------------------- | --------------------------------| --------- |
+| v3.4.0 (Release)        | quay.io/cephcsi/cephcsi         | v3.4.0    |
 | v3.3.1 (Release)        | quay.io/cephcsi/cephcsi         | v3.3.1    |
 | v3.3.0 (Release)        | quay.io/cephcsi/cephcsi         | v3.3.0    |
 | v3.2.2 (Release)        | quay.io/cephcsi/cephcsi         | v3.2.2    |


### PR DESCRIPTION
As we have 3.6.0 release available now, moving 3.4.0
to unsupported version.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

