### PR TITLE
ci: automatically remove `ok-to-test` and set it when queuing a PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,6 +43,15 @@ queue_rules:
               - "status-success=ci/centos/jjb-validate"
 
 pull_request_rules:
+  - name: start CI jobs for queued PR
+    conditions:
+      - base~=^(devel)|(release-.+)$
+      - "check-pending=Queue: Embarked in merge train"
+    actions:
+      label:
+        add:
+          - ok-to-test
+
   - name: remove outdated approvals
     conditions:
       - base~=^(devel)|(release-.+)$
@@ -50,6 +59,10 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
+      label:
+        remove:
+          - ok-to-test
+
   - name: ask to resolve conflict
     conditions:
       - conflict
@@ -60,6 +73,10 @@ pull_request_rules:
         message: "This pull request now has conflicts with the target branch.
         Could you please resolve conflicts and force push the corrected
         changes? 🙏"
+      label:
+        remove:
+          - ok-to-test
+
   - name: update dependencies by dependabot (skip commitlint)
     conditions:
       - author=dependabot[bot]
@@ -91,6 +108,9 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
+      label:
+        remove:
+          - ok-to-test
 
   - name: dismiss review of merged pull request
     conditions:
@@ -98,6 +118,9 @@ pull_request_rules:
       - merged
     actions:
       dismiss_reviews: {}
+      label:
+        remove:
+          - ok-to-test
 
   - name: automatic merge
     conditions:
@@ -130,6 +153,9 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
+      label:
+        remove:
+          - ok-to-test
 
   - name: automatic merge PR having ready-to-merge label
     conditions:
@@ -161,6 +187,10 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
+      label:
+        remove:
+          - ok-to-test
+
   - name: backport patches to release-v3.6 branch
     conditions:
       - base=devel
@@ -169,6 +199,7 @@ pull_request_rules:
       backport:
         branches:
           - release-v3.6
+
   - name: backport patches to release-v3.7 branch
     conditions:
       - base=devel
@@ -177,6 +208,7 @@ pull_request_rules:
       backport:
         branches:
           - release-v3.7
+
   - name: remove outdated approvals on ci/centos
     conditions:
       - base=ci/centos
@@ -184,6 +216,7 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
+
   - name: automatic merge on ci/centos
     conditions:
       - label!=DNM
@@ -199,6 +232,7 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
+
   - name: automatic merge PR having ready-to-merge label on ci/centos
     conditions:
       - label!=DNM
@@ -213,6 +247,10 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
+      label:
+        remove:
+          - ok-to-test
+
   ##
   ## Automatically set/remove labels
   ##


### PR DESCRIPTION
The `ok-to-test` label currently needs to be removed and re-added when a PR is rebased for re-queuing.

It should be possible to automate this, by removing the `ok-to-test` label when a PR gets queued. It can automatically be added again when the PR has embarked the merge train.

Tested with the online Mergify Config Editor on PR #3505:

![image](https://user-images.githubusercontent.com/400257/200843783-f0fcb179-833a-4e1a-b2aa-becd971b9938.png)

**Note:** we will need to keep an eye on CI usage when PRs are getting queued. Hopefully the "embarked the merge train" status does not happen when PRs do not need rebasing.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
