### PR TITLE
Ceph FS fscrypt support

### DIFF
--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -117,6 +117,12 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi-provisioner.sock
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # - name: KMS_CONFIGMAP_NAME
+          #   value: encryptionConfig
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
@@ -134,6 +140,8 @@ spec:
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
+            - name: ceph-csi-encryption-kms-config
+              mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
           image: quay.io/cephcsi/cephcsi:canary
           args:
@@ -178,3 +186,6 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
+        - name: ceph-csi-encryption-kms-config
+          configMap:
+            name: ceph-csi-encryption-kms-config

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -74,6 +74,12 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # - name: KMS_CONFIGMAP_NAME
+          #   value: encryptionConfig
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
@@ -104,6 +110,8 @@ spec:
               mountPath: /tmp/csi/keys
             - name: ceph-csi-mountinfo
               mountPath: /csi/mountinfo
+            - name: ceph-csi-encryption-kms-config
+              mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
           securityContext:
             privileged: true
@@ -173,6 +181,9 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/cephfs.csi.ceph.com/mountinfo
             type: DirectoryOrCreate
+        - name: ceph-csi-encryption-kms-config
+          configMap:
+            name: ceph-csi-encryption-kms-config
 ---
 # This is a service to expose the liveness metrics
 apiVersion: v1

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
@@ -3,3 +3,46 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cephfs-csi-nodeplugin
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  # allow to read Vault Token and connection options from the Tenants namespace
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin
+subjects:
+  - kind: ServiceAccount
+    name: cephfs-csi-nodeplugin
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cephfs-csi-nodeplugin
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
@@ -11,10 +11,6 @@ metadata:
   name: cephfs-csi-nodeplugin
 rules:
   - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get"]
-  # allow to read Vault Token and connection options from the Tenants namespace
-  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
   - apiGroups: [""]
@@ -23,12 +19,6 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["list", "get"]
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
     verbs: ["create"]

--- a/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cephfs-csi-provisioner
+  namespace: default
 
 ---
 kind: ClusterRole
@@ -11,8 +12,11 @@ metadata:
   name: cephfs-external-provisioner-runner
 rules:
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
@@ -22,6 +26,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
@@ -37,15 +44,21 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims/status"]
-    verbs: ["update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,6 +81,9 @@ metadata:
   namespace: default
   name: cephfs-external-provisioner-cfg
 rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]

--- a/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
@@ -83,7 +83,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -203,6 +203,7 @@ var _ = Describe(cephfsType, func() {
 		if err != nil {
 			e2elog.Failf("failed to create node secret: %v", err)
 		}
+		deployVault(f.ClientSet, deployTimeout)
 
 		// wait for cluster name update in deployment
 		containers := []string{cephFSContainerName}
@@ -248,6 +249,8 @@ var _ = Describe(cephfsType, func() {
 		if err != nil {
 			e2elog.Failf("failed to delete storageclass: %v", err)
 		}
+		deleteVault()
+
 		if deployCephFS {
 			deleteCephfsPlugin()
 			if cephCSINamespace != defaultNs {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -38,6 +38,7 @@ func init() {
 	flag.BoolVar(&deployRBD, "deploy-rbd", true, "deploy rbd csi driver")
 	flag.BoolVar(&deployNFS, "deploy-nfs", false, "deploy nfs csi driver")
 	flag.BoolVar(&testCephFS, "test-cephfs", true, "test cephFS csi driver")
+	flag.BoolVar(&testCephFSFscrypt, "test-cephfs-fscrypt", false, "test CephFS csi driver fscrypt support")
 	flag.BoolVar(&testRBD, "test-rbd", true, "test rbd csi driver")
 	flag.BoolVar(&testRBDFSCrypt, "test-rbd-fscrypt", false, "test rbd csi driver fscrypt support")
 	flag.BoolVar(&testNBD, "test-nbd", false, "test rbd csi driver with rbd-nbd mounter")

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -74,6 +74,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to getwd: %v", err)
 		}
+		deployVault(f.ClientSet, deployTimeout)
 		err = upgradeAndDeployCSI(upgradeVersion, "cephfs")
 		if err != nil {
 			e2elog.Failf("failed to upgrade csi: %v", err)
@@ -150,6 +151,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		if err != nil {
 			e2elog.Failf("failed to delete storageclass: %v", err)
 		}
+		deleteVault()
 		if deployCephFS {
 			deleteCephfsPlugin()
 			if cephCSINamespace != defaultNs {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -79,25 +79,26 @@ const (
 
 var (
 	// cli flags.
-	deployTimeout    int
-	deployCephFS     bool
-	deployRBD        bool
-	deployNFS        bool
-	testCephFS       bool
-	testRBD          bool
-	testRBDFSCrypt   bool
-	testNBD          bool
-	testNFS          bool
-	helmTest         bool
-	upgradeTesting   bool
-	upgradeVersion   string
-	cephCSINamespace string
-	rookNamespace    string
-	radosNamespace   string
-	poll             = 2 * time.Second
-	isOpenShift      bool
-	clusterID        string
-	nfsDriverName    string
+	deployTimeout     int
+	deployCephFS      bool
+	deployRBD         bool
+	deployNFS         bool
+	testCephFS        bool
+	testCephFSFscrypt bool
+	testRBD           bool
+	testRBDFSCrypt    bool
+	testNBD           bool
+	testNFS           bool
+	helmTest          bool
+	upgradeTesting    bool
+	upgradeVersion    string
+	cephCSINamespace  string
+	rookNamespace     string
+	radosNamespace    string
+	poll              = 2 * time.Second
+	isOpenShift       bool
+	clusterID         string
+	nfsDriverName     string
 )
 
 type cephfsFilesystem struct {

--- a/examples/cephfs/secret.yaml
+++ b/examples/cephfs/secret.yaml
@@ -12,3 +12,6 @@ stringData:
   # Required for dynamically provisioned volumes
   adminID: <plaintext ID>
   adminKey: <Ceph auth key corresponding to ID above>
+
+  # Encryption passphrase
+  encryptionPassphrase: test_passphrase

--- a/examples/cephfs/storageclass.yaml
+++ b/examples/cephfs/storageclass.yaml
@@ -52,6 +52,17 @@ parameters:
   # (defaults to `false`)
   # backingSnapshot: "true"
 
+  # (optional) Instruct the plugin it has to encrypt the volume
+  # By default it is disabled. Valid values are "true" or "false".
+  # A string is expected here, i.e. "true", not true.
+  # encrypted: "true"
+
+  # (optional) Use external key management system for encryption passphrases by
+  # specifying a unique ID matching KMS ConfigMap. The ID is only used for
+  # correlation to configmap entry.
+  # encryptionKMSID: <kms-config-id>
+
+
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 mountOptions:

--- a/examples/kms/vault/vault.yaml
+++ b/examples/kms/vault/vault.yaml
@@ -169,7 +169,7 @@ spec:
             - name: PLUGIN_ROLE
               value: csi-kubernetes
             - name: SERVICE_ACCOUNTS
-              value: rbd-csi-nodeplugin,rbd-csi-provisioner,csi-rbdplugin,csi-rbdplugin-provisioner
+              value: rbd-csi-nodeplugin,rbd-csi-provisioner,csi-rbdplugin,csi-rbdplugin-provisioner,cephfs-csi-nodeplugin,cephfs-csi-provisioner,csi-cephfsplugin,csi-cephfsplugin-provisioner
             - name: SERVICE_ACCOUNTS_NAMESPACE
               value: default
             - name: VAULT_ADDR

--- a/internal/cephfs/store/backingsnapshot.go
+++ b/internal/cephfs/store/backingsnapshot.go
@@ -36,6 +36,7 @@ func AddSnapshotBackedVolumeRef(
 	volOptions *VolumeOptions,
 	clusterName string,
 	setMetadata bool,
+	secrets map[string]string,
 ) error {
 	ioctx, err := volOptions.conn.GetIoctx(volOptions.MetadataPool)
 	if err != nil {
@@ -98,7 +99,7 @@ func AddSnapshotBackedVolumeRef(
 	// deleting the backing snapshot. Make sure the snapshot still exists by
 	// trying to retrieve it again.
 	_, _, _, err = NewSnapshotOptionsFromID(ctx,
-		volOptions.BackingSnapshotID, volOptions.conn.Creds, clusterName, setMetadata)
+		volOptions.BackingSnapshotID, volOptions.conn.Creds, secrets, clusterName, setMetadata)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to get backing snapshot %s: %v", volOptions.BackingSnapshotID, err)
 	}

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -210,6 +210,7 @@ func fmtBackingSnapshotOptionMismatch(optName, expected, actual string) error {
 
 // NewVolumeOptions generates a new instance of volumeOptions from the provided
 // CSI request parameters.
+// nolint:gocyclo,cyclop // TODO: reduce complexity
 func NewVolumeOptions(
 	ctx context.Context,
 	requestName,
@@ -324,6 +325,7 @@ func NewVolumeOptions(
 
 // newVolumeOptionsFromVolID generates a new instance of volumeOptions and VolumeIdentifier
 // from the provided CSI VolumeID.
+// nolint:gocyclo,cyclop // TODO: reduce complexity
 func NewVolumeOptionsFromVolID(
 	ctx context.Context,
 	volID string,


### PR DESCRIPTION
Add Ceph FS fscrypt support. Supports volumes, snapshots and clones.

Follow up to #3310 (adds fscrypt integration) and second in series towards #1563

Fixes: #1563 

# Usage Requirements

- Kernel with Ceph FS fscrypt support
   -   git://git.kernel.org/pub/scm/linux/kernel/git/jlayton/linux.git branch ceph-fscrypt
   -   or <https://github.com/ceph/ceph-client.git> branch wip-fscrypt
-   <https://github.com/google/fscrypt#runtime-dependencies>
-   Ceph MDS support
    -   v17: volumes supported
    -   main branch: +snapshots
    -   main branch+<https://github.com/ceph/ceph/pull/48410>: +clones


# End-to-end Testing

Testing on minikube requires a custom ISO with the latest Ceph FS patches. To test snapshots and clones a main branch build of Ceph is needed as well.

## Custom Minikube ISO

Use patches from <https://github.com/irq0/minikube/tree/custom-ceph-fscrypt-kernel> on top of minikube to build an ISO with the current Ceph FS development kernel.

Build summary:

```
make
make buildroot-image
make out/minikube-x86_64.iso
```

Then use minikube.sh with MINIKUBE_ISO_URL="file://path of minikube.iso"

## Use Ceph Main Branch Images
Either use `quay.io/ceph/daemon:latest-main-devel` or build using ceph-containers project.

## Build

In <https://github.com/ceph/ceph-container.git> clone:

```
eval $(minikube docker-env)  # will build inside minikube VM
make BASEOS_REGISTRY=quay.io/centos BASEOS_TAG=stream8 CEPH_DEVEL=true FLAVORS="main,centos,8" build
```

Optional: patch image with <https://github.com/ceph/ceph/pull/48410>
