### PR TITLE
cleanup: migration of volrep to csi-addons

### DIFF
--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	corerbd "github.com/ceph/ceph-csi/internal/rbd"
+
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -455,7 +457,7 @@ func TestValidateLastSyncTime(t *testing.T) {
 			"empty description",
 			"",
 			nil,
-			ErrLastSyncTimeNotFound.Error(),
+			corerbd.ErrLastSyncTimeNotFound.Error(),
 		},
 		{
 			"description without local_snapshot_timestamp",
@@ -473,7 +475,7 @@ func TestValidateLastSyncTime(t *testing.T) {
 			"description with no JSON",
 			`replaying`,
 			nil,
-			ErrLastSyncTimeNotFound.Error(),
+			corerbd.ErrLastSyncTimeNotFound.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -943,7 +943,7 @@ func (cs *ControllerServer) DeleteVolume(
 func cleanupRBDImage(ctx context.Context,
 	rbdVol *rbdVolume, cr *util.Credentials,
 ) (*csi.DeleteVolumeResponse, error) {
-	mirroringInfo, err := rbdVol.getImageMirroringInfo()
+	mirroringInfo, err := rbdVol.GetImageMirroringInfo()
 	if err != nil {
 		log.ErrorLog(ctx, err.Error())
 
@@ -962,7 +962,7 @@ func cleanupRBDImage(ctx context.Context,
 		// the image on all the remote (secondary) clusters will get
 		// auto-deleted. This helps in garbage collecting the OMAP, PVC and PV
 		// objects after failback operation.
-		localStatus, rErr := rbdVol.getLocalState()
+		localStatus, rErr := rbdVol.GetLocalState()
 		if rErr != nil {
 			return nil, status.Error(codes.Internal, rErr.Error())
 		}

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -38,7 +38,7 @@ type Driver struct {
 	ids *rbd.IdentityServer
 	ns  *rbd.NodeServer
 	cs  *rbd.ControllerServer
-	rs  *rbd.ReplicationServer
+	rs  *casrbd.ReplicationServer
 
 	// cas is the CSIAddonsServer where CSI-Addons services are handled
 	cas *csiaddons.CSIAddonsServer
@@ -66,8 +66,8 @@ func NewControllerServer(d *csicommon.CSIDriver) *rbd.ControllerServer {
 	}
 }
 
-func NewReplicationServer(c *rbd.ControllerServer) *rbd.ReplicationServer {
-	return &rbd.ReplicationServer{ControllerServer: c}
+func NewReplicationServer(c *rbd.ControllerServer) *casrbd.ReplicationServer {
+	return &casrbd.ReplicationServer{ControllerServer: c}
 }
 
 // NewNodeServer initialize a node server for rbd CSI driver.

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -25,8 +25,8 @@ import (
 	librbd "github.com/ceph/go-ceph/rbd"
 )
 
-// enableImageMirroring enables mirroring on an image.
-func (ri *rbdImage) enableImageMirroring(mode librbd.ImageMirrorMode) error {
+// EnableImageMirroring enables mirroring on an image.
+func (ri *rbdImage) EnableImageMirroring(mode librbd.ImageMirrorMode) error {
 	image, err := ri.open()
 	if err != nil {
 		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
@@ -41,8 +41,8 @@ func (ri *rbdImage) enableImageMirroring(mode librbd.ImageMirrorMode) error {
 	return nil
 }
 
-// disableImageMirroring disables mirroring on an image.
-func (ri *rbdImage) disableImageMirroring(force bool) error {
+// DisableImageMirroring disables mirroring on an image.
+func (ri *rbdImage) DisableImageMirroring(force bool) error {
 	image, err := ri.open()
 	if err != nil {
 		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
@@ -57,8 +57,8 @@ func (ri *rbdImage) disableImageMirroring(force bool) error {
 	return nil
 }
 
-// getImageMirroringInfo gets mirroring information of an image.
-func (ri *rbdImage) getImageMirroringInfo() (*librbd.MirrorImageInfo, error) {
+// GetImageMirroringInfo gets mirroring information of an image.
+func (ri *rbdImage) GetImageMirroringInfo() (*librbd.MirrorImageInfo, error) {
 	image, err := ri.open()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open image %q with error: %w", ri, err)
@@ -73,8 +73,8 @@ func (ri *rbdImage) getImageMirroringInfo() (*librbd.MirrorImageInfo, error) {
 	return info, nil
 }
 
-// promoteImage promotes image to primary.
-func (ri *rbdImage) promoteImage(force bool) error {
+// PromoteImage promotes image to primary.
+func (ri *rbdImage) PromoteImage(force bool) error {
 	image, err := ri.open()
 	if err != nil {
 		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
@@ -88,10 +88,10 @@ func (ri *rbdImage) promoteImage(force bool) error {
 	return nil
 }
 
-// forcePromoteImage promotes image to primary with force option with 2 minutes
+// ForcePromoteImage promotes image to primary with force option with 2 minutes
 // timeout. If there is no response within 2 minutes,the rbd CLI process will be
 // killed and an error is returned.
-func (rv *rbdVolume) forcePromoteImage(cr *util.Credentials) error {
+func (rv *rbdVolume) ForcePromoteImage(cr *util.Credentials) error {
 	promoteArgs := []string{
 		"mirror", "image", "promote",
 		rv.String(),
@@ -118,8 +118,8 @@ func (rv *rbdVolume) forcePromoteImage(cr *util.Credentials) error {
 	return nil
 }
 
-// demoteImage demotes image to secondary.
-func (ri *rbdImage) demoteImage() error {
+// DemoteImage demotes image to secondary.
+func (ri *rbdImage) DemoteImage() error {
 	image, err := ri.open()
 	if err != nil {
 		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
@@ -148,8 +148,8 @@ func (ri *rbdImage) resyncImage() error {
 	return nil
 }
 
-// getImageMirroringStatus get the mirroring status of an image.
-func (ri *rbdImage) getImageMirroringStatus() (*librbd.GlobalMirrorImageStatus, error) {
+// GetImageMirroringStatus get the mirroring status of an image.
+func (ri *rbdImage) GetImageMirroringStatus() (*librbd.GlobalMirrorImageStatus, error) {
 	image, err := ri.open()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open image %q with error: %w", ri, err)
@@ -163,8 +163,8 @@ func (ri *rbdImage) getImageMirroringStatus() (*librbd.GlobalMirrorImageStatus, 
 	return &statusInfo, nil
 }
 
-// getLocalState returns the local state of the image.
-func (ri *rbdImage) getLocalState() (librbd.SiteMirrorImageStatus, error) {
+// GetLocalState returns the local state of the image.
+func (ri *rbdImage) GetLocalState() (librbd.SiteMirrorImageStatus, error) {
 	localStatus := librbd.SiteMirrorImageStatus{}
 	image, err := ri.open()
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2018,7 +2018,7 @@ func (ri *rbdImage) isCompabitableClone(dst *rbdImage) error {
 	return nil
 }
 
-func (ri *rbdImage) addSnapshotScheduling(
+func (ri *rbdImage) AddSnapshotScheduling(
 	interval admin.Interval,
 	startTime admin.StartTime,
 ) error {

--- a/internal/rbd/replication.go
+++ b/internal/rbd/replication.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"strings"
+
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/csi-addons/spec/lib/go/replication"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (rv *rbdVolume) ResyncVol(localStatus librbd.SiteMirrorImageStatus, force bool) error {
+	if resyncRequired(localStatus) {
+		// If the force option is not set return the error message to retry
+		// with Force option.
+		if !force {
+			return status.Errorf(codes.FailedPrecondition,
+				"image is in %q state, description (%s). Force resync to recover volume",
+				localStatus.State, localStatus.Description)
+		}
+		err := rv.resyncImage()
+		if err != nil {
+			return status.Error(codes.Internal, err.Error())
+		}
+
+		// If we issued a resync, return a non-final error as image needs to be recreated
+		// locally. Caller retries till RBD syncs an initial version of the image to
+		// report its status in the resync request.
+		return status.Error(codes.Unavailable, "awaiting initial resync due to split brain")
+	}
+
+	return nil
+}
+
+// repairResyncedImageID updates the existing image ID with new one.
+func (rv *rbdVolume) RepairResyncedImageID(ctx context.Context, ready bool) error {
+	// During resync operation the local image will get deleted and a new
+	// image is recreated by the rbd mirroring. The new image will have a
+	// new image ID. Once resync is completed update the image ID in the OMAP
+	// to get the image removed from the trash during DeleteVolume.
+
+	// if the image is not completely resynced skip repairing image ID.
+	if !ready {
+		return nil
+	}
+	j, err := volJournal.Connect(rv.Monitors, rv.RadosNamespace, rv.conn.Creds)
+	if err != nil {
+		return err
+	}
+	defer j.Destroy()
+	// reset the image ID which is stored in the existing OMAP
+	return rv.repairImageID(ctx, j, true)
+}
+
+// resyncRequired returns true if local image is in split-brain state and image
+// needs resync.
+func resyncRequired(localStatus librbd.SiteMirrorImageStatus) bool {
+	// resync is required if the image is in error state or the description
+	// contains split-brain message.
+	// In some corner cases like `re-player shutdown` the local image will not
+	// be in an error state. It would be also worth considering the `description`
+	// field to make sure about split-brain.
+	if localStatus.State == librbd.MirrorImageStatusStateError ||
+		strings.Contains(localStatus.Description, "split-brain") {
+		return true
+	}
+
+	return false
+}
+
+func DisableVolumeReplication(rbdVol *rbdVolume,
+	mirroringInfo *librbd.MirrorImageInfo,
+	force bool,
+) (*replication.DisableVolumeReplicationResponse, error) {
+	if !mirroringInfo.Primary {
+		// Return success if the below condition is met
+		// Local image is secondary
+		// Local image is in up+replaying state
+
+		// If the image is in a secondary and its state is  up+replaying means
+		// its a healthy secondary and the image is primary somewhere in the
+		// remote cluster and the local image is getting replayed. Return
+		// success for the Disabling mirroring as we cannot disable mirroring
+		// on the secondary image, when the image on the primary site gets
+		// disabled the image on all the remote (secondary) clusters will get
+		// auto-deleted. This helps in garbage collecting the volume
+		// replication Kubernetes artifacts after failback operation.
+		localStatus, rErr := rbdVol.GetLocalState()
+		if rErr != nil {
+			return nil, status.Error(codes.Internal, rErr.Error())
+		}
+		if localStatus.Up && localStatus.State == librbd.MirrorImageStatusStateReplaying {
+			return &replication.DisableVolumeReplicationResponse{}, nil
+		}
+
+		return nil, status.Errorf(codes.InvalidArgument,
+			"secondary image status is up=%t and state=%s",
+			localStatus.Up,
+			localStatus.State)
+	}
+	err := rbdVol.DisableImageMirroring(force)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	// the image state can be still disabling once we disable the mirroring
+	// check the mirroring is disabled or not
+	mirroringInfo, err = rbdVol.GetImageMirroringInfo()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if mirroringInfo.State == librbd.MirrorImageDisabling {
+		return nil, status.Errorf(codes.Aborted, "%s is in disabling state", rbdVol.VolID)
+	}
+
+	return &replication.DisableVolumeReplicationResponse{}, nil
+}


### PR DESCRIPTION
This commit moves the volrep logic(replication controller server) from internal/rbd to internal/csi-addons/rbd.

Signed-off-by: riya-singhal31 <rsinghal@redhat.com>
