### PR TITLE
Remove snapshot controller check in CI and deployment scripts

### DIFF
--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -84,30 +84,6 @@ function delete_snapshot_crd() {
     kubectl delete -f "${VOLUME_SNAPSHOT}" --ignore-not-found
 }
 
-# parse the kubernetes version
-# v1.17.2 -> kube_version 1 -> 1  (Major)
-# v1.17.2 -> kube_version 2 -> 17 (Minor)
-function kube_version() {
-    echo "${KUBE_VERSION}" | sed 's/^v//' | cut -d'.' -f"${1}"
-}
-
-if ! get_kube_version=$(kubectl version --short) ||
-   [[ -z "${get_kube_version}" ]]; then
-    echo "could not get Kubernetes server version"
-    echo "hint: check if you have specified the right host or port"
-    exit 1
-fi
-
-KUBE_VERSION=$(echo "${get_kube_version}" | grep "^Server Version" | cut -d' ' -f3)
-KUBE_MAJOR=$(kube_version 1)
-KUBE_MINOR=$(kube_version 2)
-
-# skip snapshot operation if kube version is less than 1.17.0
-if [[ "${KUBE_MAJOR}" -lt 1 ]] || [[ "${KUBE_MAJOR}" -eq 1  &&  "${KUBE_MINOR}" -lt 17 ]]; then
-    echo "skipping: Kubernetes server version is < 1.17.0"
-    exit 1
-fi
-
 case "${1:-}" in
 install)
     install_snapshot_controller "$2"
@@ -115,13 +91,9 @@ install)
 cleanup)
     cleanup_snapshot_controller "$2"
     ;;
-delete-crd)
-    delete_snapshot_crd
-    ;;
 *)
     echo "usage:" >&2
     echo "  $0 install" >&2
     echo "  $0 cleanup" >&2
-    echo "  $0 delete-crd" >&2
     ;;
 esac

--- a/scripts/travis-functest.sh
+++ b/scripts/travis-functest.sh
@@ -27,21 +27,12 @@ sudo scripts/minikube.sh create-block-pool
 # pull docker images to speed up e2e
 sudo scripts/minikube.sh cephcsi
 sudo scripts/minikube.sh k8s-sidecar
-KUBE_MAJOR=$(kube_version 1)
-KUBE_MINOR=$(kube_version 2)
-# skip snapshot operation if kube version is less than 1.17.0
-if [[ "${KUBE_MAJOR}" -ge 1 ]] && [[ "${KUBE_MINOR}" -ge 17 ]]; then
-    # delete snapshot CRD created by ceph-csi in rook
-    scripts/install-snapshot.sh delete-crd
-    # install snapshot controller
-    scripts/install-snapshot.sh install
-fi
+# install snapshot controller and create snapshot CRD
+scripts/install-snapshot.sh install
 
 # functional tests
 make run-e2e E2E_ARGS="${*}"
 
-if [[ "${KUBE_MAJOR}" -ge 1 ]] && [[ "${KUBE_MINOR}" -ge 17 ]]; then
-    # delete snapshot CRD
-    scripts/install-snapshot.sh cleanup
-fi
+# cleanup
+scripts/install-snapshot.sh cleanup
 sudo scripts/minikube.sh clean

--- a/scripts/travis-helmtest.sh
+++ b/scripts/travis-helmtest.sh
@@ -35,15 +35,8 @@ sudo scripts/minikube.sh k8s-sidecar
 NAMESPACE=cephcsi-e2e-$RANDOM
 # create ns for e2e
 kubectl create ns ${NAMESPACE}
-KUBE_MAJOR=$(kube_version 1)
-KUBE_MINOR=$(kube_version 2)
-# skip snapshot operation if kube version is less than 1.17.0
-if [[ "${KUBE_MAJOR}" -ge 1 ]] && [[ "${KUBE_MINOR}" -ge 17 ]]; then
-    # delete snapshot CRD created by ceph-csi in rook
-    scripts/install-snapshot.sh delete-crd
-    # install snapshot controller
-    scripts/install-snapshot.sh install
-fi
+# install snapshot controller and create snapshot CRD
+scripts/install-snapshot.sh install
 # set up helm
 scripts/install-helm.sh up
 # install cephcsi helm charts
@@ -51,12 +44,8 @@ scripts/install-helm.sh install-cephcsi --namespace ${NAMESPACE}
 # functional tests
 make run-e2e NAMESPACE="${NAMESPACE}" E2E_ARGS="--deploy-cephfs=false --deploy-rbd=false ${*}"
 
-#cleanup
-# skip snapshot operation if kube version is less than 1.17.0
-if [[ "${KUBE_MAJOR}" -ge 1 ]] && [[ "${KUBE_MINOR}" -ge 17 ]]; then
-    # delete snapshot CRD
-    scripts/install-snapshot.sh cleanup
-fi
+# cleanup
+scripts/install-snapshot.sh cleanup
 scripts/install-helm.sh cleanup-cephcsi --namespace ${NAMESPACE}
 scripts/install-helm.sh clean
 kubectl delete ns ${NAMESPACE}


### PR DESCRIPTION
The version of kube server has been imposed on this script to check it
is < v1.17  which is no longer required.

- [x] snapshot controller installation scripts are changed


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
