### PR TITLE
ci: fix invalid mergifyio configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@
 defaults:
   actions:
     # mergify.io has removed bot_account from its free open source plan.
-    comment:
+    # comment:
     # bot_account: ceph-csi-bot # mergify[bot] will be commenting.
     queue:
       # merge_bot_account: ceph-csi-bot #mergify[bot] will be merging prs.


### PR DESCRIPTION
Comment out `comment: ` settings, since it
does not have any options set, otherwise
throws the following error.
```
The current Mergify configuration is invalid
required key not provided @ defaults → actions → comment → message
```

Signed-off-by: Rakshith R <rar@redhat.com>