### PR TITLE
ci: use ubuntu-latest for stale job

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.repository == 'ceph/ceph-csi'
     steps:
       - uses: actions/stale@v5


### PR DESCRIPTION
Currently, we use the Ubuntu 18.04 actions runner for a stale job. This runner will be [deprecated
and removed at the beginning of Dec](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/). So should change the runner to use the latest ubuntu.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
