### PR TITLE
ci: add rook v1.9.4 image to mirror

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -7,6 +7,9 @@
 #
 
 # ceph-csi devel
+docker.io/rook/ceph:v1.9.4      rook/ceph:v1.9.4
+
+# ceph-csi v3.6
 docker.io/rook/ceph:v1.8.2	rook/ceph:v1.8.2
 quay.io/ceph/ceph:v17		quay.io/ceph/ceph:v17
 


### PR DESCRIPTION
Add rook v1.9.4 image to mirror list to use the image for e2e testing.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

