### PR TITLE
ci: update dependencies in build.env

### DIFF
--- a/build.env
+++ b/build.env
@@ -16,14 +16,14 @@ BASE_IMAGE=quay.io/ceph/ceph:v17
 CEPH_VERSION=quincy
 
 # standard Golang options
-GOLANG_VERSION=1.17.10
+GOLANG_VERSION=1.18.5
 GO111MODULE=on
 
 # commitlint version
 COMMITLINT_VERSION=latest
 
 # static checks and linters
-GOLANGCI_VERSION=v1.46.2
+GOLANGCI_VERSION=v1.47.3
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases
@@ -35,7 +35,7 @@ SNAPSHOT_VERSION=v6.0.1
 #GO_COVER_DIR=_output/
 
 # helm chart generation, testing and publishing
-HELM_VERSION=v3.9.0
+HELM_VERSION=v3.9.2
 
 # minikube settings
 MINIKUBE_VERSION=v1.26.1
@@ -43,7 +43,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.9.4
+ROOK_VERSION=v1.9.8
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v17
 

--- a/internal/cephfs/util/mountinfo.go
+++ b/internal/cephfs/util/mountinfo.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	// google.golang.org/protobuf/encoding doesn't offer MessageV2().
-	"github.com/golang/protobuf/proto" // nolint:staticcheck // See comment above.
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // See comment above.
 	"google.golang.org/protobuf/encoding/protojson"
 )
 

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -169,6 +169,7 @@ linters:
     - funlen
     - testpackage
     - exhaustivestruct
+    - nosnakecase
     # This requires extra addition of unnecessary code. Hence, we
     # prefer to disable this linter. But, it can be enabled if we
     # have better resolution. For more details check the


### PR DESCRIPTION
This commits updates below items.

* Golang version to v1.18.4
* Golangci-lint to v1.47.3
* Helm version to v3.9.2
* Rook version to v1.9.8

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Note:- we have golang 1.19 released yesterday, sticking to the last stable release, for now, If required, we can update to v1.19
