### PR TITLE
rbd: setup encryption if rbdVol exits during CreateVol

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -508,6 +508,15 @@ func (cs *ControllerServer) repairExistingVolume(ctx context.Context, req *csi.C
 
 			return nil, err
 		}
+
+	default:
+		// setup encryption again to make sure everything is in place.
+		if rbdVol.isBlockEncrypted() {
+			err := rbdVol.setupBlockEncryption(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to setup encryption for image %s: %w", rbdVol, err)
+			}
+		}
 	}
 
 	// Set metadata on restart of provisioner pod when image exist


### PR DESCRIPTION
This commit adds code to setup encryption on a rbdVol being repaired in a followup CreateVolume request. This is fixes a bug wherein encryption metadata may not have been set in previous request due to container restart.

Fixes: #3402

Signed-off-by: Rakshith R <rar@redhat.com>

