### PR TITLE
nfs: delete the CephFS volume when the export is already removed

### DIFF
--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 
 	"github.com/ceph/ceph-csi/internal/cephfs"
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
@@ -140,8 +141,8 @@ func (cs *Server) DeleteVolume(
 	defer nfsVolume.Destroy()
 
 	err = nfsVolume.DeleteExport()
-	// TODO: if the export does not exist, but the backend does, delete the backend
-	if err != nil {
+	// if the export does not exist, continue with deleting the backend volume
+	if err != nil && !strings.Contains(err.Error(), "Export does not exist") {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to delete export: %v", err)
 	}
 


### PR DESCRIPTION
In case the NFS-export has already been removed from the NFS-server, but
the CSI Controller was restarted, a retry to remove the NFS-volume will
fail with an error like:

> GRPC error: ....: response status not empty: "Export does not exist"

When this error is reported, assume the NFS-export was already removed
from the NFS-server configuration, and continue with deleting the
backend volume.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
