### PR TITLE
rbd: get description from remote status

### DIFF
--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -469,6 +469,12 @@ func TestValidateLastSyncTime(t *testing.T) {
 			nil,
 			"failed to unmarshal description",
 		},
+		{
+			"description with no JSON",
+			`replaying`,
+			nil,
+			"",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
This commit gets the description from remote status instead of local status.
Local status doesn't have ',' due to which we get
array index out of range panic.

Fixes: #3388

Signed-off-by: Yati Padia <ypadia@redhat.com>
Co-authored-by: shyam Ranganathan <srangana@redhat.com>

