### PR TITLE
ci: use VM_DRIVER=podman for AWS virtual-machines

### DIFF
--- a/podman2minikube.sh
+++ b/podman2minikube.sh
@@ -7,6 +7,12 @@
 # well.
 #
 
+# no need to ssh-copy images if there is no VM
+if [[ "${VM_DRIVER}" == "none" ]] || [[ "${VM_DRIVER}" == "podman" ]]
+then
+    exit 0
+fi
+
 # fail when a command returns an error
 set -e -o pipefail
 


### PR DESCRIPTION
With the CentOS CI machines moving to AWS EC2 virtual-machines, there is no option to run minikube with a VM anymore. Instead, run minikube with the Podman driver and partition the extra xvdb EBS volume into three pieces.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
