### PR TITLE
e2e: remove the generic ephemeral volume support check for kube version

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -111,7 +111,7 @@ are available while running tests:
 After the support for snapshot/clone has been added to ceph-csi,
 you need to follow these steps before running e2e.
 
-- Install snapshot controller and Beta snapshot CRD
+- Install snapshot controller and snapshot CRD
 
     ```console
     ./scripts/install-snapshot.sh install

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -298,35 +298,32 @@ var _ = Describe(cephfsType, func() {
 				})
 			}
 			By("verify generic ephemeral volume support", func() {
-				// generic ephemeral volume support is beta since v1.21.
-				if k8sVersionGreaterEquals(f.ClientSet, 1, 21) {
-					err := createCephfsStorageClass(f.ClientSet, f, true, nil)
-					if err != nil {
-						e2elog.Failf("failed to create CephFS storageclass: %v", err)
-					}
-					// create application
-					app, err := loadApp(appEphemeralPath)
-					if err != nil {
-						e2elog.Failf("failed to load application: %v", err)
-					}
-					app.Namespace = f.UniqueName
-					err = createApp(f.ClientSet, app, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to create application: %v", err)
-					}
-					validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
-					validateOmapCount(f, 1, cephfsType, metadataPool, volumesType)
-					// delete pod
-					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to delete application: %v", err)
-					}
-					validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
-					validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
-					err = deleteResource(cephFSExamplePath + "storageclass.yaml")
-					if err != nil {
-						e2elog.Failf("failed to delete CephFS storageclass: %v", err)
-					}
+				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
+				if err != nil {
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
+				}
+				// create application
+				app, err := loadApp(appEphemeralPath)
+				if err != nil {
+					e2elog.Failf("failed to load application: %v", err)
+				}
+				app.Namespace = f.UniqueName
+				err = createApp(f.ClientSet, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create application: %v", err)
+				}
+				validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
+				validateOmapCount(f, 1, cephfsType, metadataPool, volumesType)
+				// delete pod
+				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete application: %v", err)
+				}
+				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+				validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
+				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 				}
 			})
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -715,33 +715,30 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("verify generic ephemeral volume support", func() {
-				// generic ephemeral volume support is supported from 1.21
-				if k8sVersionGreaterEquals(f.ClientSet, 1, 21) {
-					// create application
-					app, err := loadApp(appEphemeralPath)
-					if err != nil {
-						e2elog.Failf("failed to load application: %v", err)
-					}
-					app.Namespace = f.UniqueName
-					err = createApp(f.ClientSet, app, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to create application: %v", err)
-					}
-					// validate created backend rbd images
-					validateRBDImageCount(f, 1, defaultRBDPool)
-					validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
-					err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to delete application: %v", err)
-					}
-					// validate created backend rbd images
-					validateRBDImageCount(f, 0, defaultRBDPool)
-					validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
-					// validate images in trash
-					err = waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to validate rbd images in pool %s trash: %v", defaultRBDPool, err)
-					}
+				// create application
+				app, err := loadApp(appEphemeralPath)
+				if err != nil {
+					e2elog.Failf("failed to load application: %v", err)
+				}
+				app.Namespace = f.UniqueName
+				err = createApp(f.ClientSet, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create application: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+				validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to delete application: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+				validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+				// validate images in trash
+				err = waitToRemoveImagesFromTrash(f, defaultRBDPool, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to validate rbd images in pool %s trash: %v", defaultRBDPool, err)
 				}
 			})
 


### PR DESCRIPTION
at present we have the check for kube version 1.21 in the tests
which no longer required as it falls under supported kubernetes
versions with the driver.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

