### PR TITLE
cleanup: remove import alias for fence library along with other cleanup

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -296,7 +296,7 @@ var _ = Describe("cephfs", func() {
 				}
 			})
 
-			By("checking nodeplugin deamonset pods are running", func() {
+			By("checking nodeplugin daemonset pods are running", func() {
 				err := waitForDaemonSets(cephFSDeamonSetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
 					e2elog.Failf("timeout waiting for daemonset %s: %v", cephFSDeamonSetName, err)

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -339,7 +339,7 @@ func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t i
 			return false, nil
 		}
 		if stdOut == "" {
-			e2elog.Logf("no metrics received from kublet on IP %s", kubelet)
+			e2elog.Logf("no metrics received from kubelet on IP %s", kubelet)
 
 			return false, nil
 		}

--- a/internal/csi-addons/rbd/network_fence_test.go
+++ b/internal/csi-addons/rbd/network_fence_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	fence "github.com/csi-addons/spec/lib/go/fence"
+	"github.com/csi-addons/spec/lib/go/fence"
 )
 
 // TestFenceClusterNetwork is a minimal test for the FenceClusterNetwork()

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -148,7 +148,7 @@ func (ri *rbdImage) resyncImage() error {
 	return nil
 }
 
-// getImageMirroingStatus get the mirroring status of an image.
+// getImageMirroringStatus get the mirroring status of an image.
 func (ri *rbdImage) getImageMirroringStatus() (*librbd.GlobalMirrorImageStatus, error) {
 	image, err := ri.open()
 	if err != nil {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -524,7 +524,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 // complete omap mapping between imageName and volumeID.
 
 // RegenerateJournal performs below operations
-// Extract clusterID, Mons after checkig clusterID mapping
+// Extract clusterID, Mons after checking clusterID mapping
 // Extract parameters journalPool, pool from volumeAttributes
 // Extract optional parameters volumeNamePrefix, kmsID, owner from volumeAttributes
 // Extract information from volumeID

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -942,7 +942,7 @@ func genSnapFromSnapID(
 	return err
 }
 
-// updateSnapshotDetails will copies the details from the rbdVolume to the
+// updateSnapshotDetails will copy the details from the rbdVolume to the
 // rbdSnapshot. example copying size from rbdVolume to rbdSnapshot.
 func updateSnapshotDetails(rbdSnap *rbdSnapshot) error {
 	vol := generateVolFromSnap(rbdSnap)

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -464,7 +464,7 @@ func disableVolumeReplication(rbdVol *rbdVolume,
 		// Local image is in up+replaying state
 
 		// If the image is in a secondary and its state is  up+replaying means
-		// its an healthy secondary and the image is primary somewhere in the
+		// its a healthy secondary and the image is primary somewhere in the
 		// remote cluster and the local image is getting replayed. Return
 		// success for the Disabling mirroring as we cannot disable mirroring
 		// on the secondary image, when the image on the primary site gets


### PR DESCRIPTION
cleanup: remove import alias for fence library along with other cleanup
    
this commit remove unneeded import alias of fence library from the
network_fence test. also this commit correct some typos in the source
code comments.

   
 Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
