### PR TITLE
ci: retry command in Pod on "unable to upgrade connection" error

### DIFF
--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -41,6 +41,11 @@ func isRetryableAPIError(err error) bool {
 		return true
 	}
 
+	// "unable to upgrade connection" happens occasionally when executing commands in Pods
+	if strings.Contains(err.Error(), "unable to upgrade connection") {
+		return true
+	}
+
 	// "transport is closing" is an internal gRPC err, we can not use ErrConnClosing
 	if strings.Contains(err.Error(), "transport is closing") {
 		return true


### PR DESCRIPTION
Sometimes executing a command in a Pod fails with "unable to upgrade
connection". This is most likely a temporary situation, and retrying
hopefully reduces the number of spurious failures because of it.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
