### PR TITLE
cephfs: remove extra check for restore size

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -205,23 +205,7 @@ func checkValidCreateVolumeRequest(
 			return errors.New("cloning snapshot-backed volumes is currently not supported")
 		}
 	case sID != nil:
-		if vol.Size < parentVol.Size {
-			return fmt.Errorf(
-				"cannot restore from snapshot %s: volume size %d is smaller than source volume size %d",
-				sID.SnapshotID,
-				parentVol.Size,
-				vol.Size)
-		}
-
 		if vol.BackingSnapshot {
-			if vol.Size != parentVol.Size {
-				return fmt.Errorf(
-					"cannot create snapshot-backed volume of different size: expected %d bytes, got %d bytes",
-					parentVol.Size,
-					vol.Size,
-				)
-			}
-
 			volCaps := req.GetVolumeCapabilities()
 			for _, volCap := range volCaps {
 				mode := volCap.AccessMode.Mode


### PR DESCRIPTION
Looks like the cephfs snapshot size is buggy and it's getting removed in ceph fs. we cannot get the size of the snapshot during the CreateVolume call, so we cannot do any size check at CreateVolume to check if the restore size is smaller or not.

As we are removing this check it also fixes #3147 but we dont have any validation at the CSI level for smaller restore we need to depend on kubernetes external-provisioner for it.

fixes: #3147

ceph tracker https://tracker.ceph.com/issues/55822 to remove size from snapshot API.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

