### PR TITLE
cephfs: set metadata on subvolume snapshot

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -81,6 +81,7 @@ spec:
             - "--v={{ .Values.sidecarLogLevel }}"
             - "--timeout={{ .Values.provisioner.timeout }}"
             - "--leader-election=true"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: "unix:///csi/{{ .Values.provisionerSocketFile }}"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -85,6 +85,7 @@ spec:
             - "--v=1"
             - "--timeout=150s"
             - "--leader-election=true"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -601,6 +601,7 @@ func cleanUpBackingVolume(
 		snapClient := core.NewSnapshot(
 			snapParentVolOptions.GetConnection(),
 			snapID.FsSnapshotName,
+			volOptions.ClusterID,
 			&snapParentVolOptions.SubVolume,
 		)
 
@@ -819,7 +820,11 @@ func (cs *ControllerServer) CreateSnapshot(
 	if sid != nil {
 		// check snapshot is protected
 		protected := true
-		snapClient := core.NewSnapshot(parentVolOptions.GetConnection(), sid.FsSnapshotName, &parentVolOptions.SubVolume)
+		snapClient := core.NewSnapshot(
+			parentVolOptions.GetConnection(),
+			sid.FsSnapshotName,
+			parentVolOptions.ClusterID,
+			&parentVolOptions.SubVolume)
 		if !(snapInfo.Protected == core.SnapshotIsProtected) {
 			err = snapClient.ProtectSnapshot(ctx)
 			if err != nil {
@@ -887,7 +892,7 @@ func doSnapshot(
 ) (core.SnapshotInfo, error) {
 	snapID := fsutil.VolumeID(snapshotName)
 	snap := core.SnapshotInfo{}
-	snapClient := core.NewSnapshot(volOpt.GetConnection(), snapshotName, &volOpt.SubVolume)
+	snapClient := core.NewSnapshot(volOpt.GetConnection(), snapshotName, volOpt.ClusterID, &volOpt.SubVolume)
 	err := snapClient.CreateSnapshot(ctx)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create snapshot %s %v", snapID, err)
@@ -1044,7 +1049,7 @@ func (cs *ControllerServer) DeleteSnapshot(
 	if snapInfo.HasPendingClones == "yes" {
 		return nil, status.Errorf(codes.FailedPrecondition, "snapshot %s has pending clones", snapshotID)
 	}
-	snapClient := core.NewSnapshot(volOpt.GetConnection(), sid.FsSnapshotName, &volOpt.SubVolume)
+	snapClient := core.NewSnapshot(volOpt.GetConnection(), sid.FsSnapshotName, volOpt.ClusterID, &volOpt.SubVolume)
 	if snapInfo.Protected == core.SnapshotIsProtected {
 		err = snapClient.UnprotectSnapshot(ctx)
 		if err != nil {

--- a/internal/cephfs/core/clone.go
+++ b/internal/cephfs/core/clone.go
@@ -66,7 +66,7 @@ func (s *subVolumeClient) CreateCloneFromSubvolume(
 	parentvolOpt *SubVolume,
 ) error {
 	snapshotID := s.VolID
-	snapClient := NewSnapshot(s.conn, snapshotID, parentvolOpt)
+	snapClient := NewSnapshot(s.conn, snapshotID, s.clusterID, parentvolOpt)
 	err := snapClient.CreateSnapshot(ctx)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create snapshot %s %v", snapshotID, err)
@@ -165,7 +165,7 @@ func (s *subVolumeClient) CleanupSnapshotFromSubvolume(
 	// snapshot name is same as clone name as we need a name which can be
 	// identified during PVC-PVC cloning.
 	snapShotID := s.VolID
-	snapClient := NewSnapshot(s.conn, snapShotID, parentVol)
+	snapClient := NewSnapshot(s.conn, snapShotID, s.clusterID, parentVol)
 	snapInfo, err := snapClient.GetSnapshotInfo(ctx)
 	if err != nil {
 		if errors.Is(err, cerrors.ErrSnapNotFound) {
@@ -198,7 +198,7 @@ func (s *subVolumeClient) CreateCloneFromSnapshot(
 	ctx context.Context, snap Snapshot,
 ) error {
 	snapID := snap.SnapshotID
-	snapClient := NewSnapshot(s.conn, snapID, snap.SubVolume)
+	snapClient := NewSnapshot(s.conn, snapID, s.clusterID, snap.SubVolume)
 	err := snapClient.CloneSnapshot(ctx, s.SubVolume)
 	if err != nil {
 		return err

--- a/internal/cephfs/core/snapshot.go
+++ b/internal/cephfs/core/snapshot.go
@@ -62,6 +62,7 @@ type SnapshotClient interface {
 // snapshotClient is the implementation of SnapshotClient interface.
 type snapshotClient struct {
 	*Snapshot                         // Embedded snapshot struct.
+	clusterID string                  // Cluster ID.
 	conn      *util.ClusterConnection // Cluster connection.
 }
 
@@ -72,13 +73,14 @@ type Snapshot struct {
 }
 
 // NewSnapshot creates a new snapshot client.
-func NewSnapshot(conn *util.ClusterConnection, snapshotID string, vol *SubVolume) SnapshotClient {
+func NewSnapshot(conn *util.ClusterConnection, snapshotID, clusterID string, vol *SubVolume) SnapshotClient {
 	return &snapshotClient{
 		Snapshot: &Snapshot{
 			SnapshotID: snapshotID,
 			SubVolume:  vol,
 		},
-		conn: conn,
+		clusterID: clusterID,
+		conn:      conn,
 	}
 }
 

--- a/internal/cephfs/core/snapshot.go
+++ b/internal/cephfs/core/snapshot.go
@@ -51,6 +51,12 @@ type SnapshotClient interface {
 	UnprotectSnapshot(ctx context.Context) error
 	// CloneSnapshot clones the snapshot of the subvolume.
 	CloneSnapshot(ctx context.Context, cloneVolOptions *SubVolume) error
+	// SetAllSnapshotMetadata set all the metadata from arg parameters on
+	// subvolume snapshot.
+	SetAllSnapshotMetadata(parameters map[string]string) error
+	// UnsetAllSnapshotMetadata unset all the metadata from arg keys on
+	// subvolume snapshot.
+	UnsetAllSnapshotMetadata(keys []string) error
 }
 
 // snapshotClient is the implementation of SnapshotClient interface.

--- a/internal/cephfs/core/snapshot_metadata.go
+++ b/internal/cephfs/core/snapshot_metadata.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+// setSnapshotMetadata sets custom metadata on the subvolume snapshot in a
+// volume as a key-value pair.
+func (s *snapshotClient) setSnapshotMetadata(key, value string) error {
+	fsa, err := s.conn.GetFSAdmin()
+	if err != nil {
+		return err
+	}
+
+	return fsa.SetSnapshotMetadata(s.FsName, s.SubvolumeGroup, s.VolID, s.SnapshotID, key, value)
+}
+
+// removeSnapshotMetadata removes custom metadata set on the subvolume
+// snapshot in a volume using the metadata key.
+func (s *snapshotClient) removeSnapshotMetadata(key string) error {
+	fsa, err := s.conn.GetFSAdmin()
+	if err != nil {
+		return err
+	}
+
+	return fsa.RemoveSnapshotMetadata(s.FsName, s.SubvolumeGroup, s.VolID, s.SnapshotID, key)
+}
+
+// SetAllSnapshotMetadata set all the metadata from arg parameters on
+// subvolume snapshot.
+func (s *snapshotClient) SetAllSnapshotMetadata(parameters map[string]string) error {
+	for k, v := range parameters {
+		err := s.setSnapshotMetadata(k, v)
+		if err != nil {
+			return fmt.Errorf("failed to set metadata key %q, value %q on subvolume snapshot %s %s in fs %s: %w",
+				k, v, s.SnapshotID, s.VolID, s.FsName, err)
+		}
+	}
+
+	return nil
+}
+
+// UnsetAllSnapshotMetadata unset all the metadata from arg keys on subvolume
+// snapshot.
+func (s *snapshotClient) UnsetAllSnapshotMetadata(keys []string) error {
+	for _, key := range keys {
+		err := s.removeSnapshotMetadata(key)
+		// TODO: replace string comparison with errno.
+		if err != nil && !strings.Contains(err.Error(), "No such file or directory") {
+			return fmt.Errorf("failed to unset metadata key %q on subvolume snapshot %s %s in fs %s: %w",
+				key, s.SnapshotID, s.VolID, s.FsName, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -191,8 +191,9 @@ const (
 type localClusterState struct {
 	// set the enum value i.e., unknown, supported,
 	// unsupported as per the state of the cluster.
-	resizeState         operationState
-	subVolMetadataState operationState
+	resizeState                 operationState
+	subVolMetadataState         operationState
+	subVolSnapshotMetadataState operationState
 	// set true once a subvolumegroup is created
 	// for corresponding cluster.
 	subVolumeGroupCreated bool

--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -398,7 +398,7 @@ func CheckSnapExists(
 	snapUUID := snapData.ImageUUID
 	snapID := snapData.ImageAttributes.ImageName
 	sid.FsSnapshotName = snapData.ImageAttributes.ImageName
-	snapClient := core.NewSnapshot(volOptions.conn, snapID, &volOptions.SubVolume)
+	snapClient := core.NewSnapshot(volOptions.conn, snapID, volOptions.ClusterID, &volOptions.SubVolume)
 	snapInfo, err := snapClient.GetSnapshotInfo(ctx)
 	if err != nil {
 		if errors.Is(err, cerrors.ErrSnapNotFound) {

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -735,7 +735,7 @@ func NewSnapshotOptionsFromID(
 	volOptions.Features = subvolInfo.Features
 	volOptions.Size = subvolInfo.BytesQuota
 	volOptions.RootPath = subvolInfo.Path
-	snap := core.NewSnapshot(volOptions.conn, sid.FsSnapshotName, &volOptions.SubVolume)
+	snap := core.NewSnapshot(volOptions.conn, sid.FsSnapshotName, volOptions.ClusterID, &volOptions.SubVolume)
 	info, err := snap.GetSnapshotInfo(ctx)
 	if err != nil {
 		return &volOptions, nil, &sid, err


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This helps Monitoring solutions without access to Kubernetes clusters to display the details of thenapshot-name/snapshot-namespace/snapshotcontent-name in their dashboard.

## Is there anything that requires special attention ##
~~Needs: https://github.com/ceph/go-ceph/pull/698~~

~~Just for the CI to pass I have included go-ceph custom branch and hence DNM, but the reviews can continue for other commits.~~



---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
