### PR TITLE
ci: add `ci/skip/multi-arch-build` label

### DIFF
--- a/.github/workflows/build-multi-stage.yaml
+++ b/.github/workflows/build-multi-stage.yaml
@@ -15,7 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: multi-arch-build
+        # yamllint disable-line rule:line-length
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip/multi-arch-build') }}
         # podman cannot pull images with both tag and digest
         # https://github.com/containers/buildah/issues/1407
         # use docker to build images
         run: CONTAINER_CMD=docker ./scripts/build-multi-arch-image.sh
+      - name: single-arch-build
+        # yamllint disable-line rule:line-length
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/skip/multi-arch-build') }}
+        run: make containerized-build

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -251,6 +251,7 @@ A few labels interact with automation around the pull requests:
 * ready-to-merge: This PR is ready to be merged and it doesn't need second review
 * DNM: DO NOT MERGE (Mergify will not merge this PR)
 * ci/skip/e2e: skip running e2e CI jobs
+* ci/skip/multi-arch-build: skip building container images for different architectures
 
 **Review Process:**
 Once your PR has been submitted for review the following criteria will


### PR DESCRIPTION
If the `ci/skip/multi-arch-build` label is set on a PR, the GitHub
Workflow only builds for the local architecture. This makes it possible
to merge PRs faster.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
