### PR TITLE
nfs: remove node plugin RBAC for NFS provisioner

### DIFF
--- a/deploy/nfs/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/nfs/kubernetes/csi-nodeplugin-rbac.yaml
@@ -3,25 +3,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nfs-csi-nodeplugin
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: nfs-csi-nodeplugin
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: nfs-csi-nodeplugin
-subjects:
-  - kind: ServiceAccount
-    name: nfs-csi-nodeplugin
-    namespace: default
-roleRef:
-  kind: ClusterRole
-  name: nfs-csi-nodeplugin
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
this commit removes the node plugin RBAC for NFS plugin as it is
not needed.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

