### PR TITLE
ci: use rook v1.10.4 in CI

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -7,7 +7,7 @@
 #
 
 # ceph-csi devel
-docker.io/rook/ceph:v1.10.3      rook/ceph:v1.10.3
+docker.io/rook/ceph:v1.10.4      rook/ceph:v1.10.4
 
 # ceph-csi v3.7
 docker.io/rook/ceph:v1.9.8      rook/ceph:v1.9.8


### PR DESCRIPTION
update Rook image version to v1.10.4 which is latest release

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

