### PR TITLE
deploy: csidriver added to helper scripts

### DIFF
--- a/examples/cephfs/plugin-deploy.sh
+++ b/examples/cephfs/plugin-deploy.sh
@@ -8,7 +8,7 @@ fi
 
 cd "$deployment_base" || exit 1
 
-objects=(csi-provisioner-rbac csi-nodeplugin-rbac csi-config-map csi-cephfsplugin-provisioner csi-cephfsplugin)
+objects=(csi-provisioner-rbac csi-nodeplugin-rbac csi-config-map csi-cephfsplugin-provisioner csi-cephfsplugin csidriver)
 
 for obj in "${objects[@]}"; do
 	kubectl create -f "./$obj.yaml"

--- a/examples/cephfs/plugin-teardown.sh
+++ b/examples/cephfs/plugin-teardown.sh
@@ -8,7 +8,7 @@ fi
 
 cd "$deployment_base" || exit 1
 
-objects=(csi-cephfsplugin-provisioner csi-cephfsplugin csi-config-map csi-provisioner-rbac csi-nodeplugin-rbac)
+objects=(csi-cephfsplugin-provisioner csi-cephfsplugin csi-config-map csi-provisioner-rbac csi-nodeplugin-rbac csidriver)
 
 for obj in "${objects[@]}"; do
 	kubectl delete -f "./$obj.yaml"

--- a/examples/rbd/plugin-deploy.sh
+++ b/examples/rbd/plugin-deploy.sh
@@ -10,7 +10,7 @@ fi
 
 pushd "${deployment_base}" >/dev/null || exit 1
 
-objects=(csi-provisioner-rbac csi-nodeplugin-rbac csi-config-map csi-rbdplugin-provisioner csi-rbdplugin)
+objects=(csi-provisioner-rbac csi-nodeplugin-rbac csi-config-map csi-rbdplugin-provisioner csi-rbdplugin csidriver)
 
 for obj in "${objects[@]}"; do
 	kubectl create -f "./${obj}.yaml"

--- a/examples/rbd/plugin-teardown.sh
+++ b/examples/rbd/plugin-teardown.sh
@@ -10,7 +10,7 @@ fi
 
 pushd "${deployment_base}" >/dev/null || exit 1
 
-objects=(csi-rbdplugin-provisioner csi-rbdplugin csi-config-map csi-provisioner-rbac csi-nodeplugin-rbac)
+objects=(csi-rbdplugin-provisioner csi-rbdplugin csi-config-map csi-provisioner-rbac csi-nodeplugin-rbac csidriver)
 
 for obj in "${objects[@]}"; do
 	kubectl delete -f "./${obj}.yaml"


### PR DESCRIPTION
Create the CSIDriver object with the example deploy/teardown scripts.

Original PR by @Informize, but mergify fails to rebase the PR (due to permissions?).

Updates: #3309
Closes: #3504 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
