### PR TITLE
ci: use resync to sync helm charts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -77,7 +77,8 @@ push_helm_charts() {
 	fi
 
 	mkdir -p "${CHARTDIR}/csi-charts/docs/${PACKAGE}"
-	cp -R "./charts/ceph-csi-${PACKAGE}" "${CHARTDIR}/csi-charts/docs/${PACKAGE}"
+	# Use rsync to remove files from  destination when source file is deleted.
+	rsync -avh "./charts/ceph-csi-${PACKAGE}" "${CHARTDIR}/csi-charts/docs/${PACKAGE}" --delete
 	pushd "${CHARTDIR}/csi-charts/docs/${PACKAGE}" >/dev/null
 	helm package "ceph-csi-${PACKAGE}"
 	popd >/dev/null


### PR DESCRIPTION
When a file on the source is deleted same need to be deleted on the destination, with rsync we can achieve it.

fixes: #3329

* sample output

```log
modified:   index.yaml
modified:   rbd/ceph-csi-rbd/Chart.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-psp.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-role.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-rolebinding.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-rules-clusterrole.yaml
deleted:    rbd/ceph-csi-rbd/templates/provisioner-psp.yaml
deleted:    rbd/ceph-csi-rbd/templates/provisioner-rules-clusterrole.yaml

modified:   cephfs/ceph-csi-cephfs/Chart.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/nodeplugin-clusterrole.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/nodeplugin-clusterrolebinding.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/nodeplugin-role.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/nodeplugin-rolebinding.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/nodeplugin-rules-clusterrole.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/provisioner-psp.yaml
deleted:    cephfs/ceph-csi-cephfs/templates/provisioner-rules-clusterrole.yaml
modified:   index.yaml
modified:   rbd/ceph-csi-rbd/Chart.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-psp.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-role.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-rolebinding.yaml
deleted:    rbd/ceph-csi-rbd/templates/nodeplugin-rules-clusterrole.yaml
deleted:    rbd/ceph-csi-rbd/templates/provisioner-psp.yaml
deleted:    rbd/ceph-csi-rbd/templates/provisioner-rules-clusterrole.yaml
```

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
