### PR TITLE
e2e: adjust e2e test to run on kubernetes 1.25

### DIFF
--- a/build.env
+++ b/build.env
@@ -43,7 +43,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.9.8
+ROOK_VERSION=v1.10.4
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v17
 

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -29,6 +29,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	"k8s.io/pod-security-admission/api"
 )
 
 var (
@@ -146,6 +147,7 @@ func validateSubvolumePath(f *framework.Framework, pvcName, pvcNamespace, fileSy
 
 var _ = Describe(cephfsType, func() {
 	f := framework.NewDefaultFramework(cephfsType)
+	f.NamespacePodSecurityEnforceLevel = api.LevelPrivileged
 	var c clientset.Interface
 	// deploy CephFS CSI
 	BeforeEach(func() {

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -32,6 +32,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	"k8s.io/pod-security-admission/api"
 )
 
 var (
@@ -236,6 +237,7 @@ func unmountNFSVolume(f *framework.Framework, appName, pvcName string) error {
 
 var _ = Describe("nfs", func() {
 	f := framework.NewDefaultFramework("nfs")
+	f.NamespacePodSecurityEnforceLevel = api.LevelPrivileged
 	var c clientset.Interface
 	// deploy CephFS CSI
 	BeforeEach(func() {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -33,6 +33,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	"k8s.io/pod-security-admission/api"
 )
 
 var (
@@ -252,6 +253,7 @@ func ByFileAndBlockEncryption(
 
 var _ = Describe("RBD", func() {
 	f := framework.NewDefaultFramework(rbdType)
+	f.NamespacePodSecurityEnforceLevel = api.LevelPrivileged
 	var c clientset.Interface
 	var kernelRelease string
 	// deploy RBD CSI

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -30,10 +30,12 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	"k8s.io/pod-security-admission/api"
 )
 
 var _ = Describe("CephFS Upgrade Testing", func() {
 	f := framework.NewDefaultFramework("upgrade-test-cephfs")
+	f.NamespacePodSecurityEnforceLevel = api.LevelPrivileged
 	var (
 		c        clientset.Interface
 		pvc      *v1.PersistentVolumeClaim

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -30,10 +30,12 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	"k8s.io/pod-security-admission/api"
 )
 
 var _ = Describe("RBD Upgrade Testing", func() {
 	f := framework.NewDefaultFramework("upgrade-test-rbd")
+	f.NamespacePodSecurityEnforceLevel = api.LevelPrivileged
 	var (
 		// cwd stores the initial working directory.
 		cwd string

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -215,10 +215,13 @@ func validateOmapCount(f *framework.Framework, count int, driver, pool, mode str
 		filterLessCmds := []string{cmds.radosLsCmd, cmds.radosLsKeysCmd}
 		for i, cmd := range filterCmds {
 			stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
-			if err != nil || stdErr != "" {
+			if err != nil {
 				if !strings.Contains(err.Error(), exitOneErr) {
 					e2elog.Failf("failed to execute rados command '%s' : err=%v stdErr=%s", cmd, err, stdErr)
 				}
+			}
+			if stdErr != "" {
+				e2elog.Failf("failed to execute rados command '%s' : stdErr=%s", cmd, stdErr)
 			}
 			err = compareStdoutWithCount(stdOut, count)
 			if err == nil {

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -261,7 +261,7 @@ up)
     KUBE_MAJOR=$(kube_version 1)
     KUBE_MINOR=$(kube_version 2)
     if [ "${KUBE_MAJOR}" -eq 1 ] && [ "${KUBE_MINOR}" -ge 22 ];then
-        K8S_FEATURE_GATES="${K8S_FEATURE_GATES},ReadWriteOncePod=true,PodSecurity=false"
+        K8S_FEATURE_GATES="${K8S_FEATURE_GATES},ReadWriteOncePod=true"
     fi
     if [ "${KUBE_MAJOR}" -eq 1 ] && [ "${KUBE_MINOR}" -ge 23 ];then
         K8S_FEATURE_GATES="${K8S_FEATURE_GATES},RecoverVolumeExpansionFailure=true"


### PR DESCRIPTION
removed podsecurity feature-gate and adjusted e2e tests to use privileged pod security for the e2e namespace

Depends-On: #3365