### PR TITLE
doc: remove nfs daemonset deletion

### DIFF
--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -33,7 +33,6 @@
       - [6. Upgrade NFS Nodeplugin resources](#6-upgrade-nfs-nodeplugin-resources)
         - [6.1 Update the NFS Nodeplugin RBAC](#61-update-the-nfs-nodeplugin-rbac)
         - [6.2 Update the NFS Nodeplugin daemonset](#62-update-the-nfs-nodeplugin-daemonset)
-        - [6.3 Delete the old NFS Nodeplugin daemonset](#63-delete-the-old-nfs-nodeplugin-daemonset)
     - [CSI Sidecar containers consideration](#csi-sidecar-containers-consideration)
 
 ## Pre-upgrade considerations
@@ -390,13 +389,6 @@ serviceaccount/nfs-csi-nodeplugin configured
 $ kubectl apply -f deploy/nfs/kubernetes/csi-nfsplugin.yaml
 daemonset.apps/csi-nfsplugin configured
 service/csi-metrics-nfsplugin configured
-```
-
-##### 6.3 Delete the old NFS Nodeplugin daemonset
-
-```bash
-$ kubectl delete daemonsets.apps csi-nfs-node
-daemonset.apps "csi-nfs-node" deleted
 ```
 
 we have successfully upgraded nfs csi from v3.6 to v3.7


### PR DESCRIPTION
As we dont need to delete the nfs daemonset which was present in 3.6.x release in 3.8.x release as user will upgrade from 3.6.x to 3.7.x and delete the nfs daemonset.

fixes #3324

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

