### PR TITLE
util: make inode metrics optional in FilesystemNodeGetVolumeStats()

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -637,7 +637,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, false)
 	}
 
 	return nil, status.Errorf(codes.InvalidArgument, "targetpath %q is not a directory or device", targetPath)

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -88,7 +88,7 @@ func TestFilesystemNodeGetVolumeStats(t *testing.T) {
 
 	// retry until a mountpoint is found
 	for {
-		stats, err := FilesystemNodeGetVolumeStats(context.TODO(), mount.New(""), cwd)
+		stats, err := FilesystemNodeGetVolumeStats(context.TODO(), mount.New(""), cwd, true)
 		if err != nil && cwd != "/" && strings.HasSuffix(err.Error(), "is not mounted") {
 			// try again with the parent directory
 			cwd = filepath.Dir(cwd)

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -182,7 +182,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, false)
 	}
 
 	return nil, status.Errorf(codes.InvalidArgument,

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1240,7 +1240,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, true)
 	} else if (stat.Mode() & os.ModeDevice) == os.ModeDevice {
 		return blockNodeGetVolumeStats(ctx, targetPath)
 	}


### PR DESCRIPTION
CephFS does not have a concept of "free inodes", inodes get allocated on-demand in the filesystem.

This confuses alerting managers that expect a (high) number of free inodes, and warnings get produced if the number of free inodes is not high enough. This causes alerts to always get reported for CephFS.

To prevent the false-positive alerts from happening, the NodeGetVolumeStats procedure for CephFS (and CephNFS) will not contain inodes in the reply anymore.

See-also: https://bugzilla.redhat.com/2128263

## Manually Tested

```
I1006 13:03:58.475803       1 utils.go:195] ID: 43 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I1006 13:03:58.475860       1 utils.go:206] ID: 43 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-f2ac6808-4576-11ed-afe6-0a580a830013","volume_path":"/var/lib/kubelet/pods/b7ef5a15-3894-487e-a835-3df7975bb3a2/volumes/kubernetes.io~csi/pvc-8e112fb2-b642-4d81-8d00-97302d9a0880/mount"}
I1006 13:03:58.476407       1 utils.go:212] ID: 43 GRPC response: {"usage":[{"available":1073741824,"total":1073741824,"unit":1}]}
```

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
