### PR TITLE
build: add mergify rule for backport PRs in release 3.7 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -161,14 +161,6 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
-  - name: backport patches to release-v3.5 branch
-    conditions:
-      - base=devel
-      - label=backport-to-release-v3.5
-    actions:
-      backport:
-        branches:
-          - release-v3.5
   - name: backport patches to release-v3.6 branch
     conditions:
       - base=devel

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -177,6 +177,14 @@ pull_request_rules:
       backport:
         branches:
           - release-v3.6
+  - name: backport patches to release-v3.7 branch
+    conditions:
+      - base=devel
+      - label=backport-to-release-v3.7
+    actions:
+      backport:
+        branches:
+          - release-v3.7
   - name: remove outdated approvals on ci/centos
     conditions:
       - base=ci/centos


### PR DESCRIPTION
- [x] Add rule for backporting to release 3.7 branch with
label `backport-to-release-v3.7`
- [x] Remove rule for backporting to release 3.5 branch with 
label `backport-to-release-v3.5`

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

