### PR TITLE
doc: add proposal for fetching ceph credentials from KMS

### DIFF
--- a/docs/design/proposals/creds-from-kms.md
+++ b/docs/design/proposals/creds-from-kms.md
@@ -1,18 +1,37 @@
 # Fetching Ceph user credentials from KMS
 
-## Proposal:
+## Proposal
+
 Ceph-CSI supports several KMS implementations for storing and
 fetching DEKs (Data Encryption Keys) to support encryption of RBD volumes.
 Focus of this proposal is to extend the existing KMS implementation to fetch
 Ceph User credentials used for creating, deleting, mapping and resizing RBD volumes.
 
-## Background:
+### Benefits
 
-### Credentials Management:
+- For Ceph-CSI setup where Ceph is deployed externally, either as
+  a standalone or through Rook, one needs to manually obtain the Ceph user keyring(s)
+  and create the K8s required secrets. With this feature,
+  sensitive keyring(s) can be stored securely in an
+  external secret management system such as Hashicorp Vault,
+  AWS Secret Manager, etc. and have Ceph-CSI pull these
+  sensitive keys directly from them.
+- Provides additional security in comparison with K8s secrets,
+  which are relatively easy to access and
+  store sensitive secrets as unencrypted based64 encoded text.
 
-Ceph-CSI relies on K8s CSI components for fetching Ceph user credentials.
+### Drawback
+
+Adds additional overhead as on each CSI RPC call
+a request is made to KMS for fetching credentials.
+
+## Background
+
+### Credentials Management
+
+Ceph-CSI relies on K8s CSI components for obtaining the Ceph user credentials.
 K8s CSI uses the following reserved StorageClass parameters for fetching
-credentials and passes them to Ceph-CSI.
+credentials and passes them to Ceph-CSI RPC calls.
 
 ```yaml
 csi.storage.k8s.io/controller-expand-secret-name
@@ -23,20 +42,27 @@ csi.storage.k8s.io/node-stage-secret-name
 csi.storage.k8s.io/node-stage-secret-namespace
 ```
 
-### KMS Implementation:
-Ceph-CSI utilizes the encryptionKMSID StorageClass parameter and corresponding config
-entry in KMS ConfigMap (eg. [ceph-csi-encryption-kms-config](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml)) to integrate with the KMS.
+### KMS Implementation
 
-## Extending existing implementation:
+Ceph-CSI utilizes the `encryptionKMSID` StorageClass parameter and
+corresponding config entry in KMS ConfigMap
+(eg. [ceph-csi-encryption-kms-config](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml))
+to integrate with the KMS.
 
-> ### Deviation from existing approach:
-> * *StorageClass* parameters cannot be used for credentials as
-> they are not passed in all CSI requests e.g DeleteVolumeRequest.
-> * Similarly, using K8s namespace as tenant name for KMS wouldn’t
+## Extending existing implementation
+
+> ### Deviation from existing approach
+>
+> - *StorageClass* parameters, such as `encryptionKMSID`,
+> cannot be used for credentials as
+> they are not passed in all CSI requests e.g. DeleteVolumeRequest.
+> - Similarly, using K8s namespace as tenant name for KMS wouldn’t
 > be possible as this information not included as part of all CSI requests.
 
-* KMS ID is expected to be present as part of provisioner, node-stage, controller-expand secrets, along with Ceph userID.
-```
+- KMS ID is expected to be present as part of provisioner,
+  node-stage, controller-expand secrets, along with Ceph userID.
+
+```yaml
 apiVersion: v1
 kind: Secret
 metadata:
@@ -46,8 +72,9 @@ stringData:
   kmsID: <kms-id>
  ```
 
-
-* A new ConfigMap named ceph-csi-creds-kms-config similar to [ceph-csi-encryption-kms-config](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml) will be added.
+- A new ConfigMap named ceph-csi-creds-kms-config similar to
+  [ceph-csi-encryption-kms-config](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml)
+  will be added.
 
 ```yaml
 apiVersion: v1
@@ -59,10 +86,13 @@ metadata:
     name: ceph-csi-creds-kms-config
 ```
 
-* For KMS that rely on Tenant namespace, a new optional field name "tenantNamespace" is added in addition to existing KMS config.
-If "tenantNamespace" is not provided, Ceph-CSI namespace will be used to lookup required ServiceAccount, ConfigMap or Secrets.
+- For KMS that rely on Tenant namespace, a new optional field name "tenantNamespace"
+  is added in addition to existing KMS config.
+  If "tenantNamespace" is not provided, Ceph-CSI namespace will be used to lookup
+  required ServiceAccount, ConfigMap or Secrets.
 
 **Example KMS config:**
+
 ```json
     "vault-tenant-sa-test": {
         "credsKMSType": "vaulttenantsa",
@@ -77,13 +107,40 @@ If "tenantNamespace" is not provided, Ceph-CSI namespace will be used to lookup 
         "tenantNamespace": "any-tenant"
     }
 ```
-* Credential KMS config wouldn’t support nested "tenant" config that is provided in the "tenant" field,
-i.e. each tenant is expected to have their own entry in the KMS ConfigMap.
 
-## Code Changes:
-* New interface named CredStore will be introduced
+- Credential KMS config wouldn’t support nested tenant config
+  provided using the `tenant` field,
+  which implies each tenant is expected to have their own entry in the KMS ConfigMap.
 
-```code
+### Backward Compatibility
+
+KMS integration will only be enabled when `ceph-csi-creds-kms-config` ConfigMap exists
+and secrets contain the `kmsID` key. In case where secrets contain
+both `kmsID` and `userKey`
+the keyring provided secrets will be used for creating the credential object.
+
+### Integration with Rook
+
+Rook integration for KMS support for credentials would be similar
+PVC encryption.
+A new option `CSI_ENABLE_KMS_CREDS` will be added to Rook operator.
+When it is set to `true`, Rook will create
+Ceph-CSI Deployments and DaemonSets that mount the Creds KMS ConfigMap.
+
+At the time of writing this proposal, Rook only
+supports storing Ceph keyring as secrets.
+This [issue](https://github.com/rook/rook/issues/6374)
+tracks adding support for storing
+all Rook secrets in Vault. Till there is progress on this ticket,
+it is assumed that an external script will be
+responsible for creating the Ceph user and putting the keyring
+in a KMS. Rook will only deploy Ceph-CSI with correct config.
+
+## Code Changes
+
+- New interface named CredStore will be introduced
+
+```go
 // CredStore allows KMS instances to implement a modular backend for Creds
 // storage.
 type CredStore interface {
@@ -92,5 +149,5 @@ type CredStore interface {
 }
 ```
 
-* Provider Initializers will be refactored, if required,
-to accommodate both volume encryption and credential storage requirement.
+- Provider Initializers will be refactored, if required,
+  to accommodate both volume encryption and credential storage requirement.

--- a/docs/design/proposals/creds-from-kms.md
+++ b/docs/design/proposals/creds-from-kms.md
@@ -1,0 +1,96 @@
+# Fetching Ceph user credentials from KMS
+
+## Proposal:
+Ceph-CSI supports several KMS implementations for storing and
+fetching DEKs (Data Encryption Keys) to support encryption of RBD volumes.
+Focus of this proposal is to extend the existing KMS implementation to fetch
+Ceph User credentials used for creating, deleting, mapping and resizing RBD volumes.
+
+## Background:
+
+### Credentials Management:
+
+Ceph-CSI relies on K8s CSI components for fetching Ceph user credentials.
+K8s CSI uses the following reserved StorageClass parameters for fetching
+credentials and passes them to Ceph-CSI.
+
+```yaml
+csi.storage.k8s.io/controller-expand-secret-name
+csi.storage.k8s.io/controller-expand-secret-namespace
+csi.storage.k8s.io/provisioner-secret-name
+csi.storage.k8s.io/provisioner-secret-namespace
+csi.storage.k8s.io/node-stage-secret-name
+csi.storage.k8s.io/node-stage-secret-namespace
+```
+
+### KMS Implementation:
+Ceph-CSI utilizes the encryptionKMSID StorageClass parameter and corresponding config
+entry in KMS ConfigMap (eg. [ceph-csi-encryption-kms-config](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml)) to integrate with the KMS.
+
+## Extending existing implementation:
+
+> ### Deviation from existing approach:
+> * *StorageClass* parameters cannot be used for credentials as
+> they are not passed in all CSI requests e.g DeleteVolumeRequest.
+> * Similarly, using K8s namespace as tenant name for KMS wouldn’t
+> be possible as this information not included as part of all CSI requests.
+
+* KMS ID is expected to be present as part of provisioner, node-stage, controller-expand secrets, along with Ceph userID.
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-rbd-provisioner
+stringData:
+  userID: <ceph-user-id>
+  kmsID: <kms-id>
+ ```
+
+
+* A new ConfigMap named ceph-csi-creds-kms-config similar to [ceph-csi-encryption-kms-config](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml) will be added.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+data:
+    config.json: |-
+        {<kms-id>: <config>}
+metadata:
+    name: ceph-csi-creds-kms-config
+```
+
+* For KMS that rely on Tenant namespace, a new optional field name "tenantNamespace" is added in addition to existing KMS config.
+If "tenantNamespace" is not provided, Ceph-CSI namespace will be used to lookup required ServiceAccount, ConfigMap or Secrets.
+
+**Example KMS config:**
+```json
+    "vault-tenant-sa-test": {
+        "credsKMSType": "vaulttenantsa",
+        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackend": "kv-v2",
+        "vaultBackendPath": "shared-secrets",
+        "vaultDestroyKeys": "false",
+        "vaultTLSServerName": "vault.default.svc.cluster.local",
+        "vaultCAVerify": "false",
+        "tenantConfigName": "ceph-csi-kms-config",
+        "tenantSAName": "ceph-csi-vault-sa",
+        "tenantNamespace": "any-tenant"
+    }
+```
+* Credential KMS config wouldn’t support nested "tenant" config that is provided in the "tenant" field,
+i.e. each tenant is expected to have their own entry in the KMS ConfigMap.
+
+## Code Changes:
+* New interface named CredStore will be introduced
+
+```code
+// CredStore allows KMS instances to implement a modular backend for Creds
+// storage.
+type CredStore interface {
+    // FetchCreds reads the Creds from the configured store
+    FetchCreds(userID string) (map[string]string, error)
+}
+```
+
+* Provider Initializers will be refactored, if required,
+to accommodate both volume encryption and credential storage requirement.

--- a/docs/design/proposals/creds-from-kms.md
+++ b/docs/design/proposals/creds-from-kms.md
@@ -25,36 +25,12 @@ Ceph User credentials used for creating, deleting, mapping and resizing RBD volu
 Adds additional overhead as on each CSI RPC call
 a request is made to KMS for fetching credentials.
 
-## Background
-
-### Credentials Management
-
-Ceph-CSI relies on K8s CSI components for obtaining the Ceph user credentials.
-K8s CSI uses the following reserved StorageClass parameters for fetching
-credentials and passes them to Ceph-CSI RPC calls.
-
-```yaml
-csi.storage.k8s.io/controller-expand-secret-name
-csi.storage.k8s.io/controller-expand-secret-namespace
-csi.storage.k8s.io/provisioner-secret-name
-csi.storage.k8s.io/provisioner-secret-namespace
-csi.storage.k8s.io/node-stage-secret-name
-csi.storage.k8s.io/node-stage-secret-namespace
-```
-
-### KMS Implementation
-
-Ceph-CSI utilizes the `encryptionKMSID` StorageClass parameter and
-corresponding config entry in KMS ConfigMap
-(eg. [ceph-csi-encryption-kms-config](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml))
-to integrate with the KMS.
-
 ## Extending existing implementation
 
 > ### Deviation from existing approach
 >
 > - *StorageClass* parameters, such as `encryptionKMSID`,
-> cannot be used for credentials as
+> cannot be used in case of credentials as
 > they are not passed in all CSI requests e.g. DeleteVolumeRequest.
 > - Similarly, using K8s namespace as tenant name for KMS wouldn’t
 > be possible as this information not included as part of all CSI requests.

--- a/docs/design/proposals/creds-from-kms.md
+++ b/docs/design/proposals/creds-from-kms.md
@@ -118,3 +118,14 @@ type CredStore interface {
 
 - Provider Initializers will be refactored, if required,
   to accommodate both volume encryption and credential storage requirement.
+
+- An in-memory cache of `Credentials` will be maintained on the Ceph-CSI daemons.
+  Credentials will be fetched from KMS only when there is a cache miss,
+  or when Ceph auth fails, probably due to outdated cached credentials.
+  Caching credentials majorly solves two problems;
+  (a) risk of hitting the KMS rate limit
+  (b) reduces the performance impact caused due repeated KMS GET
+  queries in the critical path of volume requests.
+
+- The credentials cache entries will be deleted when the Ceph-CSI daemon fails
+  to connect to Ceph or KMS due to connection/auth issues.


### PR DESCRIPTION
Add proposal to support fetching Ceph credentials from KMS

Signed-off-by: Prashanth Dintyala <vdintyala@nvidia.com>

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Ceph-CSI currently relies on K8s secrets for ceph user (provisioner, node-stage, expand-secret)  credentials. Given that ceph-csi already supports managing volume encryption keys through vault and other KMS, it should be possible to extend the existing implementation to fetch Ceph user credentials as well.

This PR has a high level design proposal for this feature. 

Related slack discussion with @Madhu-1  @nixpanic: https://cephcsi.slack.com/archives/CJV6G2DFT/p1662485493014329 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
