### PR TITLE
rbd: use `vaultAuthPath` variable name in error msg

### DIFF
--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -352,7 +352,7 @@ func initVaultKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 
 	kms.vaultConfig[vault.AuthMountPath], err = detectAuthMountPath(vaultAuthPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set %s in Vault config: %w", vault.AuthMountPath, err)
+		return nil, fmt.Errorf("failed to set \"vaultAuthPath\" in Vault config: %w", err)
 	}
 
 	vaultRole := vaultDefaultRole


### PR DESCRIPTION
Before the change, the error msg was the following:
```
failed to set VAULT_AUTH_MOUNT_PATH in Vault config: path is empty
```
`vaultAuthPath` is the actual variable name set by the
user. The error message will now be the following:
```
failed to set 'vaultAuthPath' in vault config: path is empty
```

Signed-off-by: Rakshith R <rar@redhat.com>
