### PR TITLE
ci: install `openssl` for Fedora 37 testing image

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -33,6 +33,7 @@ RUN source /build.env \
 	findutils \
 	librados-devel \
 	librbd-devel \
+	openssl \
 	rubygems \
 	ShellCheck \
 	codespell \

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -21,7 +21,7 @@ failed=0
 for gopackage in ${GOPACKAGES}; do
 	echo "--- testing: ${gopackage} ---"
 	# shellcheck disable=SC2086
-	go test "${GO_TAGS}" "${MOD_VENDOR}" -v ${GOTESTOPTS[*]} "${gopackage}" || ((failed += 1))
+	go test "${GO_TAGS}" "${MOD_VENDOR}" -v "${GOTESTOPTS[@]}" "${gopackage}" || ((failed += 1))
 	if [[ -f cover.out ]]; then
 		# Append to coverfile
 		grep -v "^mode: count" cover.out >>"${COVERFILE}"


### PR DESCRIPTION
GitHub Workflows fail installing Helm if the `openssl` package is not available. Fedora 36 installs `openssl` by default, Fedora 37 does not.

An example of a failure is at https://github.com/ceph/ceph-csi/actions/runs/3472171037/jobs/5802639192

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
