### PR TITLE
rbd: healer detect Kubernetes version for right StagingTargetPath

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -67,7 +67,7 @@ spec:
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath={{ .Values.kubeletDir }}/plugins"
-            - "--stagingpath={{ .Values.kubeletDir }}/plugins/kubernetes.io/csi/pv/"
+            - "--stagingpath={{ .Values.kubeletDir }}/plugins/kubernetes.io/csi/"
             - "--type=rbd"
             - "--nodeserver=true"
             - "--pidlimit=-1"

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -54,7 +54,7 @@ const (
 	defaultNS = "default"
 
 	defaultPluginPath  = "/var/lib/kubelet/plugins"
-	defaultStagingPath = defaultPluginPath + "/kubernetes.io/csi/pv/"
+	defaultStagingPath = defaultPluginPath + "/kubernetes.io/csi/"
 )
 
 var conf util.Config

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -55,7 +55,7 @@ spec:
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
-            - "--stagingpath=/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+            - "--stagingpath=/var/lib/kubelet/plugins/kubernetes.io/csi/"
             - "--type=rbd"
             - "--nodeserver=true"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Kubernetes 1.24 and newer use a different path for staging the volume.
That means the CSI-driver is requested to mount the volume at an other
location, compared to previous versions of Kubernetes. CSI-drivers
implementing the volumeHealer, must receive the correct path,
otherwise the after a nodeplugin restart the NBD mounts will bailout
attempting to NodeStageVolume() call and return an error.

See-also: kubernetes/kubernetes#107065


## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #3176

## Other ##
Related rook PR: https://github.com/rook/rook/pull/10490

## Credits ##

Thanks @nixpanic for https://github.com/csi-addons/kubernetes-csi-addons/pull/165/commits/3f23be1facc1f3773a37ad6a814ba27ed7085ab5 which made the PR easy.

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
