### PR TITLE
doc: add Open Source Security Foundation (OpenSSF) best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report
 Card](https://goreportcard.com/badge/github.com/ceph/ceph-csi)](https://goreportcard.com/report/github.com/ceph/ceph-csi)
 [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/ceph/ceph-csi/devel)](https://www.tickgit.com/browse?repo=github.com/ceph/ceph-csi&branch=devel)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5940/badge)](https://bestpractices.coreinfrastructure.org/projects/5940)
 
 - [Ceph CSI](#ceph-csi)
   - [Overview](#overview)


### PR DESCRIPTION
The project is currently at 54% of the best practices. Hopefully this
badge creates some interest in increasing the grade.

See-also: https://bestpractices.coreinfrastructure.org/projects/5940

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
