### PR TITLE
ci: disable e2e tests by default in CI

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -3,11 +3,11 @@
     name: k8s-e2e-external-storage
     k8s_version:
       - '1.22':
-          only_run_on_request: false
+          only_run_on_request: true
       - '1.23':
-          only_run_on_request: false
+          only_run_on_request: true
       - '1.24':
-          only_run_on_request: false
+          only_run_on_request: true
       - '1.25':
           only_run_on_request: true
       - '1.26':

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -3,11 +3,11 @@
     name: mini-e2e
     k8s_version:
       - '1.22':
-          only_run_on_request: false
+          only_run_on_request: true
       - '1.23':
-          only_run_on_request: false
+          only_run_on_request: true
       - '1.24':
-          only_run_on_request: false
+          only_run_on_request: true
       - '1.25':
           only_run_on_request: true
       - '1.26':

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -2,6 +2,7 @@
 - project:
     name: upgrade-tests
     k8s_version: '1.21'
+    only_run_on_request: true
     test_type:
       - 'cephfs'
       - 'rbd'
@@ -52,6 +53,7 @@
           status-context: 'ci/centos/upgrade-tests-{test_type}'
           # yamllint disable-line rule:line-length
           trigger-phrase: '/(re)?test ((all)|(ci/centos/upgrade-tests(-{test_type})?))'
+          only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
           black-list-target-branches:


### PR DESCRIPTION
Disable e2e tests by default in CI to save resources. cephcsi maintainers or contributors can add the `ok-to-test` label to trigger the e2e tests.

depends on #3468

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

