### PR TITLE
RFC: Use minikube prerelease ISO on CI

### DIFF
--- a/build.env
+++ b/build.env
@@ -39,6 +39,7 @@ HELM_VERSION=v3.9.2
 
 # minikube settings
 MINIKUBE_VERSION=v1.26.1
+MINIKUBE_ISO_URL=https://storage.googleapis.com/minikube-builds/iso/14783/minikube-v1.26.1-1661377864-14783-amd64.iso
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -150,6 +150,7 @@ function disable_storage_addons() {
 # configure minikube
 MINIKUBE_ARCH=${MINIKUBE_ARCH:-"amd64"}
 MINIKUBE_VERSION=${MINIKUBE_VERSION:-"latest"}
+MINIKUBE_ISO_URL=${MINIKUBE_ISO_URL:-""}
 KUBE_VERSION=${KUBE_VERSION:-"latest"}
 CONTAINER_CMD=${CONTAINER_CMD:-"docker"}
 MEMORY=${MEMORY:-"4096"}
@@ -174,6 +175,10 @@ if [[ "${VM_DRIVER}" == "kvm2" ]] || [[ "${VM_DRIVER}" == "hyperkit" ]]; then
     DISK_CONFIG=${DISK_CONFIG:-" --extra-disks=${NUM_DISKS} --disk-size=${DISK_SIZE} "}
 else
     DISK_CONFIG=""
+fi
+
+if [[ -n "${MINIKUBE_ISO_URL}" ]]; then
+    EXTRA_CONFIG="${EXTRA_CONFIG} --iso-url ${MINIKUBE_ISO_URL}"
 fi
 
 # configure csi image version


### PR DESCRIPTION
Now that minikube fscrypt kernel support is merged (https://github.com/kubernetes/minikube/pull/14783), I'm looking for a way to run https://github.com/ceph/ceph-csi/pull/3310 on the Ceph CSI CI with that ISO. A updated ISO was build and is available for download: https://storage.googleapis.com/minikube-builds/iso/14783/minikube-v1.26.1-1661377864-14783-amd64.iso

 Would this be a way forward until the next minikube release?