### PR TITLE
ci: drop `ok-to-test` label when a PR is rebased

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,6 @@
 ---
 defaults:
   actions:
-    # mergify.io has removed bot_account from its free open source plan.
-    # comment:
-    # bot_account: ceph-csi-bot # mergify[bot] will be commenting.
     queue:
       # merge_bot_account: ceph-csi-bot #mergify[bot] will be merging prs.
       # update_bot_account: ceph-csi-bot #mergify will randomly pick and use
@@ -12,6 +9,9 @@ defaults:
       method: rebase
       rebase_fallback: merge
       update_method: rebase
+    rebase:
+      # Use ceph-csi-bot for rebasing, not the account of the PR owner.
+      bot_account: ceph-csi-bot
 
 queue_rules:
   - name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -59,6 +59,9 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
+      label:
+        remove:
+          - ok-to-test
 
   - name: ask to resolve conflict
     conditions:


### PR DESCRIPTION
When reviews are dropped, tests should most often not automatically start again.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
