### PR TITLE
ci: add support for VM_DRIVER=podman to scripts/minikube.sh

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -39,6 +39,7 @@ func init() {
 	flag.BoolVar(&deployNFS, "deploy-nfs", false, "deploy nfs csi driver")
 	flag.BoolVar(&testCephFS, "test-cephfs", true, "test cephFS csi driver")
 	flag.BoolVar(&testRBD, "test-rbd", true, "test rbd csi driver")
+	flag.BoolVar(&testNBD, "test-nbd", false, "test rbd csi driver with rbd-nbd mounter")
 	flag.BoolVar(&testNFS, "test-nfs", false, "test nfs csi driver")
 	flag.BoolVar(&helmTest, "helm-test", false, "tests running on deployment via helm")
 	flag.BoolVar(&upgradeTesting, "upgrade-testing", false, "perform upgrade testing")

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1047,6 +1047,12 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("create a PVC and bind it to an app using rbd-nbd mounter", func() {
+				if !testNBD {
+					e2elog.Logf("skipping NBD test")
+
+					return
+				}
+
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass: %v", err)
@@ -1083,6 +1089,12 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("Resize rbd-nbd PVC and check application directory size", func() {
+				if !testNBD {
+					e2elog.Logf("skipping NBD test")
+
+					return
+				}
+
 				if util.CheckKernelSupport(kernelRelease, nbdResizeSupport) {
 					err := deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
@@ -1290,6 +1302,12 @@ var _ = Describe("RBD", func() {
 
 			By("create PVC with journaling,fast-diff image-features and bind it to an app using rbd-nbd mounter",
 				func() {
+					if !testNBD {
+						e2elog.Logf("skipping NBD test")
+
+						return
+					}
+
 					if util.CheckKernelSupport(kernelRelease, fastDiffSupport) {
 						err := deleteResource(rbdExamplePath + "storageclass.yaml")
 						if err != nil {
@@ -1330,6 +1348,12 @@ var _ = Describe("RBD", func() {
 			// NOTE: RWX is restricted for FileSystem VolumeMode at ceph-csi,
 			// see pull#261 for more details.
 			By("Create RWX+Block Mode PVC and bind to multiple pods via deployment using rbd-nbd mounter", func() {
+				if !testNBD {
+					e2elog.Logf("skipping NBD test")
+
+					return
+				}
+
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass: %v", err)
@@ -1415,6 +1439,12 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("Create ROX+FS Mode PVC and bind to multiple pods via deployment using rbd-nbd mounter", func() {
+				if !testNBD {
+					e2elog.Logf("skipping NBD test")
+
+					return
+				}
+
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass: %v", err)
@@ -1540,6 +1570,12 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("Create ROX+Block Mode PVC and bind to multiple pods via deployment using rbd-nbd mounter", func() {
+				if !testNBD {
+					e2elog.Logf("skipping NBD test")
+
+					return
+				}
+
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass: %v", err)
@@ -1666,6 +1702,12 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("perform IO on rbd-nbd volume after nodeplugin restart", func() {
+				if !testNBD {
+					e2elog.Logf("skipping NBD test")
+
+					return
+				}
+
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass: %v", err)
@@ -1830,6 +1872,12 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("create a PVC and bind it to an app using rbd-nbd mounter with encryption", func() {
+				if !testNBD {
+					e2elog.Logf("skipping NBD test")
+
+					return
+				}
+
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {
 					e2elog.Failf("failed to delete storageclass: %v", err)
@@ -2199,6 +2247,12 @@ var _ = Describe("RBD", func() {
 			By(
 				"create a PVC and Bind it to an app with journaling/exclusive-lock image-features and rbd-nbd mounter",
 				func() {
+					if !testNBD {
+						e2elog.Logf("skipping NBD test")
+
+						return
+					}
+
 					err := deleteResource(rbdExamplePath + "storageclass.yaml")
 					if err != nil {
 						e2elog.Failf("failed to delete storageclass: %v", err)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -85,6 +85,7 @@ var (
 	deployNFS        bool
 	testCephFS       bool
 	testRBD          bool
+	testNBD          bool
 	testNFS          bool
 	helmTest         bool
 	upgradeTesting   bool

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -136,7 +136,7 @@ install() {
         mkdir -p ${TEMP}
         # shellcheck disable=SC2021
         dist=$(echo "${dist}" | tr "[A-Z]" "[a-z]")
-        wget "https://get.helm.sh/helm-${HELM_VERSION}-${dist}-${arch}.tar.gz" -O "${TEMP}/helm.tar.gz"
+        wget "https://get.helm.sh/helm-${HELM_VERSION}-${dist}-${arch}.tar.gz" -O "${TEMP}/helm.tar.gz" || exit 1
         tar -C "${TEMP}" -zxvf "${TEMP}/helm.tar.gz"
     fi
     echo "Helm install successful"


### PR DESCRIPTION
When running on AWE EC2 virtual-machines, we'll use Podman instead of installing a VM. The "none" driver might work as well, but it requires additional dependencies to be installed, which may change over time with new minikube or Kubernetes releases. Hopefully the Podman driver is less affected with changes in dependencies.

Depends-on: #3419
Closes: #3415

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
