### PR TITLE
build: resolve a fixme and disable tcmu repo

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -23,10 +23,10 @@ RUN source /build.env && \
 # test if the downloaded version of Golang works (different arch?)
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 
-# FIXME: Ceph does not need Apache Arrow anymore, some container images may
-# still have the repository enabled. Disabling the repository can be removed in
-# the future, see https://github.com/ceph/ceph-container/pull/1990 .
-RUN dnf config-manager --disable apache-arrow-centos || true
+# TODO: remove the following cmd, when issue
+# https://github.com/ceph/ceph-container/issues/2034 is fixed.
+RUN dnf config-manager --disable \
+    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch || true
 
 RUN dnf -y install \
 	librados-devel librbd-devel \


### PR DESCRIPTION
# Describe what this PR does #

Cmd to disable apache arrow repo is removed, since
it is no longer needed.
Cmd to disable tcmu repo is added to make build pass.

refer: https://github.com/ceph/ceph-container/issues/2034

Signed-off-by: Rakshith R <rar@redhat.com>

related failures can be seen here 
https://jenkins-ceph-csi.apps.ocp.ci.centos.org/blue/organizations/jenkins/mini-e2e-helm_k8s-1.21/detail/mini-e2e-helm_k8s-1.21/4591/pipeline


```
[rakshith@fedora ~]$ docker run quay.io/ceph/ceph:v17  dnf install -y make
CentOS Stream 8 - AppStream                     7.0 MB/s |  24 MB     00:03    
CentOS Stream 8 - BaseOS                        8.1 MB/s |  23 MB     00:02    
CentOS Stream 8 - Extras                         27 kB/s |  18 kB     00:00    
Copr repo for python-scikit-learn owned by tcha  11 kB/s |  20 kB     00:01    
Copr repo for python3-asyncssh owned by tchaiko 619  B/s | 3.5 kB     00:05    
Ceph packages for x86_64                         53 kB/s |  77 kB     00:01    
Ceph noarch packages                            7.7 kB/s | 9.1 kB     00:01    
Ceph source packages                            1.6 kB/s | 1.7 kB     00:01    
ceph-iscsi noarch packages                      2.6 kB/s | 2.9 kB     00:01    
Extra Packages for Enterprise Linux 8 - x86_64  7.4 MB/s |  12 MB     00:01    
Extra Packages for Enterprise Linux Modular 8 - 2.0 MB/s | 1.0 MB     00:00    
Extra Packages for Enterprise Linux 8 - Next -  1.3 MB/s | 562 kB     00:00    
ganesha                                         2.9 kB/s | 7.3 kB     00:02    
tcmu-runner packages for x86_64                  85  B/s | 162  B     00:01    
Errors during downloading metadata for repository 'tcmu-runner':
  - Status code: 404 for https://3.chacra.ceph.com/r/tcmu-runner/master/245914c1446dddf07d5b58b0a7b2060b50fde4d7/centos/8/flavors/default/x86_64/repodata/repomd.xml (IP: 158.69.93.173)
Error: Failed to download metadata for repo 'tcmu-runner': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```

After disabling tcmu repo
```
[rakshith@fedora ~]$ docker run -ti quay.io/ceph/ceph:v17  bash
[root@40bbac250045 /]# dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch
Failed to set locale, defaulting to C
[root@40bbac250045 /]# dnf install -y make
Failed to set locale, defaulting to C
CentOS Stream 8 - AppStream                                7.4 MB/s |  24 MB     00:03    
CentOS Stream 8 - BaseOS                                   6.8 MB/s |  23 MB     00:03    
CentOS Stream 8 - Extras                                    33 kB/s |  18 kB     00:00    
Copr repo for python-scikit-learn owned by tchaikov         11 kB/s |  20 kB     00:01    
Copr repo for python3-asyncssh owned by tchaikov           4.9 kB/s | 3.5 kB     00:00    
Ceph packages for x86_64                                    70 kB/s |  77 kB     00:01    
Ceph noarch packages                                       8.6 kB/s | 9.1 kB     00:01    
Ceph source packages                                       1.7 kB/s | 1.7 kB     00:01    
ceph-iscsi noarch packages                                 2.9 kB/s | 2.9 kB     00:01    
Extra Packages for Enterprise Linux 8 - x86_64             5.2 MB/s |  12 MB     00:02    
Extra Packages for Enterprise Linux Modular 8 - x86_64     978 kB/s | 1.0 MB     00:01    
Extra Packages for Enterprise Linux 8 - Next - x86_64      423 kB/s | 562 kB     00:01    
ganesha                                                    3.0 kB/s | 7.3 kB     00:02    
Dependencies resolved.

```