### PR TITLE
nfs: return gRPC status from CephFS CreateVolume failure

### DIFF
--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/cephfs"
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
@@ -75,7 +74,7 @@ func (cs *Server) CreateVolume(
 	req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	res, err := cs.backendServer.CreateVolume(ctx, req)
 	if err != nil {
-		return res, fmt.Errorf("failed to create CephFS volume: %w", err)
+		return nil, err
 	}
 
 	backend := res.Volume


### PR DESCRIPTION
The NFS Controller returns a non-gRPC error in case the CreateVolume
call for the CephFS volume fails. It is better to return the gRPC-status
of the error that the CephFS Controller sets.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
