### PR TITLE
ci: move `ci-job-validation` to `duffy` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ following files:
      and configuration to request a bare-metal machine
   1. checkout the `centos/ci` branch of the repository, which contains scripts
      for provisioning and preparing the environment for running tests
-  1. reserve a bare-metal machine with `cico` (configured on the Jenkins Slave)
+  1. reserve a bare-metal machine with `duffy` (configured on the Jenkins
+     Slave)
   1. provision the reserved bare-metal machine with additional tools and
      dependencies to run the test (see `prepare.sh` below)
   1. run `make containerized-tests` and `make containerized-build` in parallel

--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -1,5 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
+def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'
@@ -18,6 +19,18 @@ def ssh(cmd) {
 
 def podman_login(registry, username, passwd) {
 	ssh "podman login --authfile=~/.podman-auth.json --username='${username}' --password='${passwd}' ${registry}"
+}
+
+def create_duffy_config() {
+	writeFile(
+		file: '/home/jenkins/.config/duffy',
+		text: """client:
+			|  url: https://duffy.ci.centos.org/api/v1
+			|  auth:
+			|    name: ceph-csi
+			|    key: ${env.CICO_API_KEY}
+			|""".stripMargin()
+	)
 }
 
 // podman_pull pulls image from the source (CI internal) registry, and tags it
@@ -64,18 +77,21 @@ node('cico-workspace') {
 	}
 
 	stage('reserve bare-metal machine') {
+		create_duffy_config()
+
 		def firstAttempt = true
 		retry(30) {
 			if (!firstAttempt) {
 				sleep(time: 5, unit: "MINUTES")
 			}
 			firstAttempt = false
-			cico = sh(
-				script: "cico node get -f value -c hostname -c comment --release=8-stream --retry-count=${cico_retries} --retry-interval=${cico_retry_interval}",
+			def cmd = sh(
+				script: "duffy client request-session pool=${duffy_pool},quantity=1",
 				returnStdout: true
-			).trim().tokenize(' ')
-			env.CICO_NODE = "${cico[0]}.ci.centos.org"
-			env.CICO_SSID = "${cico[1]}"
+			)
+			def duffy = new groovy.json.JsonSlurper().parseText(cmd)
+			env.CICO_NODE = "${duffy.session.nodes[0].hostname}"
+			env.CICO_SSID = "${duffy.session.id}"
 		}
 	}
 
@@ -113,7 +129,7 @@ node('cico-workspace') {
 
 	finally {
 		stage('return bare-metal machine') {
-			sh 'cico node done ${CICO_SSID}'
+			sh 'duffy client retire-session ${CICO_SSID}'
 		}
 	}
 }


### PR DESCRIPTION
It seems all jobs were converted to the new `duffy` command, except ci-job-validation which still used the old `cico` command.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
