### PR TITLE
ci: use latest :v17 Ceph contaimer-image again

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -11,9 +11,7 @@ docker.io/rook/ceph:v1.9.4      rook/ceph:v1.9.4
 
 # ceph-csi v3.6
 docker.io/rook/ceph:v1.8.2	rook/ceph:v1.8.2
-# FIXME: Ceph Mgr in v17.2.2 segfaults (see ceph/ceph-csi#3259)
-#quay.io/ceph/ceph:v17		quay.io/ceph/ceph:v17
-quay.io/ceph/ceph:v17.2.1	quay.io/ceph/ceph:v17
+quay.io/ceph/ceph:v17		quay.io/ceph/ceph:v17
 
 # ceph-csi v3.5
 quay.io/ceph/ceph:v16		quay.io/ceph/ceph:v16


### PR DESCRIPTION
A new Ceph container-image has been released. This should address the
Ceph Mgr issue that was present in :v17.2.2.

Closes: #3259

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
