### PR TITLE
ci: run e2e on Kubernetes v1.24 by default

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -2,8 +2,6 @@
 - project:
     name: k8s-e2e-external-storage
     k8s_version:
-      - '1.21':
-          only_run_on_request: false
       - '1.22':
           only_run_on_request: false
       - '1.23':

--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -9,7 +9,7 @@
       - '1.23':
           only_run_on_request: false
       - '1.24':
-          only_run_on_request: true
+          only_run_on_request: false
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,6 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.21':
-          only_run_on_request: false
       - '1.22':
           only_run_on_request: false
       - '1.23':

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -9,7 +9,7 @@
       - '1.23':
           only_run_on_request: false
       - '1.24':
-          only_run_on_request: true
+          only_run_on_request: false
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
This PR adds the below commits for the Kubernetes version in CI.

As we have a stable CI for kubernetes v1.24 and Kubernetes v1.24 released sometime back, defaulting Kubernetes v1.24 for the CI run.

We will run CI on 3 latest kubernetes releases removing Kubernetes 1.21 support as we have Kubernetes 1.22, 1.23, and 1.24 for CI Jobs.

updates #3086 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>