### PR TITLE
nfs: add nodeserver

### DIFF
--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -2,154 +2,134 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: csi-nfs-node
+  name: csi-nfsplugin
 spec:
   selector:
     matchLabels:
-      app: csi-nfs-node
+      app: csi-nfsplugin
   template:
     metadata:
       labels:
-        app: csi-nfs-node
+        app: csi-nfsplugin
     spec:
+      serviceAccountName: nfs-csi-nodeplugin
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      # to use e.g. Rook orchestrated cluster, and mons' FQDN is
+      # resolved through k8s service, set dns policy to cluster first
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - args:
-            - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
-            - --health-port=29653
-            - --v=2
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
-          imagePullPolicy: IfNotPresent
-          name: liveness-probe
-          resources:
-            limits:
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          volumeMounts:
-            - mountPath: /csi
-              name: socket-dir
-        - args:
-            - --v=1
-            - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - name: driver-registrar
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          args:
+            - "--v=1"
+            - "--csi-address=/csi/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/nfs.csi.ceph.com/csi.sock"
           env:
-            - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/nfs.csi.ceph.com/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
-                  apiVersion: v1
                   fieldPath: spec.nodeName
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
-          imagePullPolicy: IfNotPresent
-          livenessProbe:
-            exec:
-              command:
-                - /csi-node-driver-registrar
-                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-                - --mode=kubelet-registration-probe
-            failureThreshold: 3
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 15
-          name: node-driver-registrar
-          resources:
-            limits:
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-nfsplugin
           securityContext:
             privileged: true
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          volumeMounts:
-            - mountPath: /csi
-              name: socket-dir
-            - mountPath: /registration
-              name: registration-dir
-        - args:
-            - -v=1
-            - --drivername=nfs.csi.ceph.com
-            - --nodeid=$(NODE_ID)
-            - --endpoint=$(CSI_ENDPOINT)
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          # for stable functionality replace canary with latest release version
+          image: quay.io/cephcsi/cephcsi:canary
+          args:
+            - "--nodeid=$(NODE_ID)"
+            - "--type=nfs"
+            - "--nodeserver=true"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--v=5"
+            - "--drivername=nfs.csi.ceph.com"
+            - "--enableprofiling=false"
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NODE_ID
               valueFrom:
                 fieldRef:
-                  apiVersion: v1
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          image: registry.k8s.io/sig-storage/nfsplugin:v4.0.0
-          imagePullPolicy: IfNotPresent
-          livenessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /healthz
-              port: healthz
-              scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 10
-          name: nfs
-          ports:
-            - containerPort: 29653
-              hostPort: 29653
-              name: healthz
-              protocol: TCP
-          resources:
-            limits:
-              memory: 300Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
-          securityContext:
-            allowPrivilegeEscalation: true
-            capabilities:
-              add:
-                - SYS_ADMIN
-            privileged: true
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
+          imagePullPolicy: "IfNotPresent"
           volumeMounts:
-            - mountPath: /csi
-              name: socket-dir
-            - mountPath: /var/lib/kubelet/pods
+            - name: socket-dir
+              mountPath: /csi
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
-              name: pods-mount-dir
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: linux
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      serviceAccountName: nfs-csi-nodeplugin
-      terminationGracePeriodSeconds: 30
-      tolerations:
-        - operator: Exists
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins
+              mountPropagation: "Bidirectional"
+            - name: host-sys
+              mountPath: /sys
+            - name: etc-selinux
+              mountPath: /etc/selinux
+              readOnly: true
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: host-dev
+              mountPath: /dev
+            - name: host-mount
+              mountPath: /run/mount
+            - name: ceph-config
+              mountPath: /etc/ceph/
+            - name: ceph-csi-config
+              mountPath: /etc/ceph-csi-config/
       volumes:
-        - hostPath:
-            path: /var/lib/kubelet/plugins/nfs.csi.ceph.com
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/nfs.csi.ceph.com/
             type: DirectoryOrCreate
-          name: socket-dir
-        - hostPath:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: mountpoint-dir
+          hostPath:
             path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
             type: Directory
-          name: pods-mount-dir
-        - hostPath:
-            path: /var/lib/kubelet/plugins_registry
-            type: Directory
-          name: registration-dir
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
-    type: RollingUpdate
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-dev
+          hostPath:
+            path: /dev
+        - name: host-mount
+          hostPath:
+            path: /run/mount
+        - name: ceph-config
+          configMap:
+            name: ceph-config
+        - name: ceph-csi-config
+          configMap:
+            name: ceph-csi-config

--- a/deploy/nfs/kubernetes/csidriver.yaml
+++ b/deploy/nfs/kubernetes/csidriver.yaml
@@ -14,3 +14,4 @@ spec:
   attachRequired: false
   volumeLifecycleModes:
     - Persistent
+  fsGroupPolicy: File

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -43,7 +43,7 @@ var (
 	nfsNodePluginPSP   = "csi-nodeplugin-psp.yaml"
 	nfsRookCephNFS     = "rook-nfs.yaml"
 	nfsDeploymentName  = "csi-nfsplugin-provisioner"
-	nfsDeamonSetName   = "csi-nfs-node"
+	nfsDeamonSetName   = "csi-nfsplugin"
 	nfsDirPath         = "../deploy/nfs/kubernetes/"
 	nfsExamplePath     = examplePath + "nfs/"
 	nfsPoolName        = ".nfs"
@@ -235,7 +235,7 @@ func unmountNFSVolume(f *framework.Framework, appName, pvcName string) error {
 		cmd,
 		nfsDeamonSetName,
 		pod.Spec.NodeName,
-		"nfs", // name of the container
+		"csi-nfsplugin", // name of the container
 		cephCSINamespace)
 	if stdErr != "" {
 		e2elog.Logf("StdErr occurred: %s", stdErr)
@@ -299,7 +299,7 @@ var _ = Describe("nfs", func() {
 			// log provisioner
 			logsCSIPods("app=csi-nfsplugin-provisioner", c)
 			// log node plugin
-			logsCSIPods("app=csi-nfs-node", c)
+			logsCSIPods("app=csi-nfsplugin", c)
 
 			// log all details from the namespace where Ceph-CSI is deployed
 			framework.DumpAllNamespaceInfo(c, cephCSINamespace)

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,15 +52,15 @@ option `clusterID`, can now be created on the cluster.
 
 ## Running CephCSI with pod networking
 
-The current problem with Pod Networking, is when a CephFS/RBD volume is mounted
-in a pod using Ceph CSI and then the CSI CephFS/RBD plugin is restarted or
+The current problem with Pod Networking, is when a CephFS/RBD/NFS volume is mounted
+in a pod using Ceph CSI and then the CSI CephFS/RBD/NFS plugin is restarted or
 terminated (e.g. by restarting or deleting its DaemonSet), all operations on
 the volume become blocked, even after restarting the CSI pods.
 
 The only workaround is to restart the node where the Ceph CSI plugin pod was
 restarted. This can be mitigated by running the `rbd map`/`mount -t` commands
 in a different network namespace which does not get deleted when the CSI
-CephFS/RBD plugin is restarted or terminated.
+CephFS/RBD/NFS plugin is restarted or terminated.
 
 If someone wants to run the CephCSI with the pod networking they can still do
 by setting the `netNamespaceFilePath`. If this path is set CephCSI will execute

--- a/examples/csi-config-map-sample.yaml
+++ b/examples/csi-config-map-sample.yaml
@@ -24,6 +24,10 @@ kind: ConfigMap
 # path for the Ceph cluster identified by the <cluster-id>, This will be used
 # by the CephFS CSI plugin to execute the mount -t in the
 # network namespace specified by the "cephFS.netNamespaceFilePath".
+# The "nfs.netNamespaceFilePath" fields are the various network namespace
+# path for the Ceph cluster identified by the <cluster-id>, This will be used
+# by the NFS CSI plugin to execute the mount -t in the
+# network namespace specified by the "nfs.netNamespaceFilePath".
 # The "rbd.netNamespaceFilePath" fields are the various network namespace
 # path for the Ceph cluster identified by the <cluster-id>, This will be used
 # by the RBD CSI plugin to execute the rbd map/unmap in the
@@ -59,6 +63,9 @@ data:
         "cephFS": {
           "subvolumeGroup": "<subvolumegroup for cephFS volumes>"
           "netNamespaceFilePath": "<kubeletRootPath>/plugins/cephfs.csi.ceph.com/net",
+        }
+        "nfs": {
+          "netNamespaceFilePath": "<kubeletRootPath>/plugins/nfs.csi.ceph.com/net",
         }
       }
     ]

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -29,6 +29,7 @@ import (
 
 // DefaultNodeServer stores driver object.
 type DefaultNodeServer struct {
+	csi.UnimplementedNodeServer
 	Driver  *CSIDriver
 	Type    string
 	Mounter mount.Interface

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeserver
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	mount "k8s.io/mount-utils"
+	netutil "k8s.io/utils/net"
+)
+
+const (
+	defaultMountPermission = os.FileMode(0o777)
+	// Address of the NFS server.
+	paramServer    = "server"
+	paramShare     = "share"
+	paramClusterID = "clusterID"
+)
+
+// NodeServer struct of ceph CSI driver with supported methods of CSI
+// node server spec.
+type NodeServer struct {
+	csicommon.DefaultNodeServer
+}
+
+// NewNodeServer initialize a node server for ceph CSI driver.
+func NewNodeServer(
+	d *csicommon.CSIDriver,
+	t string,
+) *NodeServer {
+	return &NodeServer{
+		DefaultNodeServer: *csicommon.NewDefaultNodeServer(d, t, map[string]string{}),
+	}
+}
+
+// NodePublishVolume mount the volume.
+func (ns *NodeServer) NodePublishVolume(
+	ctx context.Context,
+	req *csi.NodePublishVolumeRequest,
+) (*csi.NodePublishVolumeResponse, error) {
+	err := validateNodePublishVolumeRequest(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	volumeID := req.GetVolumeId()
+	volCap := req.GetVolumeCapability()
+	targetPath := req.GetTargetPath()
+	mountOptions := volCap.GetMount().GetMountFlags()
+	if req.GetReadonly() {
+		mountOptions = append(mountOptions, "ro")
+	}
+
+	source, err := getSource(req.GetVolumeContext())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	clusterID := req.GetVolumeContext()[paramClusterID]
+	netNamespaceFilePath := ""
+	if clusterID != "" {
+		netNamespaceFilePath, err = util.GetNFSNetNamespaceFilePath(
+			util.CsiConfigFile,
+			clusterID)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+	}
+
+	err = ns.mountNFS(ctx,
+		volumeID,
+		source,
+		targetPath,
+		netNamespaceFilePath,
+		mountOptions)
+	if err != nil {
+		if os.IsPermission(err) {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
+		if strings.Contains(err.Error(), "invalid argument") {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	log.DebugLog(ctx, "nfs: successfully mounted volume %q mount %q to %q succeeded",
+		volumeID, source, targetPath)
+
+	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+// NodeUnpublishVolume unmount the volume.
+func (ns *NodeServer) NodeUnpublishVolume(
+	ctx context.Context,
+	req *csi.NodeUnpublishVolumeRequest,
+) (*csi.NodeUnpublishVolumeResponse, error) {
+	err := util.ValidateNodeUnpublishVolumeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeID := req.GetVolumeId()
+	targetPath := req.GetTargetPath()
+	log.DebugLog(ctx, "nfs: unmounting volume %s on %s", volumeID, targetPath)
+	err = mount.CleanupMountPoint(targetPath, ns.Mounter, true)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to unmount target %q: %v",
+			targetPath, err)
+	}
+	log.DebugLog(ctx, "nfs: successfully unbounded volume %q from %q",
+		volumeID, targetPath)
+
+	return &csi.NodeUnpublishVolumeResponse{}, nil
+}
+
+// NodeGetCapabilities returns the supported capabilities of the node server.
+func (ns *NodeServer) NodeGetCapabilities(
+	ctx context.Context,
+	req *csi.NodeGetCapabilitiesRequest,
+) (*csi.NodeGetCapabilitiesResponse, error) {
+	return &csi.NodeGetCapabilitiesResponse{
+		Capabilities: []*csi.NodeServiceCapability{
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+					},
+				},
+			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// NodeGetVolumeStats get volume stats.
+func (ns *NodeServer) NodeGetVolumeStats(
+	ctx context.Context,
+	req *csi.NodeGetVolumeStatsRequest,
+) (*csi.NodeGetVolumeStatsResponse, error) {
+	var err error
+	targetPath := req.GetVolumePath()
+	if targetPath == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			fmt.Sprintf("targetpath %v is empty", targetPath))
+	}
+
+	stat, err := os.Stat(targetPath)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"failed to get stat for targetpath %q: %v", targetPath, err)
+	}
+
+	if stat.Mode().IsDir() {
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath)
+	}
+
+	return nil, status.Errorf(codes.InvalidArgument,
+		"targetpath %q is not a directory or device", targetPath)
+}
+
+// mountNFS mounts nfs volumes.
+func (ns *NodeServer) mountNFS(
+	ctx context.Context,
+	volumeID, source, mountPoint, netNamespaceFilePath string,
+	mountOptions []string,
+) error {
+	var (
+		stderr string
+		err    error
+	)
+
+	notMnt, err := ns.Mounter.IsLikelyNotMountPoint(mountPoint)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(mountPoint, defaultMountPermission)
+			if err != nil {
+				return err
+			}
+			notMnt = true
+		} else {
+			return err
+		}
+	}
+	if !notMnt {
+		log.DebugLog(ctx, "nfs: volume is already mounted to %s", mountPoint)
+
+		return nil
+	}
+
+	args := []string{
+		"-t", "nfs",
+		source,
+		mountPoint,
+	}
+
+	if len(mountOptions) > 0 {
+		args = append(append(args, "-o"), mountOptions...)
+	}
+
+	log.DefaultLog("nfs: mounting volumeID(%v) source(%s) targetPath(%s) mountflags(%v)",
+		volumeID, source, mountPoint, mountOptions)
+	if netNamespaceFilePath != "" {
+		_, stderr, err = util.ExecuteCommandWithNSEnter(
+			ctx, netNamespaceFilePath, "mount", args[:]...)
+	} else {
+		err = ns.Mounter.Mount(source, mountPoint, "nfs", mountOptions)
+	}
+	if err != nil {
+		return fmt.Errorf("nfs: failed to mount %q to %q : %w stderr: %q",
+			source, mountPoint, err, stderr)
+	}
+	if stderr != "" {
+		return fmt.Errorf("nfs: failed to mount %q to %q : stderr %q",
+			source, mountPoint, stderr)
+	}
+
+	return err
+}
+
+// validateNodePublishVolumeRequest validates node publish volume request.
+func validateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
+	switch {
+	case req.GetVolumeId() == "":
+		return errors.New("volume ID missing in request")
+	case req.GetVolumeCapability() == nil:
+		return errors.New("volume capability missing in request")
+	case req.GetTargetPath() == "":
+		return errors.New("target path missing in request")
+	}
+
+	return nil
+}
+
+// getSource validates volume context, extracts and returns source.
+// This function expects `server` and `share` parameters to be set
+// and validates for the same.
+func getSource(volContext map[string]string) (string, error) {
+	server := volContext[paramServer]
+	if server == "" {
+		return "", fmt.Errorf("%v missing in request", paramServer)
+	}
+	baseDir := volContext[paramShare]
+	if baseDir == "" {
+		return "", fmt.Errorf("%v missing in request", paramShare)
+	}
+
+	if netutil.IsIPv6String(server) {
+		// if server is IPv6, format to [IPv6].
+		server = fmt.Sprintf("[%s]", server)
+	}
+
+	return fmt.Sprintf("%s:%s", server, baseDir), nil
+}

--- a/internal/nfs/nodeserver/nodeserver_test.go
+++ b/internal/nfs/nodeserver/nodeserver_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeserver
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+func Test_validateNodePublishVolumeRequest(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		req *csi.NodePublishVolumeRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "passing testcase",
+			args: args{
+				req: &csi.NodePublishVolumeRequest{
+					VolumeId:         "123",
+					TargetPath:       "/target",
+					VolumeCapability: &csi.VolumeCapability{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing VolumeId",
+			args: args{
+				req: &csi.NodePublishVolumeRequest{
+					VolumeId:         "",
+					TargetPath:       "/target",
+					VolumeCapability: &csi.VolumeCapability{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing TargetPath",
+			args: args{
+				req: &csi.NodePublishVolumeRequest{
+					VolumeId:         "123",
+					TargetPath:       "",
+					VolumeCapability: &csi.VolumeCapability{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing VolumeCapability",
+			args: args{
+				req: &csi.NodePublishVolumeRequest{
+					VolumeId:         "123",
+					TargetPath:       "/target",
+					VolumeCapability: nil,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		currentTT := tt
+		t.Run(currentTT.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateNodePublishVolumeRequest(currentTT.args.req)
+			if (err != nil) != currentTT.wantErr {
+				t.Errorf("validateNodePublishVoluemRequest() error = %v, wantErr %v", err, currentTT.wantErr)
+			}
+		})
+	}
+}
+
+func Test_getSource(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		volContext map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "hostname as address",
+			args: args{
+				volContext: map[string]string{
+					paramServer: "example.io",
+					paramShare:  "/a",
+				},
+			},
+			want:    "example.io:/a",
+			wantErr: false,
+		},
+		{
+			name: "ipv4 address",
+			args: args{
+				volContext: map[string]string{
+					paramServer: "10.12.1.0",
+					paramShare:  "/a",
+				},
+			},
+			want:    "10.12.1.0:/a",
+			wantErr: false,
+		},
+		{
+			name: "ipv6 address",
+			args: args{
+				volContext: map[string]string{
+					paramServer: "2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b",
+					paramShare:  "/a",
+				},
+			},
+			want:    "[2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b]:/a",
+			wantErr: false,
+		},
+		{
+			name: "missing server parameter",
+			args: args{
+				volContext: map[string]string{
+					paramServer: "",
+					paramShare:  "/a",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "missing share parameter",
+			args: args{
+				volContext: map[string]string{
+					paramServer: "10.12.1.0",
+					paramShare:  "",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		currentTT := tt
+		t.Run(currentTT.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := getSource(currentTT.args.volContext)
+			if (err != nil) != currentTT.wantErr {
+				t.Errorf("getSource() error = %v, wantErr %v", err, currentTT.wantErr)
+
+				return
+			}
+			if got != currentTT.want {
+				t.Errorf("getSource() = %v, want %v", got, currentTT.want)
+			}
+		})
+	}
+}

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -59,6 +59,11 @@ type ClusterInfo struct {
 		// RadosNamespace is a rados namespace in the pool
 		RadosNamespace string `json:"radosNamespace"`
 	} `json:"rbd"`
+	// NFS contains NFS specific options
+	NFS struct {
+		// symlink filepath for the network namespace where we need to execute commands.
+		NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+	} `json:"nfs"`
 }
 
 // Expected JSON structure in the passed in config file is,
@@ -193,4 +198,14 @@ func GetCephFSNetNamespaceFilePath(pathToConfig, clusterID string) (string, erro
 	}
 
 	return cluster.CephFS.NetNamespaceFilePath, nil
+}
+
+// GetNFSNetNamespaceFilePath returns the netNamespaceFilePath for NFS volumes.
+func GetNFSNetNamespaceFilePath(pathToConfig, clusterID string) (string, error) {
+	cluster, err := readClusterInfo(pathToConfig, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	return cluster.NFS.NetNamespaceFilePath, nil
 }

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -100,9 +100,9 @@ func readClusterInfo(pathToConfig, clusterID string) (*ClusterInfo, error) {
 			err, string(content))
 	}
 
-	for _, cluster := range config {
-		if cluster.ClusterID == clusterID {
-			return &cluster, nil
+	for i := range config {
+		if config[i].ClusterID == clusterID {
+			return &config[i], nil
 		}
 	}
 

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -291,3 +291,77 @@ func TestGetCephFSNetNamespaceFilePath(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNFSNetNamespaceFilePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		clusterID string
+		want      string
+	}{
+		{
+			name:      "get NFS specific NetNamespaceFilePath for cluster-1",
+			clusterID: "cluster-1",
+			want:      "/var/lib/kubelet/plugins/nfs.ceph.csi.com/cluster1-net",
+		},
+		{
+			name:      "get NFS specific NetNamespaceFilePath for cluster-2",
+			clusterID: "cluster-2",
+			want:      "/var/lib/kubelet/plugins/nfs.ceph.csi.com/cluster2-net",
+		},
+		{
+			name:      "when NFS specific NetNamespaceFilePath is empty",
+			clusterID: "cluster-3",
+			want:      "",
+		},
+	}
+
+	csiConfig := []ClusterInfo{
+		{
+			ClusterID: "cluster-1",
+			Monitors:  []string{"ip-1", "ip-2"},
+			NFS: struct {
+				NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+			}{
+				NetNamespaceFilePath: "/var/lib/kubelet/plugins/nfs.ceph.csi.com/cluster1-net",
+			},
+		},
+		{
+			ClusterID: "cluster-2",
+			Monitors:  []string{"ip-3", "ip-4"},
+			NFS: struct {
+				NetNamespaceFilePath string `json:"netNamespaceFilePath"`
+			}{
+				NetNamespaceFilePath: "/var/lib/kubelet/plugins/nfs.ceph.csi.com/cluster2-net",
+			},
+		},
+		{
+			ClusterID: "cluster-3",
+			Monitors:  []string{"ip-5", "ip-6"},
+		},
+	}
+	csiConfigFileContent, err := json.Marshal(csiConfig)
+	if err != nil {
+		t.Errorf("failed to marshal csi config info %v", err)
+	}
+	tmpConfPath := t.TempDir() + "/ceph-csi.json"
+	err = os.WriteFile(tmpConfPath, csiConfigFileContent, 0o600)
+	if err != nil {
+		t.Errorf("failed to write %s file content: %v", CsiConfigFile, err)
+	}
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := GetNFSNetNamespaceFilePath(tmpConfPath, ts.clusterID)
+			if err != nil {
+				t.Errorf("GetNFSNetNamespaceFilePath() error = %v", err)
+
+				return
+			}
+			if got != ts.want {
+				t.Errorf("GetNFSNetNamespaceFilePath() = %v, want %v", got, ts.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

This commit adds nfs nodeserver capable of
mounting nfs volumes, even with pod networking
using NSenter design similar to rbd and cephfs.
NodePublish, NodeUnpublish, NodeGetVolumeStats
and NodeGetCapabilities have been implemented.

Signed-off-by: Rakshith R <rar@redhat.com>

Resolves: #3182 
