### PR TITLE
cephfs: report detailed error message on clone failure

### DIFF
--- a/internal/cephfs/core/clone_test.go
+++ b/internal/cephfs/core/clone_test.go
@@ -17,23 +17,25 @@ limitations under the License.
 package core
 
 import (
+	"errors"
 	"testing"
 
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 
+	fsa "github.com/ceph/go-ceph/cephfs/admin"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCloneStateToError(t *testing.T) {
 	t.Parallel()
 	errorState := make(map[cephFSCloneState]error)
-	errorState[CephFSCloneComplete] = nil
+	errorState[cephFSCloneState{fsa.CloneComplete, "", ""}] = nil
 	errorState[CephFSCloneError] = cerrors.ErrInvalidClone
-	errorState[CephFSCloneInprogress] = cerrors.ErrCloneInProgress
-	errorState[CephFSClonePending] = cerrors.ErrClonePending
-	errorState[CephFSCloneFailed] = cerrors.ErrCloneFailed
+	errorState[cephFSCloneState{fsa.CloneInProgress, "", ""}] = cerrors.ErrCloneInProgress
+	errorState[cephFSCloneState{fsa.ClonePending, "", ""}] = cerrors.ErrClonePending
+	errorState[cephFSCloneState{fsa.CloneFailed, "", ""}] = cerrors.ErrCloneFailed
 
 	for state, err := range errorState {
-		assert.Equal(t, state.toError(), err)
+		assert.True(t, errors.Is(state.ToError(), err))
 	}
 }

--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -119,15 +119,17 @@ func CheckVolExists(ctx context.Context,
 
 			return nil, err
 		}
-		if cloneState == core.CephFSCloneInprogress {
-			return nil, cerrors.ErrCloneInProgress
+		err = cloneState.ToError()
+		if errors.Is(err, cerrors.ErrCloneInProgress) {
+			return nil, err
 		}
-		if cloneState == core.CephFSClonePending {
-			return nil, cerrors.ErrClonePending
+		if errors.Is(err, cerrors.ErrClonePending) {
+			return nil, err
 		}
-		if cloneState == core.CephFSCloneFailed {
+		if errors.Is(err, cerrors.ErrCloneFailed) {
 			log.ErrorLog(ctx,
-				"clone failed, deleting subvolume clone. vol=%s, subvol=%s subvolgroup=%s",
+				"clone failed (%v), deleting subvolume clone. vol=%s, subvol=%s subvolgroup=%s",
+				err,
 				volOptions.FsName,
 				vid.FsSubvolName,
 				volOptions.SubvolumeGroup)
@@ -149,8 +151,8 @@ func CheckVolExists(ctx context.Context,
 
 			return nil, err
 		}
-		if cloneState != core.CephFSCloneComplete {
-			return nil, fmt.Errorf("clone is not in complete state for %s", vid.FsSubvolName)
+		if err != nil {
+			return nil, fmt.Errorf("clone is not in complete state for %s: %w", vid.FsSubvolName, err)
 		}
 	}
 


### PR DESCRIPTION
go-ceph provides a new GetFailure() method to retrieve details errors
when cloning failed. This is now included in the `cephFSCloneState`
struct, which was a simple string before.

While modifying the `cephFSCloneState` struct, the constants have been
removed, as go-ceph provides them as well.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
