### PR TITLE
rbd: fix bug with missing supported_features 

### DIFF
--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -17,7 +17,9 @@ limitations under the License.
 package rbddriver
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	casrbd "github.com/ceph/ceph-csi/internal/csi-addons/rbd"
 	csiaddons "github.com/ceph/ceph-csi/internal/csi-addons/server"
@@ -144,7 +146,7 @@ func (r *Driver) Run(conf *util.Config) {
 		}
 		var attr string
 		attr, err = rbd.GetKrbdSupportedFeatures()
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.FatalLogMsg(err.Error())
 		}
 		var krbdFeatures uint

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -328,7 +328,12 @@ func HexStringToInteger(hexString string) (uint, error) {
 
 // isKrbdFeatureSupported checks if a given Image Feature is supported by krbd
 // driver or not.
-func isKrbdFeatureSupported(ctx context.Context, imageFeatures string) bool {
+func isKrbdFeatureSupported(ctx context.Context, imageFeatures string) (bool, error) {
+	// return false when /sys/bus/rbd/supported_features is absent and we are
+	// not in a position to prepare krbd feature attributes, i.e. if kernel <= 3.8
+	if krbdFeatures == 0 {
+		return false, os.ErrNotExist
+	}
 	arr := strings.Split(imageFeatures, ",")
 	log.UsefulLog(ctx, "checking for ImageFeatures: %v", arr)
 	imageFeatureSet := librbd.FeatureSetFromNames(arr)
@@ -343,7 +348,7 @@ func isKrbdFeatureSupported(ctx context.Context, imageFeatures string) bool {
 		}
 	}
 
-	return supported
+	return supported, nil
 }
 
 // Connect an rbdVolume to the Ceph cluster.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

* continue running rbd driver when /sys/bus/rbd/supported_features file is
missing, do not bail out.
* handle when krbdFeatures is zero


## Related issues ##

Fixes: #2678 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
