### PR TITLE
cleanup: fix varnamelen linter

### DIFF
--- a/internal/cephfs/util/mountinfo.go
+++ b/internal/cephfs/util/mountinfo.go
@@ -58,13 +58,13 @@ func fmtNodeStageMountinfoFilename(volID VolumeID) string {
 }
 
 func (mi *NodeStageMountinfo) toNodeStageMountinfoRecord() (*nodeStageMountinfoRecord, error) {
-	bs, err := protojson.Marshal(proto.MessageV2(mi.VolumeCapability))
+	data, err := protojson.Marshal(proto.MessageV2(mi.VolumeCapability))
 	if err != nil {
 		return nil, err
 	}
 
 	return &nodeStageMountinfoRecord{
-		VolumeCapabilityProtoJSON: string(bs),
+		VolumeCapabilityProtoJSON: string(data),
 		MountOptions:              mi.MountOptions,
 		Secrets:                   mi.Secrets,
 	}, nil
@@ -92,14 +92,14 @@ func WriteNodeStageMountinfo(volID VolumeID, mi *NodeStageMountinfo) error {
 		return err
 	}
 
-	bs, err := json.Marshal(r)
+	data, err := json.Marshal(r)
 	if err != nil {
 		return err
 	}
 
 	// Write the byte slice into file.
 
-	err = os.WriteFile(fmtNodeStageMountinfoFilename(volID), bs, 0o600)
+	err = os.WriteFile(fmtNodeStageMountinfoFilename(volID), data, 0o600)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -112,7 +112,7 @@ func WriteNodeStageMountinfo(volID VolumeID, mi *NodeStageMountinfo) error {
 func GetNodeStageMountinfo(volID VolumeID) (*NodeStageMountinfo, error) {
 	// Read the file.
 
-	bs, err := os.ReadFile(fmtNodeStageMountinfoFilename(volID))
+	data, err := os.ReadFile(fmtNodeStageMountinfoFilename(volID))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -124,7 +124,7 @@ func GetNodeStageMountinfo(volID VolumeID) (*NodeStageMountinfo, error) {
 	// Unmarshall JSON-formatted byte slice into NodeStageMountinfo struct.
 
 	r := &nodeStageMountinfoRecord{}
-	if err = json.Unmarshal(bs, r); err != nil {
+	if err = json.Unmarshal(data, r); err != nil {
 		return nil, err
 	}
 

--- a/internal/kms/aws_metadata.go
+++ b/internal/kms/aws_metadata.go
@@ -125,13 +125,13 @@ func initAWSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 }
 
 func (kms *awsMetadataKMS) getSecrets() (map[string]interface{}, error) {
-	c, err := k8s.NewK8sClient()
+	client, err := k8s.NewK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Kubernetes to "+
 			"get Secret %s/%s: %w", kms.namespace, kms.secretName, err)
 	}
 
-	secret, err := c.CoreV1().Secrets(kms.namespace).Get(context.TODO(),
+	secret, err := client.CoreV1().Secrets(kms.namespace).Get(context.TODO(),
 		kms.secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w",

--- a/internal/kms/aws_sts_metadata.go
+++ b/internal/kms/aws_sts_metadata.go
@@ -117,13 +117,13 @@ func initAWSSTSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 
 // getSecrets returns required STS configuration options from the Kubernetes Secret.
 func (as *awsSTSMetadataKMS) getSecrets() (map[string]string, error) {
-	c, err := k8s.NewK8sClient()
+	client, err := k8s.NewK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Kubernetes to "+
 			"get Secret %s/%s: %w", as.namespace, as.secretName, err)
 	}
 
-	secret, err := c.CoreV1().Secrets(as.namespace).Get(context.TODO(),
+	secret, err := client.CoreV1().Secrets(as.namespace).Get(context.TODO(),
 		as.secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w",

--- a/internal/kms/keyprotect.go
+++ b/internal/kms/keyprotect.go
@@ -148,13 +148,13 @@ func initKeyProtectKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 }
 
 func (kms *keyProtectKMS) getSecrets() (map[string]interface{}, error) {
-	c, err := k8s.NewK8sClient()
+	client, err := k8s.NewK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Kubernetes to "+
 			"get Secret %s/%s: %w", kms.namespace, kms.secretName, err)
 	}
 
-	secret, err := c.CoreV1().Secrets(kms.namespace).Get(context.TODO(),
+	secret, err := client.CoreV1().Secrets(kms.namespace).Get(context.TODO(),
 		kms.secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w",

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -295,13 +295,13 @@ func (kms *kmipKMS) RequiresDEKStore() DEKStoreType {
 
 // getSecrets returns required options from the Kubernetes Secret.
 func (kms *kmipKMS) getSecrets() (map[string]string, error) {
-	c, err := k8s.NewK8sClient()
+	client, err := k8s.NewK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Kubernetes to "+
 			"get Secret %s/%s: %w", kms.namespace, kms.secretName, err)
 	}
 
-	secret, err := c.CoreV1().Secrets(kms.namespace).Get(context.TODO(),
+	secret, err := client.CoreV1().Secrets(kms.namespace).Get(context.TODO(),
 		kms.secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w",

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -159,13 +159,13 @@ func getKMSConfigMap() (map[string]interface{}, error) {
 	}
 	cmName := getKMSConfigMapName()
 
-	c, err := k8s.NewK8sClient()
+	client, err := k8s.NewK8sClient()
 	if err != nil {
 		return nil, fmt.Errorf("can not get ConfigMap %q, failed to "+
 			"connect to Kubernetes: %w", cmName, err)
 	}
 
-	cm, err := c.CoreV1().ConfigMaps(ns).Get(context.Background(),
+	cm, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(),
 		cmName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -160,13 +160,13 @@ func (kms secretsMetadataKMS) fetchEncryptionPassphrase(
 		secretNamespace = defaultNamespace
 	}
 
-	c, err := k8s.NewK8sClient()
+	client, err := k8s.NewK8sClient()
 	if err != nil {
 		return "", fmt.Errorf("can not get Secret %s/%s, failed to "+
 			"connect to Kubernetes: %w", secretNamespace, secretName, err)
 	}
 
-	secret, err := c.CoreV1().Secrets(secretNamespace).Get(context.TODO(),
+	secret, err := client.CoreV1().Secrets(secretNamespace).Get(context.TODO(),
 		secretName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get Secret %s/%s: %w",

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -483,7 +483,7 @@ func detectAuthMountPath(path string) (string, error) {
 // createTempFile writes data to a temporary file that contains the pattern in
 // the filename (see ioutil.TempFile for details).
 func createTempFile(pattern string, data []byte) (string, error) {
-	t, err := ioutil.TempFile("", pattern)
+	tempFile, err := ioutil.TempFile("", pattern)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary file: %w", err)
 	}
@@ -492,18 +492,18 @@ func createTempFile(pattern string, data []byte) (string, error) {
 	defer func() {
 		if err != nil {
 			// ignore error on failure to remove tmpfile (gosec complains)
-			_ = os.Remove(t.Name())
+			_ = os.Remove(tempFile.Name())
 		}
 	}()
 
-	s, err := t.Write(data)
+	s, err := tempFile.Write(data)
 	if err != nil || s != len(data) {
 		return "", fmt.Errorf("failed to write temporary file: %w", err)
 	}
-	err = t.Close()
+	err = tempFile.Close()
 	if err != nil {
 		return "", fmt.Errorf("failed to close temporary file: %w", err)
 	}
 
-	return t.Name(), nil
+	return tempFile.Name(), nil
 }

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -156,7 +156,71 @@ linters-settings:
     max-blank-identifiers: 3
   nestif:
     min-complexity: 7
-
+  varnamelen:
+    ignore-names:
+      - f 
+      - ok
+      - v
+      - k 
+      - ns 
+      - sa 
+      - sv 
+      - cc 
+      - cm 
+      - vc
+      - a 
+      - gf
+      - s
+      - cr 
+      - cj
+      - w 
+      - j 
+      - fs 
+      - vi
+      - cp 
+      - to 
+      - i 
+      - d 
+      - t 
+      - pv 
+      - r 
+      - c 
+      - cd 
+      - sc 
+      - wg 
+      - ds 
+      - e 
+      - tt
+      - n 
+      - p 
+      - cn 
+      - cs 
+      - co 
+      - ca 
+      - bc 
+      - ts 
+      - ip 
+      - u 
+      - id 
+      - ho 
+      - m 
+      - ss 
+      - ep 
+      - tc 
+      - rv 
+      - mh 
+      - sf 
+      - m 
+      - rc
+      - va 
+      - ls 
+      - id 
+      - ve 
+      - kv 
+      - mt 
+      - ce 
+      - op  
+      
 linters:
   enable-all: true
   disable:
@@ -189,7 +253,6 @@ linters:
     - gomnd
     - ireturn
     - tagliatelle
-    - varnamelen
     - nilnil
     # TODO enable linters added in golangci-lint 1.46
     - maintidx


### PR DESCRIPTION
This PR fix the varnamelen linter errors caused by golangci-lint 1.43.

For reference- https://github.com/ceph/ceph-csi/issues/2595

Signed-off-by: riya-singhal31 <rsinghal@redhat.com>

