### PR TITLE
rebase: make use of latest go-ceph library ( v1.18.0)

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -46,7 +46,7 @@ it is **highly** encouraged to:
 * Set up a pre-commit hook to catch issues locally.
 
    ```console
-   pip install pre-commit==2.5.1
+   pip install pre-commit
    pre-commit install
    ```
 
@@ -338,7 +338,7 @@ fresh PRs, rebase of PRs and force pushing changes to existing PRs.
 In case of failed we already documented steps  to manually
 [retrigger](#retriggering-the-ci-jobs) the CI jobs. Sometime the tests might be
 flaky which required manually retriggering always. We have newly added a github
-action which runs periodically to retest the failed PR's. Below are the cretia
+action which runs periodically to retest the failed PR's. Below are the criteria
 for auto retesting the failed PR.
 
 * Analyze the logs and make sure its a flaky test.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.1
 	github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000
 	// TODO: API for managing subvolume metadata and snapshot metadata requires `ceph_ci_untested` build-tag
-	github.com/ceph/go-ceph v0.17.0
+	github.com/ceph/go-ceph v0.18.0
 	github.com/container-storage-interface/spec v1.7.0
 	github.com/csi-addons/replication-lib-utils v0.2.0
 	github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
-github.com/ceph/go-ceph v0.17.0 h1:2McqHPqvAU+qgROJ+A5/eK70Lt7WsKizkTasDEOZa/Q=
-github.com/ceph/go-ceph v0.17.0/go.mod h1:WV8DzlYPtW3SQ/HiT3Dz6ia0+v8dPKWtYY/dWl6BqPg=
+github.com/ceph/go-ceph v0.18.0 h1:4WM6yAq/iqBDaeeADDiPKLqKiP0iZ4fffdgCr1lnOL4=
+github.com/ceph/go-ceph v0.18.0/go.mod h1:cflETVTBNAQM6jdr7hpNHHFHKYiJiWWcAeRDrRx/1ng=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -369,7 +369,7 @@ github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gocql/gocql v0.0.0-20190402132108-0e1d5de854df/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.3.0+incompatible h1:CaSVZxm5B+7o45rtab4jC2G37WGYX1zQfuU2i6DSvnc=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/vendor/github.com/ceph/go-ceph/cephfs/admin/clone_nautilus.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/admin/clone_nautilus.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 // GetFailure returns details about the CloneStatus when in CloneFailed state.

--- a/vendor/github.com/ceph/go-ceph/common/admin/nfs/admin.go
+++ b/vendor/github.com/ceph/go-ceph/common/admin/nfs/admin.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview
-// +build !nautilus,!octopus,ceph_preview
+//go:build !(nautilus || octopus)
+// +build !nautilus,!octopus
 
 package nfs
 

--- a/vendor/github.com/ceph/go-ceph/common/admin/nfs/export.go
+++ b/vendor/github.com/ceph/go-ceph/common/admin/nfs/export.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview
-// +build !nautilus,!octopus,ceph_preview
+//go:build !(nautilus || octopus)
+// +build !nautilus,!octopus
 
 package nfs
 
@@ -26,6 +26,18 @@ const (
 	Unspecifiedquash SquashMode = ""
 )
 
+// SecType indicates the kind of security/authentication to be used by an export.
+type SecType string
+
+// src: https://github.com/nfs-ganesha/nfs-ganesha/blob/next/src/config_samples/export.txt
+const (
+	SysSec   SecType = "sys"
+	NoneSec  SecType = "none"
+	Krb5Sec  SecType = "krb5"
+	Krb5iSec SecType = "krb5i"
+	Krb5pSec SecType = "krb5p"
+)
+
 // CephFSExportSpec is used to specify the parameters used to create a new
 // CephFS based export.
 type CephFSExportSpec struct {
@@ -36,6 +48,7 @@ type CephFSExportSpec struct {
 	ReadOnly       bool       `json:"readonly"`
 	ClientAddr     []string   `json:"client_addr,omitempty"`
 	Squash         SquashMode `json:"squash,omitempty"`
+	SecType        []SecType  `json:"sectype,omitempty"`
 }
 
 // ExportResult is returned along with newly created exports.
@@ -81,6 +94,7 @@ type ExportInfo struct {
 	Transports    []string     `json:"transports"`
 	FSAL          FSALInfo     `json:"fsal"`
 	Clients       []ClientInfo `json:"clients"`
+	SecType       []SecType    `json:"sectype"`
 }
 
 func parseExportResult(res commands.Response) (*ExportResult, error) {

--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_rename.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_rename.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rbd
 
 // #cgo LDFLAGS: -lrbd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/cenkalti/backoff/v3
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.17.0
+# github.com/ceph/go-ceph v0.18.0
 ## explicit; go 1.17
 github.com/ceph/go-ceph/cephfs/admin
 github.com/ceph/go-ceph/common/admin/manager


### PR DESCRIPTION
- [x]     rebase: go-ceph version has been updated to v1.18.0
- [x]      docs: update/correct development guide

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
