### PR TITLE
e2e: generate unique name for PVC

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -342,6 +342,7 @@ var _ = Describe(cephfsType, func() {
 					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				baseAppName := app.Name
 
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
@@ -706,7 +707,7 @@ var _ = Describe(cephfsType, func() {
 				app.Namespace = f.UniqueName
 				// create PVC and app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					err = createPVCAndApp(name, f, pvc, app, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to create PVC or application: %v", err)
@@ -721,7 +722,7 @@ var _ = Describe(cephfsType, func() {
 				validateOmapCount(f, totalCount, cephfsType, metadataPool, volumesType)
 				// delete PVC and app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					err = deletePVCAndApp(name, f, pvc, app)
 					if err != nil {
 						e2elog.Failf("failed to delete PVC or application: %v", err)
@@ -1178,6 +1179,7 @@ var _ = Describe(cephfsType, func() {
 
 				pvcClone.Namespace = f.UniqueName
 				appClone.Namespace = f.UniqueName
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				pvcClone.Spec.DataSource.Name = snap.Name
 
 				// create PVC from the snapshot
@@ -1252,7 +1254,7 @@ var _ = Describe(cephfsType, func() {
 				// create snapshot
 				for i := 0; i < totalCount; i++ {
 					go func(n int, s snapapi.VolumeSnapshot) {
-						s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+						s.Name = fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = createSnapshot(&s, deployTimeout)
 						wg.Done()
 					}(i, snap)
@@ -1281,13 +1283,13 @@ var _ = Describe(cephfsType, func() {
 				}
 				pvcClone.Namespace = f.UniqueName
 				appClone.Namespace = f.UniqueName
-				pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s%d", f.UniqueName, 0)
+				pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s-%d", f.UniqueName, 0)
 
 				// create multiple PVC from same snapshot
 				wg.Add(totalCount)
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
 						if wgErrs[n] == nil {
 							err = validateSubvolumePath(f, p.Name, p.Namespace, fileSystemName, subvolumegroup)
@@ -1319,7 +1321,7 @@ var _ = Describe(cephfsType, func() {
 				// delete clone and app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
 						wg.Done()
@@ -1347,7 +1349,7 @@ var _ = Describe(cephfsType, func() {
 				wg.Add(totalCount)
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
 						if wgErrs[n] == nil {
@@ -1380,7 +1382,7 @@ var _ = Describe(cephfsType, func() {
 				// delete snapshot
 				for i := 0; i < totalCount; i++ {
 					go func(n int, s snapapi.VolumeSnapshot) {
-						s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+						s.Name = fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = deleteSnapshot(&s, deployTimeout)
 						wg.Done()
 					}(i, snap)
@@ -1402,7 +1404,7 @@ var _ = Describe(cephfsType, func() {
 				// delete clone and app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
 						wg.Done()
@@ -1524,6 +1526,7 @@ var _ = Describe(cephfsType, func() {
 				}
 				pvcClone.Namespace = f.UniqueName
 				appClone.Namespace = f.UniqueName
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and app: %v", err)
@@ -1620,7 +1623,7 @@ var _ = Describe(cephfsType, func() {
 				// create clone and bind it to an app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
 						wg.Done()
 					}(i, *pvcClone, *appClone)
@@ -1652,7 +1655,7 @@ var _ = Describe(cephfsType, func() {
 				// delete clone and app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
 						wg.Done()

--- a/e2e/clone.go
+++ b/e2e/clone.go
@@ -50,6 +50,7 @@ func validateBiggerCloneFromPVC(f *framework.Framework,
 	label[appKey] = appLabel
 	app.Namespace = f.UniqueName
 	app.Labels = label
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 	opt := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
 	}
@@ -71,6 +72,7 @@ func validateBiggerCloneFromPVC(f *framework.Framework,
 	}
 	appClone.Namespace = f.UniqueName
 	appClone.Labels = label
+	appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 	err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to create pvc clone and application: %w", err)

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -453,7 +453,7 @@ var _ = Describe("nfs", func() {
 				app.Namespace = f.UniqueName
 				// create PVC and app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					err = createPVCAndApp(name, f, pvc, app, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to create PVC or application: %v", err)
@@ -467,7 +467,7 @@ var _ = Describe("nfs", func() {
 				validateSubvolumeCount(f, totalCount, fileSystemName, defaultSubvolumegroup)
 				// delete PVC and app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					err = deletePVCAndApp(name, f, pvc, app)
 					if err != nil {
 						e2elog.Failf("failed to delete PVC or application: %v", err)
@@ -620,7 +620,7 @@ var _ = Describe("nfs", func() {
 				// create snapshot
 				for i := 0; i < totalCount; i++ {
 					go func(n int, s snapapi.VolumeSnapshot) {
-						s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+						s.Name = fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = createSnapshot(&s, deployTimeout)
 						wg.Done()
 					}(i, snap)
@@ -649,14 +649,14 @@ var _ = Describe("nfs", func() {
 				}
 				pvcClone.Namespace = f.UniqueName
 				appClone.Namespace = f.UniqueName
-				pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s%d", f.UniqueName, 0)
+				pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s-%d", f.UniqueName, 0)
 				appClone.Labels = label
 
 				// create multiple PVC from same snapshot
 				wg.Add(totalCount)
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
 						if wgErrs[n] == nil {
 							err = validateSubvolumePath(f, p.Name, p.Namespace, fileSystemName, subvolumegroup)
@@ -710,7 +710,7 @@ var _ = Describe("nfs", func() {
 				// delete clone and app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
 						wg.Done()
@@ -737,7 +737,7 @@ var _ = Describe("nfs", func() {
 				wg.Add(totalCount)
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
 						if wgErrs[n] == nil {
@@ -792,7 +792,7 @@ var _ = Describe("nfs", func() {
 				// delete snapshot
 				for i := 0; i < totalCount; i++ {
 					go func(n int, s snapapi.VolumeSnapshot) {
-						s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+						s.Name = fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = deleteSnapshot(&s, deployTimeout)
 						wg.Done()
 					}(i, snap)
@@ -814,7 +814,7 @@ var _ = Describe("nfs", func() {
 				// delete clone and app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
 						wg.Done()
@@ -898,7 +898,7 @@ var _ = Describe("nfs", func() {
 				// create clone and bind it to an app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
 						if wgErrs[n] == nil {
 							filePath := a.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
@@ -954,7 +954,7 @@ var _ = Describe("nfs", func() {
 				// delete clone and app
 				for i := 0; i < totalCount; i++ {
 					go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-						name := fmt.Sprintf("%s%d", f.UniqueName, n)
+						name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 						p.Spec.DataSource.Name = name
 						wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
 						wg.Done()

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -520,7 +520,7 @@ func validateRWOPPodCreation(
 ) error {
 	var err error
 	// create one more  app with same PVC
-	name := fmt.Sprintf("%s%d", f.UniqueName, deployTimeout)
+	name := fmt.Sprintf("%s-%d", f.UniqueName, deployTimeout)
 	app.Name = name
 
 	err = createAppErr(f.ClientSet, app, deployTimeout, errRWOPConflict)

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,8 @@ func loadPVC(path string) (*v1.PersistentVolumeClaim, error) {
 	if err != nil {
 		return nil, err
 	}
+	// add new name for the pvc
+	pvc.Name = fmt.Sprintf("pvc-%s", uuid.NewString()[:16])
 
 	return pvc, err
 }

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1218,6 +1218,7 @@ var _ = Describe("RBD", func() {
 							e2elog.Failf("failed to load application: %v", aErr)
 						}
 						app.Namespace = f.UniqueName
+						app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 						err = createApp(f.ClientSet, app, deployTimeout)
 						if err != nil {
 							e2elog.Failf("failed to create application: %v", err)
@@ -1279,6 +1280,7 @@ var _ = Describe("RBD", func() {
 							e2elog.Failf("failed to load application: %v", aErr)
 						}
 						app.Namespace = f.UniqueName
+						app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 						err = createApp(f.ClientSet, app, deployTimeout)
 						if err != nil {
 							e2elog.Failf("failed to create application: %v", err)
@@ -1385,6 +1387,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to load application deployment: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 
 				err = createPVCAndDeploymentApp(f, pvc, app, deployTimeout)
 				if err != nil {
@@ -1476,6 +1479,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
@@ -1607,6 +1611,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
@@ -2568,7 +2573,7 @@ var _ = Describe("RBD", func() {
 				app.Namespace = f.UniqueName
 				// create PVC and app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					err := createPVCAndApp(name, f, pvc, app, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to create PVC and application: %v", err)
@@ -2580,7 +2585,7 @@ var _ = Describe("RBD", func() {
 				validateOmapCount(f, totalCount, rbdType, defaultRBDPool, volumesType)
 				// delete PVC and app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					err := deletePVCAndApp(name, f, pvc, app)
 					if err != nil {
 						e2elog.Failf("failed to delete PVC and application: %v", err)
@@ -2654,6 +2659,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to  load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
@@ -2944,6 +2950,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC: %v", err)
@@ -3055,6 +3062,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
@@ -3112,7 +3120,7 @@ var _ = Describe("RBD", func() {
 
 				// create PVC and app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					label := map[string]string{
 						"app": name,
 					}
@@ -3125,7 +3133,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					opt := metav1.ListOptions{
 						LabelSelector: fmt.Sprintf("app=%s", name),
 					}
@@ -3144,7 +3152,7 @@ var _ = Describe("RBD", func() {
 
 				// delete app
 				for i := 0; i < totalCount; i++ {
-					name := fmt.Sprintf("%s%d", f.UniqueName, i)
+					name := fmt.Sprintf("%s-%d", f.UniqueName, i)
 					appClone.Name = name
 					err = deletePod(appClone.Name, appClone.Namespace, f.ClientSet, deployTimeout)
 					if err != nil {
@@ -3195,6 +3203,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)
@@ -3340,6 +3349,7 @@ var _ = Describe("RBD", func() {
 						e2elog.Failf("failed to load application: %v", err)
 					}
 					app.Namespace = f.UniqueName
+					app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 					err = createPVCAndApp("", f, pvc, app, deployTimeout)
 					if err != nil {
 						e2elog.Failf("failed to create PVC and application: %v", err)
@@ -3474,6 +3484,7 @@ var _ = Describe("RBD", func() {
 					e2elog.Failf("failed to load application: %v", err)
 				}
 				app.Namespace = f.UniqueName
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create PVC and application: %v", err)

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -377,7 +377,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	wg.Add(totalCount)
 	for i := 0; i < totalCount; i++ {
 		go func(n int, s snapapi.VolumeSnapshot) {
-			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			s.Name = fmt.Sprintf("%s-%d", f.UniqueName, n)
 			wgErrs[n] = createSnapshot(&s, deployTimeout)
 			wg.Done()
 		}(i, snap)
@@ -411,12 +411,12 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 		pvcClone.Spec.StorageClassName = &cloneSc
 	}
 	appClone.Namespace = f.UniqueName
-	pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s%d", f.UniqueName, 0)
+	pvcClone.Spec.DataSource.Name = fmt.Sprintf("%s-%d", f.UniqueName, 0)
 	// create multiple PVCs from same snapshot
 	wg.Add(totalCount)
 	for i := 0; i < totalCount; i++ {
 		go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 			wgErrs[n] = createPVCAndApp(name, f, &p, &a, deployTimeout)
 			wg.Done()
 		}(i, *pvcClone, *appClone)
@@ -440,7 +440,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	// delete clone and app
 	for i := 0; i < totalCount; i++ {
 		go func(n int, p v1.PersistentVolumeClaim, a v1.Pod) {
-			name := fmt.Sprintf("%s%d", f.UniqueName, n)
+			name := fmt.Sprintf("%s-%d", f.UniqueName, n)
 			p.Spec.DataSource.Name = name
 			wgErrs[n] = deletePVCAndApp(name, f, &p, &a)
 			wg.Done()
@@ -464,7 +464,7 @@ func validateCloneInDifferentPool(f *framework.Framework, snapshotPool, cloneSc,
 	// delete snapshot
 	for i := 0; i < totalCount; i++ {
 		go func(n int, s snapapi.VolumeSnapshot) {
-			s.Name = fmt.Sprintf("%s%d", f.UniqueName, n)
+			s.Name = fmt.Sprintf("%s-%d", f.UniqueName, n)
 			wgErrs[n] = deleteSnapshot(&s, deployTimeout)
 			wg.Done()
 		}(i, snap)

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -108,6 +108,7 @@ func resizePVCAndValidateSize(pvcPath, appPath string, f *framework.Framework) e
 	pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(size)
 	app.Labels = map[string]string{"app": "resize-pvc"}
 	app.Namespace = f.UniqueName
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 
 	err = createPVCAndApp("", f, pvc, app, deployTimeout)
 	if err != nil {

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -319,6 +319,7 @@ func validateBiggerPVCFromSnapshot(f *framework.Framework,
 	}
 	label[appKey] = appLabel
 	app.Namespace = f.UniqueName
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 	app.Labels = label
 	opt := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
@@ -351,6 +352,7 @@ func validateBiggerPVCFromSnapshot(f *framework.Framework,
 		e2elog.Failf("failed to load application: %v", err)
 	}
 	appClone.Namespace = f.UniqueName
+	appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 	appClone.Labels = label
 	err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 	if err != nil {

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -294,6 +294,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				appClone.Namespace = f.UniqueName
 				appClone.Name = "snap-clone-cephfs"
 				appClone.Labels = label
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 				err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create pvc and application: %v", err)
@@ -353,6 +354,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 				appClone.Namespace = f.UniqueName
 				appClone.Name = "appclone"
 				appClone.Labels = label
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 				err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create pvc and application: %v", err)

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -218,6 +218,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				app.Namespace = f.UniqueName
 				app.Labels = label
 				pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse(pvcSize)
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
 				err = createPVCAndApp("", f, pvc, app, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create pvc: %v", err)
@@ -316,6 +317,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				appClone.Namespace = f.UniqueName
 				appClone.Name = "app-clone-from-snap"
 				appClone.Labels = label
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 				err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create pvc: %v", err)
@@ -364,6 +366,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 				appClone.Namespace = f.UniqueName
 				appClone.Name = "appclone"
 				appClone.Labels = label
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
 				err = createPVCAndApp("", f, pvcClone, appClone, deployTimeout)
 				if err != nil {
 					e2elog.Failf("failed to create pvc: %v", err)


### PR DESCRIPTION
generate unique name for PVC and snapshots which helps in debugging E2E test failures.

fixes #2533

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

