### PR TITLE
e2e: remove TODO update nfs node-plugin with fix csi-driver-nfs#319

### DIFF
--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -482,13 +482,6 @@ var _ = Describe("nfs", func() {
 			})
 
 			By("Create PVC, bind it to an app, unmount volume and check app deletion", func() {
-				// TODO: update nfs node-plugin that has kubernetes-csi/csi-driver-nfs#319
-				if true {
-					e2elog.Logf("skipping test, needs kubernetes-csi/csi-driver-nfs#319")
-
-					return
-				}
-
 				pvc, app, err := createPVCAndAppBinding(pvcPath, appPath, f, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC or application: %v", err)


### PR DESCRIPTION
This commits removes
TODO: update nfs node-plugin that has kubernetes-csi/csi-driver-nfs#319
Since, the nfsplugin image is already updated to v4.0.0.

Signed-off-by: Rakshith R <rar@redhat.com>
