### PR TITLE
cephfs: go with default permissions while creating subvolumes

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -9,3 +9,4 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: false
+  fsGroupPolicy: File

--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -8,3 +8,4 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: false
+  fsGroupPolicy: File

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -39,12 +39,6 @@ import (
 // taken through this additional cluster information.
 var clusterAdditionalInfo = make(map[string]*localClusterState)
 
-const (
-	// modeAllRWX can be used for setting permissions to Read-Write-eXecute
-	// for User, Group and Other.
-	modeAllRWX = 0o777
-)
-
 // Subvolume holds subvolume information. This includes only the needed members
 // from fsAdmin.SubVolumeInfo.
 type Subvolume struct {
@@ -231,7 +225,6 @@ func (s *subVolumeClient) CreateVolume(ctx context.Context) error {
 
 	opts := fsAdmin.SubVolumeOptions{
 		Size: fsAdmin.ByteCount(s.Size),
-		Mode: modeAllRWX,
 	}
 	if s.Pool != "" {
 		opts.PoolLayout = s.Pool


### PR DESCRIPTION
While creating subvolumes, CephFS driver set the mode to `777`
and pass it along to go ceph apis which cause the subvolume
permission to be on 777, however if we create a subvolume
directly in the ceph cluster, the default permission bits are
set which is 755 for the subvolume. This commit try to stick
to the default behaviour even while creating the subvolume.

This also means that we can work with fsgrouppolicy set to
`File` in csiDriver object which is also addressed in this commit.

Additional Note for reviewer:

Rook Changes: https://github.com/rook/rook/pull/10503

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

