### PR TITLE
Remove metadata from snapshot/clone/parent RBD image

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	librbd "github.com/ceph/go-ceph/rbd"
@@ -205,6 +206,13 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 			}
 		}
 	}()
+
+	err = tempClone.unsetAllMetadata(k8s.GetVolumeMetadataKeys())
+	if err != nil {
+		log.ErrorLog(ctx, "failed to unset volume metadata on temp clone image %q: %v", tempClone, err)
+
+		return err
+	}
 
 	// create snap of temp clone from temporary cloned image
 	// create final clone

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -331,7 +331,8 @@ func (cs *ControllerServer) CreateVolume(
 	}
 
 	// Set Metadata on PV Create
-	err = rbdVol.setVolumeMetadata(req.GetParameters())
+	metadata := k8s.GetVolumeMetadata(req.GetParameters())
+	err = rbdVol.setAllMetadata(metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +455,8 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 	}
 
 	// Set metadata on restart of provisioner pod when image exist
-	err := rbdVol.setVolumeMetadata(req.GetParameters())
+	metadata := k8s.GetVolumeMetadata(req.GetParameters())
+	err := rbdVol.setAllMetadata(metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -1074,7 +1076,8 @@ func (cs *ControllerServer) CreateSnapshot(
 
 	// Set snapshot-name/snapshot-namespace/snapshotcontent-name details
 	// on RBD backend image as metadata on create
-	err = rbdVol.setSnapshotMetadata(req.GetParameters())
+	metadata := k8s.GetSnapshotMetadata(req.GetParameters())
+	err = rbdVol.setAllMetadata(metadata)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -1131,7 +1134,8 @@ func cloneFromSnapshot(
 	// Update snapshot-name/snapshot-namespace/snapshotcontent-name details on
 	// RBD backend image as metadata on restart of provisioner pod when image exist
 	if len(parameters) != 0 {
-		err = rbdVol.setSnapshotMetadata(parameters)
+		metadata := k8s.GetSnapshotMetadata(parameters)
+		err = rbdVol.setAllMetadata(metadata)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -971,7 +971,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 }
 
 // CreateSnapshot creates the snapshot in backend and stores metadata in store.
-// nolint:cyclop // TODO: reduce complexity
+// nolint:gocyclo,cyclop // TODO: reduce complexity.
 func (cs *ControllerServer) CreateSnapshot(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
@@ -1074,6 +1074,10 @@ func (cs *ControllerServer) CreateSnapshot(
 	// Update the metadata on snapshot not on the original image
 	rbdVol.RbdImageName = rbdSnap.RbdSnapName
 
+	err = rbdVol.unsetAllMetadata(k8s.GetVolumeMetadataKeys())
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	// Set snapshot-name/snapshot-namespace/snapshotcontent-name details
 	// on RBD backend image as metadata on create
 	metadata := k8s.GetSnapshotMetadata(req.GetParameters())

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -591,6 +591,12 @@ func (cs *ControllerServer) createVolumeFromSnapshot(
 
 		return err
 	}
+	err = rbdVol.unsetAllMetadata(k8s.GetSnapshotMetadataKeys())
+	if err != nil {
+		log.ErrorLog(ctx, "failed to unset snapshot metadata on rbd image %q: %v", rbdVol, err)
+
+		return err
+	}
 
 	log.DebugLog(ctx, "create volume %s from snapshot %s", rbdVol, rbdSnap)
 

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -617,7 +617,7 @@ func RegenerateJournal(
 		}
 		// Update Metadata on reattach of the same old PV
 		parameters := k8s.PrepareVolumeMetadata(claimName, rbdVol.Owner, "")
-		err = rbdVol.setVolumeMetadata(parameters)
+		err = rbdVol.setAllMetadata(parameters)
 		if err != nil {
 			return "", fmt.Errorf("failed to set volume metadata: %w", err)
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/ceph/go-ceph/rados"
@@ -1913,22 +1912,9 @@ func genVolFromVolIDWithMigration(
 	return rv, err
 }
 
-// setVolumeMetadata set PV/PVC/PVCNamespace metadata on RBD image.
-func (rv *rbdVolume) setVolumeMetadata(parameters map[string]string) error {
-	for k, v := range k8s.GetVolumeMetadata(parameters) {
-		err := rv.SetMetadata(k, v)
-		if err != nil {
-			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w", k, v, err)
-		}
-	}
-
-	return nil
-}
-
-// setSnapshotMetadata Set snapshot-name/snapshot-namespace/snapshotcontent-name metadata
-// on RBD image.
-func (rv *rbdVolume) setSnapshotMetadata(parameters map[string]string) error {
-	for k, v := range k8s.GetSnapshotMetadata(parameters) {
+// setAllMetadata set all the metadata from arg parameters on RBD image.
+func (rv *rbdVolume) setAllMetadata(parameters map[string]string) error {
+	for k, v := range parameters {
 		err := rv.SetMetadata(k, v)
 		if err != nil {
 			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w", k, v, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1923,3 +1923,16 @@ func (rv *rbdVolume) setAllMetadata(parameters map[string]string) error {
 
 	return nil
 }
+
+// unsetAllMetadata unset all the metadata from arg keys on RBD image.
+func (rv *rbdVolume) unsetAllMetadata(keys []string) error {
+	for _, key := range keys {
+		err := rv.RemoveMetadata(key)
+		// TODO: replace string comparison with errno.
+		if err != nil && !strings.Contains(err.Error(), "No such file or directory") {
+			return fmt.Errorf("failed to unset metadata key %q on %q: %w", key, rv, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -69,6 +69,15 @@ func GetVolumeMetadata(parameters map[string]string) map[string]string {
 	return newParam
 }
 
+// GetVolumeMetadataKeys return volume metadata keys.
+func GetVolumeMetadataKeys() []string {
+	return []string{
+		pvcNameKey,
+		pvcNamespaceKey,
+		pvNameKey,
+	}
+}
+
 // PrepareVolumeMetadata return PV/PVC/PVCNamespace metadata based on inputs.
 func PrepareVolumeMetadata(pvcName, pvcNamespace, pvName string) map[string]string {
 	newParam := map[string]string{}
@@ -99,4 +108,13 @@ func GetSnapshotMetadata(parameters map[string]string) map[string]string {
 	}
 
 	return newParam
+}
+
+// GetSnapshotMetadataKeys return snapshot metadata keys.
+func GetSnapshotMetadataKeys() []string {
+	return []string{
+		volSnapNameKey,
+		volSnapNamespaceKey,
+		volSnapContentNameKey,
+	}
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Remove metadata on images for various scenarios:
* Unset the PVC metadata on the rbd image created for the snapshot
* Unset the snapshot metadata from the rbd image created from the snapshot
* Unset the parent PVC metadata on the temp clone rbd image
* Also add various testcases to validate unset of metadata
## Related issues ##

Fixes: #2970

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
