### PR TITLE
ci: Update golangci-lint to v1.46.2

### DIFF
--- a/actions/retest/main.go
+++ b/actions/retest/main.go
@@ -59,7 +59,6 @@ func getConfig() *retestConfig {
 			if len(strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")) == 2 {
 				return strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")[0], strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")[1]
 			}
-
 		}
 		return "", ""
 	}()
@@ -168,7 +167,7 @@ func main() {
 							log.Printf("failed to create comment %v\n", err)
 							continue
 						}
-						//Post comment with target URL for retesting
+						// Post comment with target URL for retesting
 						msg = fmt.Sprintf("@%s %q test failed. Logs are available at [location](%s) for debugging", re.GetUser().GetLogin(), r.GetContext(), r.GetTargetURL())
 						comment.Body = github.String(msg)
 						_, _, err = c.client.Issues.CreateComment(context.TODO(), c.owner, c.repo, prNumber, comment)

--- a/api/deploy/ocp/scc_test.go
+++ b/api/deploy/ocp/scc_test.go
@@ -55,7 +55,7 @@ func TestNewSecurityContextConstraints(t *testing.T) {
 
 		rookValues := SecurityContextConstraintsValues{
 			Namespace: "rook-ceph",
-			Deployer: "rook",
+			Deployer:  "rook",
 		}
 
 		getSCC := func() {
@@ -77,7 +77,7 @@ func TestNewSecurityContextConstraintsYAML(t *testing.T) {
 	t.Parallel()
 
 	var (
-		err error
+		err  error
 		yaml string
 	)
 

--- a/build.env
+++ b/build.env
@@ -23,7 +23,7 @@ GO111MODULE=on
 COMMITLINT_VERSION=latest
 
 # static checks and linters
-GOLANGCI_VERSION=v1.43.0
+GOLANGCI_VERSION=v1.46.2
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -514,8 +514,8 @@ var _ = Describe(cephfsType, func() {
 					e2elog.Failf("failed to list pods for Deployment: %v", err)
 				}
 
-				doStat := func(podName string) (stdErr string, err error) {
-					_, stdErr, err = execCommandInContainerByPodName(
+				doStat := func(podName string) (string, error) {
+					_, stdErr, execErr := execCommandInContainerByPodName(
 						f,
 						fmt.Sprintf("stat %s", depl.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath),
 						depl.Namespace,
@@ -523,7 +523,7 @@ var _ = Describe(cephfsType, func() {
 						depl.Spec.Template.Spec.Containers[0].Name,
 					)
 
-					return stdErr, err
+					return stdErr, execErr
 				}
 				ensureStatSucceeds := func(podName string) error {
 					stdErr, statErr := doStat(podName)

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -60,7 +60,8 @@ func createCephfsStorageClass(
 	c kubernetes.Interface,
 	f *framework.Framework,
 	enablePool bool,
-	params map[string]string) error {
+	params map[string]string,
+) error {
 	scPath := fmt.Sprintf("%s/%s", cephFSExamplePath, "storageclass.yaml")
 	sc, err := getStorageClass(scPath)
 	if err != nil {
@@ -253,7 +254,8 @@ func getSnapName(snapNamespace, snapName string) (string, error) {
 func deleteBackingCephFSSubvolumeSnapshot(
 	f *framework.Framework,
 	pvc *v1.PersistentVolumeClaim,
-	snap *snapapi.VolumeSnapshot) error {
+	snap *snapapi.VolumeSnapshot,
+) error {
 	snapshotName, err := getSnapName(snap.Namespace, snap.Name)
 	if err != nil {
 		return err

--- a/e2e/clone.go
+++ b/e2e/clone.go
@@ -30,7 +30,8 @@ func validateBiggerCloneFromPVC(f *framework.Framework,
 	pvcPath,
 	appPath,
 	pvcClonePath,
-	appClonePath string) error {
+	appClonePath string,
+) error {
 	const (
 		size    = "1Gi"
 		newSize = "2Gi"

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -95,7 +95,8 @@ func createConfigMap(pluginPath string, c kubernetes.Interface, f *framework.Fra
 func createCustomConfigMap(
 	c kubernetes.Interface,
 	pluginPath string,
-	clusterInfo map[string]map[string]string) error {
+	clusterInfo map[string]map[string]string,
+) error {
 	path := pluginPath + configMap
 	cm := v1.ConfigMap{}
 	err := unmarshal(path, &cm)

--- a/e2e/deployment.go
+++ b/e2e/deployment.go
@@ -40,7 +40,8 @@ func execCommandInPodWithName(
 	cmdString,
 	podName,
 	containerName,
-	nameSpace string) (string, string, error) {
+	nameSpace string,
+) (string, string, error) {
 	cmd := []string{"/bin/sh", "-c", cmdString}
 	podOpt := framework.ExecOptions{
 		Command:            cmd,

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -143,7 +143,8 @@ func createNFSStorageClass(
 	c clientset.Interface,
 	f *framework.Framework,
 	enablePool bool,
-	params map[string]string) error {
+	params map[string]string,
+) error {
 	scPath := fmt.Sprintf("%s/%s", nfsExamplePath, "storageclass.yaml")
 	sc, err := getStorageClass(scPath)
 	if err != nil {

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -136,7 +136,8 @@ func findPodAndContainerName(f *framework.Framework, ns, cn string, opt *metav1.
 func getCommandInPodOpts(
 	f *framework.Framework,
 	c, ns, cn string,
-	opt *metav1.ListOptions) (framework.ExecOptions, error) {
+	opt *metav1.ListOptions,
+) (framework.ExecOptions, error) {
 	cmd := []string{"/bin/sh", "-c", c}
 	pName, cName, err := findPodAndContainerName(f, ns, cn, opt)
 	if err != nil {
@@ -161,7 +162,8 @@ func getCommandInPodOpts(
 // stderr is returned as a string, and err will be set on a failure.
 func execCommandInDaemonsetPod(
 	f *framework.Framework,
-	c, daemonsetName, nodeName, containerName, ns string) (string, error) {
+	c, daemonsetName, nodeName, containerName, ns string,
+) (string, error) {
 	selector, err := getDaemonSetLabelSelector(f, ns, daemonsetName)
 	if err != nil {
 		return "", err
@@ -224,7 +226,8 @@ func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOpti
 }
 
 func execCommandInContainer(
-	f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions) (string, string, error) {
+	f *framework.Framework, c, ns, cn string, opt *metav1.ListOptions,
+) (string, string, error) {
 	podOpt, err := getCommandInPodOpts(f, c, ns, cn, opt)
 	if err != nil {
 		return "", "", err
@@ -468,7 +471,8 @@ func validateRWOPPodCreation(
 	f *framework.Framework,
 	pvc *v1.PersistentVolumeClaim,
 	app *v1.Pod,
-	baseAppName string) error {
+	baseAppName string,
+) error {
 	var err error
 	// create one more  app with same PVC
 	name := fmt.Sprintf("%s%d", f.UniqueName, deployTimeout)

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -239,7 +239,8 @@ func getPersistentVolume(c kubernetes.Interface, name string) (*v1.PersistentVol
 
 func getPVCAndPV(
 	c kubernetes.Interface,
-	pvcName, pvcNamespace string) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	pvcName, pvcNamespace string,
+) (*v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
 	pvc, err := getPersistentVolumeClaim(c, pvcNamespace, pvcName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get PVC: %w", err)

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -117,7 +117,8 @@ func createRBDStorageClass(
 	f *framework.Framework,
 	name string,
 	scOptions, parameters map[string]string,
-	policy v1.PersistentVolumeReclaimPolicy) error {
+	policy v1.PersistentVolumeReclaimPolicy,
+) error {
 	scPath := fmt.Sprintf("%s/%s", rbdExamplePath, "storageclass.yaml")
 	sc, err := getStorageClass(scPath)
 	if err != nil {
@@ -281,7 +282,7 @@ func getImageMeta(rbdImageSpec, metaKey string, f *framework.Framework) (string,
 		return "", err
 	}
 	if stdErr != "" {
-		return strings.TrimSpace(stdOut), fmt.Errorf(stdErr)
+		return strings.TrimSpace(stdOut), fmt.Errorf("%s", stdErr)
 	}
 
 	return strings.TrimSpace(stdOut), nil
@@ -757,7 +758,8 @@ func checkPVCImageInPool(f *framework.Framework, pvc *v1.PersistentVolumeClaim, 
 func checkPVCDataPoolForImageInPool(
 	f *framework.Framework,
 	pvc *v1.PersistentVolumeClaim,
-	pool, dataPool string) error {
+	pool, dataPool string,
+) error {
 	stdOut, err := getPVCImageInfoInPool(f, pvc, pool)
 	if err != nil {
 		return err

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -300,7 +300,8 @@ func validateBiggerPVCFromSnapshot(f *framework.Framework,
 	appPath,
 	snapPath,
 	pvcClonePath,
-	appClonePath string) error {
+	appClonePath string,
+) error {
 	const (
 		size    = "1Gi"
 		newSize = "2Gi"

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -41,7 +41,8 @@ const (
 func getStaticPV(
 	name, volName, size, secretName, secretNS, sc, driverName string,
 	blockPV bool,
-	options, annotations map[string]string, policy v1.PersistentVolumeReclaimPolicy) *v1.PersistentVolume {
+	options, annotations map[string]string, policy v1.PersistentVolumeReclaimPolicy,
+) *v1.PersistentVolume {
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -491,7 +492,8 @@ func validateRBDStaticResize(
 	app *v1.Pod,
 	appOpt *metav1.ListOptions,
 	pvc *v1.PersistentVolumeClaim,
-	rbdImageName string) error {
+	rbdImageName string,
+) error {
 	// resize rbd image
 	size := staticPVNewSize
 	cmd := fmt.Sprintf(

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -341,7 +341,8 @@ func createPVCAndApp(
 	f *framework.Framework,
 	pvc *v1.PersistentVolumeClaim,
 	app *v1.Pod,
-	pvcTimeout int) error {
+	pvcTimeout int,
+) error {
 	if name != "" {
 		pvc.Name = name
 		app.Name = name
@@ -361,7 +362,8 @@ func createPVCAndDeploymentApp(
 	f *framework.Framework,
 	pvc *v1.PersistentVolumeClaim,
 	app *appsv1.Deployment,
-	pvcTimeout int) error {
+	pvcTimeout int,
+) error {
 	err := createPVCAndvalidatePV(f.ClientSet, pvc, pvcTimeout)
 	if err != nil {
 		return err
@@ -414,7 +416,8 @@ func validatePVCAndDeploymentAppBinding(
 func deletePVCAndDeploymentApp(
 	f *framework.Framework,
 	pvc *v1.PersistentVolumeClaim,
-	app *appsv1.Deployment) error {
+	app *appsv1.Deployment,
+) error {
 	err := deleteDeploymentApp(f.ClientSet, app.Name, app.Namespace, deployTimeout)
 	if err != nil {
 		return err
@@ -445,7 +448,8 @@ func deletePVCAndApp(name string, f *framework.Framework, pvc *v1.PersistentVolu
 func createPVCAndAppBinding(
 	pvcPath, appPath string,
 	f *framework.Framework,
-	pvcTimeout int) (*v1.PersistentVolumeClaim, *v1.Pod, error) {
+	pvcTimeout int,
+) (*v1.PersistentVolumeClaim, *v1.Pod, error) {
 	pvc, err := loadPVC(pvcPath)
 	if err != nil {
 		return nil, nil, err
@@ -486,7 +490,7 @@ func getMountType(selector, mountPath string, f *framework.Framework) (string, e
 		return "", err
 	}
 	if stdErr != "" {
-		return strings.TrimSpace(stdOut), fmt.Errorf(stdErr)
+		return strings.TrimSpace(stdOut), fmt.Errorf("%s", stdErr)
 	}
 
 	return strings.TrimSpace(stdOut), nil
@@ -802,7 +806,8 @@ func validatePVCClone(
 	dataPool string,
 	kms kmsConfig,
 	validatePVC validateFunc,
-	f *framework.Framework) {
+	f *framework.Framework,
+) {
 	var wg sync.WaitGroup
 	wgErrs := make([]error, totalCount)
 	chErrs := make([]error, totalCount)
@@ -1013,7 +1018,8 @@ func validatePVCSnapshot(
 	totalCount int,
 	pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath string,
 	kms, restoreKMS kmsConfig, restoreSCName,
-	dataPool string, f *framework.Framework) {
+	dataPool string, f *framework.Framework,
+) {
 	var wg sync.WaitGroup
 	wgErrs := make([]error, totalCount)
 	chErrs := make([]error, totalCount)
@@ -1358,7 +1364,8 @@ func validatePVCSnapshot(
 func validateController(
 	f *framework.Framework,
 	pvcPath, appPath, scPath string,
-	scOptions, scParams map[string]string) error {
+	scOptions, scParams map[string]string,
+) error {
 	size := "1Gi"
 	poolName := defaultRBDPool
 	expandSize := "10Gi"

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -59,7 +59,8 @@ func (cs *ControllerServer) createBackingVolume(
 	volOptions,
 	parentVolOpt *store.VolumeOptions,
 	pvID *store.VolumeIdentifier,
-	sID *store.SnapshotIdentifier) error {
+	sID *store.SnapshotIdentifier,
+) error {
 	var err error
 	volClient := core.NewSubVolume(volOptions.GetConnection(), &volOptions.SubVolume, volOptions.ClusterID)
 
@@ -113,7 +114,8 @@ func (cs *ControllerServer) createBackingVolume(
 func checkContentSource(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
-	cr *util.Credentials) (*store.VolumeOptions, *store.VolumeIdentifier, *store.SnapshotIdentifier, error) {
+	cr *util.Credentials,
+) (*store.VolumeOptions, *store.VolumeIdentifier, *store.SnapshotIdentifier, error) {
 	if req.VolumeContentSource == nil {
 		return nil, nil, nil, nil
 	}
@@ -155,7 +157,8 @@ func checkValidCreateVolumeRequest(
 	vol,
 	parentVol *store.VolumeOptions,
 	pvID *store.VolumeIdentifier,
-	sID *store.SnapshotIdentifier) error {
+	sID *store.SnapshotIdentifier,
+) error {
 	switch {
 	case pvID != nil:
 		if vol.Size < parentVol.Size {
@@ -182,7 +185,8 @@ func checkValidCreateVolumeRequest(
 // nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
 func (cs *ControllerServer) CreateVolume(
 	ctx context.Context,
-	req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	req *csi.CreateVolumeRequest,
+) (*csi.CreateVolumeResponse, error) {
 	if err := cs.validateCreateVolumeRequest(req); err != nil {
 		log.ErrorLog(ctx, "CreateVolumeRequest validation failed: %v", err)
 
@@ -279,12 +283,11 @@ func (cs *ControllerServer) CreateVolume(
 			VolumeContext: volumeContext,
 		}
 		if volOptions.Topology != nil {
-			volume.AccessibleTopology =
-				[]*csi.Topology{
-					{
-						Segments: volOptions.Topology,
-					},
-				}
+			volume.AccessibleTopology = []*csi.Topology{
+				{
+					Segments: volOptions.Topology,
+				},
+			}
 		}
 
 		return &csi.CreateVolumeResponse{Volume: volume}, nil
@@ -353,12 +356,11 @@ func (cs *ControllerServer) CreateVolume(
 		VolumeContext: volumeContext,
 	}
 	if volOptions.Topology != nil {
-		volume.AccessibleTopology =
-			[]*csi.Topology{
-				{
-					Segments: volOptions.Topology,
-				},
-			}
+		volume.AccessibleTopology = []*csi.Topology{
+			{
+				Segments: volOptions.Topology,
+			},
+		}
 	}
 
 	return &csi.CreateVolumeResponse{Volume: volume}, nil
@@ -367,7 +369,8 @@ func (cs *ControllerServer) CreateVolume(
 // DeleteVolume deletes the volume in backend and its reservation.
 func (cs *ControllerServer) DeleteVolume(
 	ctx context.Context,
-	req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	req *csi.DeleteVolumeRequest,
+) (*csi.DeleteVolumeResponse, error) {
 	if err := cs.validateDeleteVolumeRequest(); err != nil {
 		log.ErrorLog(ctx, "DeleteVolumeRequest validation failed: %v", err)
 
@@ -474,7 +477,8 @@ func (cs *ControllerServer) DeleteVolume(
 // are supported.
 func (cs *ControllerServer) ValidateVolumeCapabilities(
 	ctx context.Context,
-	req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	req *csi.ValidateVolumeCapabilitiesRequest,
+) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	// Cephfs doesn't support Block volume
 	for _, capability := range req.VolumeCapabilities {
 		if capability.GetBlock() != nil {
@@ -492,7 +496,8 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 // ControllerExpandVolume expands CephFS Volumes on demand based on resizer request.
 func (cs *ControllerServer) ControllerExpandVolume(
 	ctx context.Context,
-	req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+	req *csi.ControllerExpandVolumeRequest,
+) (*csi.ControllerExpandVolumeResponse, error) {
 	if err := cs.validateExpandVolumeRequest(req); err != nil {
 		log.ErrorLog(ctx, "ControllerExpandVolumeRequest validation failed: %v", err)
 
@@ -551,7 +556,8 @@ func (cs *ControllerServer) ControllerExpandVolume(
 // nolint:gocyclo,cyclop // golangci-lint did not catch this earlier, needs to get fixed late
 func (cs *ControllerServer) CreateSnapshot(
 	ctx context.Context,
-	req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+	req *csi.CreateSnapshotRequest,
+) (*csi.CreateSnapshotResponse, error) {
 	if err := cs.validateSnapshotReq(ctx, req); err != nil {
 		return nil, err
 	}
@@ -714,7 +720,8 @@ func (cs *ControllerServer) CreateSnapshot(
 func doSnapshot(
 	ctx context.Context,
 	volOpt *store.VolumeOptions,
-	snapshotName string) (core.SnapshotInfo, error) {
+	snapshotName string,
+) (core.SnapshotInfo, error) {
 	snapID := fsutil.VolumeID(snapshotName)
 	snap := core.SnapshotInfo{}
 	snapClient := core.NewSnapshot(volOpt.GetConnection(), snapshotName, &volOpt.SubVolume)
@@ -775,7 +782,8 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 // snapshot metadata from store.
 func (cs *ControllerServer) DeleteSnapshot(
 	ctx context.Context,
-	req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+	req *csi.DeleteSnapshotRequest,
+) (*csi.DeleteSnapshotResponse, error) {
 	if err := cs.Driver.ValidateControllerServiceRequest(
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
 		log.ErrorLog(ctx, "invalid delete snapshot req: %v", protosanitizer.StripSecrets(req))

--- a/internal/cephfs/core/clone.go
+++ b/internal/cephfs/core/clone.go
@@ -64,7 +64,8 @@ func (cs cephFSCloneState) toError() error {
 // CreateCloneFromSubvolume creates a clone from a subvolume.
 func (s *subVolumeClient) CreateCloneFromSubvolume(
 	ctx context.Context,
-	parentvolOpt *SubVolume) error {
+	parentvolOpt *SubVolume,
+) error {
 	snapshotID := s.VolID
 	snapClient := NewSnapshot(s.conn, snapshotID, parentvolOpt)
 	err := snapClient.CreateSnapshot(ctx)
@@ -159,7 +160,8 @@ func (s *subVolumeClient) CreateCloneFromSubvolume(
 
 // CleanupSnapshotFromSubvolume	removes the snapshot from the subvolume.
 func (s *subVolumeClient) CleanupSnapshotFromSubvolume(
-	ctx context.Context, parentVol *SubVolume) error {
+	ctx context.Context, parentVol *SubVolume,
+) error {
 	// snapshot name is same as clone name as we need a name which can be
 	// identified during PVC-PVC cloning.
 	snapShotID := s.VolID
@@ -193,7 +195,8 @@ func (s *subVolumeClient) CleanupSnapshotFromSubvolume(
 
 // CreateSnapshotFromSubvolume creates a clone from subvolume snapshot.
 func (s *subVolumeClient) CreateCloneFromSnapshot(
-	ctx context.Context, snap Snapshot) error {
+	ctx context.Context, snap Snapshot,
+) error {
 	snapID := snap.SnapshotID
 	snapClient := NewSnapshot(s.conn, snapID, snap.SubVolume)
 	err := snapClient.CloneSnapshot(ctx, s.SubVolume)

--- a/internal/cephfs/identityserver.go
+++ b/internal/cephfs/identityserver.go
@@ -33,7 +33,8 @@ type IdentityServer struct {
 // GetPluginCapabilities returns available capabilities of the ceph driver.
 func (is *IdentityServer) GetPluginCapabilities(
 	ctx context.Context,
-	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	req *csi.GetPluginCapabilitiesRequest,
+) (*csi.GetPluginCapabilitiesResponse, error) {
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/internal/cephfs/mounter/fuse.go
+++ b/internal/cephfs/mounter/fuse.go
@@ -107,7 +107,8 @@ func (m *FuseMounter) Mount(
 	ctx context.Context,
 	mountPoint string,
 	cr *util.Credentials,
-	volOptions *store.VolumeOptions) error {
+	volOptions *store.VolumeOptions,
+) error {
 	if err := util.CreateMountPoint(mountPoint); err != nil {
 		return err
 	}

--- a/internal/cephfs/mounter/kernel.go
+++ b/internal/cephfs/mounter/kernel.go
@@ -72,7 +72,8 @@ func (m *KernelMounter) Mount(
 	ctx context.Context,
 	mountPoint string,
 	cr *util.Credentials,
-	volOptions *store.VolumeOptions) error {
+	volOptions *store.VolumeOptions,
+) error {
 	if err := util.CreateMountPoint(mountPoint); err != nil {
 		return err
 	}

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -47,7 +47,8 @@ type NodeServer struct {
 
 func getCredentialsForVolume(
 	volOptions *store.VolumeOptions,
-	secrets map[string]string) (*util.Credentials, error) {
+	secrets map[string]string,
+) (*util.Credentials, error) {
 	var (
 		err error
 		cr  *util.Credentials
@@ -103,7 +104,8 @@ func (ns *NodeServer) getVolumeOptions(
 // NodeStageVolume mounts the volume to a staging path on the node.
 func (ns *NodeServer) NodeStageVolume(
 	ctx context.Context,
-	req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	req *csi.NodeStageVolumeRequest,
+) (*csi.NodeStageVolumeResponse, error) {
 	if err := util.ValidateNodeStageVolumeRequest(req); err != nil {
 		return nil, err
 	}
@@ -253,7 +255,8 @@ func (*NodeServer) mount(
 // path.
 func (ns *NodeServer) NodePublishVolume(
 	ctx context.Context,
-	req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	req *csi.NodePublishVolumeRequest,
+) (*csi.NodePublishVolumeResponse, error) {
 	mountOptions := []string{"bind", "_netdev"}
 	if err := util.ValidateNodePublishVolumeRequest(req); err != nil {
 		return nil, err
@@ -336,7 +339,8 @@ func (ns *NodeServer) NodePublishVolume(
 // NodeUnpublishVolume unmounts the volume from the target path.
 func (ns *NodeServer) NodeUnpublishVolume(
 	ctx context.Context,
-	req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	req *csi.NodeUnpublishVolumeRequest,
+) (*csi.NodeUnpublishVolumeResponse, error) {
 	var err error
 	if err = util.ValidateNodeUnpublishVolumeRequest(req); err != nil {
 		return nil, err
@@ -391,7 +395,8 @@ func (ns *NodeServer) NodeUnpublishVolume(
 // NodeUnstageVolume unstages the volume from the staging path.
 func (ns *NodeServer) NodeUnstageVolume(
 	ctx context.Context,
-	req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	req *csi.NodeUnstageVolumeRequest,
+) (*csi.NodeUnstageVolumeResponse, error) {
 	var err error
 	if err = util.ValidateNodeUnstageVolumeRequest(req); err != nil {
 		return nil, err
@@ -451,7 +456,8 @@ func (ns *NodeServer) NodeUnstageVolume(
 // NodeGetCapabilities returns the supported capabilities of the node server.
 func (ns *NodeServer) NodeGetCapabilities(
 	ctx context.Context,
-	req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	req *csi.NodeGetCapabilitiesRequest,
+) (*csi.NodeGetCapabilitiesResponse, error) {
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{
 			{
@@ -482,7 +488,8 @@ func (ns *NodeServer) NodeGetCapabilities(
 // NodeGetVolumeStats returns volume stats.
 func (ns *NodeServer) NodeGetVolumeStats(
 	ctx context.Context,
-	req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	req *csi.NodeGetVolumeStatsRequest,
+) (*csi.NodeGetVolumeStatsResponse, error) {
 	var err error
 	targetPath := req.GetVolumePath()
 	if targetPath == "" {

--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -77,7 +77,8 @@ func CheckVolExists(ctx context.Context,
 
 	pvID *VolumeIdentifier,
 	sID *SnapshotIdentifier,
-	cr *util.Credentials) (*VolumeIdentifier, error) {
+	cr *util.Credentials,
+) (*VolumeIdentifier, error) {
 	var vid VolumeIdentifier
 	// Connect to cephfs' default radosNamespace (csi)
 	j, err := VolJournal.Connect(volOptions.Monitors, fsutil.RadosNamespace, cr)
@@ -205,7 +206,8 @@ func UndoVolReservation(
 	ctx context.Context,
 	volOptions *VolumeOptions,
 	vid VolumeIdentifier,
-	secret map[string]string) error {
+	secret map[string]string,
+) error {
 	cr, err := util.NewAdminCredentials(secret)
 	if err != nil {
 		return err
@@ -294,7 +296,8 @@ func ReserveSnap(
 	volOptions *VolumeOptions,
 	parentSubVolName string,
 	snap *SnapshotOption,
-	cr *util.Credentials) (*SnapshotIdentifier, error) {
+	cr *util.Credentials,
+) (*SnapshotIdentifier, error) {
 	var (
 		vid       SnapshotIdentifier
 		imageUUID string
@@ -335,7 +338,8 @@ func UndoSnapReservation(
 	volOptions *VolumeOptions,
 	vid SnapshotIdentifier,
 	snapName string,
-	cr *util.Credentials) error {
+	cr *util.Credentials,
+) error {
 	// Connect to cephfs' default radosNamespace (csi)
 	j, err := SnapJournal.Connect(volOptions.Monitors, fsutil.RadosNamespace, cr)
 	if err != nil {
@@ -367,7 +371,8 @@ func CheckSnapExists(
 	ctx context.Context,
 	volOptions *VolumeOptions,
 	snap *SnapshotOption,
-	cr *util.Credentials) (*SnapshotIdentifier, *core.SnapshotInfo, error) {
+	cr *util.Credentials,
+) (*SnapshotIdentifier, *core.SnapshotInfo, error) {
 	// Connect to cephfs' default radosNamespace (csi)
 	j, err := SnapJournal.Connect(volOptions.Monitors, fsutil.RadosNamespace, cr)
 	if err != nil {

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -187,7 +187,8 @@ func (vo *VolumeOptions) GetConnection() *util.ClusterConnection {
 // NewVolumeOptions generates a new instance of volumeOptions from the provided
 // CSI request parameters.
 func NewVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVolumeRequest,
-	cr *util.Credentials) (*VolumeOptions, error) {
+	cr *util.Credentials,
+) (*VolumeOptions, error) {
 	var (
 		opts VolumeOptions
 		err  error
@@ -268,7 +269,8 @@ func NewVolumeOptions(ctx context.Context, requestName string, req *csi.CreateVo
 func NewVolumeOptionsFromVolID(
 	ctx context.Context,
 	volID string,
-	volOpt, secrets map[string]string) (*VolumeOptions, *VolumeIdentifier, error) {
+	volOpt, secrets map[string]string,
+) (*VolumeOptions, *VolumeIdentifier, error) {
 	var (
 		vi         util.CSIIdentifier
 		volOptions VolumeOptions
@@ -383,7 +385,8 @@ func NewVolumeOptionsFromVolID(
 // VolumeIdentifier from the provided CSI volume context.
 func NewVolumeOptionsFromMonitorList(
 	volID string,
-	options, secrets map[string]string) (*VolumeOptions, *VolumeIdentifier, error) {
+	options, secrets map[string]string,
+) (*VolumeOptions, *VolumeIdentifier, error) {
 	var (
 		opts                VolumeOptions
 		vid                 VolumeIdentifier
@@ -446,7 +449,8 @@ func NewVolumeOptionsFromMonitorList(
 // detected to be a statically provisioned volume.
 func NewVolumeOptionsFromStaticVolume(
 	volID string,
-	options map[string]string) (*VolumeOptions, *VolumeIdentifier, error) {
+	options map[string]string,
+) (*VolumeOptions, *VolumeIdentifier, error) {
 	var (
 		opts      VolumeOptions
 		vid       VolumeIdentifier
@@ -515,7 +519,8 @@ func NewVolumeOptionsFromStaticVolume(
 func NewSnapshotOptionsFromID(
 	ctx context.Context,
 	snapID string,
-	cr *util.Credentials) (*VolumeOptions, *core.SnapshotInfo, *SnapshotIdentifier, error) {
+	cr *util.Credentials,
+) (*VolumeOptions, *core.SnapshotInfo, *SnapshotIdentifier, error) {
 	var (
 		vi         util.CSIIdentifier
 		volOptions VolumeOptions

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -93,7 +93,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 func (r *ReconcilePersistentVolume) getCredentials(
 	ctx context.Context,
 	name,
-	namespace string) (*util.Credentials, error) {
+	namespace string,
+) (*util.Credentials, error) {
 	var cr *util.Credentials
 
 	if name == "" || namespace == "" {
@@ -199,7 +200,8 @@ func (r ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime.
 // Reconcile reconciles the PersistentVolume object and creates a new omap entries
 // for the volume.
 func (r *ReconcilePersistentVolume) Reconcile(ctx context.Context,
-	request reconcile.Request) (reconcile.Result, error) {
+	request reconcile.Request,
+) (reconcile.Result, error) {
 	pv := &corev1.PersistentVolume{}
 	err := r.client.Get(ctx, request.NamespacedName, pv)
 	if err != nil {

--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -39,7 +39,8 @@ func NewNetworkFence(
 	ctx context.Context,
 	cr *util.Credentials,
 	cidrs []*fence.CIDR,
-	fenceOptions map[string]string) (*NetworkFence, error) {
+	fenceOptions map[string]string,
+) (*NetworkFence, error) {
 	var err error
 	nwFence := &NetworkFence{}
 

--- a/internal/csi-addons/rbd/identity.go
+++ b/internal/csi-addons/rbd/identity.go
@@ -49,7 +49,8 @@ func (is *IdentityServer) RegisterService(server grpc.ServiceRegistrar) {
 // GetIdentity returns available capabilities of the rbd driver.
 func (is *IdentityServer) GetIdentity(
 	ctx context.Context,
-	req *identity.GetIdentityRequest) (*identity.GetIdentityResponse, error) {
+	req *identity.GetIdentityRequest,
+) (*identity.GetIdentityResponse, error) {
 	// only include Name and VendorVersion, Manifest is optional
 	res := &identity.GetIdentityResponse{
 		Name:          is.config.DriverName,
@@ -62,7 +63,8 @@ func (is *IdentityServer) GetIdentity(
 // GetCapabilities returns available capabilities of the rbd driver.
 func (is *IdentityServer) GetCapabilities(
 	ctx context.Context,
-	req *identity.GetCapabilitiesRequest) (*identity.GetCapabilitiesResponse, error) {
+	req *identity.GetCapabilitiesRequest,
+) (*identity.GetCapabilitiesResponse, error) {
 	// build the list of capabilities, depending on the config
 	caps := make([]*identity.Capability, 0)
 
@@ -121,7 +123,8 @@ func (is *IdentityServer) GetCapabilities(
 // still healthy.
 func (is *IdentityServer) Probe(
 	ctx context.Context,
-	req *identity.ProbeRequest) (*identity.ProbeResponse, error) {
+	req *identity.ProbeRequest,
+) (*identity.ProbeResponse, error) {
 	// there is nothing that would cause a delay in getting ready
 	res := &identity.ProbeResponse{
 		Ready: &wrapperspb.BoolValue{Value: true},

--- a/internal/csi-addons/rbd/network_fence.go
+++ b/internal/csi-addons/rbd/network_fence.go
@@ -60,7 +60,8 @@ func validateNetworkFenceReq(fenceClients []*fence.CIDR, options map[string]stri
 // to the malicious clients to prevent data corruption.
 func (fcs *FenceControllerServer) FenceClusterNetwork(
 	ctx context.Context,
-	req *fence.FenceClusterNetworkRequest) (*fence.FenceClusterNetworkResponse, error) {
+	req *fence.FenceClusterNetworkRequest,
+) (*fence.FenceClusterNetworkResponse, error) {
 	err := validateNetworkFenceReq(req.GetCidrs(), req.Parameters)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -88,7 +89,8 @@ func (fcs *FenceControllerServer) FenceClusterNetwork(
 // UnfenceClusterNetwork unblocks the access to a CIDR block by removing the network fence.
 func (fcs *FenceControllerServer) UnfenceClusterNetwork(
 	ctx context.Context,
-	req *fence.UnfenceClusterNetworkRequest) (*fence.UnfenceClusterNetworkResponse, error) {
+	req *fence.UnfenceClusterNetworkRequest,
+) (*fence.UnfenceClusterNetworkResponse, error) {
 	err := validateNetworkFenceReq(req.GetCidrs(), req.Parameters)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -49,7 +49,8 @@ func (rscs *ReclaimSpaceControllerServer) RegisterService(server grpc.ServiceReg
 
 func (rscs *ReclaimSpaceControllerServer) ControllerReclaimSpace(
 	ctx context.Context,
-	req *rs.ControllerReclaimSpaceRequest) (*rs.ControllerReclaimSpaceResponse, error) {
+	req *rs.ControllerReclaimSpaceRequest,
+) (*rs.ControllerReclaimSpaceResponse, error) {
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
@@ -97,10 +98,10 @@ func (rsns *ReclaimSpaceNodeServer) RegisterService(server grpc.ServiceRegistrar
 // an error is returned to prevent potential data corruption.
 func (rsns *ReclaimSpaceNodeServer) NodeReclaimSpace(
 	ctx context.Context,
-	req *rs.NodeReclaimSpaceRequest) (*rs.NodeReclaimSpaceResponse, error) {
+	req *rs.NodeReclaimSpaceRequest,
+) (*rs.NodeReclaimSpaceResponse, error) {
 	// volumeID is a required attribute, it is part of the path to run the
 	// space reducing command on
-	// nolint:ifshort // volumeID is incorrectly assumed to be used only once
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")

--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -34,28 +34,32 @@ type DefaultControllerServer struct {
 // ControllerPublishVolume publish volume on node.
 func (cs *DefaultControllerServer) ControllerPublishVolume(
 	ctx context.Context,
-	req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	req *csi.ControllerPublishVolumeRequest,
+) (*csi.ControllerPublishVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ControllerUnpublishVolume unpublish on node.
 func (cs *DefaultControllerServer) ControllerUnpublishVolume(
 	ctx context.Context,
-	req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	req *csi.ControllerUnpublishVolumeRequest,
+) (*csi.ControllerUnpublishVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ListVolumes lists volumes.
 func (cs *DefaultControllerServer) ListVolumes(
 	ctx context.Context,
-	req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	req *csi.ListVolumesRequest,
+) (*csi.ListVolumesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // GetCapacity get volume capacity.
 func (cs *DefaultControllerServer) GetCapacity(
 	ctx context.Context,
-	req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+	req *csi.GetCapacityRequest,
+) (*csi.GetCapacityResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
@@ -63,7 +67,8 @@ func (cs *DefaultControllerServer) GetCapacity(
 // Default supports all capabilities.
 func (cs *DefaultControllerServer) ControllerGetCapabilities(
 	ctx context.Context,
-	req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+	req *csi.ControllerGetCapabilitiesRequest,
+) (*csi.ControllerGetCapabilitiesResponse, error) {
 	log.TraceLog(ctx, "Using default ControllerGetCapabilities")
 	if cs.Driver == nil {
 		return nil, status.Error(codes.Unimplemented, "Controller server is not enabled")
@@ -77,13 +82,15 @@ func (cs *DefaultControllerServer) ControllerGetCapabilities(
 // ListSnapshots lists snapshots.
 func (cs *DefaultControllerServer) ListSnapshots(
 	ctx context.Context,
-	req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+	req *csi.ListSnapshotsRequest,
+) (*csi.ListSnapshotsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ControllerGetVolume fetch volume information.
 func (cs *DefaultControllerServer) ControllerGetVolume(
 	ctx context.Context,
-	req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
+	req *csi.ControllerGetVolumeRequest,
+) (*csi.ControllerGetVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -100,7 +100,8 @@ func (d *CSIDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceC
 
 // AddVolumeCapabilityAccessModes stores volume access modes.
 func (d *CSIDriver) AddVolumeCapabilityAccessModes(
-	vc []csi.VolumeCapability_AccessMode_Mode) []*csi.VolumeCapability_AccessMode {
+	vc []csi.VolumeCapability_AccessMode_Mode,
+) []*csi.VolumeCapability_AccessMode {
 	vca := make([]*csi.VolumeCapability_AccessMode, 0, len(vc))
 	for _, c := range vc {
 		log.DefaultLog("Enabling volume access mode: %v", c.String())

--- a/internal/csi-common/identityserver-default.go
+++ b/internal/csi-common/identityserver-default.go
@@ -34,7 +34,8 @@ type DefaultIdentityServer struct {
 // GetPluginInfo returns plugin information.
 func (ids *DefaultIdentityServer) GetPluginInfo(
 	ctx context.Context,
-	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+	req *csi.GetPluginInfoRequest,
+) (*csi.GetPluginInfoResponse, error) {
 	log.TraceLog(ctx, "Using default GetPluginInfo")
 
 	if ids.Driver.name == "" {
@@ -59,7 +60,8 @@ func (ids *DefaultIdentityServer) Probe(ctx context.Context, req *csi.ProbeReque
 // GetPluginCapabilities returns plugin capabilities.
 func (ids *DefaultIdentityServer) GetPluginCapabilities(
 	ctx context.Context,
-	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	req *csi.GetPluginCapabilitiesRequest,
+) (*csi.GetPluginCapabilitiesResponse, error) {
 	log.TraceLog(ctx, "Using default capabilities")
 
 	return &csi.GetPluginCapabilitiesResponse{

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -35,14 +35,16 @@ type DefaultNodeServer struct {
 // NodeExpandVolume returns unimplemented response.
 func (ns *DefaultNodeServer) NodeExpandVolume(
 	ctx context.Context,
-	req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	req *csi.NodeExpandVolumeRequest,
+) (*csi.NodeExpandVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // NodeGetInfo returns node ID.
 func (ns *DefaultNodeServer) NodeGetInfo(
 	ctx context.Context,
-	req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	req *csi.NodeGetInfoRequest,
+) (*csi.NodeGetInfoResponse, error) {
 	log.TraceLog(ctx, "Using default NodeGetInfo")
 
 	csiTopology := &csi.Topology{
@@ -58,7 +60,8 @@ func (ns *DefaultNodeServer) NodeGetInfo(
 // NodeGetCapabilities returns RPC unknown capability.
 func (ns *DefaultNodeServer) NodeGetCapabilities(
 	ctx context.Context,
-	req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	req *csi.NodeGetCapabilitiesRequest,
+) (*csi.NodeGetCapabilitiesResponse, error) {
 	log.TraceLog(ctx, "Using default NodeGetCapabilities")
 
 	return &csi.NodeGetCapabilitiesResponse{

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -173,7 +173,8 @@ func contextIDInjector(
 	ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
-	handler grpc.UnaryHandler) (resp interface{}, err error) {
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
 	atomic.AddUint64(&id, 1)
 	ctx = context.WithValue(ctx, log.CtxKey, id)
 	if reqID := getReqID(req); reqID != "" {
@@ -187,7 +188,8 @@ func logGRPC(
 	ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
-	handler grpc.UnaryHandler) (interface{}, error) {
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
 	log.ExtendedLog(ctx, "GRPC call: %s", info.FullMethod)
 	if isReplicationRequest(req) {
 		log.TraceLog(ctx, "GRPC request: %s", rp.StripReplicationSecrets(req))
@@ -205,11 +207,13 @@ func logGRPC(
 	return resp, err
 }
 
+//nolint:nonamedreturns // named return used to send recovered panic error.
 func panicHandler(
 	ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
-	handler grpc.UnaryHandler) (resp interface{}, err error) {
+	handler grpc.UnaryHandler,
+) (resp interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.Errorf("panic occurred: %v", r)

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -34,7 +34,8 @@ const chunkSize int64 = 512
 func getOMapValues(
 	ctx context.Context,
 	conn *Connection,
-	poolName, namespace, oid, prefix string, keys []string) (map[string]string, error) {
+	poolName, namespace, oid, prefix string, keys []string,
+) (map[string]string, error) {
 	// fetch and configure the rados ioctx
 	ioctx, err := conn.conn.GetIoctx(poolName)
 	if err != nil {
@@ -93,7 +94,8 @@ func getOMapValues(
 func removeMapKeys(
 	ctx context.Context,
 	conn *Connection,
-	poolName, namespace, oid string, keys []string) error {
+	poolName, namespace, oid string, keys []string,
+) error {
 	// fetch and configure the rados ioctx
 	ioctx, err := conn.conn.GetIoctx(poolName)
 	if err != nil {
@@ -129,7 +131,8 @@ func removeMapKeys(
 func setOMapKeys(
 	ctx context.Context,
 	conn *Connection,
-	poolName, namespace, oid string, pairs map[string]string) error {
+	poolName, namespace, oid string, pairs map[string]string,
+) error {
 	// fetch and configure the rados ioctx
 	ioctx, err := conn.conn.GetIoctx(poolName)
 	if err != nil {

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -275,7 +275,8 @@ Return values:
 	- error: non-nil in case of any errors
 */
 func (conn *Connection) CheckReservation(ctx context.Context,
-	journalPool, reqName, namePrefix, snapParentName, kmsConfig string) (*ImageData, error) {
+	journalPool, reqName, namePrefix, snapParentName, kmsConfig string,
+) (*ImageData, error) {
 	var (
 		snapSource       bool
 		objUUID          string
@@ -415,7 +416,8 @@ Input arguments:
 	  different if image is created in a topology constrained pool)
 */
 func (conn *Connection) UndoReservation(ctx context.Context,
-	csiJournalPool, volJournalPool, volName, reqName string) error {
+	csiJournalPool, volJournalPool, volName, reqName string,
+) error {
 	// delete volume UUID omap (first, inverse of create order)
 
 	cj := conn.config
@@ -467,7 +469,8 @@ func reserveOMapName(
 	ctx context.Context,
 	monitors string,
 	cr *util.Credentials,
-	pool, namespace, oMapNamePrefix, volUUID string) (string, error) {
+	pool, namespace, oMapNamePrefix, volUUID string,
+) (string, error) {
 	var iterUUID string
 
 	maxAttempts := 5
@@ -534,7 +537,8 @@ Return values:
 func (conn *Connection) ReserveName(ctx context.Context,
 	journalPool string, journalPoolID int64,
 	imagePool string, imagePoolID int64,
-	reqName, namePrefix, parentName, kmsConf, volUUID, owner string) (string, string, error) {
+	reqName, namePrefix, parentName, kmsConf, volUUID, owner string,
+) (string, string, error) {
 	// TODO: Take in-arg as ImageAttributes?
 	var (
 		snapSource bool
@@ -658,7 +662,8 @@ type ImageAttributes struct {
 func (conn *Connection) GetImageAttributes(
 	ctx context.Context,
 	pool, objectUUID string,
-	snapSource bool) (*ImageAttributes, error) {
+	snapSource bool,
+) (*ImageAttributes, error) {
 	var (
 		err             error
 		imageAttributes = &ImageAttributes{}
@@ -782,7 +787,8 @@ func (conn *Connection) Destroy() {
 // CheckNewUUIDMapping checks is there any UUID mapping between old
 // volumeHandle and the newly generated volumeHandle.
 func (conn *Connection) CheckNewUUIDMapping(ctx context.Context,
-	journalPool, volumeHandle string) (string, error) {
+	journalPool, volumeHandle string,
+) (string, error) {
 	cj := conn.config
 
 	// check if request name is already part of the directory omap
@@ -812,7 +818,8 @@ func (conn *Connection) CheckNewUUIDMapping(ctx context.Context,
 // secondary cluster cephcsi will generate the new mapping and keep it for
 // internal reference.
 func (conn *Connection) ReserveNewUUIDMapping(ctx context.Context,
-	journalPool, oldVolumeHandle, newVolumeHandle string) error {
+	journalPool, oldVolumeHandle, newVolumeHandle string,
+) error {
 	cj := conn.config
 
 	setKeys := map[string]string{

--- a/internal/kms/aws_metadata.go
+++ b/internal/kms/aws_metadata.go
@@ -199,8 +199,7 @@ func (kms *awsMetadataKMS) EncryptDEK(volumeID, plainDEK string) (string, error)
 
 	// base64 encode the encrypted DEK, so that storing it should not have
 	// issues
-	encryptedDEK :=
-		base64.StdEncoding.EncodeToString(result.CiphertextBlob)
+	encryptedDEK := base64.StdEncoding.EncodeToString(result.CiphertextBlob)
 
 	return encryptedDEK, nil
 }

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -269,7 +269,8 @@ func RegisterProvider(provider Provider) bool {
 func (kf *kmsProviderList) buildKMS(
 	tenant string,
 	config map[string]interface{},
-	secrets map[string]string) (EncryptionKMS, error) {
+	secrets map[string]string,
+) (EncryptionKMS, error) {
 	providerName, err := getProvider(config)
 	if err != nil {
 		return nil, err

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -138,7 +138,8 @@ func initSecretsMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 // fetchEncryptionPassphrase fetches encryptionPassphrase from user provided secret.
 func (kms secretsMetadataKMS) fetchEncryptionPassphrase(
 	config map[string]interface{},
-	defaultNamespace string) (string, error) {
+	defaultNamespace string,
+) (string, error) {
 	var (
 		secretName      string
 		secretNamespace string

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -302,6 +302,7 @@ func (vc *vaultConnection) Destroy() {
 		tmpFile, ok := vc.vaultConfig[api.EnvVaultCACert]
 		if ok {
 			// ignore error on failure to remove tmpfile (gosec complains)
+			//nolint:forcetypeassert // ignore error on failure to remove tmpfile
 			_ = os.Remove(tmpFile.(string))
 		}
 	}

--- a/internal/kms/vault_tokens_test.go
+++ b/internal/kms/vault_tokens_test.go
@@ -120,6 +120,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	// add tenant "bob"
 	bob := make(map[string]interface{})
 	bob["vaultAddress"] = "https://vault.bob.example.org"
+	//nolint:forcetypeassert // as its a test we dont need to check assertion here.
 	args.Config["tenants"].(map[string]interface{})["bob"] = bob
 
 	_, err = initVaultTokensKMS(args)

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -57,7 +57,8 @@ func NewControllerServer(d *csicommon.CSIDriver) *Server {
 // capabilities that were set in the Driver.Run() function.
 func (cs *Server) ControllerGetCapabilities(
 	ctx context.Context,
-	req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+	req *csi.ControllerGetCapabilitiesRequest,
+) (*csi.ControllerGetCapabilitiesResponse, error) {
 	return cs.backendServer.ControllerGetCapabilities(ctx, req)
 }
 
@@ -65,7 +66,8 @@ func (cs *Server) ControllerGetCapabilities(
 // are supported.
 func (cs *Server) ValidateVolumeCapabilities(
 	ctx context.Context,
-	req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	req *csi.ValidateVolumeCapabilitiesRequest,
+) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	return cs.backendServer.ValidateVolumeCapabilities(ctx, req)
 }
 
@@ -73,7 +75,8 @@ func (cs *Server) ValidateVolumeCapabilities(
 // created entities.
 func (cs *Server) CreateVolume(
 	ctx context.Context,
-	req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	req *csi.CreateVolumeRequest,
+) (*csi.CreateVolumeResponse, error) {
 	res, err := cs.backendServer.CreateVolume(ctx, req)
 	if err != nil {
 		return nil, err
@@ -120,7 +123,8 @@ func (cs *Server) CreateVolume(
 // DeleteVolume deletes the volume in backend and its reservation.
 func (cs *Server) DeleteVolume(
 	ctx context.Context,
-	req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	req *csi.DeleteVolumeRequest,
+) (*csi.DeleteVolumeResponse, error) {
 	secret := req.GetSecrets()
 	cr, err := util.NewAdminCredentials(secret)
 	if err != nil {
@@ -157,7 +161,8 @@ func (cs *Server) DeleteVolume(
 // new size.
 func (cs *Server) ControllerExpandVolume(
 	ctx context.Context,
-	req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+	req *csi.ControllerExpandVolumeRequest,
+) (*csi.ControllerExpandVolumeResponse, error) {
 	return cs.backendServer.ControllerExpandVolume(ctx, req)
 }
 
@@ -165,7 +170,8 @@ func (cs *Server) ControllerExpandVolume(
 // There is no interaction with the NFS-server needed for snapshot creation.
 func (cs *Server) CreateSnapshot(
 	ctx context.Context,
-	req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+	req *csi.CreateSnapshotRequest,
+) (*csi.CreateSnapshotResponse, error) {
 	return cs.backendServer.CreateSnapshot(ctx, req)
 }
 
@@ -173,6 +179,7 @@ func (cs *Server) CreateSnapshot(
 // There is no interaction with the NFS-server needed for snapshot creation.
 func (cs *Server) DeleteSnapshot(
 	ctx context.Context,
-	req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+	req *csi.DeleteSnapshotRequest,
+) (*csi.DeleteSnapshotResponse, error) {
 	return cs.backendServer.DeleteSnapshot(ctx, req)
 }

--- a/internal/nfs/identity/identityserver.go
+++ b/internal/nfs/identity/identityserver.go
@@ -40,7 +40,8 @@ func NewIdentityServer(d *csicommon.CSIDriver) *Server {
 // GetPluginCapabilities returns available capabilities of the ceph driver.
 func (is *Server) GetPluginCapabilities(
 	ctx context.Context,
-	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	req *csi.GetPluginCapabilitiesRequest,
+) (*csi.GetPluginCapabilitiesResponse, error) {
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -273,7 +273,8 @@ func (ri *rbdImage) initKMS(ctx context.Context, volOptions, credentials map[str
 // ParseEncryptionOpts returns kmsID and sets Owner attribute.
 func (ri *rbdImage) ParseEncryptionOpts(
 	ctx context.Context,
-	volOptions map[string]string) (string, error) {
+	volOptions map[string]string,
+) (string, error) {
 	var (
 		err              error
 		ok               bool

--- a/internal/rbd/identityserver.go
+++ b/internal/rbd/identityserver.go
@@ -33,7 +33,8 @@ type IdentityServer struct {
 // GetPluginCapabilities returns available capabilities of the rbd driver.
 func (is *IdentityServer) GetPluginCapabilities(
 	ctx context.Context,
-	req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	req *csi.GetPluginCapabilitiesRequest,
+) (*csi.GetPluginCapabilitiesResponse, error) {
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -148,7 +148,8 @@ func healerStageTransaction(ctx context.Context, cr *util.Credentials, volOps *r
 func populateRbdVol(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest,
-	cr *util.Credentials) (*rbdVolume, error) {
+	cr *util.Credentials,
+) (*rbdVolume, error) {
 	var err error
 	var j *journal.Connection
 	volID := req.GetVolumeId()
@@ -295,7 +296,8 @@ func populateRbdVol(
 //   - Stage the device (mount the device mapped for image)
 func (ns *NodeServer) NodeStageVolume(
 	ctx context.Context,
-	req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	req *csi.NodeStageVolumeRequest,
+) (*csi.NodeStageVolumeResponse, error) {
 	var err error
 	if err = util.ValidateNodeStageVolumeRequest(req); err != nil {
 		return nil, err
@@ -384,7 +386,8 @@ func (ns *NodeServer) stageTransaction(
 	req *csi.NodeStageVolumeRequest,
 	cr *util.Credentials,
 	volOptions *rbdVolume,
-	staticVol bool) (*stageTransaction, error) {
+	staticVol bool,
+) (*stageTransaction, error) {
 	transaction := &stageTransaction{}
 
 	var err error
@@ -466,7 +469,8 @@ func resizeNodeStagePath(ctx context.Context,
 	isBlock bool,
 	transaction *stageTransaction,
 	volID,
-	stagingTargetPath string) error {
+	stagingTargetPath string,
+) error {
 	var err error
 	devicePath := transaction.devicePath
 	var ok bool
@@ -543,7 +547,8 @@ func resizeEncryptedDevice(ctx context.Context, volID, stagingTargetPath, device
 
 func flattenImageBeforeMapping(
 	ctx context.Context,
-	volOptions *rbdVolume) error {
+	volOptions *rbdVolume,
+) error {
 	var err error
 	var feature bool
 	var depth uint
@@ -579,7 +584,8 @@ func (ns *NodeServer) undoStagingTransaction(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest,
 	transaction *stageTransaction,
-	volOptions *rbdVolume) {
+	volOptions *rbdVolume,
+) {
 	var err error
 
 	stagingTargetPath := getStagingTargetPath(req)
@@ -661,7 +667,8 @@ func (ns *NodeServer) createStageMountPoint(ctx context.Context, mountPath strin
 // path.
 func (ns *NodeServer) NodePublishVolume(
 	ctx context.Context,
-	req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	req *csi.NodePublishVolumeRequest,
+) (*csi.NodePublishVolumeResponse, error) {
 	err := util.ValidateNodePublishVolumeRequest(req)
 	if err != nil {
 		return nil, err
@@ -700,7 +707,8 @@ func (ns *NodeServer) mountVolumeToStagePath(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest,
 	staticVol bool,
-	stagingPath, devicePath string) error {
+	stagingPath, devicePath string,
+) error {
 	readOnly := false
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
 	diskMounter := &mount.SafeFormatAndMount{Interface: ns.Mounter, Exec: utilexec.New()}
@@ -841,7 +849,8 @@ func (ns *NodeServer) createTargetMountPath(ctx context.Context, mountPath strin
 // NodeUnpublishVolume unmounts the volume from the target path.
 func (ns *NodeServer) NodeUnpublishVolume(
 	ctx context.Context,
-	req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	req *csi.NodeUnpublishVolumeRequest,
+) (*csi.NodeUnpublishVolumeResponse, error) {
 	err := util.ValidateNodeUnpublishVolumeRequest(req)
 	if err != nil {
 		return nil, err
@@ -898,7 +907,8 @@ func getStagingTargetPath(req interface{}) string {
 // NodeUnstageVolume unstages the volume from the staging path.
 func (ns *NodeServer) NodeUnstageVolume(
 	ctx context.Context,
-	req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	req *csi.NodeUnstageVolumeRequest,
+) (*csi.NodeUnstageVolumeResponse, error) {
 	var err error
 	if err = util.ValidateNodeUnstageVolumeRequest(req); err != nil {
 		return nil, err
@@ -1004,7 +1014,8 @@ func (ns *NodeServer) NodeUnstageVolume(
 // NodeExpandVolume resizes rbd volumes.
 func (ns *NodeServer) NodeExpandVolume(
 	ctx context.Context,
-	req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	req *csi.NodeExpandVolumeRequest,
+) (*csi.NodeExpandVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume ID must be provided")
@@ -1078,7 +1089,8 @@ func (ns *NodeServer) NodeExpandVolume(
 // NodeGetCapabilities returns the supported capabilities of the node server.
 func (ns *NodeServer) NodeGetCapabilities(
 	ctx context.Context,
-	req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	req *csi.NodeGetCapabilitiesRequest,
+) (*csi.NodeGetCapabilitiesResponse, error) {
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{
 			{
@@ -1116,7 +1128,8 @@ func (ns *NodeServer) NodeGetCapabilities(
 func (ns *NodeServer) processEncryptedDevice(
 	ctx context.Context,
 	volOptions *rbdVolume,
-	devicePath string) (string, error) {
+	devicePath string,
+) (string, error) {
 	imageSpec := volOptions.String()
 	encrypted, err := volOptions.checkRbdImageEncrypted(ctx)
 	if err != nil {
@@ -1212,7 +1225,8 @@ func (ns *NodeServer) xfsSupportsReflink() bool {
 // NodeGetVolumeStats returns volume stats.
 func (ns *NodeServer) NodeGetVolumeStats(
 	ctx context.Context,
-	req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	req *csi.NodeGetVolumeStatsRequest,
+) (*csi.NodeGetVolumeStatsResponse, error) {
 	var err error
 	targetPath := req.GetVolumePath()
 	if targetPath == "" {

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -538,7 +538,8 @@ func detachRBDDevice(ctx context.Context, devicePath, volumeID, unmapOptions str
 // when imageSpec is used to decide if image is already unmapped.
 func detachRBDImageOrDeviceSpec(
 	ctx context.Context,
-	dArgs *detachRBDImageArgs) error {
+	dArgs *detachRBDImageArgs,
+) error {
 	if dArgs.encrypted {
 		mapperFile, mapperPath := util.VolumeMapper(dArgs.volumeID)
 		mappedDevice, mapper, err := util.DeviceEncryptionStatus(ctx, mapperPath)

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -116,7 +116,8 @@ func checkSnapCloneExists(
 	ctx context.Context,
 	parentVol *rbdVolume,
 	rbdSnap *rbdSnapshot,
-	cr *util.Credentials) (bool, error) {
+	cr *util.Credentials,
+) (bool, error) {
 	err := validateRbdSnap(rbdSnap)
 	if err != nil {
 		return false, err
@@ -541,7 +542,8 @@ func RegenerateJournal(
 	volumeID,
 	requestName,
 	owner string,
-	cr *util.Credentials) (string, error) {
+	cr *util.Credentials,
+) (string, error) {
 	ctx := context.Background()
 	var (
 		vi     util.CSIIdentifier

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -722,7 +722,8 @@ func flattenClonedRbdImages(
 	ctx context.Context,
 	snaps []librbd.SnapInfo,
 	pool, monitors, rbdImageName string,
-	cr *util.Credentials) error {
+	cr *util.Credentials,
+) error {
 	rv := &rbdVolume{}
 	rv.Monitors = monitors
 	rv.Pool = pool
@@ -769,7 +770,8 @@ func flattenClonedRbdImages(
 func (ri *rbdImage) flattenRbdImage(
 	ctx context.Context,
 	forceFlatten bool,
-	hardlimit, softlimit uint) error {
+	hardlimit, softlimit uint,
+) error {
 	var depth uint
 	var err error
 
@@ -926,7 +928,8 @@ func genSnapFromSnapID(
 	rbdSnap *rbdSnapshot,
 	snapshotID string,
 	cr *util.Credentials,
-	secrets map[string]string) error {
+	secrets map[string]string,
+) error {
 	var vi util.CSIIdentifier
 
 	rbdSnap.VolID = snapshotID
@@ -1036,7 +1039,8 @@ func generateVolumeFromVolumeID(
 	volumeID string,
 	vi util.CSIIdentifier,
 	cr *util.Credentials,
-	secrets map[string]string) (*rbdVolume, error) {
+	secrets map[string]string,
+) (*rbdVolume, error) {
 	var (
 		rbdVol *rbdVolume
 		err    error
@@ -1123,7 +1127,8 @@ func GenVolFromVolID(
 	ctx context.Context,
 	volumeID string,
 	cr *util.Credentials,
-	secrets map[string]string) (*rbdVolume, error) {
+	secrets map[string]string,
+) (*rbdVolume, error) {
 	var (
 		vi  util.CSIIdentifier
 		vol *rbdVolume
@@ -1165,7 +1170,8 @@ func generateVolumeFromMapping(
 	volumeID string,
 	vi util.CSIIdentifier,
 	cr *util.Credentials,
-	secrets map[string]string) (*rbdVolume, error) {
+	secrets map[string]string,
+) (*rbdVolume, error) {
 	nvi := vi
 	vol := &rbdVolume{}
 	// extract clusterID mapping
@@ -1215,7 +1221,8 @@ func generateVolumeFromMapping(
 func genVolFromVolumeOptions(
 	ctx context.Context,
 	volOptions map[string]string,
-	disableInUseChecks, checkClusterIDMapping bool) (*rbdVolume, error) {
+	disableInUseChecks, checkClusterIDMapping bool,
+) (*rbdVolume, error) {
 	var (
 		ok         bool
 		err        error
@@ -1368,7 +1375,8 @@ func (ri *rbdImage) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) erro
 func (rv *rbdVolume) cloneRbdImageFromSnapshot(
 	ctx context.Context,
 	pSnapOpts *rbdSnapshot,
-	parentVol *rbdVolume) error {
+	parentVol *rbdVolume,
+) error {
 	var err error
 	logMsg := "rbd: clone %s %s (features: %s) using mon %s"
 
@@ -1904,7 +1912,8 @@ func (ri *rbdImage) isCompabitableClone(dst *rbdImage) error {
 
 func (ri *rbdImage) addSnapshotScheduling(
 	interval admin.Interval,
-	startTime admin.StartTime) error {
+	startTime admin.StartTime,
+) error {
 	ls := admin.NewLevelSpec(ri.Pool, ri.RadosNamespace, ri.RbdImageName)
 	ra, err := ri.conn.GetRBDAdmin()
 	if err != nil {
@@ -1965,7 +1974,8 @@ func strategicActionOnLogFile(ctx context.Context, logStrategy, logFile string) 
 
 // genVolFromVolIDWithMigration populate a rbdVol structure based on the volID format.
 func genVolFromVolIDWithMigration(
-	ctx context.Context, volID string, cr *util.Credentials, secrets map[string]string) (*rbdVolume, error) {
+	ctx context.Context, volID string, cr *util.Credentials, secrets map[string]string,
+) (*rbdVolume, error) {
 	if isMigrationVolID(volID) {
 		pmVolID, pErr := parseMigrationVolID(volID)
 		if pErr != nil {

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -457,7 +457,8 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 
 func disableVolumeReplication(rbdVol *rbdVolume,
 	mirroringInfo *librbd.MirrorImageInfo,
-	force bool) (*replication.DisableVolumeReplicationResponse, error) {
+	force bool,
+) (*replication.DisableVolumeReplicationResponse, error) {
 	if !mirroringInfo.Primary {
 		// Return success if the below condition is met
 		// Local image is secondary
@@ -913,9 +914,8 @@ func resyncRequired(localStatus librbd.SiteMirrorImageStatus) bool {
 	// In some corner cases like `re-player shutdown` the local image will not
 	// be in an error state. It would be also worth considering the `description`
 	// field to make sure about split-brain.
-	splitBrain := "split-brain"
 	if localStatus.State == librbd.MirrorImageStatusStateError ||
-		strings.Contains(localStatus.Description, splitBrain) {
+		strings.Contains(localStatus.Description, "split-brain") {
 		return true
 	}
 

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -27,7 +27,8 @@ import (
 func createRBDClone(
 	ctx context.Context,
 	parentVol, cloneRbdVol *rbdVolume,
-	snap *rbdSnapshot) error {
+	snap *rbdSnapshot,
+) error {
 	// create snapshot
 	err := parentVol.createSnapshot(ctx, snap)
 	if err != nil {
@@ -72,7 +73,8 @@ func cleanUpSnapshot(
 	ctx context.Context,
 	parentVol *rbdVolume,
 	rbdSnap *rbdSnapshot,
-	rbdVol *rbdVolume) error {
+	rbdVol *rbdVolume,
+) error {
 	err := parentVol.deleteSnapshot(ctx, rbdSnap)
 	if err != nil {
 		if !errors.Is(err, ErrSnapNotFound) {
@@ -119,7 +121,8 @@ func undoSnapshotCloning(
 	parentVol *rbdVolume,
 	rbdSnap *rbdSnapshot,
 	cloneVol *rbdVolume,
-	cr *util.Credentials) error {
+	cr *util.Credentials,
+) error {
 	err := cleanUpSnapshot(ctx, parentVol, rbdSnap, cloneVol)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to clean up  %s or %s: %v", cloneVol, rbdSnap, err)

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -119,7 +119,8 @@ func ExecCommandWithTimeout(
 	args ...string) (
 	string,
 	string,
-	error) {
+	error,
+) {
 	var (
 		sanitizedArgs = StripSecretInArgs(args)
 		stdoutBuf     bytes.Buffer

--- a/internal/util/cluster_mapping.go
+++ b/internal/util/cluster_mapping.go
@@ -139,7 +139,8 @@ func GetMappedID(key, value, id string) string {
 
 // fetchMappedClusterIDAndMons returns monitors and clusterID info after checking cluster mapping.
 func fetchMappedClusterIDAndMons(ctx context.Context,
-	clusterID, clusterMappingConfigFile, csiConfigFile string) (string, string, error) {
+	clusterID, clusterMappingConfigFile, csiConfigFile string,
+) (string, string, error) {
 	var mons string
 	clusterMappingInfo, err := getClusterMappingInfo(clusterID, clusterMappingConfigFile)
 	if err != nil {

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -187,9 +187,9 @@ func generateNewEncryptionPassphrase() (string, error) {
 }
 
 // VolumeMapper returns file name and it's path to where encrypted device should be open.
-func VolumeMapper(volumeID string) (mapperFile, mapperFilePath string) {
-	mapperFile = mapperFilePrefix + volumeID
-	mapperFilePath = path.Join(mapperFilePathPrefix, mapperFile)
+func VolumeMapper(volumeID string) (string, string) {
+	mapperFile := mapperFilePrefix + volumeID
+	mapperFilePath := path.Join(mapperFilePathPrefix, mapperFile)
 
 	return mapperFile, mapperFilePath
 }
@@ -248,7 +248,7 @@ func IsDeviceOpen(ctx context.Context, device string) (bool, error) {
 // DeviceEncryptionStatus looks to identify if the passed device is a LUKS mapping
 // and if so what the device is and the mapper name as used by LUKS.
 // If not, just returns the original device and an empty string.
-func DeviceEncryptionStatus(ctx context.Context, devicePath string) (mappedDevice, mapper string, err error) {
+func DeviceEncryptionStatus(ctx context.Context, devicePath string) (string, string, error) {
 	if !strings.HasPrefix(devicePath, mapperFilePathPrefix) {
 		return devicePath, "", nil
 	}
@@ -274,7 +274,7 @@ func DeviceEncryptionStatus(ctx context.Context, devicePath string) (mappedDevic
 			return "", "", fmt.Errorf("device encryption status output for %s is badly formatted: %s",
 				devicePath, lines[i])
 		}
-		if strings.Compare(kv[0], "device") == 0 {
+		if kv[0] == "device" {
 			return strings.TrimSpace(kv[1]), mapPath, nil
 		}
 	}

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -141,7 +141,8 @@ type TopologyConstrainedPool struct {
 // GetTopologyFromRequest extracts TopologyConstrainedPools and passed in accessibility constraints
 // from a CSI CreateVolume request.
 func GetTopologyFromRequest(
-	req *csi.CreateVolumeRequest) (*[]TopologyConstrainedPool, *csi.TopologyRequirement, error) {
+	req *csi.CreateVolumeRequest,
+) (*[]TopologyConstrainedPool, *csi.TopologyRequirement, error) {
 	var topologyPools []TopologyConstrainedPool
 
 	// check if parameters have pool configuration pertaining to topology
@@ -171,7 +172,8 @@ func GetTopologyFromRequest(
 // MatchPoolAndTopology returns the topology map, if the passed in pool matches any
 // passed in accessibility constraints.
 func MatchPoolAndTopology(topologyPools *[]TopologyConstrainedPool,
-	accessibilityRequirements *csi.TopologyRequirement, poolName string) (string, string, map[string]string, error) {
+	accessibilityRequirements *csi.TopologyRequirement, poolName string,
+) (string, string, map[string]string, error) {
 	var topologyPool []TopologyConstrainedPool
 
 	if topologyPools == nil || accessibilityRequirements == nil {
@@ -199,7 +201,8 @@ func MatchPoolAndTopology(topologyPools *[]TopologyConstrainedPool,
 // The return variables are, image poolname, data poolname, and topology map of
 // matched requirement.
 func FindPoolAndTopology(topologyPools *[]TopologyConstrainedPool,
-	accessibilityRequirements *csi.TopologyRequirement) (string, string, map[string]string, error) {
+	accessibilityRequirements *csi.TopologyRequirement,
+) (string, string, map[string]string, error) {
 	if topologyPools == nil || accessibilityRequirements == nil {
 		return "", "", nil, nil
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -260,7 +260,8 @@ func GenerateVolID(
 	cr *Credentials,
 	locationID int64,
 	pool, clusterID, objUUID string,
-	volIDVersion uint16) (string, error) {
+	volIDVersion uint16,
+) (string, error) {
 	var err error
 
 	if locationID == InvalidPoolID {

--- a/internal/util/volid.go
+++ b/internal/util/volid.go
@@ -99,7 +99,7 @@ func (ci CSIIdentifier) ComposeCSIID() (string, error) {
 /*
 DecomposeCSIID composes a CSIIdentifier from passed in string.
 */
-func (ci *CSIIdentifier) DecomposeCSIID(composedCSIID string) (err error) {
+func (ci *CSIIdentifier) DecomposeCSIID(composedCSIID string) error {
 	bytesToProcess := uint16(len(composedCSIID))
 
 	// if length is less that expected constant elements, then bail out!

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -190,3 +190,7 @@ linters:
     - tagliatelle
     - varnamelen
     - nilnil
+    # TODO enable linters added in golangci-lint 1.46
+    - maintidx
+    - exhaustruct
+    - containedctx


### PR DESCRIPTION
Update golangci-lint to v1.46.2 skipped a few complicated checks which need more time to fix and fixed all other linter errors.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>