### PR TITLE
rbd: check nbd tool features only for rbd driver

### DIFF
--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -153,6 +153,8 @@ func (r *Driver) Run(conf *util.Config) {
 			log.FatalLogMsg(err.Error())
 		}
 		rbd.SetGlobalInt("krbdFeatures", krbdFeatures)
+
+		rbd.SetRbdNbdToolFeatures()
 	}
 
 	if conf.IsControllerServer {

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -92,10 +92,6 @@ var (
 	}
 )
 
-func init() {
-	setRbdNbdToolFeatures()
-}
-
 // rbdDeviceInfo strongly typed JSON spec for rbd device list output (of type krbd).
 type rbdDeviceInfo struct {
 	ID             string `json:"id"`
@@ -216,8 +212,9 @@ func waitForPath(ctx context.Context, pool, namespace, image string, maxRetries 
 	return "", false
 }
 
-// set features available with rbd-nbd, and NBD module loaded status.
-func setRbdNbdToolFeatures() {
+// SetRbdNbdToolFeatures sets features available with rbd-nbd, and NBD module
+// loaded status.
+func SetRbdNbdToolFeatures() {
 	var stderr string
 	// check if the module is loaded or compiled in
 	_, err := os.Stat(fmt.Sprintf("/sys/module/%s", moduleNbd))


### PR DESCRIPTION
calling setRbdNbdToolFeatures inside an init gets called in main.go for both cephfs and rbd driver. instead of calling it in init function call this in rbd driver.go as this is specific to rbd.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

