### PR TITLE
ci: check more reviews in retest action

### DIFF
--- a/actions/retest/main.go
+++ b/actions/retest/main.go
@@ -198,7 +198,8 @@ func main() {
 
 // checkPRRequiredApproval check PullRequest has required approvals.
 func (c *retestConfig) checkPRRequiredApproval(prNumber int) bool {
-	rev, _, err := c.client.PullRequests.ListReviews(context.TODO(), c.owner, c.repo, prNumber, &github.ListOptions{})
+	opts := github.ListOptions{PerPage: 100} // defaults to 30 reviews, too few sometimes
+	rev, _, err := c.client.PullRequests.ListReviews(context.TODO(), c.owner, c.repo, prNumber, &opts)
 	if err != nil {
 		log.Printf("failed to list reviews %v\n", err)
 		return false


### PR DESCRIPTION
It seems PullRequests.ListReviews() returns 30 reviews by default. This
is practical for pagination, but not so much for a GitHub action. There
is the rare occasion that the number of reviews if higher than 30. If
that is the case, the retest action does not capture the latest reviews,
which is where the APPROVED status is set.

By increasing the number of results to 100 per page, we should have
sufficient space for many more reviews and automated retest-ing.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
