### PR TITLE
revert: rbd: consider remote image health for primary

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -581,7 +581,12 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 		}
 	}
 
-	err = checkHealthyPrimary(ctx, rbdVol)
+	mirrorStatus, err := rbdVol.getImageMirroringStatus()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	err = checkHealthyPrimary(ctx, rbdVol, mirrorStatus)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -618,11 +623,7 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 // checkHealthyPrimary checks if the image is a healhty primary or not.
 // healthy primary image will be in up+stopped state, for states other
 // than this it returns an error message.
-func checkHealthyPrimary(ctx context.Context, rbdVol *rbdVolume) error {
-	mirrorStatus, err := rbdVol.getImageMirroringStatus()
-	if err != nil {
-		return err
-	}
+func checkHealthyPrimary(ctx context.Context, rbdVol *rbdVolume, mirrorStatus *librbd.GlobalMirrorImageStatus) error {
 	localStatus, err := mirrorStatus.LocalStatus()
 	if err != nil {
 		// LocalStatus can fail if the local site status is not found in

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -633,7 +633,7 @@ func checkHealthyPrimary(ctx context.Context, rbdVol *rbdVolume) error {
 		return fmt.Errorf("failed to get local status: %w", err)
 	}
 
-	if !localStatus.Up && localStatus.State != librbd.MirrorImageStatusStateStopped {
+	if !localStatus.Up || localStatus.State != librbd.MirrorImageStatusStateStopped {
 		return fmt.Errorf("%s %w. State is up=%t, state=%q",
 			rbdVol,
 			ErrUnHealthyMirroredImage,

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -616,9 +616,8 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 }
 
 // checkHealthyPrimary checks if the image is a healhty primary or not.
-// healthy primary image will be in up+stopped state in local cluster and
-// up+replaying in the remote clusters, for states other than this it returns
-// an error message.
+// healthy primary image will be in up+stopped state, for states other
+// than this it returns an error message.
 func checkHealthyPrimary(ctx context.Context, rbdVol *rbdVolume) error {
 	mirrorStatus, err := rbdVol.getImageMirroringStatus()
 	if err != nil {
@@ -640,26 +639,6 @@ func checkHealthyPrimary(ctx context.Context, rbdVol *rbdVolume) error {
 			ErrUnHealthyMirroredImage,
 			localStatus.Up,
 			localStatus.State)
-	}
-
-	// Remote image should be in up+replaying state.
-	for _, s := range mirrorStatus.SiteStatuses {
-		log.UsefulLog(
-			ctx,
-			"peer site mirrorUUID=%q, daemon up=%t, mirroring state=%q, description=%q and lastUpdate=%d",
-			s.MirrorUUID,
-			s.Up,
-			s.State,
-			s.Description,
-			s.LastUpdate)
-		if s.MirrorUUID != "" {
-			if !s.Up && s.State != librbd.MirrorImageStatusStateReplaying {
-				return fmt.Errorf("remote image %s is not healthy. State is up=%t, state=%q",
-					rbdVol,
-					s.Up,
-					s.State)
-			}
-		}
 	}
 
 	return nil

--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -279,3 +279,75 @@ func TestCheckVolumeResyncStatus(t *testing.T) {
 		})
 	}
 }
+
+func Test_checkHealthyPrimary(t *testing.T) {
+	t.Parallel()
+	rbdVol := &rbdVolume{
+		rbdImage: rbdImage{
+			RbdImageName: "test",
+			Pool:         "test-pool",
+		},
+	}
+	tests := []struct {
+		name         string
+		ctx          context.Context
+		rbdVol       *rbdVolume
+		mirrorStatus *librbd.GlobalMirrorImageStatus
+		wantErr      bool
+	}{
+		{
+			name:   "when image is in up+stopped state",
+			ctx:    context.TODO(),
+			rbdVol: rbdVol,
+			mirrorStatus: &librbd.GlobalMirrorImageStatus{
+				SiteStatuses: []librbd.SiteMirrorImageStatus{
+					{
+						MirrorUUID: "",
+						State:      librbd.MirrorImageStatusStateStopped,
+						Up:         true,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "when image is in up+error state",
+			ctx:    context.TODO(),
+			rbdVol: rbdVol,
+			mirrorStatus: &librbd.GlobalMirrorImageStatus{
+				SiteStatuses: []librbd.SiteMirrorImageStatus{
+					{
+						MirrorUUID: "",
+						State:      librbd.MirrorImageStatusStateError,
+						Up:         false,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "when image is in up+replaying state",
+			ctx:    context.TODO(),
+			rbdVol: rbdVol,
+			mirrorStatus: &librbd.GlobalMirrorImageStatus{
+				SiteStatuses: []librbd.SiteMirrorImageStatus{
+					{
+						MirrorUUID: "",
+						State:      librbd.MirrorImageStatusStateReplaying,
+						Up:         true,
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
+			if err := checkHealthyPrimary(ts.ctx, ts.rbdVol, ts.mirrorStatus); (err != nil) != ts.wantErr {
+				t.Errorf("checkHealthyPrimary() error = %v, wantErr %v", err, ts.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When the image is force promoted to primary on the cluster the remote image might not be in a replaying
state because due to the split-brain state. This PR reverts back the commit c3c87f2ef33e8d8ad08d7d9f28b59d1aedc4ef31. Which we added to check the remote image status.

closes: #3215 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

