### PR TITLE
ci: mirror Rook v1.10.0 image

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -7,7 +7,7 @@
 #
 
 # ceph-csi devel
-docker.io/rook/ceph:v1.9.8      rook/ceph:v1.9.8
+docker.io/rook/ceph:v1.10.0      rook/ceph:v1.10.0
 
 # ceph-csi v3.6
 docker.io/rook/ceph:v1.8.2	rook/ceph:v1.8.2


### PR DESCRIPTION
Rook v1.10.0 is required for ceph cluster deployment on kubernetes 1.25 because older version of Rook still comes
with PSP templates which are removed in Kubernetes 1.25

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

