### PR TITLE
rebase: bump nfsplugin to v4.0.0

### DIFF
--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -86,7 +86,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          image: registry.k8s.io/sig-storage/nfsplugin:v3.1.0
+          image: registry.k8s.io/sig-storage/nfsplugin:v4.0.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5


### PR DESCRIPTION
Several bugs have been fixed and new features have been added.

See-also: https://github.com/kubernetes-csi/csi-driver-nfs/releases/tag/v4.0.0

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
