### PR TITLE
ci: use `requeue` instead of `refresh` for re-adding PRs to the queue

### DIFF
--- a/actions/retest/main.go
+++ b/actions/retest/main.go
@@ -181,8 +181,8 @@ func main() {
 				}
 
 				if failedTestFound {
-					// comment `@Mergifyio refresh` so mergifyio adds the pr back into the queue.
-					msg := "@Mergifyio refresh"
+					// comment `@Mergifyio requeue` so mergifyio adds the pr back into the queue.
+					msg := "@Mergifyio requeue"
 					comment := &github.IssueComment{
 						Body: github.String(msg),
 					}


### PR DESCRIPTION
The current version of Mergify provides a `requeue` command in addition
to `refresh`. After a CI job failed, the PR needs to be re-added to the
queue, so the `requeue` command is more appropriate.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
