### PR TITLE
ci: allow /opt/build for git repository when deploying jobs

### DIFF
--- a/deploy/checkout-repo.sh
+++ b/deploy/checkout-repo.sh
@@ -11,6 +11,7 @@ fail() {
 # exit in case a command fails
 set -e
 
+git config --global --add safe.directory ${PWD}
 git init .
 git remote add origin "${GIT_REPO}"
 git fetch origin "${GIT_REF}"


### PR DESCRIPTION
When Jenkins Jobs have been modified, they should get deployed in the Jenkins environment. This seems to fail with the following error:

```
Initialized empty Git repository in /opt/build/.git/
fatal: detected dubious ownership in repository at '/opt/build'
To add an exception for this directory, call:

	git config --global --add safe.directory /opt/build
```

By marking /opt/build as a safe directory in the global git configuration file, this problem should not occur anymore.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
