### PR TITLE
ci: use new `duffy` command for CentOS CI

### DIFF
--- a/commitlint.groovy
+++ b/commitlint.groovy
@@ -1,9 +1,22 @@
 def cico_retries = 16
 def cico_retry_interval = 60
+def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def ref = "devel"
 def git_since = 'origin/devel'
+
+def create_duffy_config() {
+	writeFile(
+		file: '/home/jenkins/.config/duffy',
+		text: """client:
+			|  url: https://duffy.ci.centos.org/api/v1
+			|  auth:
+			|    name: ceph-csi
+			|    key: ${env.CICO_API_KEY}
+			|""".stripMargin()
+	)
+}
 
 node('cico-workspace') {
 	stage('checkout ci repository') {
@@ -13,18 +26,21 @@ node('cico-workspace') {
 	}
 
 	stage('reserve bare-metal machine') {
+		create_duffy_config()
+
 		def firstAttempt = true
 		retry(30) {
 			if (!firstAttempt) {
 				sleep(time: 5, unit: "MINUTES")
 			}
 			firstAttempt = false
-			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+			def cmd = sh(
+				script: "duffy client request-session pool=${duffy_pool},quantity=1",
 				returnStdout: true
-			).trim().tokenize(' ')
-			env.CICO_NODE = "${cico[0]}.ci.centos.org"
-			env.CICO_SSID = "${cico[1]}"
+			)
+			def duffy = new groovy.json.JsonSlurper().parseText(cmd)
+			env.CICO_NODE = "${duffy.session.nodes[0].hostname}"
+			env.CICO_SSID = "${duffy.session.id}"
 		}
 	}
 
@@ -47,7 +63,7 @@ node('cico-workspace') {
 
 	finally {
 		stage('return bare-metal machine') {
-			sh 'cico node done ${CICO_SSID}'
+			sh 'duffy client retire-session ${CICO_SSID}'
 		}
 	}
 }

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -1,5 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
+def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
@@ -19,6 +20,18 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
+}
+
+def create_duffy_config() {
+	writeFile(
+		file: '/home/jenkins/.config/duffy',
+		text: """client:
+			|  url: https://duffy.ci.centos.org/api/v1
+			|  auth:
+			|    name: ceph-csi
+			|    key: ${env.CICO_API_KEY}
+			|""".stripMargin()
+	)
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it
@@ -64,18 +77,21 @@ node('cico-workspace') {
 	}
 
 	stage('reserve bare-metal machine') {
+		create_duffy_config()
+
 		def firstAttempt = true
 		retry(30) {
 			if (!firstAttempt) {
 				sleep(time: 5, unit: "MINUTES")
 			}
 			firstAttempt = false
-			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+			def cmd = sh(
+				script: "duffy client request-session pool=${duffy_pool},quantity=1",
 				returnStdout: true
-			).trim().tokenize(' ')
-			env.CICO_NODE = "${cico[0]}.ci.centos.org"
-			env.CICO_SSID = "${cico[1]}"
+			)
+			def duffy = new groovy.json.JsonSlurper().parseText(cmd)
+			env.CICO_NODE = "${duffy.session.nodes[0].hostname}"
+			env.CICO_SSID = "${duffy.session.id}"
 		}
 	}
 
@@ -165,7 +181,7 @@ node('cico-workspace') {
 
 	finally {
 		stage('return bare-metal machine') {
-			sh 'cico node done ${CICO_SSID}'
+			sh 'duffy client retire-session ${CICO_SSID}'
 		}
 	}
 }

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -1,5 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
+def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
@@ -18,6 +19,18 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
+}
+
+def create_duffy_config() {
+	writeFile(
+		file: '/home/jenkins/.config/duffy',
+		text: """client:
+			|  url: https://duffy.ci.centos.org/api/v1
+			|  auth:
+			|    name: ceph-csi
+			|    key: ${env.CICO_API_KEY}
+			|""".stripMargin()
+	)
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it
@@ -89,18 +102,21 @@ node('cico-workspace') {
 	}
 
 	stage('reserve bare-metal machine') {
+		create_duffy_config()
+
 		def firstAttempt = true
 		retry(30) {
 			if (!firstAttempt) {
 				sleep(time: 5, unit: "MINUTES")
 			}
 			firstAttempt = false
-			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+			def cmd = sh(
+				script: "duffy client request-session pool=${duffy_pool},quantity=1",
 				returnStdout: true
-			).trim().tokenize(' ')
-			env.CICO_NODE = "${cico[0]}.ci.centos.org"
-			env.CICO_SSID = "${cico[1]}"
+			)
+			def duffy = new groovy.json.JsonSlurper().parseText(cmd)
+			env.CICO_NODE = "${duffy.session.nodes[0].hostname}"
+			env.CICO_SSID = "${duffy.session.id}"
 		}
 	}
 
@@ -192,7 +208,7 @@ node('cico-workspace') {
 
 	finally {
 		stage('return bare-metal machine') {
-			sh 'cico node done ${CICO_SSID}'
+			sh 'duffy client retire-session ${CICO_SSID}'
 		}
 
 		if (failure) {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -1,5 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
+def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
@@ -17,6 +18,18 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
+}
+
+def create_duffy_config() {
+	writeFile(
+		file: '/home/jenkins/.config/duffy',
+		text: """client:
+			|  url: https://duffy.ci.centos.org/api/v1
+			|  auth:
+			|    name: ceph-csi
+			|    key: ${env.CICO_API_KEY}
+			|""".stripMargin()
+	)
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it
@@ -88,18 +101,21 @@ node('cico-workspace') {
 	}
 
 	stage('reserve bare-metal machine') {
+		create_duffy_config()
+
 		def firstAttempt = true
 		retry(30) {
 			if (!firstAttempt) {
 				sleep(time: 5, unit: "MINUTES")
 			}
 			firstAttempt = false
-			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+			def cmd = sh(
+				script: "duffy client request-session pool=${duffy_pool},quantity=1",
 				returnStdout: true
-			).trim().tokenize(' ')
-			env.CICO_NODE = "${cico[0]}.ci.centos.org"
-			env.CICO_SSID = "${cico[1]}"
+			)
+			def duffy = new groovy.json.JsonSlurper().parseText(cmd)
+			env.CICO_NODE = "${duffy.session.nodes[0].hostname}"
+			env.CICO_SSID = "${duffy.session.id}"
 		}
 	}
 
@@ -184,7 +200,7 @@ node('cico-workspace') {
 
 	finally {
 		stage('return bare-metal machine') {
-			sh 'cico node done ${CICO_SSID}'
+			sh 'duffy client retire-session ${CICO_SSID}'
 		}
 
 		if (failure) {

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -1,5 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
+def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
@@ -17,6 +18,18 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
+}
+
+def create_duffy_config() {
+	writeFile(
+		file: '/home/jenkins/.config/duffy',
+		text: """client:
+			|  url: https://duffy.ci.centos.org/api/v1
+			|  auth:
+			|    name: ceph-csi
+			|    key: ${env.CICO_API_KEY}
+			|""".stripMargin()
+	)
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it
@@ -88,18 +101,21 @@ node('cico-workspace') {
 	}
 
 	stage('reserve bare-metal machine') {
+		create_duffy_config()
+
 		def firstAttempt = true
 		retry(30) {
 			if (!firstAttempt) {
 				sleep(time: 5, unit: "MINUTES")
 			}
 			firstAttempt = false
-			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+			def cmd = sh(
+				script: "duffy client request-session pool=${duffy_pool},quantity=1",
 				returnStdout: true
-			).trim().tokenize(' ')
-			env.CICO_NODE = "${cico[0]}.ci.centos.org"
-			env.CICO_SSID = "${cico[1]}"
+			)
+			def duffy = new groovy.json.JsonSlurper().parseText(cmd)
+			env.CICO_NODE = "${duffy.session.nodes[0].hostname}"
+			env.CICO_SSID = "${duffy.session.id}"
 		}
 	}
 
@@ -188,7 +204,7 @@ node('cico-workspace') {
 
 	finally {
 		stage('return bare-metal machine') {
-			sh 'cico node done ${CICO_SSID}'
+			sh 'duffy client retire-session ${CICO_SSID}'
 		}
 
 		if (failure) {


### PR DESCRIPTION
The `cico` command is getting deprecated, and the new `duffy` command should be used instead. The new command requires a `~/.config/duffy` file that contains an API endpoint and credentials.

See-also: https://sigs.centos.org/guide/ci/#installing-and-configuring-duffy-client

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
