### PR TITLE
ci: do not set `safe.directory` for commitlint checkout

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          set-safe-directory: false
       - name: commitlint
         # yamllint disable-line rule:line-length
         run: make containerized-test CONTAINER_CMD=docker TARGET=commitlint GIT_SINCE="origin/${GITHUB_BASE_REF}"


### PR DESCRIPTION
Commitlint fails with errors like:

```
git fetch -v origin devel
fatal: unsafe repository ('/go/src/github.com/ceph/ceph-csi' is owned by
someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory /go/src/github.com/ceph/ceph-csi
make: *** [Makefile:153: commitlint] Error 128
```

By not setting the option with actions/checkout@v3, the error should not
happen anymore.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
