### PR TITLE
ci: use golangci-lint --fix instead of go-fmt in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,11 @@ repos:
     hooks:
       - id: check-signoff
 
-  # Catch gofmt issues, if any.
-  - repo: git://github.com/dnephin/pre-commit-golang
-    rev: v0.3.5
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.46.2
     hooks:
-      - id: go-fmt
+      - id: golangci-lint
+        entry: golangci-lint run --config=scripts/golangci.yml --fix --new
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0


### PR DESCRIPTION
`make test` no longer relies on go-fmt, but rather gofumpt. To catch as
many linters as possible use golangci-lint just like make test does.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>
