### PR TITLE
CI: run upgrade testing with latest release

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -6,7 +6,7 @@
     test_type:
       - 'cephfs'
       - 'rbd'
-    csi_upgrade_version: 'v3.3.1'
+    csi_upgrade_version: 'v3.7.2'
     jobs:
       - 'upgrade-tests-{test_type}'
 

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.21'
+    k8s_version: '1.24'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
Run E2E tests with latest available release and also use latest used kubernetes version or supported kubernetes version for upgrade testing.

fixes: #2818
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
