### PR TITLE
[wip] cephfs: enable fsgrouppolicy for cephfs tests

### DIFF
--- a/scripts/k8s-storage/driver-cephfs.yaml
+++ b/scripts/k8s-storage/driver-cephfs.yaml
@@ -34,7 +34,7 @@ DriverInfo:
     persistence: true
 
     # Volume ownership via fsGroup
-    fsGroup: false
+    fsGroup: true
 
     # Raw block mode
     block: false


### PR DESCRIPTION
This commit enable fsgroup external test for cephfs CSI driver.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

