### PR TITLE
nfs: use latest liveness probe and node driver registrar

### DIFF
--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -18,7 +18,7 @@ spec:
             - --probe-timeout=3s
             - --health-port=29653
             - --v=2
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:
@@ -44,7 +44,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:


### PR DESCRIPTION
This commit make use of latest sidecars of livenessprobe and
node driver registrar in NFS driver deployment.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

