### PR TITLE
ci: add trivy scanner to github actions

### DIFF
--- a/.github/workflows/trivvy.yaml
+++ b/.github/workflows/trivvy.yaml
@@ -1,0 +1,33 @@
+---
+name: Trivy vulnerability scanner
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - devel
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install go
+        uses: actions/setup-go@v3.3.1
+        with:
+          go-version: ^1.18
+
+      - name: Build an image from Dockerfile
+        run: |
+          CONTAINER_CMD=docker make containerized-build
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/cephcsi/cephcsi:devel'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'


### PR DESCRIPTION
Trivy scanner check allows to scan and report vulnarabilities. This commit add the same.

Additional Note:

We dont want to take this into account for the merge rule for now. But running the security scanner helps us to know the vulnarabilities present and take action on them. Especially while we are about to release this will be helpful. 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

