### PR TITLE
nfs: make use of latest sidecars in the deployment

### DIFF
--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -55,7 +55,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -71,7 +71,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -18,7 +18,7 @@ spec:
             - --probe-timeout=3s
             - --health-port=29653
             - --v=2
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:


### PR DESCRIPTION
The sidecars in the NFS deployment has latest versions which is
also updated for RBD and CephFS drivers. This commit update
the versions in the NFS deployment too.

Additional Note for reviewer:

provisioner update has been taken care as part of #3186 
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

