### PR TITLE
cephfs: skip NetNamespaceFilePath if the volume is pre-provisioned

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -126,12 +126,18 @@ func (ns *NodeServer) NodeStageVolume(
 	}
 	defer volOptions.Destroy()
 
-	volOptions.NetNamespaceFilePath, err = util.GetCephFSNetNamespaceFilePath(
-		util.CsiConfigFile,
-		volOptions.ClusterID)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+	// Skip extracting NetNamespaceFilePath if the clusterID is empty.
+	// In case of pre-provisioned volume the clusterID is not set in the
+	// volume context.
+	if volOptions.ClusterID != "" {
+		volOptions.NetNamespaceFilePath, err = util.GetCephFSNetNamespaceFilePath(
+			util.CsiConfigFile,
+			volOptions.ClusterID)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
+
 	mnt, err := mounter.New(volOptions)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create mounter for volume %s: %v", volID, err)


### PR DESCRIPTION
In the case of pre-provisionVolume the clusterID is not set in the volume context as the clusterID is missing
we cannot extract the NetNamespaceFilePath from the configuration file. For static volume and dynamically provisioned volume, the clusterID is set.

Note:- This is a special case to support mounting PV without clusterID parameter.

closes #3153 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

