### PR TITLE
rbd: use vaultAuthPath variable name in error msg

### DIFF
--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -208,7 +208,7 @@ func (kms *vaultTenantSA) parseConfig(config map[string]interface{}) error {
 	} else if err == nil {
 		kms.vaultConfig[vault.AuthMountPath], err = detectAuthMountPath(vaultAuthPath)
 		if err != nil {
-			return fmt.Errorf("failed to set %s in Vault config: %w", vault.AuthMountPath, err)
+			return fmt.Errorf("failed to set \"vaultAuthPath\" in Vault config: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Before the change, the error msg was the following:
```
failed to set VAULT_AUTH_MOUNT_PATH in Vault config: path is empty
```
`vaultAuthPath` is the actual variable name set by the
user. The error message will now be the following:
```
failed to set "vaultAuthPath" in vault config: path is empty
```

Signed-off-by: Rakshith R <rar@redhat.com>

Similar to https://github.com/ceph/ceph-csi/pull/3081 
I missed this line :sweat: 