### PR TITLE
rbd: Fix volume leak if metadata operation fails

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -384,6 +384,10 @@ func (cs *ControllerServer) CreateVolume(
 	metadata := k8s.GetVolumeMetadata(req.GetParameters())
 	err = rbdVol.setAllMetadata(metadata)
 	if err != nil {
+		if deleteErr := rbdVol.deleteImage(ctx); deleteErr != nil {
+			log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", rbdVol, deleteErr)
+		}
+
 		return nil, err
 	}
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -388,7 +388,7 @@ func (cs *ControllerServer) CreateVolume(
 			log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v", rbdVol, deleteErr)
 		}
 
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	return buildCreateVolumeResponse(req, rbdVol), nil


### PR DESCRIPTION
If any operations fails after the volume creation we will cleanup the omap objects, but it is missing if setAllMetadata fails. This commits adds the code to cleanup the rbd image if metadata operation fails.

The error message return from the GRPC should be of GRPC error messages only not the normal go errors. This commits returns GRPC error if setAllMetadata fails.
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>