### PR TITLE
ci: add jobs for running with Kubernetes 1.27

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -10,6 +10,8 @@
           only_run_on_request: true
       - '1.26':
           only_run_on_request: true
+      - '1.27':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -10,6 +10,8 @@
           only_run_on_request: true
       - '1.26':
           only_run_on_request: true
+      - '1.27':
+          only_run_on_request: true
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'


### PR DESCRIPTION
Kubernetes 1.27 is available as Alpha release, and we could start testing Ceph-CSI with that.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
