### PR TITLE
rbd: return error if last sync time not present

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -804,13 +804,14 @@ func getLastSyncTime(description string) (*timestamppb.Timestamp, error) {
 	// description = "replaying,{"bytes_per_second":0.0,
 	// "bytes_per_snapshot":149504.0,"local_snapshot_timestamp":1662655501
 	// ,"remote_snapshot_timestamp":1662655501}"
-	// In case there is no local snapshot timestamp we can pass the default value
+	// In case there is no local snapshot timestamp return an error as the
+	// LastSyncTime is required.
 	if description == "" {
-		return nil, nil
+		return nil, errors.New("empty description")
 	}
 	splittedString := strings.SplitN(description, ",", 2)
 	if len(splittedString) == 1 {
-		return nil, nil
+		return nil, errors.New("no local snapshot timestamp")
 	}
 	type localStatus struct {
 		LocalSnapshotTime int64 `json:"local_snapshot_timestamp"`

--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -455,7 +455,7 @@ func TestValidateLastSyncTime(t *testing.T) {
 			"empty description",
 			"",
 			nil,
-			"",
+			"empty description",
 		},
 		{
 			"description without local_snapshot_timestamp",
@@ -473,7 +473,7 @@ func TestValidateLastSyncTime(t *testing.T) {
 			"description with no JSON",
 			`replaying`,
 			nil,
-			"",
+			"no local snapshot timestamp",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
As per the csiaddon spec, last sync time is a required parameter in the GetVolumeReplicationInfo if we are failed to parse the description, we return an error message instead of nil which is an empty response.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Note:- skipping E2E as we dont have CI for DR