### PR TITLE
Release 3.6.1 template changes

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.6-canary
+CSI_IMAGE_VERSION=v3.6.1
 
 # Ceph version to use
 BASE_IMAGE=quay.io/ceph/ceph:v17

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -88,7 +88,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.6-canary
+      tag: v3.6.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -111,7 +111,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.6-canary
+      tag: v3.6.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -105,7 +105,7 @@ spec:
               mountPath: /csi
         - name: csi-cephfsplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -144,7 +144,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -106,7 +106,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -112,7 +112,7 @@ spec:
               mountPath: /csi
         - name: csi-rbdplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -168,7 +168,7 @@ spec:
               readOnly: true
         - name: csi-rbdplugin-controller
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--type=controller"
             - "--v=5"
@@ -188,7 +188,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,7 +50,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -124,7 +124,7 @@ spec:
         - name: liveness-prometheus
           securityContext:
             privileged: true
-          image: quay.io/cephcsi/cephcsi:v3.6-canary
+          image: quay.io/cephcsi/cephcsi:v3.6.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -177,7 +177,7 @@ else
 fi
 
 # configure csi image version
-CSI_IMAGE_VERSION=${CSI_IMAGE_VERSION:-"v3.6-canary"}
+CSI_IMAGE_VERSION=${CSI_IMAGE_VERSION:-"v3.6.1"}
 
 #feature-gates for kube
 K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-""}


### PR DESCRIPTION
helm: update image tag for release 3.6.1

This commit changes the required image tag to v3.6.1 instead of v3.6-canary for the v3.6.1 release

deploy: change image versions to v3.6.1

This commit changes the required image tag to v3.6.1 instead of v3.6-canary for the v3.6.1 release

Signed-off-by: Madhu Rajanna [madhupr007@gmail.com](mailto:madhupr007@gmail.com)

closes https://github.com/ceph/ceph-csi/issues/3048

Note:- we can merge this one after backporting https://github.com/ceph/ceph-csi/pull/3055 to release-3.6 branch