### PR TITLE
e2e: pass non-empty Namespace/Name in deletePVCAndPV()

### DIFF
--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -138,8 +138,8 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 			pvcToDelete.Status.String(),
 			int(time.Since(start).Seconds()))
 		pvcToDelete, err = c.CoreV1().
-			PersistentVolumeClaims(pvcToDelete.Namespace).
-			Get(context.TODO(), pvcToDelete.Name, metav1.GetOptions{})
+			PersistentVolumeClaims(pvc.Namespace).
+			Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 		if err == nil {
 			if pvcToDelete.Status.Phase == "" {
 				// this is unexpected, an empty Phase is not defined
@@ -176,7 +176,7 @@ func deletePVCAndPV(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, pv *v
 			pvToDelete.Status.String(),
 			int(time.Since(start).Seconds()))
 
-		pvToDelete, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pvToDelete.Name, metav1.GetOptions{})
+		pvToDelete, err = c.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
 		if err == nil {
 			return false, nil
 		}


### PR DESCRIPTION
When getting the PVC or PV failed, the returned object may contain empty
values. If that happens, a retry uses the empty values for Namespace and
Name, which will never be successful.

Instead, use the Namespace and Name attributes from the original object,
and not from the object returned by the Get() call.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
