### PR TITLE
helm: update the sidecar mentions in the Chart Description

### DIFF
--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 appVersion: canary
 description: "Container Storage Interface (CSI) driver,
-provisioner, snapshotter, and attacher for Ceph RBD"
+provisioner, snapshotter, resizer and attacher for Ceph RBD"
 name: ceph-csi-rbd
 version: 3-canary
 keywords:


### PR DESCRIPTION
RBD chart description didnt have `resizer` in it and this commit
add the same.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

