### PR TITLE
ci: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-multi-stage.yaml
+++ b/.github/workflows/build-multi-stage.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: multi-arch-build

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: codespell

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     name: commitlint

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   go-test:
     name: go-test

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: golangci-lint

--- a/.github/workflows/lint-extras.yaml
+++ b/.github/workflows/lint-extras.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   lint-extras:
     name: lint-extras

--- a/.github/workflows/mod-check.yaml
+++ b/.github/workflows/mod-check.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
+
 jobs:
   mod-check:
     name: mod-check

--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -9,6 +9,9 @@ on:
       - devel
       # Push events to branches matching refs/heads/release-v*
       - 'release-v*'
+permissions:
+  contents: read
+
 jobs:
   push:
     name: Publish artifacts

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     # Run the retest action every 30 minutes
     - cron: "30 * * * *"
+
+permissions:
+  contents: read
+
 jobs:
   retest:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,8 +7,14 @@ on:
     # Run the stalebot every day at 9pm UTC
     - cron: "00 21 * * *"
 # yamllint disable rule:line-length
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-18.04
     if: github.repository == 'ceph/ceph-csi'
     steps:

--- a/.github/workflows/test-retest-action.yaml
+++ b/.github/workflows/test-retest-action.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [devel]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way,
 even if the attackers will succeed in compromising your workflow,
 they won’t be able to do much.

- Included permissions for the action.
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

Closes: #3072

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
