### PR TITLE
e2e: miscelanious changes for testing on OpenShift

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -102,6 +102,7 @@ are available while running tests:
 | timeout           | Panic test binary after duration d (default 0, timeout disabled)              |
 | v                 | Verbose: print additional output                                              |
 | filesystem        | Name of the CephFS filesystem (default: "myfs")                               |
+| is-openshift      | Run in OpenShift compatibility mode, skips certain new feature tests          |
 
 ## E2E for snapshot
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -101,6 +101,7 @@ are available while running tests:
 | kubeconfig        | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config) |
 | timeout           | Panic test binary after duration d (default 0, timeout disabled)              |
 | v                 | Verbose: print additional output                                              |
+| filesystem        | Name of the CephFS filesystem (default: "myfs")                               |
 
 ## E2E for snapshot
 

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -40,7 +40,7 @@ const (
 
 // validateSubvolumegroup validates whether subvolumegroup is present.
 func validateSubvolumegroup(f *framework.Framework, subvolgrp string) error {
-	cmd := fmt.Sprintf("ceph fs subvolumegroup getpath myfs %s", subvolgrp)
+	cmd := fmt.Sprintf("ceph fs subvolumegroup getpath %s %s", fileSystemName, subvolgrp)
 	stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to exec command in toolbox: %w", err)
@@ -67,7 +67,7 @@ func createCephfsStorageClass(
 	if err != nil {
 		return err
 	}
-	sc.Parameters["fsName"] = "myfs"
+	sc.Parameters["fsName"] = fileSystemName
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-name"] = cephFSProvisionerSecretName
 

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -47,7 +47,7 @@ func createConfigMap(pluginPath string, c kubernetes.Interface, f *framework.Fra
 
 	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to exec command in toolbox: %w", err)
 	}
 	if stdErr != "" {
 		return fmt.Errorf("error getting fsid %v", stdErr)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -44,6 +44,7 @@ func init() {
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
 	flag.StringVar(&fileSystemName, "filesystem", "myfs", "CephFS filesystem to use")
+	flag.BoolVar(&isOpenShift, "is-openshift", false, "disables certain checks on OpenShift")
 	setDefaultKubeconfig()
 
 	// Register framework flags, then handle flags

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,6 +43,7 @@ func init() {
 	flag.StringVar(&upgradeVersion, "upgrade-version", "v3.5.1", "target version for upgrade testing")
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
+	flag.StringVar(&fileSystemName, "filesystem", "myfs", "CephFS filesystem to use")
 	setDefaultKubeconfig()
 
 	// Register framework flags, then handle flags

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -331,7 +331,6 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	var (
 		cephFsVolName = "testSubVol"
 		groupName     = "testGroup"
-		fsName        = "myfs"
 		pvName        = "pv-name"
 		pvcName       = "pvc-name"
 		namespace     = f.UniqueName
@@ -361,7 +360,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	size := "4294967296"
 
 	// create subvolumegroup, command will work even if group is already present.
-	cmd := fmt.Sprintf("ceph fs subvolumegroup create %s %s", fsName, groupName)
+	cmd := fmt.Sprintf("ceph fs subvolumegroup create %s %s", fileSystemName, groupName)
 
 	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	if err != nil {
@@ -372,7 +371,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	}
 
 	// create subvolume
-	cmd = fmt.Sprintf("ceph fs subvolume create %s %s %s --size %s", fsName, cephFsVolName, groupName, size)
+	cmd = fmt.Sprintf("ceph fs subvolume create %s %s %s --size %s", fileSystemName, cephFsVolName, groupName, size)
 	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	if err != nil {
 		return err
@@ -382,7 +381,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	}
 
 	// get rootpath
-	cmd = fmt.Sprintf("ceph fs subvolume getpath %s %s %s", fsName, cephFsVolName, groupName)
+	cmd = fmt.Sprintf("ceph fs subvolume getpath %s %s %s", fileSystemName, cephFsVolName, groupName)
 	rootPath, e, err := execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	if err != nil {
 		return err
@@ -415,7 +414,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	}
 
 	opt["clusterID"] = fsID
-	opt["fsName"] = fsName
+	opt["fsName"] = fileSystemName
 	opt["staticVolume"] = strconv.FormatBool(true)
 	opt["rootPath"] = rootPath
 	pv := getStaticPV(
@@ -474,7 +473,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	}
 
 	// delete subvolume
-	cmd = fmt.Sprintf("ceph fs subvolume rm %s %s %s", fsName, cephFsVolName, groupName)
+	cmd = fmt.Sprintf("ceph fs subvolume rm %s %s %s", fileSystemName, cephFsVolName, groupName)
 	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	if err != nil {
 		return err
@@ -484,7 +483,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	}
 
 	// delete subvolume group
-	cmd = fmt.Sprintf("ceph fs subvolumegroup rm %s %s", fsName, groupName)
+	cmd = fmt.Sprintf("ceph fs subvolumegroup rm %s %s", fileSystemName, groupName)
 	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	if err != nil {
 		return err

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -526,7 +526,7 @@ func pvcDeleteWhenPoolNotFound(pvcPath string, cephFS bool, f *framework.Framewo
 			return err
 		}
 		// delete cephFS filesystem
-		err = deletePool("myfs", cephFS, f)
+		err = deletePool(fileSystemName, cephFS, f)
 		if err != nil {
 			return err
 		}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -78,6 +78,7 @@ var (
 	rookNamespace    string
 	radosNamespace   string
 	poll             = 2 * time.Second
+	isOpenShift      bool
 )
 
 func getMons(ns string, c kubernetes.Interface) ([]string, error) {
@@ -404,7 +405,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 	if pvc.Spec.VolumeMode != nil {
 		isBlockMode = (*pvc.Spec.VolumeMode == v1.PersistentVolumeBlock)
 	}
-	if !isBlockMode || k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
+	if (!isBlockMode || k8sVersionGreaterEquals(f.ClientSet, 1, 22)) && !isOpenShift {
 		err = getMetricsForPVC(f, pvc, deployTimeout)
 		if err != nil {
 			return err


### PR DESCRIPTION
While working on adding NFS-provisioner tests to the e2e suite, I found several
obstacles that prevented executing the tests on OpenShift. A couple of the
improvements to the e2e suite are included in this PR. There should not be any
functional changes to the current e2e tests, as defaults are unmodified.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
