### PR TITLE
rbd: discover if StagingTargetPath in NodeExpandVolume exists

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1731,6 +1731,14 @@ func stashRBDImageMetadata(volOptions *rbdVolume, metaDataPath string) error {
 	return nil
 }
 
+// checkRBDImageMetadataStashExists checks if the stashFile exists at the passed in path.
+func checkRBDImageMetadataStashExists(metaDataPath string) bool {
+	imageMetaPath := filepath.Join(metaDataPath, stashFileName)
+	_, err := os.Stat(imageMetaPath)
+
+	return err == nil
+}
+
 // lookupRBDImageMetadataStash reads and returns stashed image metadata at passed in path.
 func lookupRBDImageMetadataStash(metaDataPath string) (rbdImageMetadataStash, error) {
 	var imgMeta rbdImageMetadataStash


### PR DESCRIPTION
The StagingTargetPath is an optional entry in NodeExpandVolumeRequest, We cannot expect it to be permanently set, and at the same time, cephcsi depended on the StaingTargetPath to retrieve some metadata
information.

This commit will check all the mount ref and identifies the stagingTargetPath by reviewing the image-meta.json file that exists. This is a costly operation as we need to loop through all the mounts and check image-meta.json in each mount, but this happens only if the StaingTargetPath needs to be set in the NodeExpandVolumeRequest.

fixes #3623

Note :- gofmt tool I am using also fixed the indentation problem in the comment section in nodeserver.go

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

