### PR TITLE
ci: improve logging for `kubectl_retry` helper

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -16,8 +16,8 @@ kubectl_retry() {
         # in case of a failure when running "create", ignore errors with "AlreadyExists"
         if [ "${action}" == 'create' ]
         then
-            # count lines in stderr that do not have "AlreadyExists"
-            ret=$(grep -cvw 'AlreadyExists' "${stderr}")
+            # count lines in stderr that do not have "AlreadyExists" or "Warning"
+            ret=$(grep -cvw -e 'AlreadyExists' -e '^Warning:' "${stderr}")
             if [ "${ret}" -eq 0 ]
             then
                 # Success! stderr is empty after removing all "AlreadyExists" lines.
@@ -28,8 +28,8 @@ kubectl_retry() {
         # in case of a failure when running "delete", ignore errors with "NotFound"
         if [ "${action}" == 'delete' ]
         then
-            # count lines in stderr that do not have "NotFound"
-            ret=$(grep -cvw 'NotFound' "${stderr}")
+            # count lines in stderr that do not have "NotFound" or "Warning"
+            ret=$(grep -cvw -e 'NotFound' -e '^Warning:' "${stderr}")
             if [ "${ret}" -eq 0 ]
             then
                 # Success! stderr is empty after removing all "NotFound" lines.

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -11,7 +11,7 @@ kubectl_retry() {
     stdout=$(mktemp rook-kubectl-stdout.XXXXXXXX)
     stderr=$(mktemp rook-kubectl-stderr.XXXXXXXX)
 
-    while ! kubectl "${action}" "${@}" 2>"${stderr}" 1>"${stdout}"
+    while ! ( kubectl "${action}" "${@}" 2>"${stderr}" 1>"${stdout}" )
     do
         # in case of a failure when running "create", ignore errors with "AlreadyExists"
         if [ "${action}" == 'create' ]
@@ -47,7 +47,7 @@ kubectl_retry() {
 	# log stderr and empty the tmpfile
 	cat "${stderr}" > /dev/stderr
 	true > "${stderr}"
-	echo "kubectl_retry ${*} failed, will retry in ${KUBECTL_RETRY_DELAY} seconds"
+	echo "$(date): 'kubectl_retry ${*}' failed (${retries}/${KUBECTL_RETRY}), will retry in ${KUBECTL_RETRY_DELAY} seconds" > /dev/stderr
 
         sleep ${KUBECTL_RETRY_DELAY}
 
@@ -55,6 +55,8 @@ kubectl_retry() {
 	# return of the function
         ret=0
     done
+
+    echo "$(date): 'kubectl_retry ${*}' done (ret=${ret})" > /dev/stderr
 
     # write output so that calling functions can consume it
     cat "${stdout}" > /dev/stdout

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -3,6 +3,20 @@
 KUBECTL_RETRY=5
 KUBECTL_RETRY_DELAY=10
 
+# kubectl_retry calls `kubectl` with the passed arguments. In case of a
+# failure, the `kubectl` command will be retried for `KUBECTL_RETRY` times,
+# with a delay of `KUBECTL_RETRY_DELAY` between them.
+#
+# Upon creation failures, `AlreadyExists` and `Warning` are ignored, making
+# sure the create succeeds in case some objects were created successfully in a
+# previous try.
+#
+# Upon deletion failures, the same applies as for creation, except that
+# NotFound is ignored.
+#
+# Logs from `kubectl` are passed on to stdout, so that a calling function can
+# capture it. During the function, logs are written to stderr as to not
+# interfere with the log parsing of the calling function.
 kubectl_retry() {
     local retries=0 action="${1}" ret=0 stdout stderr
     shift
@@ -11,7 +25,7 @@ kubectl_retry() {
     stdout=$(mktemp rook-kubectl-stdout.XXXXXXXX)
     stderr=$(mktemp rook-kubectl-stderr.XXXXXXXX)
 
-    while ! ( kubectl "${action}" "${@}" 2>"${stderr}" 1>"${stdout}" )
+    while ! ( kubectl "${action}" "${@}" 2>"${stderr}" 1>>"${stdout}" )
     do
         # in case of a failure when running "create", ignore errors with "AlreadyExists"
         if [ "${action}" == 'create' ]
@@ -44,7 +58,8 @@ kubectl_retry() {
             break
         fi
 
-	# log stderr and empty the tmpfile
+	# write logs to stderr and empty stderr (only)
+	cat "${stdout}" > /dev/stderr
 	cat "${stderr}" > /dev/stderr
 	true > "${stderr}"
 	echo "$(date): 'kubectl_retry ${*}' failed (${retries}/${KUBECTL_RETRY}), will retry in ${KUBECTL_RETRY_DELAY} seconds" > /dev/stderr


### PR DESCRIPTION
Rook deployments fail quite regulary in the CI environment now. It is
not clear what the cause is, hopefully a little better logging will
guide us to the issue.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
