### PR TITLE
rbd: fix bug in kmip kms Decrypt function & improve error msg

### DIFF
--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -474,24 +474,27 @@ func (kms *kmipKMS) verifyResponse(
 	uniqueBatchItemID []byte,
 ) (*kmip.ResponseBatchItem, error) {
 	if respMsg.ResponseHeader.BatchCount != 1 {
-		return nil, fmt.Errorf("batch count %v should be 1", respMsg.ResponseHeader.BatchCount)
+		return nil, fmt.Errorf("batch count %q should be \"1\"",
+			respMsg.ResponseHeader.BatchCount)
 	}
 	if len(respMsg.BatchItem) != 1 {
-		return nil, fmt.Errorf("batch Intems list len %v should be 1",
+		return nil, fmt.Errorf("batch Intems list len %q should be \"1\"",
 			len(respMsg.BatchItem))
 	}
 	batchItem := respMsg.BatchItem[0]
 	if operation != batchItem.Operation {
-		return nil, fmt.Errorf("unexpected operation, real %v expected %v",
+		return nil, fmt.Errorf("unexpected operation, real %q expected %q",
 			batchItem.Operation, operation)
 	}
 	if !bytes.Equal(uniqueBatchItemID, batchItem.UniqueBatchItemID) {
-		return nil, fmt.Errorf("unexpected uniqueBatchItemID, real %v expected %v",
+		return nil, fmt.Errorf("unexpected uniqueBatchItemID, real %q expected %q",
 			batchItem.UniqueBatchItemID, uniqueBatchItemID)
 	}
 	if kmip14.ResultStatusSuccess != batchItem.ResultStatus {
-		return nil, fmt.Errorf("unexpected result status %v expected success %v",
-			batchItem.ResultStatus, kmip14.ResultStatusSuccess)
+		return nil, fmt.Errorf("unexpected result status %q expected success %q,"+
+			"result reason %q, result message %q",
+			batchItem.ResultStatus, kmip14.ResultStatusSuccess,
+			batchItem.ResultReason, batchItem.ResultMessage)
 	}
 
 	return &batchItem, nil

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -255,7 +255,7 @@ func (kms *kmipKMS) DecryptDEK(_, encryptedDEK string) (string, error) {
 		DecryptRequestPayload{
 			UniqueIdentifier: kms.uniqueIdentifier,
 			Data:             emd.DEK,
-			IVCounterNonce:   emd.DEK,
+			IVCounterNonce:   emd.Nonce,
 			CryptographicParameters: kmip.CryptographicParameters{
 				PaddingMethod:          kmip14.PaddingMethodPKCS5,
 				CryptographicAlgorithm: kmip14.CryptographicAlgorithmAES,


### PR DESCRIPTION
[rbd: fix bug in kmip kms Decrypt function](https://github.com/ceph/ceph-csi/commit/7fdfd0baadfe6fb24d2a924309742d70f2877e45) 

This commit fixes a bug in kmip kms Decrypt
function, where emd.DEK was fed in a Nonce
instead of emd.Nonce by mistake.

Signed-off-by: Rakshith R <rar@redhat.com>

[rbd: improve kmip verifyResponse() error message](https://github.com/ceph/ceph-csi/commit/69ee696586b5064093fbb8967a85708759efff3c) 

This commit uses %q instead %v in error messages
and adds result reason and message in kmip
verifyresponse().

Signed-off-by: Rakshith R <rar@redhat.com>

---

I had found this bug in testing and fixed it in a testing branch, missed to push to the branch linked to the pr. 
:facepalm: :disappointed: 


