### PR TITLE
ci: do not leave testing comments on merged PRs

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -10,7 +10,8 @@ on:
       - labeled
 jobs:
   add-comment:
-    if: github.event.label.name == 'ok-to-test'
+    # yamllint disable-line rule:line-length
+    if: github.event.label.name == 'ok-to-test' && github.event.pull_request.merged != 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
A PR with status `github.event.pull_request.merged == true` does not need to be tested again.

This happened on #3500 for example.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
