### PR TITLE
cephfs: use errors.As instead of errors.Is

### DIFF
--- a/internal/cephfs/core/metadata.go
+++ b/internal/cephfs/core/metadata.go
@@ -40,7 +40,7 @@ func (s *subVolumeClient) supportsSubVolMetadata() bool {
 
 func (s *subVolumeClient) isUnsupportedSubVolMetadata(err error) bool {
 	var invalid fsAdmin.NotImplementedError
-	if err != nil && errors.Is(err, &invalid) {
+	if err != nil && errors.As(err, &invalid) {
 		// In case the error is other than invalid command return error to the caller.
 		clusterAdditionalInfo[s.clusterID].subVolMetadataState = unsupported
 

--- a/internal/cephfs/core/snapshot_metadata.go
+++ b/internal/cephfs/core/snapshot_metadata.go
@@ -36,7 +36,7 @@ func (s *snapshotClient) supportsSubVolSnapMetadata() bool {
 
 func (s *snapshotClient) isUnsupportedSubVolSnapMetadata(err error) bool {
 	var invalid fsAdmin.NotImplementedError
-	if err != nil && errors.Is(err, &invalid) {
+	if err != nil && errors.As(err, &invalid) {
 		// In case the error is other than invalid command return error to
 		// the caller.
 		clusterAdditionalInfo[s.clusterID].subVolSnapshotMetadataState = unsupported


### PR DESCRIPTION
As we need to compare the error type instead of the error value we need to use errors.As to check the API is implemented or not.

fixes: #3347

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

* Without Fix
```
[🎩︎]mrajanna@fedora rook $]kuberc exec -it rook-ceph-tools-756db8d758-ft9rk -- sh
sh-4.4$ ceph -s
  cluster:
    id:     92444639-ab47-44ff-9074-2f53256b30ce
    health: HEALTH_OK
 
  services:
    mon: 1 daemons, quorum a (age 85s)
    mgr: a(active, since 52s)
    mds: 1/1 daemons up, 1 hot standby
    osd: 1 osds: 1 up (since 26s), 1 in (since 5m)
 
  data:
    volumes: 1/1 healthy
    pools:   4 pools, 97 pgs
    objects: 22 objects, 3.2 KiB
    usage:   6.4 MiB used, 32 GiB / 32 GiB avail
    pgs:     97 active+clean
 
  io:
    client:   1.2 KiB/s rd, 2 op/s rd, 0 op/s wr
 
sh-4.4$ ceph version
ceph version 16.2.9 (4c3647a322c0ff5a1dd2344e039859dcbd28c830) pacific (stable)

```

```
provision volume with StorageClass "rook-cephfs": rpc error: code = Internal desc = failed to set metadata key "csi.storage.k8s.io/pv/name", value "pvc-a5e2a524-a501-4aca-9e51-b726019b81ae" on subvolume &{0xc000acde40 rook-ceph  true 0xc00072d548}: API call not implemented server-side: No handler found for 'fs subvolume metadata set'
  Normal   Provisioning          3s (x4 over 7s)   rook-ceph.cephfs.csi.ceph.com_csi-cephfsplugin-provisioner-5fbcfb6d8-68m22_3297bad2-47a1-48fc-a02f-0ca80dd57174  External provisioner is provisioning volume for claim "default/cephfs-pvc"
  Warning  ProvisioningFailed    3s                rook-ceph.cephfs.csi.ceph.com_csi-cephfsplugin-provisioner-5fbcfb6d8-68m22_3297bad2-47a1-48fc-a02f-0ca80dd57174  failed to provision volume with StorageClass "rook-cephfs": rpc error: code = Internal desc = failed to set metadata key "csi.storage.k8s.io/pvc/name", value "cephfs-pvc" on subvolume &{0xc000824420 rook-ceph  true 0xc00072da88}: API call not implemented server-side: No handler found for 'fs subvolume metadata set'
```

* With Fix
```
I1011 11:47:40.730663       1 controller.go:1337] provision "default/cephfs-pvc" class "rook-cephfs": started
I1011 11:47:40.730817       1 controller.go:860] Started provisioner controller rook-ceph.cephfs.csi.ceph.com_csi-cephfsplugin-provisioner-7c8f948949-g2h2v_96282b4c-65d0-480e-8a3b-e584feba0d79!
I1011 11:47:40.732176       1 event.go:285] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"cephfs-pvc", UID:"cd765818-1c7b-4525-bde5-ab02b6275e61", APIVersion:"v1", ResourceVersion:"4435", FieldPath:""}): type: 'Normal' reason: 'Provisioning' External provisioner is provisioning volume for claim "default/cephfs-pvc"
I1011 11:47:40.831321       1 controller.go:1442] provision "default/cephfs-pvc" class "rook-cephfs": volume "pvc-cd765818-1c7b-4525-bde5-ab02b6275e61" provisioned
I1011 11:47:40.831359       1 controller.go:1455] provision "default/cephfs-pvc" class "rook-cephfs": succeeded
I1011 11:47:40.836989       1 event.go:285] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"cephfs-pvc", UID:"cd765818-1c7b-4525-bde5-ab02b6275e61", APIVersion:"v1", ResourceVersion:"4435", FieldPath:""}): type: 'Normal' reason: 'ProvisioningSucceeded' Successfully provisioned volume pvc-cd765818-1c7b-4525-bde5-ab02b6275e61
[🎩︎]mrajanna@fedora rook $]kubectl get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
cephfs-pvc   Bound    pvc-cd765818-1c7b-4525-bde5-ab02b6275e61   1Gi        RWO            rook-cephfs    119s

```