### PR TITLE
e2e: reduce defaultCloneCount to 3

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -85,7 +85,7 @@ var (
 	snapshotPath           = rbdExamplePath + "snapshot.yaml"
 	deployFSAppPath        = e2eTemplatesPath + "rbd-fs-deployment.yaml"
 	deployBlockAppPath     = e2eTemplatesPath + "rbd-block-deployment.yaml"
-	defaultCloneCount      = 10
+	defaultCloneCount      = 3 // TODO: set to 10 once issues#2327 is fixed
 
 	nbdMapOptions             = "nbd:debug-rbd=20"
 	e2eDefaultCephLogStrategy = "preserve"


### PR DESCRIPTION
# Describe what this PR does #

CI is failing very frequently hitting resource leaks issue,
until we solve the root cause for resource leaks reducing the clone
count from 10 to 3.

updates #2327 

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>
