### PR TITLE
ci: copy images into minikube container when `VM_DRIVER=podman`

### DIFF
--- a/podman2minikube.sh
+++ b/podman2minikube.sh
@@ -7,8 +7,8 @@
 # well.
 #
 
-# no need to ssh-copy images if there is no VM
-if [[ "${VM_DRIVER}" == "none" ]] || [[ "${VM_DRIVER}" == "podman" ]]
+# no need to ssh-copy images if everything runs local
+if [[ "${VM_DRIVER}" == "none" ]]
 then
     exit 0
 fi


### PR DESCRIPTION
Even when minikube is running with `--driver=podman`, `minikube ssh` works and container images can be copied into the minikube container.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
