### PR TITLE
ci: remove kubernetes 1.22 from CI

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -2,8 +2,6 @@
 - project:
     name: k8s-e2e-external-storage
     k8s_version:
-      - '1.22':
-          only_run_on_request: true
       - '1.23':
           only_run_on_request: true
       - '1.24':

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,6 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.22':
-          only_run_on_request: true
       - '1.23':
           only_run_on_request: true
       - '1.24':

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.24'
+    k8s_version: '1.25'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
As we dont longer required to test with Kubernetes 1.22 removing it from the CI.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

