### PR TITLE
cephfs: Fix subvolumegroup creation

### DIFF
--- a/internal/cephfs/core/metadata.go
+++ b/internal/cephfs/core/metadata.go
@@ -33,9 +33,7 @@ const (
 var ErrSubVolMetadataNotSupported = errors.New("subvolume metadata operations are not supported")
 
 func (s *subVolumeClient) supportsSubVolMetadata() bool {
-	if _, keyPresent := clusterAdditionalInfo[s.clusterID]; !keyPresent {
-		clusterAdditionalInfo[s.clusterID] = &localClusterState{}
-	}
+	newLocalClusterState(s.clusterID)
 
 	return clusterAdditionalInfo[s.clusterID].subVolMetadataState != unsupported
 }

--- a/internal/cephfs/core/snapshot_metadata.go
+++ b/internal/cephfs/core/snapshot_metadata.go
@@ -29,9 +29,7 @@ import (
 var ErrSubVolSnapMetadataNotSupported = errors.New("subvolume snapshot metadata operations are not supported")
 
 func (s *snapshotClient) supportsSubVolSnapMetadata() bool {
-	if _, keyPresent := clusterAdditionalInfo[s.clusterID]; !keyPresent {
-		clusterAdditionalInfo[s.clusterID] = &localClusterState{}
-	}
+	newLocalClusterState(s.clusterID)
 
 	return clusterAdditionalInfo[s.clusterID].subVolSnapshotMetadataState != unsupported
 }

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -259,6 +259,12 @@ func (s *subVolumeClient) CreateVolume(ctx context.Context) error {
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create subvolume %s in fs %s: %s", s.VolID, s.FsName, err)
 
+		if errors.Is(err, rados.ErrNotFound) {
+			// Reset the subVolumeGroupsCreated so that we can try again to create the
+			// subvolumegroup in next request if the error is Not Found.
+			clusterAdditionalInfo[s.clusterID].subVolumeGroupsCreated[s.FsName] = false
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
This PR fixes the below 2 cases.

* Fix subvolumegroup creation for multiple fs
     In a cluster, we can have multiple filesystem for that, we need to have a map of subvolumegroups to check filesystem is 
     created nor not.
* retry subvolumegroup creation if subvolume creation fails with not found error
    If the subvolumegroup is deleted and recreated, we need to restart the cephcsi provisioner pod to clear the cache
    that cephcsi maintains. With this PR, if cephcsi sees a NotFound error during  subvolume creation, it will reset the cache
    for that filesystem so that in the next RPC call, cephcsi will try to create the subvolumegroup again.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>