### PR TITLE
rbd: consider rbd as default mounter if not set.

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -241,7 +241,7 @@ func populateRbdVol(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if req.GetVolumeContext()["mounter"] == rbdDefaultMounter &&
+	if rv.Mounter == rbdDefaultMounter &&
 		!isKrbdFeatureSupported(ctx, strings.Join(rv.ImageFeatureSet.Names(), ",")) {
 		if !parseBoolOption(ctx, req.GetVolumeContext(), tryOtherMounters, false) {
 			log.ErrorLog(ctx, "unsupported krbd Feature, set `tryOtherMounters:true` or fix krbd driver")
@@ -251,8 +251,6 @@ func populateRbdVol(
 		}
 		// fallback to rbd-nbd,
 		rv.Mounter = rbdNbdMounter
-	} else {
-		rv.Mounter = req.GetVolumeContext()["mounter"]
 	}
 
 	err = getMapOptions(req, rv)


### PR DESCRIPTION
For the default mounter the mounter option will not be set in the storageclass and as it is not available in the storageclass same will not be set in the volume context, Because of this, the mapOptions are getting discarded. If the mounter is not set assuming it's an rbd mounter.

Note:- If the mounter is not set in the storageclass we can set it in the volume context explicitly, Doing this check-in node server to support backward existing volumes and the check is minimal we are not altering the volume context.

fixes: #3076

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

