### PR TITLE
e2e: remove deleteJournalInfoInPool in test

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -2767,10 +2767,6 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to check csi journal in pool: %v", err)
 				}
 
-				err = deleteJournalInfoInPool(f, pvc, "replicapool")
-				if err != nil {
-					e2elog.Failf("failed to delete omap data: %v", err)
-				}
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
 					e2elog.Failf("failed to delete PVC and application: %v", err)
@@ -2811,10 +2807,6 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to check data pool for image: %v", err)
 					}
 
-					err = deleteJournalInfoInPool(f, pvc, "replicapool")
-					if err != nil {
-						e2elog.Failf("failed to delete omap data: %v", err)
-					}
 					// cleanup and undo changes made by the test
 					err = deletePVCAndApp("", f, pvc, app)
 					if err != nil {


### PR DESCRIPTION
Removing deleteJournalInfoInPool in e2e to check on the resource leak

closes: #3111

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Note:- Created a test PR to validate the leak in the CI. Not marking it as a draft but marking it as DNM.
