### PR TITLE
rebase: update go-ceph to v0.19.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.7
 	github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000
 	// TODO: API for managing subvolume metadata and snapshot metadata requires `ceph_ci_untested` build-tag
-	github.com/ceph/go-ceph v0.18.0
+	github.com/ceph/go-ceph v0.19.0
 	github.com/container-storage-interface/spec v1.7.0
 	github.com/csi-addons/replication-lib-utils v0.2.0
 	github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
-github.com/ceph/go-ceph v0.18.0 h1:4WM6yAq/iqBDaeeADDiPKLqKiP0iZ4fffdgCr1lnOL4=
-github.com/ceph/go-ceph v0.18.0/go.mod h1:cflETVTBNAQM6jdr7hpNHHFHKYiJiWWcAeRDrRx/1ng=
+github.com/ceph/go-ceph v0.19.0 h1:cl5apHt98pCWSoUStiLdl7Mlk3ke8fUGF4HI66Nxy/A=
+github.com/ceph/go-ceph v0.19.0/go.mod h1:sdTcqdDeIPWX3TaR5HCi5YtT+BliI6fFvvWP6Io7VQE=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -371,7 +371,7 @@ github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gocql/gocql v0.0.0-20190402132108-0e1d5de854df/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/uuid v4.3.0+incompatible h1:CaSVZxm5B+7o45rtab4jC2G37WGYX1zQfuU2i6DSvnc=
+github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_alignment.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_alignment.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_requires_alignment.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx_pool_requires_alignment.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx_set_alloc_hint.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx_set_alloc_hint.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/vendor/github.com/ceph/go-ceph/rados/write_op_set_alloc_hint.go
+++ b/vendor/github.com/ceph/go-ceph/rados/write_op_set_alloc_hint.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/vendor/github.com/ceph/go-ceph/rbd/rbd.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/rbd.go
@@ -984,7 +984,7 @@ func GetTrashList(ioctx *rados.IOContext) ([]TrashInfo, error) {
 		count   C.size_t
 		entries []C.rbd_trash_image_info_t
 	)
-	retry.WithSizes(32, 1024, func(size int) retry.Hint {
+	retry.WithSizes(32, 10240, func(size int) retry.Hint {
 		count = C.size_t(size)
 		entries = make([]C.rbd_trash_image_info_t, count)
 		ret := C.rbd_trash_list(cephIoctx(ioctx), &entries[0], &count)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/cenkalti/backoff/v3
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.18.0
+# github.com/ceph/go-ceph v0.19.0
 ## explicit; go 1.17
 github.com/ceph/go-ceph/cephfs/admin
 github.com/ceph/go-ceph/common/admin/manager


### PR DESCRIPTION
updating go-ceph to the latest available release.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

