### PR TITLE
e2e: remove kubernetes 1.22 check

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -328,51 +328,49 @@ var _ = Describe(cephfsType, func() {
 			})
 
 			By("verify RWOP volume support", func() {
-				if k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
-					err := createCephfsStorageClass(f.ClientSet, f, true, nil)
-					if err != nil {
-						e2elog.Failf("failed to create CephFS storageclass: %v", err)
-					}
-					pvc, err := loadPVC(pvcRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load PVC: %v", err)
-					}
-					pvc.Namespace = f.UniqueName
+				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
+				if err != nil {
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
+				}
+				pvc, err := loadPVC(pvcRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
 
-					// create application
-					app, err := loadApp(appRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load application: %v", err)
-					}
-					app.Namespace = f.UniqueName
-					baseAppName := app.Name
+				// create application
+				app, err := loadApp(appRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load application: %v", err)
+				}
+				app.Namespace = f.UniqueName
+				baseAppName := app.Name
 
-					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
-					if err != nil {
-						if rwopMayFail(err) {
-							e2elog.Logf("RWOP is not supported: %v", err)
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					if rwopMayFail(err) {
+						e2elog.Logf("RWOP is not supported: %v", err)
 
-							return
-						}
-						e2elog.Failf("failed to create PVC: %v", err)
+						return
 					}
-					err = createApp(f.ClientSet, app, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to create application: %v", err)
-					}
-					validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
-					validateOmapCount(f, 1, cephfsType, metadataPool, volumesType)
+					e2elog.Failf("failed to create PVC: %v", err)
+				}
+				err = createApp(f.ClientSet, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create application: %v", err)
+				}
+				validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
+				validateOmapCount(f, 1, cephfsType, metadataPool, volumesType)
 
-					err = validateRWOPPodCreation(f, pvc, app, baseAppName)
-					if err != nil {
-						e2elog.Failf("failed to validate RWOP pod creation: %v", err)
-					}
-					validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
-					validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
-					err = deleteResource(cephFSExamplePath + "storageclass.yaml")
-					if err != nil {
-						e2elog.Failf("failed to delete CephFS storageclass: %v", err)
-					}
+				err = validateRWOPPodCreation(f, pvc, app, baseAppName)
+				if err != nil {
+					e2elog.Failf("failed to validate RWOP pod creation: %v", err)
+				}
+				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+				validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
+				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 				}
 			})
 

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -371,49 +371,47 @@ var _ = Describe("nfs", func() {
 			})
 
 			By("verify RWOP volume support", func() {
-				if k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
-					err := createNFSStorageClass(f.ClientSet, f, false, nil)
-					if err != nil {
-						e2elog.Failf("failed to create CephFS storageclass: %v", err)
-					}
-					pvc, err := loadPVC(pvcRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load PVC: %v", err)
-					}
-					pvc.Namespace = f.UniqueName
+				err := createNFSStorageClass(f.ClientSet, f, false, nil)
+				if err != nil {
+					e2elog.Failf("failed to create CephFS storageclass: %v", err)
+				}
+				pvc, err := loadPVC(pvcRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
 
-					// create application
-					app, err := loadApp(appRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load application: %v", err)
-					}
-					app.Namespace = f.UniqueName
-					baseAppName := app.Name
+				// create application
+				app, err := loadApp(appRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load application: %v", err)
+				}
+				app.Namespace = f.UniqueName
+				baseAppName := app.Name
 
-					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
-					if err != nil {
-						if rwopMayFail(err) {
-							e2elog.Logf("RWOP is not supported: %v", err)
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					if rwopMayFail(err) {
+						e2elog.Logf("RWOP is not supported: %v", err)
 
-							return
-						}
-						e2elog.Failf("failed to create PVC: %v", err)
+						return
 					}
-					err = createApp(f.ClientSet, app, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to create application: %v", err)
-					}
-					validateSubvolumeCount(f, 1, fileSystemName, defaultSubvolumegroup)
+					e2elog.Failf("failed to create PVC: %v", err)
+				}
+				err = createApp(f.ClientSet, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create application: %v", err)
+				}
+				validateSubvolumeCount(f, 1, fileSystemName, defaultSubvolumegroup)
 
-					err = validateRWOPPodCreation(f, pvc, app, baseAppName)
-					if err != nil {
-						e2elog.Failf("failed to validate RWOP pod creation: %v", err)
-					}
-					validateSubvolumeCount(f, 0, fileSystemName, defaultSubvolumegroup)
-					err = deleteResource(nfsExamplePath + "storageclass.yaml")
-					if err != nil {
-						e2elog.Failf("failed to delete CephFS storageclass: %v", err)
-					}
+				err = validateRWOPPodCreation(f, pvc, app, baseAppName)
+				if err != nil {
+					e2elog.Failf("failed to validate RWOP pod creation: %v", err)
+				}
+				validateSubvolumeCount(f, 0, fileSystemName, defaultSubvolumegroup)
+				err = deleteResource(nfsExamplePath + "storageclass.yaml")
+				if err != nil {
+					e2elog.Failf("failed to delete CephFS storageclass: %v", err)
 				}
 			})
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -876,85 +876,81 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("create a Block mode RWOP PVC and bind it to more than one app", func() {
-				if k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
-					pvc, err := loadPVC(rawPVCRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load PVC: %v", err)
-					}
-					pvc.Namespace = f.UniqueName
-
-					app, err := loadApp(rawAppRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load application: %v", err)
-					}
-					app.Namespace = f.UniqueName
-					baseAppName := app.Name
-					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
-					if err != nil {
-						if rwopMayFail(err) {
-							e2elog.Logf("RWOP is not supported: %v", err)
-
-							return
-						}
-						e2elog.Failf("failed to create PVC: %v", err)
-					}
-					// validate created backend rbd images
-					validateRBDImageCount(f, 1, defaultRBDPool)
-					validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
-
-					err = createApp(f.ClientSet, app, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to create application: %v", err)
-					}
-					err = validateRWOPPodCreation(f, pvc, app, baseAppName)
-					if err != nil {
-						e2elog.Failf("failed to validate RWOP pod creation: %v", err)
-					}
-					// validate created backend rbd images
-					validateRBDImageCount(f, 0, defaultRBDPool)
-					validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+				pvc, err := loadPVC(rawPVCRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
+				pvc.Namespace = f.UniqueName
+
+				app, err := loadApp(rawAppRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load application: %v", err)
+				}
+				app.Namespace = f.UniqueName
+				baseAppName := app.Name
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					if rwopMayFail(err) {
+						e2elog.Logf("RWOP is not supported: %v", err)
+
+						return
+					}
+					e2elog.Failf("failed to create PVC: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+				validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+
+				err = createApp(f.ClientSet, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create application: %v", err)
+				}
+				err = validateRWOPPodCreation(f, pvc, app, baseAppName)
+				if err != nil {
+					e2elog.Failf("failed to validate RWOP pod creation: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+				validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
 			})
 
 			By("create a RWOP PVC and bind it to more than one app", func() {
-				if k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
-					pvc, err := loadPVC(pvcRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load PVC: %v", err)
-					}
-					pvc.Namespace = f.UniqueName
-
-					app, err := loadApp(appRWOPPath)
-					if err != nil {
-						e2elog.Failf("failed to load application: %v", err)
-					}
-					app.Namespace = f.UniqueName
-					baseAppName := app.Name
-					err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
-					if err != nil {
-						if rwopMayFail(err) {
-							e2elog.Logf("RWOP is not supported: %v", err)
-
-							return
-						}
-						e2elog.Failf("failed to create PVC: %v", err)
-					}
-					// validate created backend rbd images
-					validateRBDImageCount(f, 1, defaultRBDPool)
-					validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
-
-					err = createApp(f.ClientSet, app, deployTimeout)
-					if err != nil {
-						e2elog.Failf("failed to create application: %v", err)
-					}
-					err = validateRWOPPodCreation(f, pvc, app, baseAppName)
-					if err != nil {
-						e2elog.Failf("failed to validate RWOP pod creation: %v", err)
-					}
-					// validate created backend rbd images
-					validateRBDImageCount(f, 0, defaultRBDPool)
-					validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+				pvc, err := loadPVC(pvcRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load PVC: %v", err)
 				}
+				pvc.Namespace = f.UniqueName
+
+				app, err := loadApp(appRWOPPath)
+				if err != nil {
+					e2elog.Failf("failed to load application: %v", err)
+				}
+				app.Namespace = f.UniqueName
+				baseAppName := app.Name
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					if rwopMayFail(err) {
+						e2elog.Logf("RWOP is not supported: %v", err)
+
+						return
+					}
+					e2elog.Failf("failed to create PVC: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+				validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+
+				err = createApp(f.ClientSet, app, deployTimeout)
+				if err != nil {
+					e2elog.Failf("failed to create application: %v", err)
+				}
+				err = validateRWOPPodCreation(f, pvc, app, baseAppName)
+				if err != nil {
+					e2elog.Failf("failed to validate RWOP pod creation: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+				validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
 			})
 
 			By("create an erasure coded PVC and bind it to an app", func() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -578,7 +578,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 	if pvc.Spec.VolumeMode != nil {
 		isBlockMode = (*pvc.Spec.VolumeMode == v1.PersistentVolumeBlock)
 	}
-	if (!isBlockMode || k8sVersionGreaterEquals(f.ClientSet, 1, 22)) && !isOpenShift {
+	if !isBlockMode && !isOpenShift {
 		err = getMetricsForPVC(f, pvc, deployTimeout)
 		if err != nil {
 			return err

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1479,15 +1479,13 @@ func validateController(
 	return deleteResource(rbdExamplePath + "storageclass.yaml")
 }
 
+// nolint:deadcode,unused // Unused code will be used in future.
 // k8sVersionGreaterEquals checks the ServerVersion of the Kubernetes cluster
 // and compares it to the major.minor version passed. In case the version of
 // the cluster is equal or higher to major.minor, `true` is returned, `false`
 // otherwise.
-//
 // If fetching the ServerVersion of the Kubernetes cluster fails, the calling
 // test case is marked as `FAILED` and gets aborted.
-//
-// nolint:unparam // currently major is always 1, this can change in the future
 func k8sVersionGreaterEquals(c kubernetes.Interface, major, minor int) bool {
 	v, err := c.Discovery().ServerVersion()
 	if err != nil {


### PR DESCRIPTION
We run CI jobs on kubernetes 1.22 by default, and we dont need to check to ensure we have at least Kubernetes 1.22 for a few tests. As we have CI runs on 1.22 by default, Removing unwanted checks.

updates: #3086
depends-on #3255

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
