### PR TITLE
nfs: support ExpandVolume CSI procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ for its support details.
 |        | Dynamically provision, de-provision File mode RWX volume  | Alpha          | >= v3.6.0          | >= v1.0.0        | Pacific (>=16.2.0)   | >= v1.14.0         |
 |        | Dynamically provision, de-provision File mode ROX volume  | Alpha          | >= v3.6.0          | >= v1.0.0        | Pacific (>=16.2.0)   | >= v1.14.0         |
 |        | Dynamically provision, de-provision File mode RWOP volume | Alpha          | >= v3.6.0          | >= v1.5.0        | Pacific (>=16.2.0)   | >= v1.22.0         |
+|        | Expand volume                                             | Alpha          | >= v3.7.0          | >= v1.1.0        | Pacific (>=16.2.0)   | >= v1.15.0         |
 
 `NOTE`: The `Alpha` status reflects possible non-backward
 compatible changes in the future, and is thus not recommended

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -54,6 +54,22 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--timeout=150s"
+            - "--leader-election"
+            - "--retry-interval-start=500ms"
+            - "--handle-volume-inuse-error=false"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi-provisioner.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: csi-nfsplugin
           # for stable functionality replace canary with latest release version
           image: quay.io/cephcsi/cephcsi:canary

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -556,6 +556,13 @@ var _ = Describe("nfs", func() {
 			if err != nil {
 				e2elog.Failf("failed to delete user %s: %v", keyringCephFSNodePluginUsername, err)
 			}
+
+			By("Resize PVC and check application directory size", func() {
+				err := resizePVCAndValidateSize(pvcPath, appPath, f)
+				if err != nil {
+					e2elog.Failf("failed to resize PVC: %v", err)
+				}
+			})
 		})
 	})
 })

--- a/examples/nfs/storageclass.yaml
+++ b/examples/nfs/storageclass.yaml
@@ -46,4 +46,4 @@ parameters:
   volumeNamePrefix: nfs-export-
 
 reclaimPolicy: Delete
-allowVolumeExpansion: false
+allowVolumeExpansion: true

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -150,3 +150,12 @@ func (cs *Server) DeleteVolume(
 
 	return cs.backendServer.DeleteVolume(ctx, req)
 }
+
+// ControllerExpandVolume calls the backend (CephFS) procedure to expand the
+// volume. There is no interaction with the NFS-server needed to publish the
+// new size.
+func (cs *Server) ControllerExpandVolume(
+	ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+	return cs.backendServer.ControllerExpandVolume(ctx, req)
+}

--- a/internal/nfs/driver/driver.go
+++ b/internal/nfs/driver/driver.go
@@ -46,6 +46,7 @@ func (fs *Driver) Run(conf *util.Config) {
 	cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 	})
 	// VolumeCapabilities are validated by the CephFS Controller
 	cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{


### PR DESCRIPTION
There is not much the NFS-provisioner needs to do to expand a volume,
everything is handled by the CephFS components.

NFS does not need a resize on the node, so only ControllerExpandVolume
is required.

Resizing is handled by the csi-resizer container, which needs to run in
the provisioner Pod. In addition to the container, the StorageClass also
needs to allow volume expansion.


## Related issues ##

Depends-On: #3036

The last three commits implement the `ControllerExpandVolume` CSI
procedure and validation of the functionality.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
