### PR TITLE
rbd: unset metadata if setmetadata is false

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2122,10 +2122,6 @@ func (rv *rbdVolume) setAllMetadata(parameters map[string]string) error {
 
 // unsetAllMetadata unset all the metadata from arg keys on RBD image.
 func (rv *rbdVolume) unsetAllMetadata(keys []string) error {
-	if !rv.EnableMetadata {
-		return nil
-	}
-
 	for _, key := range keys {
 		err := rv.RemoveMetadata(key)
 		// TODO: replace string comparison with errno.


### PR DESCRIPTION
We need to unset the metadata on the clone and restore PVC if the parent PVC was created when setmetadata was set to true, and it was set to false when restore and clone pvc were created.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

* When metadata is set to true for pvc and snapshot

```
[🎩︎]mrajanna@fedora rbd $]kubectl create -f pvc.yaml 
persistentvolumeclaim/rbd-pvc created
[🎩︎]mrajanna@fedora rbd $]kubectl get pvc
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
rbd-pvc   Bound    pvc-54f9a643-a303-4a2a-b148-e9613ccfd796   1Gi        RWO            rook-ceph-block   2s
[🎩︎]mrajanna@fedora rbd $]

sh-4.4$ rbd image-meta list replicapool/csi-vol-caef2998-c62b-495d-996f-270a16f4eb2d
There are 4 metadata on this image:

Key                               Value                                   
csi.ceph.com/cluster/name         my-prod-cluster                         
csi.storage.k8s.io/pv/name        pvc-54f9a643-a303-4a2a-b148-e9613ccfd796
csi.storage.k8s.io/pvc/name       rbd-pvc                                 
csi.storage.k8s.io/pvc/namespace  default                                 
sh-4.4$ 
```

```
🎩︎]mrajanna@fedora rbd $]kubectl get volumesnapshot
NAME               READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS             SNAPSHOTCONTENT                                    CREATIONTIME   AGE
rbd-pvc-snapshot   true         rbd-pvc                             1Gi           csi-rbdplugin-snapclass   snapcontent-9453ba1d-2831-47dd-a847-40091a6dcdf1   6s             6s
sh-4.4$ rbd image-meta list replicapool/csi-snap-02540945-077b-4393-93c8-17d3d5efe7a0
There are 4 metadata on this image:

Key                                            Value                                           
csi.ceph.com/cluster/name                      my-prod-cluster                                 
csi.storage.k8s.io/volumesnapshot/name         rbd-pvc-snapshot                                
csi.storage.k8s.io/volumesnapshot/namespace    default                                         
csi.storage.k8s.io/volumesnapshotcontent/name  snapcontent-9453ba1d-2831-47dd-a847-40091a6dcdf1
```

* When Metadata is set to false for clone

```
[🎩︎]mrajanna@fedora rbd $]kubectl get pvc
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
rbd-pvc         Bound    pvc-54f9a643-a303-4a2a-b148-e9613ccfd796   1Gi        RWO            rook-ceph-block   5m48s
rbd-pvc-clone   Bound    pvc-c5d265e7-493c-4dca-af14-b980f49d4902   1Gi        RWO            rook-ceph-block   2m25s

```

```
sh-4.4$ rbd image-meta list replicapool/csi-vol-caef2998-c62b-495d-996f-270a16f4eb2d
There are 4 metadata on this image:

Key                               Value                                   
csi.ceph.com/cluster/name         my-prod-cluster                         
csi.storage.k8s.io/pv/name        pvc-54f9a643-a303-4a2a-b148-e9613ccfd796
csi.storage.k8s.io/pvc/name       rbd-pvc                                 
csi.storage.k8s.io/pvc/namespace  default                                 
sh-4.4$ rbd image-meta list replicapool/csi-vol-6d8f4395-c152-4874-992f-947d9bff5431-temp
There are 0 metadata on this image.
sh-4.4$ 
sh-4.4$ rbd image-meta list replicapool/csi-vol-6d8f4395-c152-4874-992f-947d9bff5431
There are 0 metadata on this image.
```

* When Metadata is set to false for restore PVC

```
[🎩︎]mrajanna@fedora rbd $]kubectl get pvc
NAME              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
rbd-pvc           Bound    pvc-54f9a643-a303-4a2a-b148-e9613ccfd796   1Gi        RWO            rook-ceph-block   14m
rbd-pvc-restore   Bound    pvc-54fdc69b-7129-47a7-9488-0556482c8d9d   1Gi        RWO            rook-ceph-block   75s

sh-4.4$ rbd image-meta list replicapool/csi-vol-8448f73f-d062-420b-b59a-a7591027d92c
There are 0 metadata on this image.

```