### PR TITLE
helm: get rid of storage group enablement based on the version

### DIFF
--- a/api/deploy/kubernetes/nfs/csidriver.yaml
+++ b/api/deploy/kubernetes/nfs/csidriver.yaml
@@ -5,5 +5,6 @@ metadata:
   name: "{{ .Name }}"
 spec:
   attachRequired: false
+  fsGroupPolicy: File
   volumeLifecycleModes:
     - Persistent

--- a/api/deploy/kubernetes/rbd/csidriver.yaml
+++ b/api/deploy/kubernetes/rbd/csidriver.yaml
@@ -1,6 +1,4 @@
 ---
-# if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:

--- a/api/deploy/kubernetes/rbd/csidriver.yaml
+++ b/api/deploy/kubernetes/rbd/csidriver.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  fsGroupPolicy: File

--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -1,8 +1,4 @@
-{{ if semverCompare ">=1.18.0-beta.1" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
-{{ else }}
-apiVersion: storage.k8s.io/v1beta1
-{{ end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.driverName }}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -287,9 +287,6 @@ cephconf: |
     auth_service_required = cephx
     auth_client_required = cephx
 
-    # Workaround for http://tracker.ceph.com/issues/23446
-    fuse_set_user_groups = false
-
     # ceph-fuse which uses libfuse2 by default has write buffer size of 2KiB
     # adding 'fuse_big_writes = true' option by default to override this limit
     # see https://github.com/ceph/ceph-csi/issues/1928

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -1,8 +1,4 @@
-{{ if semverCompare ">=1.18.0-beta.1" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
-{{ else }}
-apiVersion: storage.k8s.io/v1beta1
-{{ end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.driverName }}

--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -1,6 +1,4 @@
 ---
-# if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:

--- a/deploy/nfs/kubernetes/csidriver.yaml
+++ b/deploy/nfs/kubernetes/csidriver.yaml
@@ -12,6 +12,6 @@ metadata:
   name: "nfs.csi.ceph.com"
 spec:
   attachRequired: false
+  fsGroupPolicy: File
   volumeLifecycleModes:
     - Persistent
-  fsGroupPolicy: File

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -6,8 +6,6 @@
 # your modifications there.
 #
 ---
-# if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csidriver.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csidriver.yaml
@@ -5,5 +5,6 @@ metadata:
   name: "{{ .Name }}"
 spec:
   attachRequired: false
+  fsGroupPolicy: File
   volumeLifecycleModes:
     - Persistent

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd/csidriver.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd/csidriver.yaml
@@ -1,6 +1,4 @@
 ---
-# if Kubernetes version is less than 1.18 change
-# apiVersion to storage.k8s.io/v1beta1
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
@@ -8,3 +6,4 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  fsGroupPolicy: File


### PR DESCRIPTION
- [x]  helm: get rid of storage group enablement based on the version
- [x]  helm: fuse_set_user_groups need not be part of the config
- [x]  deploy: remove beta1 mention from csidriver yaml
- [x] deploy : add missing fsgrouppolicy to th api and do generate-deploy 