### PR TITLE
e2e: use CurrentSpecReport for failed spec run

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -200,7 +200,7 @@ var _ = Describe(cephfsType, func() {
 		if !testCephFS || upgradeTesting {
 			Skip("Skipping CephFS E2E")
 		}
-		if CurrentGinkgoTestDescription().Failed {
+		if CurrentSpecReport().Failed() {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-cephfs", c)
 			// log provisioner

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -285,7 +285,7 @@ var _ = Describe("nfs", func() {
 		if !testNFS || upgradeTesting {
 			Skip("Skipping NFS E2E")
 		}
-		if CurrentGinkgoTestDescription().Failed {
+		if CurrentSpecReport().Failed() {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-nfs", c)
 			// log provisioner

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -345,7 +345,7 @@ var _ = Describe("RBD", func() {
 		if !testRBD || upgradeTesting {
 			Skip("Skipping RBD E2E")
 		}
-		if CurrentGinkgoTestDescription().Failed {
+		if CurrentSpecReport().Failed() {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-rbd", c)
 			// log provisioner

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -115,7 +115,7 @@ var _ = Describe("CephFS Upgrade Testing", func() {
 		if !testCephFS || !upgradeTesting {
 			Skip("Skipping CephFS Upgrade Test")
 		}
-		if CurrentGinkgoTestDescription().Failed {
+		if CurrentSpecReport().Failed() {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-cephfs", c)
 			// log provisoner

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -121,7 +121,7 @@ var _ = Describe("RBD Upgrade Testing", func() {
 		if !testRBD || !upgradeTesting {
 			Skip("Skipping RBD Upgrade Testing")
 		}
-		if CurrentGinkgoTestDescription().Failed {
+		if CurrentSpecReport().Failed() {
 			// log pods created by helm chart
 			logsCSIPods("app=ceph-csi-rbd", c)
 			// log provisoner


### PR DESCRIPTION
CurrentGinkgoTestDescription() has been deprecated in favor of CurrentSpecReport and this commit address the same.

Ref# https://github.com/onsi/ginkgo/blob/master/deprecated_dsl.go#L53

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

