### PR TITLE
ci: fix commitlint problem

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          set-safe-directory: false
       - name: commitlint
         # yamllint disable-line rule:line-length
         run: make containerized-test CONTAINER_CMD=docker TARGET=commitlint GIT_SINCE="origin/${GITHUB_BASE_REF}"

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -18,6 +18,7 @@ ENV \
  GOPATH=${GOPATH} \
  GOROOT=${GOROOT} \
  GO111MODULE=on \
+ CEPHCSIPATH=/go/src/github.com/ceph/ceph-csi \
  PATH="${GOPATH}/bin:${GOROOT}/bin:/opt/commitlint/node_modules/.bin:${PATH}"
 
 COPY build.env /
@@ -53,6 +54,7 @@ RUN source /build.env \
     && npm init -y \
     && npm install @commitlint/cli@"${COMMITLINT_VERSION}" \
     && popd \
+    && git config --global --add safe.directory ${CEPHCSIPATH} \
     && true
 
-WORKDIR /go/src/github.com/ceph/ceph-csi
+WORKDIR ${CEPHCSIPATH}


### PR DESCRIPTION
Still seeing the issue of the commitlint as below

fatal: unsafe repository ('/go/src/github.com/ceph/ceph-csi' is owned by someone else) To add an exception for this directory,
call:

git config --global --add safe.directory /go/src/github.com/ceph/ceph-csi

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

This is not fixed yet happening at https://github.com/ceph/ceph-csi/runs/6345425683?check_suite_focus=true#step:3:1419


Note:
```
Setting this in Dockerfile which is used for the tests instead of Makefile as the issue is not seen in the local environment and we run tests inside the container in the CI.
```