### PR TITLE
ci: do not immediately remove the `ok-to-test` label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -59,9 +59,6 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
-      label:
-        remove:
-          - ok-to-test
 
   - name: ask to resolve conflict
     conditions:


### PR DESCRIPTION
It seems that Mergify removes the `ok-to-test` label as soon as someone adds it. We don't want that, as it can trigger more CI runs than needed.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
