### PR TITLE
rbd: fix namespace name update in metadata and rados object

### DIFF
--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -864,3 +864,9 @@ func (conn *Connection) ReserveNewUUIDMapping(ctx context.Context,
 
 	return setOMapKeys(ctx, conn, journalPool, cj.namespace, cj.csiDirectory, setKeys)
 }
+
+// ResetVolumeOwner updates the owner in the rados object.
+func (conn *Connection) ResetVolumeOwner(ctx context.Context, pool, reservedUUID, owner string) error {
+	return setOMapKeys(ctx, conn, pool, conn.config.namespace, conn.config.cephUUIDDirectoryPrefix+reservedUUID,
+		map[string]string{conn.config.ownerKey: owner})
+}

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -538,7 +538,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 // Generate new volume Handler
 // The volume handler won't remain same as its contains poolID,clusterID etc
 // which are not same across clusters.
-// nolint:gocyclo,cyclop // TODO: reduce complexity
+// nolint:gocyclo,cyclop,nestif // TODO: reduce complexity
 func RegenerateJournal(
 	volumeAttributes map[string]string,
 	claimName,
@@ -621,6 +621,12 @@ func RegenerateJournal(
 		rbdVol.RbdImageName = imageData.ImageAttributes.ImageName
 		if rbdVol.ImageID == "" {
 			err = rbdVol.storeImageID(ctx, j)
+			if err != nil {
+				return "", err
+			}
+		}
+		if rbdVol.Owner != owner {
+			err = j.ResetVolumeOwner(ctx, rbdVol.JournalPool, rbdVol.ReservedID, owner)
 			if err != nil {
 				return "", err
 			}

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -626,7 +626,7 @@ func RegenerateJournal(
 			}
 		}
 		// Update Metadata on reattach of the same old PV
-		parameters := k8s.PrepareVolumeMetadata(claimName, rbdVol.Owner, "")
+		parameters := k8s.PrepareVolumeMetadata(claimName, owner, "")
 		err = rbdVol.setAllMetadata(parameters)
 		if err != nil {
 			return "", fmt.Errorf("failed to set volume metadata: %w", err)


### PR DESCRIPTION
If a PV is reattached to a new PVC in a different namespace, we need to update the namespace name in the rbd image metadata.
If a PV is reattached to a new PVC in a different namespace, we need to update the namespace name in the rados object.

* Create a RBD PVC in default namespace
```bash
[🎩︎]mrajanna@fedora rbd $]kubectl get pvc
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
rbd-pvc   Bound    pvc-2e85eed4-b13a-478b-afb0-3217069d5ca7   1Gi        RWO            rook-ceph-block   76s
```
* check metadata of the image
```bash
sh-4.4$ rbd image-meta ls replicapool/csi-vol-333a1bdc-55fb-11ed-b453-be69662ea197
There are 4 metadata on this image:

Key                               Value                                   
csi.ceph.com/cluster/name         my-prod-cluster                         
csi.storage.k8s.io/pv/name        pvc-2e85eed4-b13a-478b-afb0-3217069d5ca7
csi.storage.k8s.io/pvc/name       rbd-pvc                                 
csi.storage.k8s.io/pvc/namespace  default         
```

* Attach same PV to different PVC in new namespace

```bash
[🎩︎]mrajanna@fedora rbd $]kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                   STORAGECLASS      REASON   AGE
pvc-2e85eed4-b13a-478b-afb0-3217069d5ca7   1Gi        RWO            Retain           Bound    rook-ceph/rbd-pvc-new   rook-ceph-block            3m47s
[🎩︎]mrajanna@fedora rbd $]
[🎩︎]mrajanna@fedora rbd $]
[🎩︎]mrajanna@fedora rbd $]kuberc get pvc
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
rbd-pvc-new   Bound    pvc-2e85eed4-b13a-478b-afb0-3217069d5ca7   1Gi        RWO            rook-ceph-block   13s
```
* Check metadata of the image
```bash
sh-4.4$ rbd image-meta ls replicapool/csi-vol-333a1bdc-55fb-11ed-b453-be69662ea197
There are 4 metadata on this image:

Key                               Value                                   
csi.ceph.com/cluster/name         my-prod-cluster                         
csi.storage.k8s.io/pv/name        pvc-2e85eed4-b13a-478b-afb0-3217069d5ca7
csi.storage.k8s.io/pvc/name       rbd-pvc-new                             
csi.storage.k8s.io/pvc/namespace  default                                 
sh-4.4$ 
```
```
sh-4.4$ rados listomapvals csi.volume.333a1bdc-55fb-11ed-b453-be69662ea197 --pool=replicapool
csi.imageid
value (12 bytes) :
00000000  31 31 35 32 32 39 30 30  33 63 66 35              |115229003cf5|
0000000c

csi.imagename
value (44 bytes) :
00000000  63 73 69 2d 76 6f 6c 2d  33 33 33 61 31 62 64 63  |csi-vol-333a1bdc|
00000010  2d 35 35 66 62 2d 31 31  65 64 2d 62 34 35 33 2d  |-55fb-11ed-b453-|
00000020  62 65 36 39 36 36 32 65  61 31 39 37              |be69662ea197|
0000002c

csi.volname
value (40 bytes) :
00000000  70 76 63 2d 32 65 38 35  65 65 64 34 2d 62 31 33  |pvc-2e85eed4-b13|
00000010  61 2d 34 37 38 62 2d 61  66 62 30 2d 33 32 31 37  |a-478b-afb0-3217|
00000020  30 36 39 64 35 63 61 37                           |069d5ca7|
00000028

csi.volume.owner
value (7 bytes) :
00000000  64 65 66 61 75 6c 74                              |default|
00000007
```
As we can notice here, only the PVC name got updated not the namespace name in both metadata and in rados object also.

With this fix even the namespace name also got updated

```bash
sh-4.4$ rbd image-meta ls replicapool/csi-vol-333a1bdc-55fb-11ed-b453-be69662ea197
There are 4 metadata on this image:

Key                               Value                                   
csi.ceph.com/cluster/name         my-prod-cluster                         
csi.storage.k8s.io/pv/name        pvc-2e85eed4-b13a-478b-afb0-3217069d5ca7
csi.storage.k8s.io/pvc/name       rbd-pvc-new                             
csi.storage.k8s.io/pvc/namespace  rook-ceph                               
```
```
sh-4.4$ rados listomapvals csi.volume.333a1bdc-55fb-11ed-b453-be69662ea197  --pool=replicapool
csi.imageid
value (12 bytes) :
00000000  31 31 35 32 32 39 30 30  33 63 66 35              |115229003cf5|
0000000c

csi.imagename
value (44 bytes) :
00000000  63 73 69 2d 76 6f 6c 2d  33 33 33 61 31 62 64 63  |csi-vol-333a1bdc|
00000010  2d 35 35 66 62 2d 31 31  65 64 2d 62 34 35 33 2d  |-55fb-11ed-b453-|
00000020  62 65 36 39 36 36 32 65  61 31 39 37              |be69662ea197|
0000002c

csi.volname
value (40 bytes) :
00000000  70 76 63 2d 32 65 38 35  65 65 64 34 2d 62 31 33  |pvc-2e85eed4-b13|
00000010  61 2d 34 37 38 62 2d 61  66 62 30 2d 33 32 31 37  |a-478b-afb0-3217|
00000020  30 36 39 64 35 63 61 37                           |069d5ca7|
00000028

csi.volume.owner
value (9 bytes) :
00000000  72 6f 6f 6b 2d 63 65 70  68                       |rook-ceph|
00000009
```