### PR TITLE
Update doc 3.6.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ environments.
 
 | Ceph CSI Version | Container Orchestrator Name | Version Tested|
 | -----------------| --------------------------- | --------------|
+| v3.6.1 | Kubernetes | v1.21, v1.22, v1.23|
 | v3.6.0 | Kubernetes | v1.21, v1.22, v1.23|
 | v3.5.1 | Kubernetes | v1.21, v1.22, v1.23|
 | v3.5.0 | Kubernetes | v1.21, v1.22, v1.23|
@@ -125,6 +126,7 @@ in the Kubernetes documentation.
 | Ceph CSI Release/Branch | Container image name         | Image Tag |
 | ----------------------- | ---------------------------- | --------- |
 | devel (Branch)          | quay.io/cephcsi/cephcsi      | canary    |
+| v3.6.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.6.1    |
 | v3.6.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.6.0    |
 | v3.5.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.5.1    |
 | v3.5.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.5.0    |

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -90,12 +90,12 @@ compatibility support and without prior notice.
 **Also, we do not recommend any direct upgrades to 3.6 except from 3.5 to 3.6.**
 For example, upgrading from 3.4 to 3.6 is not recommended.
 
-git checkout v3.6.0 tag
+git checkout v3.6.1 tag
 
 ```bash
 git clone https://github.com/ceph/ceph-csi.git
 cd ./ceph-csi
-git checkout v3.6.0
+git checkout v3.6.1
 ```
 
 ```console


### PR DESCRIPTION
updated doc for the 3.6.1 release, this will be backported to the release-v3.6 branch and we will make deployment changes and do a release.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

