### PR TITLE
separate netNamespaceFilePath for cephfs and RBD

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -27,7 +27,7 @@ serviceAccounts:
 #       - "<MONValue2>"
 #     cephFS:
 #       subvolumeGroup: "csi"
-#     netNamespaceFilePath: "{{ .kubeletDir }}/plugins/{{ .driverName }}/net"
+#       netNamespaceFilePath: "{{ .kubeletDir }}/plugins/{{ .driverName }}/net"
 csiConfig: []
 
 # Set logging level for csi containers.

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -25,7 +25,8 @@ serviceAccounts:
 #     monitors:
 #       - "<MONValue1>"
 #       - "<MONValue2>"
-#     netNamespaceFilePath: "{{ .kubeletDir }}/plugins/{{ .driverName }}/net"
+#     rbd:
+#       netNamespaceFilePath: "{{ .kubeletDir }}/plugins/{{ .driverName }}/net"
 csiConfig: []
 
 # Configuration details of clusterID,PoolID and FscID mapping

--- a/docs/design/proposals/clusterid-mapping.md
+++ b/docs/design/proposals/clusterid-mapping.md
@@ -44,7 +44,9 @@ data:
     [
       {
        "clusterID": "rook-ceph",
-       "radosNamespace": "<rados-namespace>",
+       "rbd": {
+          "radosNamespace": "<rados-namespace>",
+       },
        "monitors": [
          "192.168.39.82:6789"
        ],
@@ -54,7 +56,9 @@ data:
       },
       {
        "clusterID": "fs-id",
-       "radosNamespace": "<rados-namespace>",
+       "rbd": {
+          "radosNamespace": "<rados-namespace>",
+       },
        "monitors": [
          "192.168.39.83:6789"
        ],

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -60,9 +60,14 @@ func createConfigMap(pluginPath string, c kubernetes.Interface, f *framework.Fra
 		return err
 	}
 	conmap := []util.ClusterInfo{{
-		ClusterID:      fsID,
-		Monitors:       mons,
-		RadosNamespace: radosNamespace,
+		ClusterID: fsID,
+		Monitors:  mons,
+		RBD: struct {
+			NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+			RadosNamespace       string `json:"radosNamespace"`
+		}{
+			RadosNamespace: radosNamespace,
+		},
 	}}
 	if upgradeTesting {
 		subvolumegroup = "csi"
@@ -132,7 +137,7 @@ func createCustomConfigMap(
 			case "radosNamespace":
 				for c := range conmap {
 					if conmap[c].ClusterID == cluster {
-						conmap[c].RadosNamespace = j
+						conmap[c].RBD.RadosNamespace = j
 					}
 				}
 			}

--- a/examples/csi-config-map-sample.yaml
+++ b/examples/csi-config-map-sample.yaml
@@ -20,6 +20,10 @@ kind: ConfigMap
 # NOTE: Make sure you don't add radosNamespace option to a currently in use
 # configuration as it will cause issues.
 # The field "cephFS.subvolumeGroup" is optional and defaults to "csi".
+# The "cephFS.netNamespaceFilePath" fields are the various network namespace
+# path for the Ceph cluster identified by the <cluster-id>, This will be used
+# by the CephFS CSI plugin to execute the mount -t in the
+# network namespace specified by the "cephFS.netNamespaceFilePath".
 # The "rbd.netNamespaceFilePath" fields are the various network namespace
 # path for the Ceph cluster identified by the <cluster-id>, This will be used
 # by the RBD CSI plugin to execute the rbd map/unmap in the
@@ -54,6 +58,7 @@ data:
         ],
         "cephFS": {
           "subvolumeGroup": "<subvolumegroup for cephFS volumes>"
+          "netNamespaceFilePath": "<kubeletRootPath>/plugins/cephfs.csi.ceph.com/net",
         }
       }
     ]

--- a/examples/csi-config-map-sample.yaml
+++ b/examples/csi-config-map-sample.yaml
@@ -13,9 +13,9 @@ kind: ConfigMap
 # each such cluster in use.
 # To add more clusters or edit MON addresses in an existing configmap, use
 # the `kubectl replace` command.
-# The <rados-namespace> is optional and represents a radosNamespace in the pool.
-# If any given, all of the rbd images, snapshots, and other metadata will be
-# stored within the radosNamespace.
+# The "rbd.rados-namespace" is optional and represents a radosNamespace in the
+# pool. If any given, all of the rbd images, snapshots, and other metadata will
+# be stored within the radosNamespace.
 # NOTE: The given radosNamespace must already exists in the pool.
 # NOTE: Make sure you don't add radosNamespace option to a currently in use
 # configuration as it will cause issues.
@@ -42,9 +42,9 @@ data:
     [
       {
         "clusterID": "<cluster-id>",
-        "radosNamespace": "<rados-namespace>",
         "rbd": {
            "netNamespaceFilePath": "<kubeletRootPath>/plugins/rbd.csi.ceph.com/net",
+           "radosNamespace": "<rados-namespace>",
         },
         "monitors": [
           "<MONValue1>",

--- a/examples/csi-config-map-sample.yaml
+++ b/examples/csi-config-map-sample.yaml
@@ -20,10 +20,10 @@ kind: ConfigMap
 # NOTE: Make sure you don't add radosNamespace option to a currently in use
 # configuration as it will cause issues.
 # The field "cephFS.subvolumeGroup" is optional and defaults to "csi".
-# The <netNamespaceFilePath#> fields are the various network namespace
+# The "rbd.netNamespaceFilePath" fields are the various network namespace
 # path for the Ceph cluster identified by the <cluster-id>, This will be used
-# by the CSI plugin to execute the rbd map/unmap and mount -t commands in the
-# network namespace specified by the <netNamespaceFilePath#>.
+# by the RBD CSI plugin to execute the rbd map/unmap in the
+# network namespace specified by the "rbd.netNamespaceFilePath".
 # If a CSI plugin is using more than one Ceph cluster, repeat the section for
 # each such cluster in use.
 # NOTE: Changes to the configmap is automatically updated in the running pods,
@@ -43,7 +43,9 @@ data:
       {
         "clusterID": "<cluster-id>",
         "radosNamespace": "<rados-namespace>",
-        "netNamespaceFilePath": "<kubeletRootPath>/plugins/rbd.csi.ceph.com/net",
+        "rbd": {
+           "netNamespaceFilePath": "<kubeletRootPath>/plugins/rbd.csi.ceph.com/net",
+        },
         "monitors": [
           "<MONValue1>",
           "<MONValue2>",

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -126,6 +126,12 @@ func (ns *NodeServer) NodeStageVolume(
 	}
 	defer volOptions.Destroy()
 
+	volOptions.NetNamespaceFilePath, err = util.GetCephFSNetNamespaceFilePath(
+		util.CsiConfigFile,
+		volOptions.ClusterID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	mnt, err := mounter.New(volOptions)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create mounter for volume %s: %v", volID, err)

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -126,11 +126,6 @@ func (ns *NodeServer) NodeStageVolume(
 	}
 	defer volOptions.Destroy()
 
-	volOptions.NetNamespaceFilePath, err = util.GetNetNamespaceFilePath(util.CsiConfigFile, volOptions.ClusterID)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
 	mnt, err := mounter.New(volOptions)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create mounter for volume %s: %v", volID, err)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -332,7 +332,7 @@ func (ns *NodeServer) NodeStageVolume(
 	}
 	defer rv.Destroy()
 
-	rv.NetNamespaceFilePath, err = util.GetNetNamespaceFilePath(util.CsiConfigFile, rv.ClusterID)
+	rv.NetNamespaceFilePath, err = util.GetRBDNetNamespaceFilePath(util.CsiConfigFile, rv.ClusterID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -46,6 +46,8 @@ type ClusterInfo struct {
 	Monitors []string `json:"monitors"`
 	// CephFS contains CephFS specific options
 	CephFS struct {
+		// symlink filepath for the network namespace where we need to execute commands.
+		NetNamespaceFilePath string `json:"netNamespaceFilePath"`
 		// SubvolumeGroup contains the name of the SubvolumeGroup for CSI volumes
 		SubvolumeGroup string `json:"subvolumeGroup"`
 	} `json:"cephFS"`
@@ -181,4 +183,14 @@ func GetRBDNetNamespaceFilePath(pathToConfig, clusterID string) (string, error) 
 	}
 
 	return cluster.RBD.NetNamespaceFilePath, nil
+}
+
+// GetCephFSNetNamespaceFilePath returns the netNamespaceFilePath for CephFS volumes.
+func GetCephFSNetNamespaceFilePath(pathToConfig, clusterID string) (string, error) {
+	cluster, err := readClusterInfo(pathToConfig, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	return cluster.CephFS.NetNamespaceFilePath, nil
 }

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -60,24 +60,22 @@ type ClusterInfo struct {
 }
 
 // Expected JSON structure in the passed in config file is,
-// [
-// 	{
-//      "clusterID": "<cluster-id>",
-//      "rbd": {
-//		   "radosNamespace": "<rados-namespace>"
-//       },
-//      "monitors":
-//       [
-//         "<monitor-value>",
-//         "<monitor-value>",
-// 				...
-// 			],
-//         "cephFS": {
-//           "subvolumeGroup": "<subvolumegroup for cephfs volumes>"
-//         }
-// 	},
-// 	...
-// ].
+// nolint:godot // example json content should not contain unwanted dot.
+/*
+[{
+	"clusterID": "<cluster-id>",
+	"rbd": {
+		"radosNamespace": "<rados-namespace>"
+	},
+	"monitors": [
+		"<monitor-value>",
+		"<monitor-value>"
+	],
+	"cephFS": {
+		"subvolumeGroup": "<subvolumegroup for cephfs volumes>"
+	}
+}]
+*/
 func readClusterInfo(pathToConfig, clusterID string) (*ClusterInfo, error) {
 	var config []ClusterInfo
 

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -49,8 +49,12 @@ type ClusterInfo struct {
 		// SubvolumeGroup contains the name of the SubvolumeGroup for CSI volumes
 		SubvolumeGroup string `json:"subvolumeGroup"`
 	} `json:"cephFS"`
-	// symlink filepath for the network namespace where we need to execute commands.
-	NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+
+	// RBD Contains RBD specific options
+	RBD struct {
+		// symlink filepath for the network namespace where we need to execute commands.
+		NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+	} `json:"rbd"`
 }
 
 // Expected JSON structure in the passed in config file is,
@@ -164,11 +168,11 @@ func GetClusterID(options map[string]string) (string, error) {
 	return clusterID, nil
 }
 
-func GetNetNamespaceFilePath(pathToConfig, clusterID string) (string, error) {
+func GetRBDNetNamespaceFilePath(pathToConfig, clusterID string) (string, error) {
 	cluster, err := readClusterInfo(pathToConfig, clusterID)
 	if err != nil {
 		return "", err
 	}
 
-	return cluster.NetNamespaceFilePath, nil
+	return cluster.RBD.NetNamespaceFilePath, nil
 }

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -41,7 +41,7 @@ type ClusterInfo struct {
 	// ClusterID is used for unique identification
 	ClusterID string `json:"clusterID"`
 	// RadosNamespace is a rados namespace in the pool
-	RadosNamespace string `json:"radosNamespace"`
+	RadosNamespace string `json:"radosNamespace"` // For backward compatibility. TODO: Remove this in 3.7.0
 	// Monitors is monitor list for corresponding cluster ID
 	Monitors []string `json:"monitors"`
 	// CephFS contains CephFS specific options
@@ -54,18 +54,22 @@ type ClusterInfo struct {
 	RBD struct {
 		// symlink filepath for the network namespace where we need to execute commands.
 		NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+		// RadosNamespace is a rados namespace in the pool
+		RadosNamespace string `json:"radosNamespace"`
 	} `json:"rbd"`
 }
 
 // Expected JSON structure in the passed in config file is,
 // [
 // 	{
-// 		"clusterID": "<cluster-id>",
-//		"radosNamespace": "<rados-namespace>",
-// 		"monitors":
-// 			[
-// 				"<monitor-value>",
-// 				"<monitor-value>",
+//      "clusterID": "<cluster-id>",
+//      "rbd": {
+//		   "radosNamespace": "<rados-namespace>"
+//       },
+//      "monitors":
+//       [
+//         "<monitor-value>",
+//         "<monitor-value>",
 // 				...
 // 			],
 //         "cephFS": {
@@ -119,6 +123,10 @@ func GetRadosNamespace(pathToConfig, clusterID string) (string, error) {
 	cluster, err := readClusterInfo(pathToConfig, clusterID)
 	if err != nil {
 		return "", err
+	}
+
+	if cluster.RBD.RadosNamespace != "" {
+		return cluster.RBD.RadosNamespace, nil
 	}
 
 	return cluster.RadosNamespace, nil

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -170,6 +170,7 @@ func TestGetRBDNetNamespaceFilePath(t *testing.T) {
 			Monitors:  []string{"ip-1", "ip-2"},
 			RBD: struct {
 				NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+				RadosNamespace       string `json:"radosNamespace"`
 			}{
 				NetNamespaceFilePath: "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster1-net",
 			},
@@ -179,6 +180,7 @@ func TestGetRBDNetNamespaceFilePath(t *testing.T) {
 			Monitors:  []string{"ip-3", "ip-4"},
 			RBD: struct {
 				NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+				RadosNamespace       string `json:"radosNamespace"`
 			}{
 				NetNamespaceFilePath: "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster2-net",
 			},

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -140,7 +140,7 @@ func TestCSIConfig(t *testing.T) {
 	}
 }
 
-func TestGetNetNamespaceFilePath(t *testing.T) {
+func TestGetRBDNetNamespaceFilePath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
@@ -148,17 +148,17 @@ func TestGetNetNamespaceFilePath(t *testing.T) {
 		want      string
 	}{
 		{
-			name:      "get NetNamespaceFilePath for cluster-1",
+			name:      "get RBD NetNamespaceFilePath for cluster-1",
 			clusterID: "cluster-1",
 			want:      "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster1-net",
 		},
 		{
-			name:      "get NetNamespaceFilePath for cluster-2",
+			name:      "get RBD NetNamespaceFilePath for cluster-2",
 			clusterID: "cluster-2",
 			want:      "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster2-net",
 		},
 		{
-			name:      "when NetNamespaceFilePath is empty",
+			name:      "when RBD NetNamespaceFilePath is empty",
 			clusterID: "cluster-3",
 			want:      "",
 		},
@@ -166,14 +166,22 @@ func TestGetNetNamespaceFilePath(t *testing.T) {
 
 	csiConfig := []ClusterInfo{
 		{
-			ClusterID:            "cluster-1",
-			Monitors:             []string{"ip-1", "ip-2"},
-			NetNamespaceFilePath: "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster1-net",
+			ClusterID: "cluster-1",
+			Monitors:  []string{"ip-1", "ip-2"},
+			RBD: struct {
+				NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+			}{
+				NetNamespaceFilePath: "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster1-net",
+			},
 		},
 		{
-			ClusterID:            "cluster-2",
-			Monitors:             []string{"ip-3", "ip-4"},
-			NetNamespaceFilePath: "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster2-net",
+			ClusterID: "cluster-2",
+			Monitors:  []string{"ip-3", "ip-4"},
+			RBD: struct {
+				NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+			}{
+				NetNamespaceFilePath: "/var/lib/kubelet/plugins/rbd.ceph.csi.com/cluster2-net",
+			},
 		},
 		{
 			ClusterID: "cluster-3",
@@ -193,14 +201,14 @@ func TestGetNetNamespaceFilePath(t *testing.T) {
 		ts := tt
 		t.Run(ts.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := GetNetNamespaceFilePath(tmpConfPath, ts.clusterID)
+			got, err := GetRBDNetNamespaceFilePath(tmpConfPath, ts.clusterID)
 			if err != nil {
-				t.Errorf("GetNetNamespaceFilePath() error = %v", err)
+				t.Errorf("GetRBDNetNamespaceFilePath() error = %v", err)
 
 				return
 			}
 			if got != ts.want {
-				t.Errorf("GetNetNamespaceFilePath() = %v, want %v", got, ts.want)
+				t.Errorf("GetRBDNetNamespaceFilePath() = %v, want %v", got, ts.want)
 			}
 		})
 	}


### PR DESCRIPTION
Currently, netNamespaceFilePath is the path of the core ceph configuration in the ceph-csi configmap and this makes the configuration and automation really hard for the users for the below reasons

* A single netNamespaceFilePath will be used for both cephfs and rbd. Need to have a shared hostPath where the pid symlink exists between the cephfs and rbd pod.
* When we define a new holder pod the taints and toleration need to be added separately, this introduces new configurations at the consumer level and adds complexity for maintenance.
 
As this is more of an rbd and cephfs specific configuration good to have it under the cephfs and rbd umbrella in ceph configurations.

As we introduced the RBD specific section in the config file, moving the radosNamespace to the RBD as its RBD specific option and keeping radosNamespace still at the global level to be backward compatible.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>