### PR TITLE
ci: reduce comments in ci action

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -15,79 +15,30 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Add comment to trigger external storage tests for Kubernetes 1.22
+      - name: Add comment to trigger external storage tests for Kubernetes
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            /test ci/centos/k8s-e2e-external-storage/1.22
+            /test ci/centos/k8s-e2e-external-storage
 
-      - name: Add comment to trigger external storage tests for Kubernetes 1.23
+      - name: Add comment to trigger helm E2E tests for Kubernetes
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            /test ci/centos/k8s-e2e-external-storage/1.23
+            /test ci/centos/mini-e2e-helm
 
-      - name: Add comment to trigger external storage tests for Kubernetes 1.24
+      - name: Add comment to trigger E2E tests for Kubernetes
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            /test ci/centos/k8s-e2e-external-storage/1.24
+            /test ci/centos/mini-e2e
 
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.22
+      - name: Add comment to trigger upgrade tests
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.22
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.23
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.23
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.24
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.24
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.22
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.22
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.23
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.23
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.24
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.24
-
-      - name: Add comment to trigger cephfs upgrade tests
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/upgrade-tests-cephfs
-
-      - name: Add comment to trigger rbd upgrade tests
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/upgrade-tests-rbd
+            /test ci/centos/upgrade-tests


### PR DESCRIPTION
We dont need to run individual tests to start the Jenkins jobs, We already have a regex to start similar tests are different kubernetes versions.

See https://github.com/ceph/ceph-csi/pull/3362#issuecomment-1291597227 for test result

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

