### PR TITLE
e2e: re-order deployment components

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -69,6 +69,7 @@ func deleteCephfsPlugin() {
 
 func createORDeleteCephfsResources(action kubectlAction) {
 	resources := []ResourceDeployer{
+		// shared resources
 		&yamlResource{
 			filename:     cephFSDirPath + csiDriverObject,
 			allowMissing: true,
@@ -77,11 +78,7 @@ func createORDeleteCephfsResources(action kubectlAction) {
 			filename:     examplePath + cephConfconfigMap,
 			allowMissing: true,
 		},
-		&yamlResourceNamespaced{
-			filename:   cephFSDirPath + cephFSProvisioner,
-			namespace:  cephCSINamespace,
-			oneReplica: true,
-		},
+		// dependencies for provisioner
 		&yamlResourceNamespaced{
 			filename:  cephFSDirPath + cephFSProvisionerRBAC,
 			namespace: cephCSINamespace,
@@ -90,16 +87,24 @@ func createORDeleteCephfsResources(action kubectlAction) {
 			filename:  cephFSDirPath + cephFSProvisionerPSP,
 			namespace: cephCSINamespace,
 		},
+		// the provisioner itself
 		&yamlResourceNamespaced{
-			filename:  cephFSDirPath + cephFSNodePlugin,
-			namespace: cephCSINamespace,
+			filename:   cephFSDirPath + cephFSProvisioner,
+			namespace:  cephCSINamespace,
+			oneReplica: true,
 		},
+		// dependencies for the node-plugin
 		&yamlResourceNamespaced{
 			filename:  cephFSDirPath + cephFSNodePluginRBAC,
 			namespace: cephCSINamespace,
 		},
 		&yamlResourceNamespaced{
 			filename:  cephFSDirPath + cephFSNodePluginPSP,
+			namespace: cephCSINamespace,
+		},
+		// the node-plugin itself
+		&yamlResourceNamespaced{
+			filename:  cephFSDirPath + cephFSNodePlugin,
 			namespace: cephCSINamespace,
 		},
 	}

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -78,6 +78,7 @@ func deleteNFSPlugin() {
 
 func createORDeleteNFSResources(f *framework.Framework, action kubectlAction) {
 	resources := []ResourceDeployer{
+		// shared resources
 		&yamlResource{
 			filename:     nfsDirPath + csiDriverObject,
 			allowMissing: true,
@@ -86,6 +87,7 @@ func createORDeleteNFSResources(f *framework.Framework, action kubectlAction) {
 			filename:     examplePath + cephConfconfigMap,
 			allowMissing: true,
 		},
+		// dependencies for provisioner
 		&yamlResourceNamespaced{
 			filename:  nfsDirPath + nfsProvisionerRBAC,
 			namespace: cephCSINamespace,
@@ -94,11 +96,13 @@ func createORDeleteNFSResources(f *framework.Framework, action kubectlAction) {
 			filename:  nfsDirPath + nfsProvisionerPSP,
 			namespace: cephCSINamespace,
 		},
+		// the provisioner itself
 		&yamlResourceNamespaced{
 			filename:   nfsDirPath + nfsProvisioner,
 			namespace:  cephCSINamespace,
 			oneReplica: true,
 		},
+		// dependencies for the node-plugin
 		&yamlResourceNamespaced{
 			filename:  nfsDirPath + nfsNodePluginRBAC,
 			namespace: cephCSINamespace,
@@ -107,10 +111,12 @@ func createORDeleteNFSResources(f *framework.Framework, action kubectlAction) {
 			filename:  nfsDirPath + nfsNodePluginPSP,
 			namespace: cephCSINamespace,
 		},
+		// the node-plugin itself
 		&yamlResourceNamespaced{
 			filename:  nfsDirPath + nfsNodePlugin,
 			namespace: cephCSINamespace,
 		},
+		// NFS-export management by Rook
 		&rookNFSResource{
 			f:           f,
 			modules:     []string{"rook", "nfs"},

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -131,6 +131,7 @@ func deleteRBDPlugin() {
 
 func createORDeleteRbdResources(action kubectlAction) {
 	resources := []ResourceDeployer{
+		// shared resources
 		&yamlResource{
 			filename:     rbdDirPath + csiDriverObject,
 			allowMissing: true,
@@ -139,12 +140,7 @@ func createORDeleteRbdResources(action kubectlAction) {
 			filename:     examplePath + cephConfconfigMap,
 			allowMissing: true,
 		},
-		&yamlResourceNamespaced{
-			filename:       rbdDirPath + rbdProvisioner,
-			namespace:      cephCSINamespace,
-			oneReplica:     true,
-			enableTopology: true,
-		},
+		// dependencies for provisioner
 		&yamlResourceNamespaced{
 			filename:  rbdDirPath + rbdProvisionerRBAC,
 			namespace: cephCSINamespace,
@@ -153,11 +149,14 @@ func createORDeleteRbdResources(action kubectlAction) {
 			filename:  rbdDirPath + rbdProvisionerPSP,
 			namespace: cephCSINamespace,
 		},
+		// the provisioner itself
 		&yamlResourceNamespaced{
-			filename:    rbdDirPath + rbdNodePlugin,
-			namespace:   cephCSINamespace,
-			domainLabel: nodeRegionLabel + "," + nodeZoneLabel,
+			filename:       rbdDirPath + rbdProvisioner,
+			namespace:      cephCSINamespace,
+			oneReplica:     true,
+			enableTopology: true,
 		},
+		// dependencies for the node-plugin
 		&yamlResourceNamespaced{
 			filename:  rbdDirPath + rbdNodePluginRBAC,
 			namespace: cephCSINamespace,
@@ -165,6 +164,12 @@ func createORDeleteRbdResources(action kubectlAction) {
 		&yamlResourceNamespaced{
 			filename:  rbdDirPath + rbdNodePluginPSP,
 			namespace: cephCSINamespace,
+		},
+		// the node-plugin itself
+		&yamlResourceNamespaced{
+			filename:    rbdDirPath + rbdNodePlugin,
+			namespace:   cephCSINamespace,
+			domainLabel: nodeRegionLabel + "," + nodeZoneLabel,
 		},
 	}
 


### PR DESCRIPTION
Some of the deployment artifacts refer to others (like ServiceAccount in
a Deployment). If the dependencies are not available (yet), there will
be errors reported in the logs. By deploying the components in a more
correct order, fewer errors are reported, making the logs a little
easier to understand.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
