### PR TITLE
ci: Included githubactions in the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,13 @@ updates:
       - ci/skip/e2e
     commit-message:
       prefix: "rebase"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    rebase-strategy: disabled
+    labels:
+      - rebase
+      - ci/skip/e2e
+    commit-message:
+      prefix: rebase


### PR DESCRIPTION
This should help with keeping the GitHub actions updated on new
releases. This will also help with keeping it secure.

Dependabot helps in keeping the supply chain secure:
https://docs.github.com/en/code-security/dependabot

GitHub actions up to dat: e
https://docs.github.com/en/code-security/dependabot/ \
  working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

dependency-update-tool:
https://github.com/ossf/scorecard/blob/main/docs/checks.md

Closes: #3077

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
