### PR TITLE
Cleanup snapshots before removing rbd image

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -652,6 +652,13 @@ func (ri *rbdImage) deleteImage(ctx context.Context) error {
 		return err
 	}
 
+	// Make sure there are no snapshots for the image before removing, otherwise it's stuck in the trash.
+	err = ri.purgeSnapshots(ctx)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to purge image snapshots: %s, error: %v", ri, err)
+		return err
+	}
+
 	rbdImage := librbd.GetImage(ri.ioctx, image)
 	err = rbdImage.Trash(0)
 	if err != nil {
@@ -1440,6 +1447,30 @@ func (ri *rbdImage) deleteSnapshot(ctx context.Context, pOpts *rbdSnapshot) erro
 	}
 
 	return err
+}
+
+func (ri *rbdImage) purgeSnapshots(ctx context.Context) error {
+	rbdSnap := &rbdSnapshot{}
+
+	snaps, err := ri.listSnapshots()
+	if err != nil {
+		log.DebugLog(ctx, "rbd: failed to get list of snapshots %v", err)
+	}
+
+	for _, snap := range snaps {
+		log.DebugLog(ctx, "rbd: found image snapshot %s", snap.Name)
+		rbdSnap.RbdSnapName = snap.Name
+		rbdSnap.Monitors = ri.Monitors
+
+		err = ri.deleteSnapshot(ctx, rbdSnap)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to delete rbd image snapshot: %s, error: %v", ri, err)
+
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (rv *rbdVolume) cloneRbdImageFromSnapshot(


### PR DESCRIPTION
Hello!

# Describe what this PR does #

Ceph csi couldn't remove pvc with snapshots that was created directly in
ceph using rbd or other clients. As a result, the rbd image remains permanently in the trash.
As solution we can cleanup snapshots before removing rbd image.

## Related issues ##

Fixes: #3416
