### PR TITLE
ci: add github action to trigger E2E

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -1,0 +1,93 @@
+---
+name: Add comment
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target:
+    branches:
+      - devel
+      - "release-v*"
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'ok-to-test'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add comment to trigger external storage tests for Kubernetes 1.22
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/k8s-e2e-external-storage/1.22
+
+      - name: Add comment to trigger external storage tests for Kubernetes 1.23
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/k8s-e2e-external-storage/1.23
+
+      - name: Add comment to trigger external storage tests for Kubernetes 1.24
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/k8s-e2e-external-storage/1.24
+
+      - name: Add comment to trigger helm E2E tests for Kubernetes 1.22
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e-helm/k8s-1.22
+
+      - name: Add comment to trigger helm E2E tests for Kubernetes 1.23
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e-helm/k8s-1.23
+
+      - name: Add comment to trigger helm E2E tests for Kubernetes 1.24
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e-helm/k8s-1.24
+
+      - name: Add comment to trigger E2E tests for Kubernetes 1.22
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e/k8s-1.22
+
+      - name: Add comment to trigger E2E tests for Kubernetes 1.23
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e/k8s-1.23
+
+      - name: Add comment to trigger E2E tests for Kubernetes 1.24
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e/k8s-1.24
+
+      - name: Add comment to trigger cephfs upgrade tests
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/upgrade-tests-cephfs
+
+      - name: Add comment to trigger rbd upgrade tests
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/upgrade-tests-rbd

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -252,6 +252,7 @@ A few labels interact with automation around the pull requests:
 * DNM: DO NOT MERGE (Mergify will not merge this PR)
 * ci/skip/e2e: skip running e2e CI jobs
 * ci/skip/multi-arch-build: skip building container images for different architectures
+* ok-to-test: PR is ready for e2e testing.
 
 **Review Process:**
 Once your PR has been submitted for review the following criteria will
@@ -268,6 +269,9 @@ need to be met before it will be merged:
   community feedback.
 * The 24 working hours counts hours occurring Mon-Fri in the local timezone
   of the submitter.
+* ceph-csi-maintainers/ceph-csi-contributors can add `ok-to-test` label to the
+  pull request when they think it is ready for e2e testing. This is done to avoid
+  load on the CI.
 * Each PR must be fully updated to devel and tests must have passed
 * If the PR is having trivial changes or the reviewer is confident enough that
   PR doesn't need a second review, the reviewer can set `ready-to-merge` label


### PR DESCRIPTION
based on the discussion on the slack channel. we are adding a github action
to trigger the CI jobs when a `ok-to-test` label is added on the PR.

This action is based on below github action https://github.com/peter-evans/create-or-update-comment

Sample Demo avaiable at https://github.com/Madhu-1/label-commentor-action-testing/pull/4

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

