### PR TITLE
cleanup: fix ireturn linter

### DIFF
--- a/internal/cephfs/core/filesystem.go
+++ b/internal/cephfs/core/filesystem.go
@@ -42,7 +42,7 @@ type fileSystem struct {
 }
 
 // NewFileSystem returns a new instance of fileSystem.
-func NewFileSystem(conn *util.ClusterConnection) FileSystem {
+func NewFileSystem(conn *util.ClusterConnection) FileSystem { //nolint:ireturn
 	return &fileSystem{
 		conn: conn,
 	}

--- a/internal/cephfs/core/snapshot.go
+++ b/internal/cephfs/core/snapshot.go
@@ -75,7 +75,7 @@ type Snapshot struct {
 }
 
 // NewSnapshot creates a new snapshot client.
-func NewSnapshot(
+func NewSnapshot( //nolint:ireturn
 	conn *util.ClusterConnection,
 	snapshotID,
 	clusterID,

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -99,7 +99,7 @@ type SubVolume struct {
 }
 
 // NewSubVolume returns a new subvolume client.
-func NewSubVolume(
+func NewSubVolume( //nolint:ireturn
 	conn *util.ClusterConnection,
 	vol *SubVolume,
 	clusterID,

--- a/internal/cephfs/mounter/volumemounter.go
+++ b/internal/cephfs/mounter/volumemounter.go
@@ -103,7 +103,7 @@ type VolumeMounter interface {
 	Name() string
 }
 
-func New(volOptions *store.VolumeOptions) (VolumeMounter, error) {
+func New(volOptions *store.VolumeOptions) (VolumeMounter, error) { //nolint:ireturn
 	// Get the mounter from the configuration
 
 	wantMounter := volOptions.Mounter

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -61,7 +61,7 @@ func (r *ReconcilePersistentVolume) Add(mgr manager.Manager, config ctrl.Config)
 }
 
 // newReconciler returns a ReconcilePersistentVolume.
-func newPVReconciler(mgr manager.Manager, config ctrl.Config) reconcile.Reconciler {
+func newPVReconciler(mgr manager.Manager, config ctrl.Config) reconcile.Reconciler { //nolint:ireturn
 	r := &ReconcilePersistentVolume{
 		client: mgr.GetClient(),
 		config: config,

--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -54,7 +54,7 @@ type Servers struct {
 }
 
 // NewNonBlockingGRPCServer return non-blocking GRPC.
-func NewNonBlockingGRPCServer() NonBlockingGRPCServer {
+func NewNonBlockingGRPCServer() NonBlockingGRPCServer { //nolint:ireturn
 	return &nonBlockingGRPCServer{}
 }
 

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -111,7 +111,7 @@ func isReplicationRequest(req interface{}) bool {
 
 // NewMiddlewareServerOption creates a new grpc.ServerOption that configures a
 // common format for log messages and other gRPC related handlers.
-func NewMiddlewareServerOption(withMetrics bool) grpc.ServerOption {
+func NewMiddlewareServerOption(withMetrics bool) grpc.ServerOption { //nolint:ireturn
 	middleWare := []grpc.UnaryServerInterceptor{contextIDInjector, logGRPC, panicHandler}
 
 	if withMetrics {

--- a/internal/kms/aws_metadata.go
+++ b/internal/kms/aws_metadata.go
@@ -78,7 +78,7 @@ type awsMetadataKMS struct {
 	cmk             string
 }
 
-func initAWSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func initAWSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	kms := &awsMetadataKMS{
 		namespace: args.Namespace,
 	}

--- a/internal/kms/aws_sts_metadata.go
+++ b/internal/kms/aws_sts_metadata.go
@@ -75,7 +75,7 @@ type awsSTSMetadataKMS struct {
 	role string
 }
 
-func initAWSSTSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func initAWSSTSMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	kms := &awsSTSMetadataKMS{
 		awsMetadataKMS: awsMetadataKMS{
 			namespace: args.Tenant,

--- a/internal/kms/dummy.go
+++ b/internal/kms/dummy.go
@@ -34,7 +34,7 @@ func RegisterTestProvider(provider ProviderTest) bool {
 	return true
 }
 
-func GetKMSTestDummy(kmsID string) EncryptionKMS {
+func GetKMSTestDummy(kmsID string) EncryptionKMS { //nolint:ireturn
 	provider, ok := kmsTestManager.providers[kmsID]
 	if !ok {
 		return nil
@@ -47,12 +47,12 @@ func GetKMSTestProvider() map[string]ProviderTest {
 	return kmsTestManager.providers
 }
 
-func newDefaultTestDummy() EncryptionKMS {
+func newDefaultTestDummy() EncryptionKMS { //nolint:ireturn
 	return secretsKMS{passphrase: base64.URLEncoding.EncodeToString(
 		[]byte("test dummy passphrase"))}
 }
 
-func newSecretsMetadataTestDummy() EncryptionKMS {
+func newSecretsMetadataTestDummy() EncryptionKMS { //nolint:ireturn
 	smKMS := secretsMetadataKMS{}
 	smKMS.secretsKMS = secretsKMS{passphrase: base64.URLEncoding.EncodeToString(
 		[]byte("test dummy passphrase"))}

--- a/internal/kms/keyprotect.go
+++ b/internal/kms/keyprotect.go
@@ -79,7 +79,7 @@ type keyProtectKMS struct {
 	crk               string
 }
 
-func initKeyProtectKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func initKeyProtectKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	kms := &keyProtectKMS{
 		namespace: args.Namespace,
 	}

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -94,7 +94,7 @@ type kmipKMS struct {
 	writeTimeout     uint8
 }
 
-func initKMIPKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func initKMIPKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	kms := &kmipKMS{
 		namespace: args.Namespace,
 	}

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -66,7 +66,7 @@ var (
 // - kmsID is the service name of the KMS configuration
 // - secrets contain additional details, like TLS certificates to connect to
 //   the KMS
-func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, error) {
+func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, error) { //nolint:ireturn
 	if kmsID == "" || kmsID == DefaultKMSType {
 		return GetDefaultKMS(secrets)
 	}
@@ -272,7 +272,7 @@ func RegisterProvider(provider Provider) bool {
 // buildKMS creates a new Provider instance, based on the configuration that
 // was passed. This uses getProvider() internally to identify the
 // Provider to instantiate.
-func (kf *kmsProviderList) buildKMS(
+func (kf *kmsProviderList) buildKMS( //nolint:ireturn
 	tenant string,
 	config map[string]interface{},
 	secrets map[string]string,
@@ -304,7 +304,7 @@ func (kf *kmsProviderList) buildKMS(
 	return provider.Initializer(kmsInitArgs)
 }
 
-func GetDefaultKMS(secrets map[string]string) (EncryptionKMS, error) {
+func GetDefaultKMS(secrets map[string]string) (EncryptionKMS, error) { //nolint:ireturn
 	provider, ok := kmsManager.providers[DefaultKMSType]
 	if !ok {
 		return nil, fmt.Errorf("could not find KMS provider %q", DefaultKMSType)

--- a/internal/kms/kms_test.go
+++ b/internal/kms/kms_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func noinitKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func noinitKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	return nil, nil
 }
 

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -63,7 +63,7 @@ var _ = RegisterProvider(Provider{
 // newSecretsKMS initializes a secretsKMS that uses the passphrase from the
 // secret that is configured for the StorageClass. This KMS provider uses a
 // single (LUKS) passhprase for all volumes.
-func newSecretsKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func newSecretsKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	passphraseValue, ok := args.Secrets[encryptionPassphraseKey]
 	if !ok {
 		return nil, errors.New("missing encryption passphrase in secrets")
@@ -108,7 +108,7 @@ var _ = RegisterProvider(Provider{
 // initSecretsMetadataKMS initializes a secretsMetadataKMS that wraps a secretKMS,
 // so that the passphrase from the user provided or StorageClass secrets can be used
 // for encrypting/decrypting DEKs that are stored in a detached DEKStore.
-func initSecretsMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func initSecretsMetadataKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	var (
 		smKMS                secretsMetadataKMS
 		encryptionPassphrase string

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -333,7 +333,7 @@ var _ = RegisterProvider(Provider{
 })
 
 // InitVaultKMS returns an interface to HashiCorp Vault KMS.
-func initVaultKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func initVaultKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	kms := &vaultKMS{}
 	err := kms.initConnection(args.Config)
 	if err != nil {

--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -86,7 +86,7 @@ var _ = RegisterProvider(Provider{
 
 // initVaultTenantSA returns an interface to HashiCorp Vault KMS where Tenants
 // use their ServiceAccount to access the service.
-func initVaultTenantSA(args ProviderInitArgs) (EncryptionKMS, error) {
+func initVaultTenantSA(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	var err error
 
 	config := args.Config

--- a/internal/kms/vault_tokens.go
+++ b/internal/kms/vault_tokens.go
@@ -216,7 +216,7 @@ var _ = RegisterProvider(Provider{
 })
 
 // InitVaultTokensKMS returns an interface to HashiCorp Vault KMS.
-func initVaultTokensKMS(args ProviderInitArgs) (EncryptionKMS, error) {
+func initVaultTokensKMS(args ProviderInitArgs) (EncryptionKMS, error) { //nolint:ireturn
 	var err error
 
 	config := args.Config

--- a/internal/util/reftracker/radoswrapper/fakerados.go
+++ b/internal/util/reftracker/radoswrapper/fakerados.go
@@ -158,7 +158,7 @@ func (c *FakeIOContext) GetXattr(oid, key string, data []byte) (int, error) {
 	return len(xattr), nil
 }
 
-func (c *FakeIOContext) CreateWriteOp() WriteOpW {
+func (c *FakeIOContext) CreateWriteOp() WriteOpW { //nolint:ireturn
 	return &FakeWriteOp{
 		IoCtx: c,
 		steps: make(map[fakeWriteOpStepExecutorIdx]fakeWriteOpStepExecutor),
@@ -193,7 +193,7 @@ func (w *FakeWriteOp) Operate(oid string) error {
 
 func (w *FakeWriteOp) Release() {}
 
-func (c *FakeIOContext) CreateReadOp() ReadOpW {
+func (c *FakeIOContext) CreateReadOp() ReadOpW { //nolint:ireturn
 	return &FakeReadOp{
 		IoCtx: c,
 		steps: make(map[fakeReadOpStepExecutorIdx]fakeReadOpStepExecutor),
@@ -497,7 +497,7 @@ func (s *FakeReadOpOmapGetValsByKeysStep) Next() (*rados.OmapKeyValue, error) {
 	return omapKeyValue, nil
 }
 
-func (r *FakeReadOp) GetOmapValuesByKeys(keys []string) ReadOpOmapGetValsByKeysStepW {
+func (r *FakeReadOp) GetOmapValuesByKeys(keys []string) ReadOpOmapGetValsByKeysStepW { //nolint:ireturn
 	keysCopy := append([]string(nil), keys...)
 
 	s := &FakeReadOpOmapGetValsByKeysStep{}

--- a/internal/util/reftracker/radoswrapper/radoswrapper.go
+++ b/internal/util/reftracker/radoswrapper/radoswrapper.go
@@ -42,7 +42,7 @@ type (
 
 var _ IOContextW = &IOContext{}
 
-func NewIOContext(ioctx *rados.IOContext) IOContextW {
+func NewIOContext(ioctx *rados.IOContext) IOContextW { //nolint:ireturn
 	return &IOContext{
 		IOContext: ioctx,
 	}
@@ -56,14 +56,14 @@ func (c *IOContext) GetXattr(oid, key string, data []byte) (int, error) {
 	return c.IOContext.GetXattr(oid, key, data)
 }
 
-func (c *IOContext) CreateWriteOp() WriteOpW {
+func (c *IOContext) CreateWriteOp() WriteOpW { //nolint:ireturn
 	return &WriteOp{
 		IoCtx:   c.IOContext,
 		WriteOp: rados.CreateWriteOp(),
 	}
 }
 
-func (c *IOContext) CreateReadOp() ReadOpW {
+func (c *IOContext) CreateReadOp() ReadOpW { //nolint:ireturn
 	return &ReadOp{
 		IoCtx:  c.IOContext,
 		ReadOp: rados.CreateReadOp(),
@@ -110,7 +110,7 @@ func (r *ReadOp) Read(offset uint64, buffer []byte) *rados.ReadOpReadStep {
 	return r.ReadOp.Read(offset, buffer)
 }
 
-func (r *ReadOp) GetOmapValuesByKeys(keys []string) ReadOpOmapGetValsByKeysStepW {
+func (r *ReadOp) GetOmapValuesByKeys(keys []string) ReadOpOmapGetValsByKeysStepW { //nolint:ireturn
 	return &ReadOpOmapGetValsByKeysStep{
 		ReadOpOmapGetValsByKeysStep: r.ReadOp.GetOmapValuesByKeys(keys),
 	}

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -187,7 +187,6 @@ linters:
     # TODO: enable linters added in golangci-lint 1.43
     - contextcheck
     - gomnd
-    - ireturn
     - tagliatelle
     - varnamelen
     - nilnil


### PR DESCRIPTION
This PR fix the ireturn linter errors caused by golangci-lint 1.43.

For reference- https://github.com/ceph/ceph-csi/issues/2595

Signed-off-by: riya-singhal31 <rsinghal@redhat.com>
