### PR TITLE
ci: run e2e on kubernetes 1.25

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -8,6 +8,8 @@
           only_run_on_request: false
       - '1.24':
           only_run_on_request: false
+      - '1.25':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -8,6 +8,8 @@
           only_run_on_request: false
       - '1.24':
           only_run_on_request: false
+      - '1.25':
+          only_run_on_request: true
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
Deploy kubernetes 1.25 and run e2e tests on it on demand.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

