### PR TITLE
rbd: remove the clone in case of failure

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -138,6 +138,16 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 		return err
 	}
 
+	defer func() {
+		if err != nil {
+			log.DebugLog(ctx, "Removing clone image %q", rv)
+			errDefer := rv.deleteImage(ctx)
+			if errDefer != nil {
+				log.ErrorLog(ctx, "failed to delete clone image %q: %v", rv, errDefer)
+			}
+		}
+	}()
+
 	err = rv.getImageID()
 	if err != nil {
 		log.ErrorLog(ctx, "failed to get volume id %s: %v", rv, err)


### PR DESCRIPTION
This commit removes the clone incase
unsetAllMetadata or copyEncryptionConfig or
expand fails for createVolumeFromSnapshot
and CreateSnapshot.
It also removes the clone in case of
any failure in createCloneFromImage.

issue: #3103

Signed-off-by: Yati Padia <ypadia@redhat.com>

