### PR TITLE
ci: install `wget` for downloading Helm

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -78,7 +78,7 @@ done
 
 set -x
 
-dnf -y install git podman make
+dnf -y install git podman make wget
 
 # minikube wants the user (everything runs as root) to be in the libvirt group
 getent group libvirt || groupadd --system libvirt


### PR DESCRIPTION
Installing Helm fails if `wget` is not available. The script that installs Helm does not seem to abort though.

By installing `wget` in preparation for deploying with Helm, the CI jobs should get ready to run successfully.

Failures look like the following:

![image](https://user-images.githubusercontent.com/400257/195396195-97b4c9f3-3b82-4d83-9348-cfe27d3dc613.png)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
