### PR TITLE
e2e: improve OpenShift compatibility

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -87,22 +87,23 @@ Thanks to [minikube](../scripts/minikube.sh) script for the handy `deploy-rook` 
 In addition to standard go tests parameters, the following custom parameters
 are available while running tests:
 
-| flag              | description                                                                   |
-| ----------------- | ----------------------------------------------------------------------------- |
-| deploy-timeout    | Timeout to wait for created kubernetes resources (default: 10 minutes)        |
-| deploy-cephfs     | Deploy cephFS CSI driver as part of E2E (default: true)                       |
-| deploy-rbd        | Deploy rbd CSI driver as part of E2E (default: true)                          |
-| test-cephfs       | Test cephFS CSI driver as part of E2E (default: true)                         |
-| upgrade-testing   | Perform upgrade testing (default: false)                                      |
-| upgrade-version   | Target version for upgrade testing (default: "v3.5.1")                        |
-| test-rbd          | Test rbd CSI driver as part of E2E (default: true)                            |
-| cephcsi-namespace | The namespace in which cephcsi driver will be created (default: "default")    |
-| rook-namespace    | The namespace in which rook operator is installed (default: "rook-ceph")      |
-| kubeconfig        | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config) |
-| timeout           | Panic test binary after duration d (default 0, timeout disabled)              |
-| v                 | Verbose: print additional output                                              |
-| is-openshift      | Run in OpenShift compatibility mode, skips certain new feature tests          |
-| filesystem        | Name of the CephFS filesystem (default: "myfs")                               |
+| flag              | description                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------- |
+| deploy-timeout    | Timeout to wait for created kubernetes resources (default: 10 minutes)                            |
+| deploy-cephfs     | Deploy cephFS CSI driver as part of E2E (default: true)                                           |
+| deploy-rbd        | Deploy rbd CSI driver as part of E2E (default: true)                                              |
+| test-cephfs       | Test cephFS CSI driver as part of E2E (default: true)                                             |
+| upgrade-testing   | Perform upgrade testing (default: false)                                                          |
+| upgrade-version   | Target version for upgrade testing (default: "v3.5.1")                                            |
+| test-rbd          | Test rbd CSI driver as part of E2E (default: true)                                                |
+| cephcsi-namespace | The namespace in which cephcsi driver will be created (default: "default")                        |
+| rook-namespace    | The namespace in which rook operator is installed (default: "rook-ceph")                          |
+| kubeconfig        | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config)                     |
+| timeout           | Panic test binary after duration d (default 0, timeout disabled)                                  |
+| v                 | Verbose: print additional output                                                                  |
+| is-openshift      | Run in OpenShift compatibility mode, skips certain new feature tests                              |
+| filesystem        | Name of the CephFS filesystem (default: "myfs")                                                   |
+| clusterid         | Use the Ceph cluster id in the StorageClasses and SnapshotClasses (default: `ceph fsid` detected) |
 
 ## E2E for snapshot
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -101,8 +101,8 @@ are available while running tests:
 | kubeconfig        | Path to kubeconfig containing embedded authinfo (default: $HOME/.kube/config) |
 | timeout           | Panic test binary after duration d (default 0, timeout disabled)              |
 | v                 | Verbose: print additional output                                              |
-| filesystem        | Name of the CephFS filesystem (default: "myfs")                               |
 | is-openshift      | Run in OpenShift compatibility mode, skips certain new feature tests          |
+| filesystem        | Name of the CephFS filesystem (default: "myfs")                               |
 
 ## E2E for snapshot
 

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -339,6 +339,11 @@ var _ = Describe("cephfs", func() {
 
 					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
+						if rwopMayFail(err) {
+							e2elog.Logf("RWOP is not supported: %v", err)
+
+							return
+						}
 						e2elog.Failf("failed to create PVC: %v", err)
 					}
 					err = createApp(f.ClientSet, app, deployTimeout)

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -92,14 +92,12 @@ func createCephfsStorageClass(
 
 	// fetch and set fsID from the cluster if not set in params
 	if _, found := params["clusterID"]; !found {
-		fsID, stdErr, failErr := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
-		if failErr != nil {
-			return failErr
+		var fsID string
+		fsID, err = getClusterID(f)
+		if err != nil {
+			return fmt.Errorf("failed to get clusterID: %w", err)
 		}
-		if stdErr != "" {
-			return fmt.Errorf("error getting fsid %v", stdErr)
-		}
-		sc.Parameters["clusterID"] = strings.Trim(fsID, "\n")
+		sc.Parameters["clusterID"] = fsID
 	}
 	sc.Namespace = cephCSINamespace
 

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/ceph/ceph-csi/internal/util"
 
@@ -45,15 +44,11 @@ func createConfigMap(pluginPath string, c kubernetes.Interface, f *framework.Fra
 		return err
 	}
 
-	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
+	fsID, err := getClusterID(f)
 	if err != nil {
-		return fmt.Errorf("failed to exec command in toolbox: %w", err)
+		return fmt.Errorf("failed to get clusterID: %w", err)
 	}
-	if stdErr != "" {
-		return fmt.Errorf("error getting fsid %v", stdErr)
-	}
-	// remove new line present in fsID
-	fsID = strings.Trim(fsID, "\n")
+
 	// get mon list
 	mons, err := getMons(rookNamespace, c)
 	if err != nil {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -45,6 +45,7 @@ func init() {
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
 	flag.BoolVar(&isOpenShift, "is-openshift", false, "disables certain checks on OpenShift")
 	flag.StringVar(&fileSystemName, "filesystem", "myfs", "CephFS filesystem to use")
+	flag.StringVar(&clusterID, "clusterid", "", "Ceph cluster ID to use (defaults to `ceph fsid` detection)")
 	setDefaultKubeconfig()
 
 	// Register framework flags, then handle flags

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,8 +43,8 @@ func init() {
 	flag.StringVar(&upgradeVersion, "upgrade-version", "v3.5.1", "target version for upgrade testing")
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
-	flag.StringVar(&fileSystemName, "filesystem", "myfs", "CephFS filesystem to use")
 	flag.BoolVar(&isOpenShift, "is-openshift", false, "disables certain checks on OpenShift")
+	flag.StringVar(&fileSystemName, "filesystem", "myfs", "CephFS filesystem to use")
 	setDefaultKubeconfig()
 
 	// Register framework flags, then handle flags

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -794,6 +794,11 @@ var _ = Describe("RBD", func() {
 					baseAppName := app.Name
 					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
+						if rwopMayFail(err) {
+							e2elog.Logf("RWOP is not supported: %v", err)
+
+							return
+						}
 						e2elog.Failf("failed to create PVC: %v", err)
 					}
 					// validate created backend rbd images
@@ -828,6 +833,11 @@ var _ = Describe("RBD", func() {
 					baseAppName := app.Name
 					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 					if err != nil {
+						if rwopMayFail(err) {
+							e2elog.Logf("RWOP is not supported: %v", err)
+
+							return
+						}
 						e2elog.Failf("failed to create PVC: %v", err)
 					}
 					// validate created backend rbd images

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -136,15 +136,10 @@ func createRBDStorageClass(
 	sc.Parameters["csi.storage.k8s.io/node-stage-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/node-stage-secret-name"] = rbdNodePluginSecretName
 
-	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
+	fsID, err := getClusterID(f)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get clusterID: %w", err)
 	}
-	if stdErr != "" {
-		return fmt.Errorf("error getting fsid %v", stdErr)
-	}
-	// remove new line present in fsID
-	fsID = strings.Trim(fsID, "\n")
 
 	sc.Parameters["clusterID"] = fsID
 	for k, v := range parameters {

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -158,14 +157,10 @@ func createRBDSnapshotClass(f *framework.Framework) error {
 	sc.Parameters["csi.storage.k8s.io/snapshotter-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/snapshotter-secret-name"] = rbdProvisionerSecretName
 
-	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
+	fsID, err := getClusterID(f)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get clusterID: %w", err)
 	}
-	if stdErr != "" {
-		return fmt.Errorf("failed to get fsid from ceph cluster %s", stdErr)
-	}
-	fsID = strings.Trim(fsID, "\n")
 	sc.Parameters["clusterID"] = fsID
 	sclient, err := newSnapshotClient()
 	if err != nil {
@@ -193,14 +188,11 @@ func createCephFSSnapshotClass(f *framework.Framework) error {
 	sc := getSnapshotClass(scPath)
 	sc.Parameters["csi.storage.k8s.io/snapshotter-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/snapshotter-secret-name"] = cephFSProvisionerSecretName
-	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
+
+	fsID, err := getClusterID(f)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get clusterID: %w", err)
 	}
-	if stdErr != "" {
-		return fmt.Errorf("failed to get fsid from ceph cluster %s", stdErr)
-	}
-	fsID = strings.Trim(fsID, "\n")
 	sc.Parameters["clusterID"] = fsID
 	sclient, err := newSnapshotClient()
 	if err != nil {

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -127,15 +127,11 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 
 	c := f.ClientSet
 
-	fsID, e, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
+	fsID, err := getClusterID(f)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get clusterID: %w", err)
 	}
-	if e != "" {
-		return fmt.Errorf("failed to get fsid from ceph cluster %s", e)
-	}
-	// remove new line present in fsID
-	fsID = strings.Trim(fsID, "\n")
+
 	size := staticPVSize
 	// create rbd image
 	cmd := fmt.Sprintf(
@@ -144,7 +140,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 		staticPVSize,
 		rbdOptions(defaultRBDPool))
 
-	_, e, err = execCommandInToolBoxPod(f, cmd, rookNamespace)
+	_, e, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
 	if err != nil {
 		return err
 	}
@@ -346,15 +342,10 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 		LabelSelector: "app=rook-ceph-tools",
 	}
 
-	fsID, e, err := execCommandInPod(f, "ceph fsid", rookNamespace, &listOpt)
+	fsID, err := getClusterID(f)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get clusterID: %w", err)
 	}
-	if e != "" {
-		return fmt.Errorf("failed to get fsid from ceph cluster %s", e)
-	}
-	// remove new line present in fsID
-	fsID = strings.Trim(fsID, "\n")
 
 	// 4GiB in bytes
 	size := "4294967296"
@@ -362,7 +353,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	// create subvolumegroup, command will work even if group is already present.
 	cmd := fmt.Sprintf("ceph fs subvolumegroup create %s %s", fileSystemName, groupName)
 
-	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
+	_, e, err := execCommandInPod(f, cmd, rookNamespace, &listOpt)
 	if err != nil {
 		return err
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -79,6 +79,7 @@ var (
 	radosNamespace   string
 	poll             = 2 * time.Second
 	isOpenShift      bool
+	clusterID        string
 )
 
 func getMons(ns string, c kubernetes.Interface) ([]string, error) {
@@ -122,6 +123,10 @@ func getMonsHash(mons string) string {
 }
 
 func getClusterID(f *framework.Framework) (string, error) {
+	if clusterID != "" {
+		return clusterID, nil
+	}
+
 	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed getting clusterID through toolbox: %w", err)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -121,6 +121,18 @@ func getMonsHash(mons string) string {
 	return fmt.Sprintf("%x", md5.Sum([]byte(mons))) //nolint:gosec // hash generation
 }
 
+func getClusterID(f *framework.Framework) (string, error) {
+	fsID, stdErr, err := execCommandInToolBoxPod(f, "ceph fsid", rookNamespace)
+	if err != nil {
+		return "", fmt.Errorf("failed getting clusterID through toolbox: %w", err)
+	}
+	if stdErr != "" {
+		return "", fmt.Errorf("error getting fsid: %s", stdErr)
+	}
+	// remove new line present in fsID
+	return strings.Trim(fsID, "\n"), nil
+}
+
 func getStorageClass(path string) (scv1.StorageClass, error) {
 	sc := scv1.StorageClass{}
 	err := unmarshal(path, &sc)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1492,3 +1492,22 @@ func retryKubectlArgs(namespace string, action kubectlAction, t int, args ...str
 		return true, nil
 	})
 }
+
+// rwopSupported indicates that a test using RWOP is expected to succeed. If
+// the accessMode is reported as invalid, rwopSupported will be set to false.
+var rwopSupported = true
+
+// rwopMayFail returns true if the accessMode is not valid. k8s v1.22 requires
+// a feature gate, which might not be set. In case the accessMode is invalid,
+// the featuregate is not set, and testing RWOP is not possible.
+func rwopMayFail(err error) bool {
+	if !rwopSupported {
+		return true
+	}
+
+	if strings.Contains(err.Error(), `invalid: spec.accessModes: Unsupported value: "ReadWriteOncePod"`) {
+		rwopSupported = false
+	}
+
+	return !rwopSupported
+}


### PR DESCRIPTION
The Ceph cluster-id is usually detected with `ceph fsid`. This is not
always correct, as the the Ceph cluster can also be configured by name.
If the -clusterid=... is passed, it will be used instead of trying to
detect it with `ceph fsid`.

A new -filesystem=... option has been added so that the e2e tests can
run against environments that do not have a "myfs" CephFS filesystem.

Current versions of OpenShift does not support the ReadWriteOncePod
accessMode. Kubernetes v1.22 requires a feature-gate to be enabled. In
case the accessMode is reported as invalid, assume support is missing
and allow the RWOP tests to fail/skip.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
