### PR TITLE
deploy: use k8s.gcr.io registry for the NFS-nodeplugin

### DIFF
--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -86,7 +86,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          image: mcr.microsoft.com/k8s/csi/nfs-csi:v3.1.0
+          image: k8s.gcr.io/sig-storage/nfsplugin:v3.1.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5


### PR DESCRIPTION
Kubernetes CSI now hosts the container-image for the NFS-nodeplugin in
the the k8s.gcr.io instead of the Microsoft registry.

See-also: kubernetes-csi/csi-driver-nfs@7b5b6f3

**Note:** added `ci/skip/e2e` as there is no e2e for the NFS-provisioner yet.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
