### PR TITLE
deploy: change the snapshot v1beta1 references from manifests

### DIFF
--- a/examples/cephfs/snapshot.yaml
+++ b/examples/cephfs/snapshot.yaml
@@ -1,12 +1,4 @@
 ---
-# Snapshot API version compatibility matrix:
-# v1beta1:
-#   v1.17 =< k8s < v1.20
-#   2.x =< snapshot-controller < v4.x
-# v1:
-#   k8s >= v1.20
-#   snapshot-controller >= v4.x
-# We recommend to use {sidecar, controller, crds} of same version
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:

--- a/examples/cephfs/snapshotclass.yaml
+++ b/examples/cephfs/snapshotclass.yaml
@@ -1,19 +1,11 @@
 ---
-# Snapshot API version compatibility matrix:
-# v1beta1:
-#   v1.17 =< k8s < v1.20
-#   2.x =< snapshot-controller < v4.x
-# v1:
-#   k8s >= v1.20
-#   snapshot-controller >= v4.x
-# We recommend to use {sidecar, controller, crds} of same version
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-cephfsplugin-snapclass
 driver: cephfs.csi.ceph.com
 parameters:
-  # String representing a Ceph cluster to provision storage from.
+  # String representing a Ceph cluster to provision storage snapshot from.
   # Should be unique across all Ceph clusters in use for provisioning,
   # cannot be greater than 36 bytes in length, and should remain immutable for
   # the lifetime of the StorageClass in use.

--- a/examples/nfs/snapshotclass.yaml
+++ b/examples/nfs/snapshotclass.yaml
@@ -5,7 +5,7 @@ metadata:
   name: csi-nfsplugin-snapclass
 driver: nfs.csi.ceph.com
 parameters:
-  # String representing a Ceph cluster to provision storage from.
+  # String representing a Ceph cluster to provision storage snapshot from.
   # Should be unique across all Ceph clusters in use for provisioning,
   # cannot be greater than 36 bytes in length, and should remain immutable for
   # the lifetime of the StorageClass in use.

--- a/examples/rbd/snapshot.yaml
+++ b/examples/rbd/snapshot.yaml
@@ -1,12 +1,4 @@
 ---
-# Snapshot API version compatibility matrix:
-# v1beta1:
-#   v1.17 =< k8s < v1.20
-#   2.x =< snapshot-controller < v4.x
-# v1:
-#   k8s >= v1.20
-#   snapshot-controller >= v4.x
-# We recommend to use {sidecar, controller, crds} of same version
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:

--- a/examples/rbd/snapshotclass.yaml
+++ b/examples/rbd/snapshotclass.yaml
@@ -1,19 +1,11 @@
 ---
-# Snapshot API version compatibility matrix:
-# v1beta1:
-#   v1.17 =< k8s < v1.20
-#   2.x =< snapshot-controller < v4.x
-# v1:
-#   k8s >= v1.20
-#   snapshot-controller >= v4.x
-# We recommend to use {sidecar, controller, crds} of same version
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-rbdplugin-snapclass
 driver: rbd.csi.ceph.com
 parameters:
-  # String representing a Ceph cluster to provision storage from.
+  # String representing a Ceph cluster to provision storage snapshot from.
   # Should be unique across all Ceph clusters in use for provisioning,
   # cannot be greater than 36 bytes in length, and should remain immutable for
   # the lifetime of the StorageClass in use.


### PR DESCRIPTION
this commit remove the v1beta1 snapshot references as its no longer valid or to be concerned about.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

