### PR TITLE
cephfs: delete subvolume if SetAllMetadata fails

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -409,6 +409,11 @@ func (cs *ControllerServer) CreateVolume(
 		// Set Metadata on PV Create
 		err = volClient.SetAllMetadata(metadata)
 		if err != nil {
+			purgeErr := volClient.PurgeVolume(ctx, true)
+			if purgeErr != nil {
+				log.ErrorLog(ctx, "failed to delete volume %s: %v", vID.FsSubvolName, purgeErr)
+			}
+
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}


### PR DESCRIPTION
To avoid subvolume leaks if the SetAllMetadata operations fails delete the subvolume.
If any operation fails after creating the subvolume we will remove the omap as the omap gets removed we will need to remove the subvolume to avoid stale resources.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

