### PR TITLE
rbd: support pvc-pvc clone with different sc & encryption

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -199,8 +199,12 @@ provisioner:
 
   provisioner:
     image:
-      repository: registry.k8s.io/sig-storage/csi-provisioner
-      tag: v3.1.0
+      # TODO: replace with released image version.
+      # canary image is being to be used to test pvc-pvc clone
+      # with differe sc feature.
+      # see: https://github.com/kubernetes-csi/external-provisioner/pull/699
+      repository: gcr.io/k8s-staging-sig-storage/csi-provisioner
+      tag: canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -47,7 +47,11 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+          # TODO: replace with released image version.
+          # Canary image is being to be used to test pvc-pvc clone
+          # with differe sc feature.
+          # see: https://github.com/kubernetes-csi/external-provisioner/pull/699
+          image: gcr.io/k8s-staging-sig-storage/csi-provisioner:canary
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -651,6 +651,7 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 func validatePVCClone(
 	totalCount int,
 	sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath,
+	restoreSCName,
 	dataPool string,
 	kms kmsConfig,
 	validatePVC validateFunc,
@@ -702,6 +703,10 @@ func validatePVCClone(
 	}
 	pvcClone.Spec.DataSource.Name = pvc.Name
 	pvcClone.Namespace = f.UniqueName
+	if restoreSCName != "" {
+		pvcClone.Spec.StorageClassName = &restoreSCName
+	}
+
 	appClone, err := loadApp(clonePvcAppPath)
 	if err != nil {
 		e2elog.Failf("failed to load application: %v", err)

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -144,11 +144,9 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 		return err
 	}
 
-	if parentVol.isEncrypted() {
-		err = parentVol.copyEncryptionConfig(&rv.rbdImage, false)
-		if err != nil {
-			return fmt.Errorf("failed to copy encryption config for %q: %w", rv, err)
-		}
+	err = parentVol.copyEncryptionConfig(&rv.rbdImage, true)
+	if err != nil {
+		return fmt.Errorf("failed to copy encryption config for %q: %w", rv, err)
 	}
 
 	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
@@ -214,6 +212,11 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 	errClone = createRBDClone(ctx, tempClone, rv, cloneSnap)
 	if errClone != nil {
 		return errClone
+	}
+
+	err = parentVol.copyEncryptionConfig(&rv.rbdImage, true)
+	if err != nil {
+		return fmt.Errorf("failed to copy encryption config for %q: %w", rv, err)
 	}
 
 	return nil

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -324,8 +324,8 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 		return false, err
 	}
 
-	if parentVol != nil && parentVol.isEncrypted() {
-		err = parentVol.copyEncryptionConfig(&rv.rbdImage, false)
+	if parentVol != nil {
+		err = parentVol.copyEncryptionConfig(&rv.rbdImage, true)
 		if err != nil {
 			log.ErrorLog(ctx, err.Error())
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1366,15 +1366,6 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(
 		}
 	}()
 
-	if pSnapOpts.isEncrypted() {
-		pSnapOpts.conn = rv.conn.Copy()
-
-		err = pSnapOpts.copyEncryptionConfig(&rv.rbdImage, true)
-		if err != nil {
-			return fmt.Errorf("failed to clone encryption config: %w", err)
-		}
-	}
-
 	// get image latest information
 	err = rv.getImageInfo()
 	if err != nil {


### PR DESCRIPTION
This commit makes modification so as to allow pvc-pvc clone
with different storageclass having different encryption
configs.

refer: kubernetes-csi/external-provisioner#699

Signed-off-by: Rakshith R <rar@redhat.com>
