### PR TITLE
rbd: change default FsGroupPolicy to "File" for RBD CSI driver

### DIFF
--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -9,3 +9,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  fsGroupPolicy: File

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -15,3 +15,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  fsGroupPolicy: File


### PR DESCRIPTION
This commit change the default fsgroup policy for csi driver object
to "File" type which is the better/correct setting for the CSI volumes
as it works regardless of fstype or access mode

We have been using default value which is "ReadWriteOnceWithFSType"

With this change backward compatibility should be preserved.


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
