### PR TITLE
deploy: snapshot deployment is no longer beta

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -106,30 +106,6 @@ are available while running tests:
 
 After the support for snapshot/clone has been added to ceph-csi,
 you need to follow these steps before running e2e.
-Please note that the snapshot operation works only if the Kubernetes version
-is greater than or equal to 1.17.0.
-
-- Delete Alpha snapshot CRD created by ceph-csi in rook.
-  - Check if you have any `v1alpha1` CRD created in our Kubernetes cluster
-
-      ```bash
-      $ kubectl get crd volumesnapshotclasses.snapshot.storage.k8s.io -o yaml |grep v1alpha1
-        - name: v1alpha1
-        - v1alpha1
-      $ kubectl get crd volumesnapshotcontents.snapshot.storage.k8s.io -o yaml |grep v1alpha1
-        - name: v1alpha1
-        - v1alpha1
-      $ kubectl get crd volumesnapshots.snapshot.storage.k8s.io -o yaml |grep v1alpha1
-        - name: v1alpha1
-        - v1alpha1
-      ```
-
-  - If you have Alpha CRD, delete it as from Kubernetes 1.17.0+ the snapshot
-    should be `v1beta1`
-
-    ```console
-    ./scripts/install-snapshot.sh delete-crd
-    ```
 
 - Install snapshot controller and Beta snapshot CRD
 

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -456,7 +456,7 @@ var _ = Describe("cephfs", func() {
 				// clean up after ourselves
 				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
-					e2elog.Failf("failed to  delete PVC: %v", err)
+					e2elog.Failf("failed to delete PVC: %v", err)
 				}
 				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
@@ -575,7 +575,7 @@ var _ = Describe("cephfs", func() {
 				if err != nil {
 					e2elog.Failf("killall command failed: err %v, stderr %s", err, stdErr)
 				}
-				// Verify Pod podName2 that stat()-ing the mountpoint results in ENOTCONN.
+				// Verify Pod pod2Name that stat()-ing the mountpoint results in ENOTCONN.
 				stdErr, err = doStat(pod2Name)
 				if err == nil || !strings.Contains(stdErr, "not connected") {
 					e2elog.Failf(
@@ -583,7 +583,7 @@ var _ = Describe("cephfs", func() {
 						err, stdErr,
 					)
 				}
-				// Delete podName2 Pod. This serves two purposes: it verifies that deleting pods with
+				// Delete pod2Name Pod. This serves two purposes: it verifies that deleting pods with
 				// corrupted ceph-fuse mountpoints works, and it lets the replicaset controller recreate
 				// the pod with hopefully mounts working again.
 				err = deletePod(pod2Name, depl.Namespace, c, deployTimeout)
@@ -616,7 +616,7 @@ var _ = Describe("cephfs", func() {
 					}
 					e2elog.Failf("no new replica found ; found replicas %v", podNames)
 				}
-				// Verify Pod podName3 has its ceph-fuse mount working again.
+				// Verify Pod pod2Name has its ceph-fuse mount working again.
 				err = ensureStatSucceeds(pod2Name)
 				if err != nil {
 					e2elog.Failf(err.Error())

--- a/e2e/kms.go
+++ b/e2e/kms.go
@@ -31,7 +31,7 @@ const (
 
 // kmsConfig is an interface that should be used when passing a configuration
 // for a KMS to validation functions. This allows the validation functions to
-// work independently from the actual KMS.
+// work independently of the actual KMS.
 type kmsConfig interface {
 	canGetPassphrase() bool
 	getPassphrase(f *framework.Framework, key string) (string, string)

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# This script can be used to install/delete snapshotcontroller and snapshot beta CRD
+# This script can be used to install/delete snapshotcontroller and snapshot CRD
 
 SCRIPT_DIR="$(dirname "${0}")"
 


### PR DESCRIPTION

    deploy: snapshot deployment is no longer beta
    
    Considering snapshot controllers have been moved to GA since
    kube version 1.20, we no longer need to have a mention of beta
    version of the same in our deployment.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>