### PR TITLE
ci: remove podsecurity feature-gate

### DIFF
--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -325,11 +325,13 @@ func loadApp(path string) (*v1.Pod, error) {
 		return nil, err
 	}
 
+	var user int64 = 2000
 	if app.Spec.SecurityContext == nil {
 		app.Spec.SecurityContext = &v1.PodSecurityContext{}
 	}
 	app.Spec.SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
 	app.Spec.SecurityContext.SeccompProfile = &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}
+	app.Spec.SecurityContext.FSGroup = &user
 
 	for i := range app.Spec.Containers {
 		app.Spec.Containers[i].ImagePullPolicy = v1.PullIfNotPresent
@@ -340,8 +342,10 @@ func loadApp(path string) (*v1.Pod, error) {
 		app.Spec.Containers[i].SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
 		if app.Spec.Containers[i].SecurityContext.Capabilities == nil {
 			app.Spec.Containers[i].SecurityContext.Capabilities = &v1.Capabilities{}
+			app.Spec.Containers[i].SecurityContext.RunAsUser = &user
 		}
 		app.Spec.Containers[i].SecurityContext.Capabilities.Drop = []v1.Capability{"ALL"}
+		app.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = pointer.BoolPtr(false)
 	}
 
 	return &app, nil

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -224,7 +224,7 @@ func execWithRetry(f *framework.Framework, opts *framework.ExecOptions) (string,
 				return false, nil
 			}
 
-			e2elog.Logf("failed to execute command: %v", execErr)
+			e2elog.Logf("failed to execute command: %v, stdError: %s", execErr, stdErr)
 
 			return false, fmt.Errorf("failed to execute command: %w", execErr)
 		}

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -197,6 +197,7 @@ func checkAppMntSize(f *framework.Framework, opt *metav1.ListOptions, size, cmd,
 
 			return false, nil
 		}
+		e2elog.Logf("%s the output is %s", cmd, output)
 		s := resource.MustParse(strings.TrimSpace(output))
 		actualSize, err := helpers.RoundUpToGiB(s)
 		if err != nil {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -567,7 +567,7 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 	}
 	_, stdErr, err := execCommandInPod(f, "echo testing > /target/testing", app.Namespace, &opt)
 	if err != nil {
-		return fmt.Errorf("failed to exec command in pod: %w", err)
+		return fmt.Errorf("failed to exec command in pod: %w, stdError: %s", err, stdErr)
 	}
 	if stdErr != "" {
 		return fmt.Errorf("failed to touch a file as non-root user %v", stdErr)
@@ -652,7 +652,7 @@ func checkDataPersist(pvcPath, appPath string, f *framework.Framework) error {
 
 	_, stdErr, err := execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, filePath), app.Namespace, &opt)
 	if err != nil {
-		return fmt.Errorf("failed to exec command in pod: %w", err)
+		return fmt.Errorf("failed to exec command in pod: %w, stdError: %s", err, stdErr)
 	}
 	if stdErr != "" {
 		return fmt.Errorf("failed to write data to a file %v", stdErr)

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -224,7 +224,7 @@ up)
     KUBE_MAJOR=$(kube_version 1)
     KUBE_MINOR=$(kube_version 2)
     if [ "${KUBE_MAJOR}" -eq 1 ] && [ "${KUBE_MINOR}" -ge 22 ];then
-        K8S_FEATURE_GATES="${K8S_FEATURE_GATES},ReadWriteOncePod=true,PodSecurity=false"
+        K8S_FEATURE_GATES="${K8S_FEATURE_GATES},ReadWriteOncePod=true"
     fi
     if [ "${KUBE_MAJOR}" -eq 1 ] && [ "${KUBE_MINOR}" -ge 23 ];then
         K8S_FEATURE_GATES="${K8S_FEATURE_GATES},RecoverVolumeExpansionFailure=true"


### PR DESCRIPTION
remove the podsecurity feature-gate from minikube.sh, because of it kubernetes 1.25.0 deployment is failing

fixes: #3358

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

