### PR TITLE
ci: include `journalctl --boot` from the host in system status

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -22,6 +22,9 @@ function log() {
     echo "###" >/dev/stderr
 }
 
+# get the logs from the host
+log journalctl --boot
+
 # get the status of the VM in libvirt
 log virsh list
 


### PR DESCRIPTION
Now that we run with Podman, the journal from the container that was started by minikube is not very useful. In addition to the journal from the minikube container or VM, include the journal from the host.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
