### PR TITLE
nfs: add provisioner & plugin sa to scc.yaml

### DIFF
--- a/api/deploy/ocp/scc.yaml
+++ b/api/deploy/ocp/scc.yaml
@@ -41,3 +41,5 @@ users:
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-plugin-sa"
   # yamllint disable-line rule:line-length
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-provisioner-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-plugin-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-provisioner-sa"

--- a/deploy/scc.yaml
+++ b/deploy/scc.yaml
@@ -48,3 +48,5 @@ users:
   - "system:serviceaccount:ceph-csi:csi-cephfs-plugin-sa"
   # yamllint disable-line rule:line-length
   - "system:serviceaccount:ceph-csi:csi-cephfs-provisioner-sa"
+  - "system:serviceaccount:ceph-csi:csi-nfs-plugin-sa"
+  - "system:serviceaccount:ceph-csi:csi-nfs-provisioner-sa"

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
@@ -41,3 +41,5 @@ users:
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-plugin-sa"
   # yamllint disable-line rule:line-length
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-provisioner-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-plugin-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-provisioner-sa"


### PR DESCRIPTION
This commit adds nfs provisioner & plugin sa to
scc.yaml to be used with openshift.

Signed-off-by: Rakshith R <rar@redhat.com>
