### PR TITLE
rbd: Use rados namespace when getting clone depth

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -681,6 +681,7 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 	vol.Pool = ri.Pool
 	vol.Monitors = ri.Monitors
 	vol.RbdImageName = ri.RbdImageName
+	vol.RadosNamespace = ri.RadosNamespace
 	vol.conn = ri.conn.Copy()
 
 	for {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Description

When the Ceph user is restricted to a specific namespace in the pool, it is
crucial that evey interaction with the cluster is done within that namespace.
This wasn't the case in `getCloneDepth()`.

This issue was causing snapshot creation to fail with

```
Failed to check and update snapshot content: failed to take snapshot of the volume X: "rpc error: code = Internal desc = rbd: ret=-1, Operation not permitted"
```

## Related issues ##

Fixes: #3231 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>