### PR TITLE
rbd: ignore extra data in kmip credential secret

### DIFF
--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -313,9 +313,6 @@ func (kms *kmipKMS) getSecrets() (map[string]string, error) {
 		switch k {
 		case kmipClientKey, kmipCLientCert, kmipCACert, kmipUniqueIdentifier:
 			config[k] = string(v)
-		default:
-			return nil, fmt.Errorf("unsupported option for KMS "+
-				"provider %q: %s", kmsTypeKMIP, k)
 		}
 	}
 


### PR DESCRIPTION
This commit removes check for unsupported option
for `kmip` KMS since user may store extra data here and
it does not affect functionality of the feature.

Signed-off-by: Rakshith R <rar@redhat.com>
