### PR TITLE
rbd: have dummy attacher implementation

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1587,3 +1587,36 @@ func (cs *ControllerServer) ControllerExpandVolume(
 		NodeExpansionRequired: nodeExpansion,
 	}, nil
 }
+
+// ControllerPublishVolume is a dummy publish implementation to mimic a successful attach operation being a NOOP.
+func (cs *ControllerServer) ControllerPublishVolume(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+) (*csi.ControllerPublishVolumeResponse, error) {
+	if req.GetVolumeId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
+	}
+	if req.GetNodeId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "Node ID cannot be empty")
+	}
+	if req.GetVolumeCapability() == nil {
+		return nil, status.Error(codes.InvalidArgument, "Volume Capabilities cannot be empty")
+	}
+
+	return &csi.ControllerPublishVolumeResponse{
+		// the dummy response carry an empty map in its response.
+		PublishContext: map[string]string{},
+	}, nil
+}
+
+// ControllerUnPublishVolume is a dummy unpublish implementation to mimic a successful attach operation being a NOOP.
+func (cs *ControllerServer) ControllerUnpublishVolume(
+	ctx context.Context,
+	req *csi.ControllerUnpublishVolumeRequest,
+) (*csi.ControllerUnpublishVolumeResponse, error) {
+	if req.GetVolumeId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
+	}
+
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
+}


### PR DESCRIPTION
    previously, it was a requirement to have attacher sidecar for CSI
    drivers and there had an implementation of dummy mode of operation.
    However skipAttach implementation has been stabilized and the dummy
    mode of operation is going to be removed from the external-attacher.
    Considering this driver  work on volumeattachment objects for NBD driver
    use cases, we have to implement dummy controllerpublish and unpublish
    and thus keep supporting our operations even in absence of dummy mode
    of operation in the sidecar.
    
    This commit make a NOOP controller publish and unpublish for RBD driver.
    
    CephFS driver does not require attacher and it has already been made free
    from the attachment operations.
    
    Ref# https://github.com/ceph/ceph-csi/pull/3149
    Ref# https://github.com/kubernetes-csi/external-attacher/issues/226

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

