### PR TITLE
ci: prevent panic in retest action on `nil` strings

### DIFF
--- a/actions/retest/main.go
+++ b/actions/retest/main.go
@@ -116,7 +116,7 @@ func main() {
 		log.Fatalf("failed to list pull requests %v\n", err)
 	}
 	for _, re := range req {
-		if *re.State == "open" {
+		if (re.State != nil) && (*re.State == "open") {
 			prNumber := re.GetNumber()
 			log.Printf("PR with ID %d with Title %q is open\n", prNumber, re.GetTitle())
 			for _, l := range re.Labels {
@@ -149,7 +149,7 @@ func main() {
 						log.Printf("found failed test %s\n", r.GetContext())
 						failedTestFound = true
 						// rebase the pr if it is behind the devel branch.
-						if *re.MergeableState == "BEHIND" {
+						if (re.MergeableState != nil) && (*re.MergeableState == "BEHIND") {
 							comment := &github.IssueComment{
 								Body: github.String("@mergifyio rebase"),
 							}


### PR DESCRIPTION
In case a PullRequest does not have a MergeableState set, it will be
`nil`. Dereferencing the pointer will cause a Go panic, and the action
won't work as intended.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
