### PR TITLE
doc: add missing csidriver creation

### DIFF
--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -129,6 +129,12 @@ the Docker daemon of the cluster nodes must allow shared mounts.
 
 YAML manifests are located in `deploy/cephfs/kubernetes`.
 
+**Create CSIDriver object:**
+
+```bash
+kubectl create -f csidriver.yaml
+```
+
 **Deploy RBACs for sidecar containers and node plugins:**
 
 ```bash

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -98,6 +98,12 @@ the Docker daemon of the cluster nodes must allow shared mounts.
 
 YAML manifests are located in `deploy/rbd/kubernetes`.
 
+**Create CSIDriver object:**
+
+```bash
+kubectl create -f csidriver.yaml
+```
+
 **Deploy RBACs for sidecar containers and node plugins:**
 
 ```bash


### PR DESCRIPTION
Add missing csidriver object creation steps from the cephfs and rbd deployment guide.

fixes: #3476

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

