### PR TITLE
cephfs: round to cephfs size to multiple of 4Mib

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -277,7 +277,7 @@ func (cs *ControllerServer) CreateVolume(
 	defer volOptions.Destroy()
 
 	if req.GetCapacityRange() != nil {
-		volOptions.Size = util.RoundOffBytes(req.GetCapacityRange().GetRequiredBytes())
+		volOptions.Size = util.RoundOffCephFSVolSize(req.GetCapacityRange().GetRequiredBytes())
 	}
 
 	parentVol, pvID, sID, err := checkContentSource(ctx, req, cr)
@@ -672,7 +672,8 @@ func (cs *ControllerServer) ControllerExpandVolume(
 		return nil, status.Error(codes.InvalidArgument, "cannot expand snapshot-backed volume")
 	}
 
-	RoundOffSize := util.RoundOffBytes(req.GetCapacityRange().GetRequiredBytes())
+	RoundOffSize := util.RoundOffCephFSVolSize(req.GetCapacityRange().GetRequiredBytes())
+
 	volClient := core.NewSubVolume(volOptions.GetConnection(), &volOptions.SubVolume, volOptions.ClusterID)
 	if err = volClient.ResizeVolume(ctx, RoundOffSize); err != nil {
 		log.ErrorLog(ctx, "failed to expand volume %s: %v", fsutil.VolumeID(volIdentifier.FsSubvolName), err)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -58,6 +58,22 @@ func RoundOffBytes(bytes int64) int64 {
 	return num
 }
 
+// RoundOffCephFSVolSize rounds up the bytes to 4MiB if the request is less
+// than 4MiB or if its greater it rounds up to multiple of 4MiB.
+func RoundOffCephFSVolSize(bytes int64) int64 {
+	// Minimum supported size is 1MiB in CephCSI, if the request is <4MiB,
+	// round off to 4MiB.
+	if bytes < helpers.MiB {
+		return 4 * helpers.MiB
+	}
+
+	bytes /= helpers.MiB
+
+	bytes = int64(math.Ceil(float64(bytes)/4) * 4)
+
+	return RoundOffBytes(bytes * helpers.MiB)
+}
+
 // variables which will be set during the build time.
 var (
 	// GitCommit tell the latest git commit image is built from.

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -352,3 +352,52 @@ func TestCheckKernelSupport(t *testing.T) {
 		}
 	}
 }
+
+func TestRoundOffCephFSVolSize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		size int64
+		want int64
+	}{
+		{
+			"1000kiB conversion",
+			1000,
+			4194304, // 4 MiB
+		},
+		{
+			"1MiB conversions",
+			1048576,
+			4194304, // 4 MiB
+		},
+		{
+			"1.5Mib conversion",
+			1677722,
+			4194304, // 4 MiB
+		},
+		{
+			"1023MiB conversion",
+			1072693248,
+			1073741824, // 1024 MiB
+		},
+		{
+			"1.5GiB conversion",
+			1585446912,
+			2147483648, // 2 GiB
+		},
+		{
+			"1555MiB conversion",
+			1630535680,
+			2147483648, // 2 GiB
+		},
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
+			if got := RoundOffCephFSVolSize(ts.size); got != ts.want {
+				t.Errorf("RoundOffCephFSVolSize() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Due to the bug in the df stat we need to round off the subvolume size to align with 4Mib.

Note:- Minimum supported size in cephcsi is 1Mib,
we dont need to take care of Kib.

fixes #3240

More details at https://github.com/ceph/ceph/pull/46905

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

# Logs with fix


## 3Mib PVC
```
[🎩︎]mrajanna@fedora cephfs $]kubectl get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
cephfs-pvc   Bound    pvc-0e91cc59-785a-4bf9-be18-a180fa3ec70f   4Mi        RWO            rook-cephfs    2s
[🎩︎]mrajanna@fedora cephfs $]cat pvc.yaml 
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: cephfs-pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 3Mi
  storageClassName: rook-cephfs
[🎩︎]mrajanna@fedora cephfs $]kubectl create -f pod.yaml 
pod/csicephfs-demo-pod created
[🎩︎]mrajanna@fedora cephfs $]kubectl exec -it pod/csicephfs-demo-pod -- sh
# df -h
Filesystem                                                                                                        Size  Used Avail Use% Mounted on
overlay                                                                                                            28G  6.5G   20G  25% /
tmpfs                                                                                                              64M     0   64M   0% /dev
tmpfs                                                                                                             2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/vda1                                                                                                          28G  6.5G   20G  25% /etc/hosts
shm                                                                                                                64M     0   64M   0% /dev/shm
10.97.50.161:6789:/volumes/csi/csi-vol-d67b85ab-01b9-11ed-9045-e63b4f507f02/1926b8ae-4ceb-440b-ab24-caa7756e965f  4.0M     0  4.0M   0% /var/lib/www/html
tmpfs                                                                                                             3.9G   12K  3.9G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs                                                                                                             2.0G     0  2.0G   0% /proc/acpi
tmpfs                                                                                                             2.0G     0  2.0G   0% /proc/scsi
tmpfs                                                                                                             2.0G     0  2.0G   0% /sys/firmware
# 
```

## 4Mib PVC
```
[🎩︎]mrajanna@fedora cephfs $]cat pvc.yaml 
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: cephfs-pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 4Mi
  storageClassName: rook-cephfs
[🎩︎]mrajanna@fedora cephfs $]kubectl create -f pvc.yaml 
persistentvolumeclaim/cephfs-pvc created
[🎩︎]mrajanna@fedora cephfs $]kubectl get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
cephfs-pvc   Bound    pvc-d906625b-5181-4e38-8596-842fa29286db   4Mi        RWO            rook-cephfs    2s
[🎩︎]mrajanna@fedora cephfs $]kubectl create -f pod.yaml 
pod/csicephfs-demo-pod created
[🎩︎]mrajanna@fedora cephfs $]kubectl exec -it pod/csicephfs-demo-pod -- sh
# df -h
Filesystem                                                                                                        Size  Used Avail Use% Mounted on
overlay                                                                                                            28G  6.5G   20G  25% /
tmpfs                                                                                                              64M     0   64M   0% /dev
tmpfs                                                                                                             2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/vda1                                                                                                          28G  6.5G   20G  25% /etc/hosts
shm                                                                                                                64M     0   64M   0% /dev/shm
10.97.50.161:6789:/volumes/csi/csi-vol-0ebfc24a-01ba-11ed-9045-e63b4f507f02/a05967d1-5b9e-4d5a-9e90-f68c939af7bc  4.0M     0  4.0M   0% /var/lib/www/html
tmpfs                                                                                                             3.9G   12K  3.9G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs                                                                                                             2.0G     0  2.0G   0% /proc/acpi
tmpfs                                                                                                             2.0G     0  2.0G   0% /proc/scsi
tmpfs                                                                                                             2.0G     0  2.0G   0% /sys/firmware
# 
```

## 1023 Mib PVC
```
[🎩︎]mrajanna@fedora cephfs $]cat pvc.yaml 
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: cephfs-pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1023Mi
  storageClassName: rook-cephfs
[🎩︎]mrajanna@fedora cephfs $]kubectl create -f pvc.yaml 
persistentvolumeclaim/cephfs-pvc created
[🎩︎]mrajanna@fedora cephfs $]kubectl get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
cephfs-pvc   Bound    pvc-73babf43-2164-4b86-9ca2-9fb896822675   1Gi        RWO            rook-cephfs    3s
[🎩︎]mrajanna@fedora cephfs $]kubectl create -f pod.yaml 
pod/csicephfs-demo-pod created
[🎩︎]mrajanna@fedora cephfs $]kubectl execectl exec -it pod/csicephfs-demo-pod -- sh
# df -h
Filesystem                                                                                                        Size  Used Avail Use% Mounted on
overlay                                                                                                            28G  6.5G   20G  25% /
tmpfs                                                                                                              64M     0   64M   0% /dev
tmpfs                                                                                                             2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/vda1                                                                                                          28G  6.5G   20G  25% /etc/hosts
shm                                                                                                                64M     0   64M   0% /dev/shm
10.97.50.161:6789:/volumes/csi/csi-vol-37269de4-01ba-11ed-9045-e63b4f507f02/9ee1f2dc-50fd-401d-ae48-b1a611bd9a74  1.0G     0  1.0G   0% /var/lib/www/html
tmpfs                                                                                                             3.9G   12K  3.9G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs                                                                                                             2.0G     0  2.0G   0% /proc/acpi
tmpfs                                                                                                             2.0G     0  2.0G   0% /proc/scsi
tmpfs                                                                                                             2.0G     0  2.0G   0% /sys/firmware
# 
```