### PR TITLE
cleanup: changes in dockerfile and go version update

### DIFF
--- a/build.env
+++ b/build.env
@@ -16,7 +16,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v17
 CEPH_VERSION=quincy
 
 # standard Golang options
-GOLANG_VERSION=1.18.5
+GOLANG_VERSION=1.18.8
 GO111MODULE=on
 
 # commitlint version

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -28,7 +28,8 @@ RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch || true
 
-RUN dnf -y install \
+RUN dnf -y update \
+        && dnf -y install --nodocs \
 	librados-devel librbd-devel \
 	/usr/bin/cc \
 	make \


### PR DESCRIPTION
    build: add dnf update and add switch --nodocs to install command
    
    this commit update the packages and then do installation of the
    packages in docker build process.

    build: update golang version to 1.18.8
    
    the latest 1.18 version of go binary is 1.18.8 and this commit
    update the package to the latest.
