### PR TITLE
[wip] e2e: enable expansion in external tests

### DIFF
--- a/scripts/k8s-storage/driver-cephfs.yaml
+++ b/scripts/k8s-storage/driver-cephfs.yaml
@@ -46,7 +46,7 @@ DriverInfo:
     volumeLimits: false
 
     # Support for volume expansion in controllers
-    controllerExpansion: false
+    controllerExpansion: true
 
     # Support for volume expansion in nodes
     nodeExpansion: false

--- a/scripts/k8s-storage/driver-rbd-rwo.yaml
+++ b/scripts/k8s-storage/driver-rbd-rwo.yaml
@@ -51,7 +51,7 @@ DriverInfo:
     volumeLimits: false
 
     # Support for volume expansion in controllers
-    controllerExpansion: false
+    controllerExpansion: true
 
     # Support for volume expansion in nodes
     nodeExpansion: true


### PR DESCRIPTION
this commit enable controller and node expansion external tests
for RBD and CephFS CI tests. 

Updates: #2015
