### PR TITLE
doc: update doc for 3.7.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ environments.
 
 | Ceph CSI Version | Container Orchestrator Name | Version Tested|
 | -----------------| --------------------------- | --------------|
+| v3.7.1 | Kubernetes | v1.22, v1.23, v1.24|
 | v3.7.0 | Kubernetes | v1.22, v1.23, v1.24|
 | v3.6.1 | Kubernetes | v1.21, v1.22, v1.23|
 | v3.6.0 | Kubernetes | v1.21, v1.22, v1.23|
@@ -132,6 +133,7 @@ in the Kubernetes documentation.
 | Ceph CSI Release/Branch | Container image name         | Image Tag |
 | ----------------------- | ---------------------------- | --------- |
 | devel (Branch)          | quay.io/cephcsi/cephcsi      | canary    |
+| v3.7.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.7.1    |
 | v3.7.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.7.0    |
 | v3.6.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.6.1    |
 | v3.6.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.6.0    |

--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ environments.
 | v3.7.0 | Kubernetes | v1.22, v1.23, v1.24|
 | v3.6.1 | Kubernetes | v1.21, v1.22, v1.23|
 | v3.6.0 | Kubernetes | v1.21, v1.22, v1.23|
-| v3.5.1 | Kubernetes | v1.21, v1.22, v1.23|
-| v3.5.0 | Kubernetes | v1.21, v1.22, v1.23|
-| v3.4.0 | Kubernetes | v1.20, v1.21, v1.22|
 
 There is work in progress to make this CO-independent and thus
 support other orchestration environments (Nomad, Mesos..etc).
@@ -137,11 +134,11 @@ in the Kubernetes documentation.
 | v3.7.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.7.0    |
 | v3.6.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.6.1    |
 | v3.6.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.6.0    |
-| v3.5.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.5.1    |
-| v3.5.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.5.0    |
 
 | Deprecated Ceph CSI Release/Branch | Container image name | Image Tag |
 | ----------------------- | --------------------------------| --------- |
+| v3.5.1 (Release)        | quay.io/cephcsi/cephcsi         | v3.5.1    |
+| v3.5.0 (Release)        | quay.io/cephcsi/cephcsi         | v3.5.0    |
 | v3.4.0 (Release)        | quay.io/cephcsi/cephcsi         | v3.4.0    |
 | v3.3.1 (Release)        | quay.io/cephcsi/cephcsi         | v3.3.1    |
 | v3.3.0 (Release)        | quay.io/cephcsi/cephcsi         | v3.3.0    |

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -106,12 +106,12 @@ compatibility support and without prior notice.
 **Also, we do not recommend any direct upgrades to 3.7 except from 3.6 to 3.7.**
 For example, upgrading from 3.5 to 3.7 is not recommended.
 
-git checkout v3.7.0 tag
+git checkout v3.7.1 tag
 
 ```bash
 git clone https://github.com/ceph/ceph-csi.git
 cd ./ceph-csi
-git checkout v3.7.0
+git checkout v3.7.1
 ```
 
 ```console


### PR DESCRIPTION
updated doc for 3.7.1 release is available with this commit.

Additional Note:
* This will be backported to v3.7 branch
* A follow up PR merge of template changes are intended 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

