### PR TITLE
rebase: use v0.17.0 of go-ceph library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ GO_PROJECT=github.com/ceph/ceph-csi
 CEPH_VERSION ?= $(shell . $(CURDIR)/build.env ; echo $${CEPH_VERSION})
 # TODO: ceph_preview tag may be removed with go-ceph 0.17.0
 # TODO: ceph_ci_untested is added for subvolume metadata (go-ceph#691) and snapshot metadata management (go-ceph#698)
-GO_TAGS_LIST ?= $(CEPH_VERSION) ceph_preview ceph_ci_untested
+GO_TAGS_LIST ?= $(CEPH_VERSION) ceph_preview ceph_ci_untested ceph_pre_quincy
 
 # go build flags
 LDFLAGS ?=

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.17
 
 require (
 	github.com/IBM/keyprotect-go-client v0.8.0
-	github.com/aws/aws-sdk-go v1.44.62
+	github.com/aws/aws-sdk-go v1.44.67
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.13
 	github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000
 	// TODO: API for managing subvolume metadata and snapshot metadata requires `ceph_ci_untested` build-tag
-	github.com/ceph/go-ceph v0.16.0
+	github.com/ceph/go-ceph v0.17.0
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/csi-addons/replication-lib-utils v0.2.0
 	github.com/csi-addons/spec v0.1.2-0.20220804080457-522edd16192e

--- a/go.sum
+++ b/go.sum
@@ -150,9 +150,8 @@ github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.25.41/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.44.28/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.62 h1:N8qOPnBhl2ZCIFiqyB640Xt5CeX9D8CEVhG/Vj7jGJU=
-github.com/aws/aws-sdk-go v1.44.62/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.67 h1:+nxfXbMe8QUB6svLsuLYsp+WhZBKM26w62Zidir739A=
+github.com/aws/aws-sdk-go v1.44.67/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.11 h1:xM1ZPSvty3xVmdxiGr7ay/wlqv+MWhH0rMlyLdbC0YQ=
 github.com/aws/aws-sdk-go-v2 v1.16.11/go.mod h1:WTACcleLz6VZTp7fak4EO5b9Q4foxbn+8PIz3PmyKlo=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.18 h1:OmiwoVyLKEqqD5GvB683dbSqxiOfvx4U2lDZhG2Esc4=
@@ -193,8 +192,8 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
-github.com/ceph/go-ceph v0.16.0 h1:hEhVfEFsLoGJF+i3r7Wwh4QlMN+MnWqNxfic9v6GV04=
-github.com/ceph/go-ceph v0.16.0/go.mod h1:SzhpLdyU+ixxJ68bbqoEa481P5N5d5lv5jVMxcRMLfU=
+github.com/ceph/go-ceph v0.17.0 h1:2McqHPqvAU+qgROJ+A5/eK70Lt7WsKizkTasDEOZa/Q=
+github.com/ceph/go-ceph v0.17.0/go.mod h1:WV8DzlYPtW3SQ/HiT3Dz6ia0+v8dPKWtYY/dWl6BqPg=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -1113,7 +1112,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -10821,6 +10821,9 @@ var awsPartition = partition{
 					Region: "ap-northeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
 					Region: "ap-southeast-2",
 				}: endpoint{},
 				endpointKey{
@@ -15704,6 +15707,9 @@ var awsPartition = partition{
 					Region: "ap-southeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-southeast-3",
+				}: endpoint{},
+				endpointKey{
 					Region: "ca-central-1",
 				}: endpoint{},
 				endpointKey{
@@ -19901,6 +19907,9 @@ var awsPartition = partition{
 					Region: "ap-northeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
 					Region: "ap-south-1",
 				}: endpoint{},
 				endpointKey{
@@ -19908,6 +19917,9 @@ var awsPartition = partition{
 				}: endpoint{},
 				endpointKey{
 					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-3",
 				}: endpoint{},
 				endpointKey{
 					Region: "ca-central-1",
@@ -25086,8 +25098,20 @@ var awscnPartition = partition{
 					Region: "cn-north-1",
 				}: endpoint{},
 				endpointKey{
+					Region:  "cn-north-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "firehose.cn-north-1.api.amazonwebservices.com.cn",
+				},
+				endpointKey{
 					Region: "cn-northwest-1",
 				}: endpoint{},
+				endpointKey{
+					Region:  "cn-northwest-1",
+					Variant: dualStackVariant,
+				}: endpoint{
+					Hostname: "firehose.cn-northwest-1.api.amazonwebservices.com.cn",
+				},
 			},
 		},
 		"fms": service{

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.44.62"
+const SDKVersion = "1.44.67"

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/metadata.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/metadata.go
@@ -1,9 +1,7 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
-// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
+// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
 
 package admin
-
-import "C"
 
 // GetMetadata gets custom metadata on the subvolume in a volume belonging to
 // an optional subvolume group based on provided key name.

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/snapshot_metadata.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/snapshot_metadata.go
@@ -1,9 +1,7 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
-// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
+// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
 
 package admin
-
-import "C"
 
 // GetSnapshotMetadata gets custom metadata on the subvolume snapshot in a
 // volume belonging to an optional subvolume group based on provided key name.

--- a/vendor/github.com/ceph/go-ceph/rados/alloc_hint_flags.go
+++ b/vendor/github.com/ceph/go-ceph/rados/alloc_hint_flags.go
@@ -1,0 +1,37 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+//
+import "C"
+
+// AllocHintFlags control the behavior of read and write operations.
+type AllocHintFlags uint32
+
+const (
+	// AllocHintNoHint indicates no predefined behavior
+	AllocHintNoHint = AllocHintFlags(0)
+	// AllocHintSequentialWrite TODO
+	AllocHintSequentialWrite = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_SEQUENTIAL_WRITE)
+	// AllocHintRandomWrite TODO
+	AllocHintRandomWrite = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_RANDOM_WRITE)
+	// AllocHintSequentialRead TODO
+	AllocHintSequentialRead = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_SEQUENTIAL_READ)
+	// AllocHintRandomRead TODO
+	AllocHintRandomRead = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_RANDOM_READ)
+	// AllocHintAppendOnly TODO
+	AllocHintAppendOnly = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_APPEND_ONLY)
+	// AllocHintImmutable TODO
+	AllocHintImmutable = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_IMMUTABLE)
+	// AllocHintShortlived TODO
+	AllocHintShortlived = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_SHORTLIVED)
+	// AllocHintLonglived TODO
+	AllocHintLonglived = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_LONGLIVED)
+	// AllocHintCompressible TODO
+	AllocHintCompressible = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_COMPRESSIBLE)
+	// AllocHintIncompressible TODO
+	AllocHintIncompressible = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_INCOMPRESSIBLE)
+)

--- a/vendor/github.com/ceph/go-ceph/rados/conn.go
+++ b/vendor/github.com/ceph/go-ceph/rados/conn.go
@@ -100,7 +100,7 @@ func (c *Conn) ReadDefaultConfigFile() error {
 func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
 	cPool := C.CString(pool)
 	defer C.free(unsafe.Pointer(cPool))
-	ioctx := &IOContext{}
+	ioctx := &IOContext{conn: c}
 	ret := C.rados_ioctx_create(c.cluster, cPool, &ioctx.ioctx)
 	if ret == 0 {
 		return ioctx, nil

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx.go
@@ -99,6 +99,11 @@ type LockInfo struct {
 // IOContext represents a context for performing I/O within a pool.
 type IOContext struct {
 	ioctx C.rados_ioctx_t
+
+	// Hold a reference back to the connection that the ioctx depends on so
+	// that Go's GC doesn't trigger the Conn's finalizer before this
+	// IOContext is destroyed.
+	conn *Conn
 }
 
 // validate returns an error if the ioctx is not ready to be used

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_alignment.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_alignment.go
@@ -1,0 +1,27 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// Alignment returns the required stripe size in bytes for pools supporting/requiring it, or an error if unsuccessful.
+// For an EC pool, a buffer size multiple of its stripe size is required to call Append. To know if the pool requires
+// alignment or not, use RequiresAlignment.
+//
+// Implements:
+//  int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)
+func (ioctx *IOContext) Alignment() (uint64, error) {
+	var alignSizeBytes C.uint64_t
+	ret := C.rados_ioctx_pool_required_alignment2(
+		ioctx.ioctx,
+		&alignSizeBytes)
+	if ret != 0 {
+		return 0, getError(ret)
+	}
+	return uint64(alignSizeBytes), nil
+}

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_requires_alignment.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_requires_alignment.go
@@ -1,0 +1,27 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// RequiresAlignment returns true if the pool supports/requires alignment or an error if not successful.
+// For an EC pool, a buffer size multiple of its stripe size is required to call Append. See
+// Alignment to know how to get the stripe size for pools requiring it.
+//
+// Implements:
+//  int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int *req)
+func (ioctx *IOContext) RequiresAlignment() (bool, error) {
+	var alignRequired C.int
+	ret := C.rados_ioctx_pool_requires_alignment2(
+		ioctx.ioctx,
+		&alignRequired)
+	if ret != 0 {
+		return false, getError(ret)
+	}
+	return (alignRequired != 0), nil
+}

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx_set_alloc_hint.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx_set_alloc_hint.go
@@ -1,0 +1,38 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+import (
+	"unsafe"
+)
+
+// SetAllocationHint sets allocation hint for an object. This is an advisory
+// operation, it will always succeed (as if it was submitted with a
+// LIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on
+// the backend.
+//
+// Implements:
+//  int rados_set_alloc_hint2(rados_ioctx_t io,
+//                            const char *o,
+//                            uint64_t expected_object_size,
+//                            uint64_t expected_write_size,
+//                            uint32_t flags);
+func (ioctx *IOContext) SetAllocationHint(oid string, expectedObjectSize uint64, expectedWriteSize uint64, flags AllocHintFlags) error {
+	coid := C.CString(oid)
+	defer C.free(unsafe.Pointer(coid))
+
+	return getError(C.rados_set_alloc_hint2(
+		ioctx.ioctx,
+		coid,
+		(C.uint64_t)(expectedObjectSize),
+		(C.uint64_t)(expectedWriteSize),
+		(C.uint32_t)(flags),
+	))
+}

--- a/vendor/github.com/ceph/go-ceph/rados/operation.go
+++ b/vendor/github.com/ceph/go-ceph/rados/operation.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/log"
 )
 
 // The file operation.go exists to support both read op and write op types that
@@ -116,6 +118,7 @@ func (o *operation) update(kind opKind, ret C.int) error {
 
 func opStepFinalizer(s opStep) {
 	if s != nil {
+		log.Warnf("unreachable opStep object found. Cleaning up.")
 		s.free()
 	}
 }

--- a/vendor/github.com/ceph/go-ceph/rados/rados.go
+++ b/vendor/github.com/ceph/go-ceph/rados/rados.go
@@ -9,6 +9,8 @@ import "C"
 import (
 	"runtime"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/log"
 )
 
 const (
@@ -120,6 +122,7 @@ func NewConnWithClusterAndUser(clusterName string, userName string) (*Conn, erro
 // called.
 func freeConn(conn *Conn) {
 	if conn.cluster != nil {
+		log.Warnf("unreachable Conn object has not been shut down. Cleaning up.")
 		C.rados_shutdown(conn.cluster)
 		// prevent calling rados_shutdown() more than once
 		conn.cluster = nil

--- a/vendor/github.com/ceph/go-ceph/rados/rados_set_locator.go
+++ b/vendor/github.com/ceph/go-ceph/rados/rados_set_locator.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/vendor/github.com/ceph/go-ceph/rados/write_op_set_alloc_hint.go
+++ b/vendor/github.com/ceph/go-ceph/rados/write_op_set_alloc_hint.go
@@ -1,0 +1,28 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// SetAllocationHint sets allocation hint for an object. This is an advisory
+// operation, it will always succeed (as if it was submitted with a
+// LIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on
+// the backend.
+//
+// Implements:
+//  void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,
+//                                      uint64_t expected_object_size,
+//                                      uint64_t expected_write_size,
+//                                      uint32_t flags);
+func (w *WriteOp) SetAllocationHint(expectedObjectSize uint64, expectedWriteSize uint64, flags AllocHintFlags) {
+	C.rados_write_op_set_alloc_hint2(
+		w.op,
+		C.uint64_t(expectedObjectSize),
+		C.uint64_t(expectedWriteSize),
+		C.uint32_t(flags))
+}

--- a/vendor/github.com/ceph/go-ceph/rbd/mirror.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/mirror.go
@@ -1,11 +1,6 @@
 //go:build !nautilus
 // +build !nautilus
 
-// Initially, we're only providing mirroring related functions for octopus as
-// that version of ceph deprecated a number of the functions in nautilus. If
-// you need mirroring on an earlier supported version of ceph please file an
-// issue in our tracker.
-
 package rbd
 
 // #cgo LDFLAGS: -lrbd

--- a/vendor/github.com/ceph/go-ceph/rbd/mirror_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/mirror_nautilus.go
@@ -1,0 +1,408 @@
+//go:build nautilus
+// +build nautilus
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <errno.h>
+// #include <stdlib.h>
+// #include <rados/librados.h>
+// #include <rbd/librbd.h>
+import "C"
+import (
+	"unsafe"
+
+	"github.com/ceph/go-ceph/rados"
+)
+
+// MirrorMode indicates the current mode of mirroring that is applied onto a
+// pool. A pool that doesn't have an explicit mirroring mode applied to it is
+// said to be disabled - that's the default.
+type MirrorMode int
+
+const (
+	// MirrorModeDisabled disables mirroring.
+	MirrorModeDisabled = MirrorMode(C.RBD_MIRROR_MODE_DISABLED)
+	// MirrorModeImage enables mirroring on a per-image basis.
+	MirrorModeImage = MirrorMode(C.RBD_MIRROR_MODE_IMAGE)
+	// MirrorModePool enables mirroring on all journaled images.
+	MirrorModePool = MirrorMode(C.RBD_MIRROR_MODE_POOL)
+)
+
+// MirrorModeGet returns the mode of mirroring currently applied to a pool.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_mode_get(rados_ioctx_t p, rbd_mirror_mode_t *mirror_mode)
+func MirrorModeGet(ioctx *rados.IOContext) (MirrorMode, error) {
+	var rmm C.rbd_mirror_mode_t
+
+	ret := C.rbd_mirror_mode_get(cephIoctx(ioctx), &rmm)
+	if ret != 0 {
+		return -1, getError(ret)
+	}
+
+	return MirrorMode(rmm), nil
+}
+
+// MirrorModeSet sets the mirror mode for a pool.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  rbd_mirror_mode_set(rados_ioctx_t p, rbd_mirror_mode_t mirror_mode)
+func MirrorModeSet(ioctx *rados.IOContext, mode MirrorMode) error {
+	cMode := C.rbd_mirror_mode_t(mode)
+
+	ret := C.rbd_mirror_mode_set(cephIoctx(ioctx), cMode)
+
+	return getError(ret)
+}
+
+// MirrorPeerAdd configures a peering relationship with another cluster. Note
+// that it does not transfer over that cluster's config or keyrings, which must
+// already be available to the rbd-mirror daemon(s).
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_peer_add(rados_ioctx_t p, char *uuid,
+//  												size_t uuid_max_length,
+// 													const char *cluster_name,
+//													const char *client_name)
+func MirrorPeerAdd(ioctx *rados.IOContext, clusterName, clientName string) (string, error) {
+	// librbd uses 36-byte UUIDs with a trailing null. rbd_mirror_add_peer will
+	// return -E2BIG if we pass a UUID buffer smaller than 37 bytes.
+	const cUUIDMaxLen = C.size_t(37)
+	cUUID := make([]C.char, cUUIDMaxLen)
+
+	cClusterName := C.CString(clusterName)
+	defer C.free(unsafe.Pointer(cClusterName))
+
+	cClientName := C.CString(clientName)
+	defer C.free(unsafe.Pointer(cClientName))
+
+	ret := C.rbd_mirror_peer_add(cephIoctx(ioctx), &cUUID[0], cUUIDMaxLen,
+		cClusterName, cClientName)
+
+	return C.GoString(&cUUID[0]), getError(ret)
+}
+
+// MirrorPeerRemove tears down a peering relationship.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_peer_remove(rados_ioctx_t io_ctx, const char *uuid)
+func MirrorPeerRemove(ioctx *rados.IOContext, uuid string) error {
+	cUUID := C.CString(uuid)
+	defer C.free(unsafe.Pointer(cUUID))
+
+	ret := C.rbd_mirror_peer_remove(cephIoctx(ioctx), cUUID)
+
+	return getError(ret)
+}
+
+// MirrorPeerInfo contains information about a configured mirroring peer.
+type MirrorPeerInfo struct {
+	UUID        string
+	ClusterName string
+	ClientName  string
+}
+
+// MirrorPeerList returns a list of configured mirroring peers.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_peer_list(rados_ioctx_t io_ctx,
+//  												 rbd_mirror_peer_list_t *peers,
+// 										 			 int *max_peers);
+func MirrorPeerList(ioctx *rados.IOContext) ([]*MirrorPeerInfo, error) {
+	var mpi []*MirrorPeerInfo
+	cMaxPeers := C.int(5)
+
+	var cPeers []C.rbd_mirror_peer_t
+	for {
+		cPeers = make([]C.rbd_mirror_peer_t, cMaxPeers)
+		ret := C.rbd_mirror_peer_list(cephIoctx(ioctx), &cPeers[0], &cMaxPeers)
+		if ret == -C.ERANGE {
+			// There are too many peers to fit in the list, and the number of peers has been
+			// returned in cMaxPeers. Try again with the returned value.
+			continue
+		}
+		if ret != 0 {
+			return nil, getError(ret)
+		}
+
+		// ret == 0
+		break
+	}
+	defer C.rbd_mirror_peer_list_cleanup(&cPeers[0], cMaxPeers)
+	cPeers = cPeers[:cMaxPeers]
+
+	for _, cPeer := range cPeers {
+		mpi = append(mpi, &MirrorPeerInfo{
+			UUID:        C.GoString(cPeer.uuid),
+			ClusterName: C.GoString(cPeer.cluster_name),
+			ClientName:  C.GoString(cPeer.client_name),
+		})
+	}
+
+	return mpi, nil
+}
+
+// MirrorImageState indicates whether mirroring is enabled or disabled on an
+// image.
+//
+// A mirrored image might not immediately change its status to disabled if it has
+// offsets left to sync with its peers - this is denoted by 'disabling' state.
+//
+// It is important to note that mirroring cannot be enabled on an image without
+// first flipping on the 'journaling' image feature for it.
+type MirrorImageState int
+
+const (
+	// MirrorImageDisabling is the representation of
+	// RBD_MIRROR_IMAGE_DISABLING from librbd.
+	MirrorImageDisabling = MirrorImageState(C.RBD_MIRROR_IMAGE_DISABLING)
+	// MirrorImageEnabled is the representation of
+	// RBD_MIRROR_IMAGE_ENABLED from librbd.
+	MirrorImageEnabled = MirrorImageState(C.RBD_MIRROR_IMAGE_ENABLED)
+	// MirrorImageDisabled is the representation of
+	// RBD_MIRROR_IMAGE_DISABLED from librbd.
+	MirrorImageDisabled = MirrorImageState(C.RBD_MIRROR_IMAGE_DISABLED)
+)
+
+// MirrorImageStatusState denotes the current replication status of a given
+// image.
+type MirrorImageStatusState int
+
+const (
+	// MirrorImageStatusStateUnknown is equivalent to MIRROR_IMAGE_STATUS_STATE_UNKNOWN.
+	MirrorImageStatusStateUnknown = MirrorImageStatusState(C.MIRROR_IMAGE_STATUS_STATE_UNKNOWN)
+	// MirrorImageStatusStateError is equivalent to MIRROR_IMAGE_STATUS_STATE_ERROR.
+	MirrorImageStatusStateError = MirrorImageStatusState(C.MIRROR_IMAGE_STATUS_STATE_ERROR)
+	// MirrorImageStatusStateSyncing is equivalent to MIRROR_IMAGE_STATUS_STATE_SYNCING.
+	MirrorImageStatusStateSyncing = MirrorImageStatusState(C.MIRROR_IMAGE_STATUS_STATE_SYNCING)
+	// MirrorImageStatusStateStartingReplay is equivalent to MIRROR_IMAGE_STATUS_STATE_STARTING_REPLAY.
+	MirrorImageStatusStateStartingReplay = MirrorImageStatusState(C.MIRROR_IMAGE_STATUS_STATE_STARTING_REPLAY)
+	// MirrorImageStatusStateReplaying is equivalent to MIRROR_IMAGE_STATUS_STATE_REPLAYING.
+	MirrorImageStatusStateReplaying = MirrorImageStatusState(C.MIRROR_IMAGE_STATUS_STATE_REPLAYING)
+	// MirrorImageStatusStateStoppingReplay is equivalent to MIRROR_IMAGE_STATUS_STATE_STOPPING_REPLAY.
+	MirrorImageStatusStateStoppingReplay = MirrorImageStatusState(C.MIRROR_IMAGE_STATUS_STATE_STOPPING_REPLAY)
+	// MirrorImageStatusStateStopped is equivalent to MIRROR_IMAGE_STATUS_STATE_STOPPED.
+	MirrorImageStatusStateStopped = MirrorImageStatusState(C.MIRROR_IMAGE_STATUS_STATE_STOPPED)
+)
+
+// MirrorImageInfo provides information about the mirroring progress of an image.
+type MirrorImageInfo struct {
+	Name        string
+	Description string
+	State       MirrorImageState
+	StatusState MirrorImageStatusState
+	GlobalID    string
+	IsPrimary   bool
+	IsUp        bool
+}
+
+// MirrorGetImage returns the MirrorImageInfo for an image.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  rbd_mirror_image_get_info(rbd_image_t image,
+//                            rbd_mirror_image_info_t *mirror_image_info,
+//                            size_t info_size)
+func (image *Image) MirrorGetImage() (*MirrorImageInfo, error) {
+	err := image.validate(imageIsOpen)
+	if err != nil {
+		return nil, err
+	}
+
+	var status C.rbd_mirror_image_status_t
+	ret := C.rbd_mirror_image_get_status(image.image, &status, C.sizeof_rbd_mirror_image_status_t)
+	if ret != 0 {
+		return nil, getError(ret)
+	}
+
+	return &MirrorImageInfo{
+		Name:        C.GoString(status.name),
+		Description: C.GoString(status.description),
+		State:       MirrorImageState(status.info.state),
+		StatusState: MirrorImageStatusState(status.state),
+		GlobalID:    C.GoString(status.info.global_id),
+		IsPrimary:   bool(status.info.primary),
+		IsUp:        bool(status.up),
+	}, nil
+}
+
+// MirrorImageList returns a MirrorImageInfo for each mirrored image.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_image_status_list(rados_ioctx_t io_ctx,
+//  				      									 const char *start_id, size_t max,
+//  				      									 char **image_ids,
+//  				      									 rbd_mirror_image_status_t *images,
+//  				      									 size_t *len)
+func MirrorImageList(ioctx *rados.IOContext) ([]*MirrorImageInfo, error) {
+	imageInfos := make([]*MirrorImageInfo, 0)
+	const cMaxIter C.size_t = 100
+	var startID string
+
+	for {
+		// We need to wrap all the actions within the for loop in a function
+		// in order to ensure that we correctly reclaim all allocated memory
+		// from C at the end of every iteration.
+		ret, done := iterateImageList(ioctx, &imageInfos, &startID, cMaxIter)
+		if ret != 0 {
+			return imageInfos, getError(ret)
+		}
+
+		if done {
+			break
+		}
+	}
+	return imageInfos, nil
+}
+
+func iterateImageList(ioctx *rados.IOContext, imageInfos *[]*MirrorImageInfo, startID *string, cMaxIter C.size_t) (C.int, bool) {
+	cImageIDs := make([]*C.char, cMaxIter)
+	cImageStatus := make([]C.rbd_mirror_image_status_t, cMaxIter)
+	done := false
+
+	var cLen C.size_t
+	ret := C.rbd_mirror_image_status_list(cephIoctx(ioctx), C.CString(*startID),
+		cMaxIter, &cImageIDs[0], &cImageStatus[0], &cLen)
+	if ret != 0 {
+		return ret, done
+	}
+
+	// If the list length is 0 or less than the max size
+	// specified we know we are on the last page of the list,
+	// and we don't need to continue iterating.
+	if cLen < cMaxIter {
+		done = true
+	}
+
+	if cLen == 0 {
+		return C.int(0), done
+	}
+
+	defer func() {
+		C.rbd_mirror_image_status_list_cleanup(&cImageIDs[0], &cImageStatus[0], cLen)
+	}()
+
+	for i := 0; i < int(cLen); i++ {
+		mi := &MirrorImageInfo{
+			Name:        C.GoString(cImageStatus[i].name),
+			Description: C.GoString(cImageStatus[i].description),
+			State:       MirrorImageState(cImageStatus[i].info.state),
+			StatusState: MirrorImageStatusState(cImageStatus[i].state),
+			GlobalID:    C.GoString(cImageStatus[i].info.global_id),
+			IsPrimary:   bool(cImageStatus[i].info.primary),
+			IsUp:        bool(cImageStatus[i].up),
+		}
+
+		*imageInfos = append(*imageInfos, mi)
+	}
+
+	*startID = C.GoString(cImageIDs[cLen-1])
+	return C.int(0), done
+}
+
+// MirrorEnable will enable mirroring for an image.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_image_enable(rbd_image_t image)
+func (image *Image) MirrorEnable() error {
+	err := image.validate(imageIsOpen)
+	if err != nil {
+		return err
+	}
+
+	ret := C.rbd_mirror_image_enable(image.image)
+	return getError(ret)
+}
+
+// MirrorDisable will disable mirroring for an image.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_image_disable(rbd_image_t image, bool force)
+func (image *Image) MirrorDisable(force bool) error {
+	err := image.validate(imageIsOpen)
+	if err != nil {
+		return err
+	}
+
+	ret := C.rbd_mirror_image_disable(image.image, C.bool(force))
+	return getError(ret)
+}
+
+// MirrorPromote will promote an image to primary status.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_image_promote(rbd_image_t image, bool force)
+func (image *Image) MirrorPromote(force bool) error {
+	err := image.validate(imageIsOpen)
+	if err != nil {
+		return err
+	}
+
+	ret := C.rbd_mirror_image_promote(image.image, C.bool(force))
+	return getError(ret)
+}
+
+// MirrorDemote will demote an image to secondary status.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_image_demote(rbd_image_t image)
+func (image *Image) MirrorDemote() error {
+	err := image.validate(imageIsOpen)
+	if err != nil {
+		return err
+	}
+
+	ret := C.rbd_mirror_image_demote(image.image)
+	return getError(ret)
+}
+
+// MirrorResync is used to manually resolve split-brain status by triggering
+// resynchronization.
+//
+// Note: this can only be used if go-ceph is compiled with the `nautilus` build
+// tag.
+//
+// Implements:
+//  int rbd_mirror_image_resync(rbd_image_t image)
+func (image *Image) MirrorResync() error {
+	err := image.validate(imageIsOpen)
+	if err != nil {
+		return err
+	}
+
+	ret := C.rbd_mirror_image_resync(image.image)
+	return getError(ret)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/armon/go-metrics
 # github.com/armon/go-radix v1.0.0
 ## explicit
 github.com/armon/go-radix
-# github.com/aws/aws-sdk-go v1.44.62
+# github.com/aws/aws-sdk-go v1.44.67
 ## explicit; go 1.11
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
@@ -125,8 +125,8 @@ github.com/cenkalti/backoff/v3
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.16.0
-## explicit; go 1.12
+# github.com/ceph/go-ceph v0.17.0
+## explicit; go 1.17
 github.com/ceph/go-ceph/cephfs/admin
 github.com/ceph/go-ceph/common/admin/manager
 github.com/ceph/go-ceph/common/admin/nfs


### PR DESCRIPTION
new version of go ceph is available and this commit make use
of the same.
Ref # https://github.com/ceph/go-ceph/releases/tag/v0.17.0

This go-ceph version also bring changes to some APIs which is part of pre release tag of Ceph build quincy.
Enabling the tag `ceph_pre_quincy` for the same reason.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

