### PR TITLE
nfs: add support for `secTypes` parameter in StorageClass

### DIFF
--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -408,7 +408,24 @@ var _ = Describe("nfs", func() {
 			})
 
 			By("create a storageclass with pool and a PVC then bind it to an app", func() {
-				err := createNFSStorageClass(f.ClientSet, f, false, nil)
+				err := createNFSStorageClass(f.ClientSet, f, true, nil)
+				if err != nil {
+					framework.Failf("failed to create NFS storageclass: %v", err)
+				}
+				err = validatePVCAndAppBinding(pvcPath, appPath, f)
+				if err != nil {
+					framework.Failf("failed to validate NFS pvc and application binding: %v", err)
+				}
+				err = deleteResource(nfsExamplePath + "storageclass.yaml")
+				if err != nil {
+					framework.Failf("failed to delete NFS storageclass: %v", err)
+				}
+			})
+
+			By("create a storageclass with sys,krb5i security and a PVC then bind it to an app", func() {
+				err := createNFSStorageClass(f.ClientSet, f, false, map[string]string{
+					"secTypes": "sys,krb5i",
+				})
 				if err != nil {
 					framework.Failf("failed to create NFS storageclass: %v", err)
 				}

--- a/examples/nfs/storageclass.yaml
+++ b/examples/nfs/storageclass.yaml
@@ -45,5 +45,11 @@ parameters:
   # If omitted, defaults to "csi-vol-".
   volumeNamePrefix: nfs-export-
 
+  # (optional) Security requirements for the NFS-export. Valid flavours
+  # include: none, sys, krb5, krb5i and krb5p. The <sectype-list> is a comma
+  # delimited string, for example "sys,krb5".
+  # This option is available with Ceph v17.2.6 and newer.
+  # secTypes: <sectype-list>
+
 reclaimPolicy: Delete
 allowVolumeExpansion: true


### PR DESCRIPTION
CephNFS can enable different security flavours for exported volumes.
This can be configured in the optional `secTypes` parameter in the
StorageClass.

Depends-on: ceph/ceph#48531
Related: rook/rook#11869
Closes: #3387

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
