### PR TITLE
ci: add Kubernetes 1.26 as default version to test

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -37,6 +37,13 @@ jobs:
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.25
 
+      - name: Add comment to trigger external storage tests for Kubernetes 1.26
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/k8s-e2e-external-storage/1.26
+
       - name: Add comment to trigger helm E2E tests for Kubernetes 1.23
         uses: peter-evans/create-or-update-comment@v2
         with:
@@ -58,6 +65,13 @@ jobs:
           body: |
             /test ci/centos/mini-e2e-helm/k8s-1.25
 
+      - name: Add comment to trigger helm E2E tests for Kubernetes 1.26
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e-helm/k8s-1.26
+
       - name: Add comment to trigger E2E tests for Kubernetes 1.23
         uses: peter-evans/create-or-update-comment@v2
         with:
@@ -78,6 +92,13 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e/k8s-1.25
+
+      - name: Add comment to trigger E2E tests for Kubernetes 1.26
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e/k8s-1.26
 
       - name: Add comment to trigger cephfs upgrade tests
         uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
Kubernetes 1.26 has been released at the end of 2022 and should be tested frequently.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
