### PR TITLE
ci: run tests on kubernetes 1.24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,24 @@
+# build directory
+_output
+
+# e2e test executable
+e2e.test
+
+# docker build
+deploy/cephcsi/image/cephcsi
+
+# cached container image IDs
+.devel-container-id
 .test-container-id
+
+# detected 'docker' or 'podman'
+.container-cmd
+
+# git merge files
+*.orig
+*.patch
+*.rej
+
+# generated golangci-lint configuration
+scripts/golangci.yml
+scripts/golangci.yml.buildtags.in

--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -8,6 +8,8 @@
           only_run_on_request: false
       - '1.23':
           only_run_on_request: false
+      - '1.24':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -8,6 +8,8 @@
           only_run_on_request: false
       - '1.23':
           only_run_on_request: false
+      - '1.24':
+          only_run_on_request: true
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
Adds the Kubernetes 1.24 to run on request for now.
Exact copy of the gitignore from the devel branch to ignore files from the git.    
   
Note:- Once the kubernetes 1.24 job is stable will run it by default

updates #3086 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>