### PR TITLE
build: Update packages in release image

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -2,7 +2,13 @@ ARG SRC_DIR="/go/src/github.com/ceph/ceph-csi/"
 ARG GO_ARCH
 ARG BASE_IMAGE
 
-FROM ${BASE_IMAGE} as builder
+FROM ${BASE_IMAGE} as updated_base
+
+RUN dnf -y update \
+       && dnf clean all \
+       && rm -rf /var/cache/yum
+
+FROM updated_base as builder
 
 LABEL stage="build"
 
@@ -28,8 +34,7 @@ RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch || true
 
-RUN dnf -y update \
-        && dnf -y install --nodocs \
+RUN dnf -y install --nodocs \
 	librados-devel librbd-devel \
 	/usr/bin/cc \
 	make \
@@ -56,7 +61,7 @@ COPY . ${SRC_DIR}
 RUN make cephcsi
 
 #-- Final container
-FROM ${BASE_IMAGE}
+FROM updated_base
 
 ARG SRC_DIR
 


### PR DESCRIPTION
# Describe what this PR does #

This will get updates released after the base image was built. This adds a layer and increase the image size, but significantly reduce the number of CVEs in the resultant image.

This PR uses DNF to update the OS packages to the latest versions available at container build time.

Currently, this reduces the number of OS package CVEs (as detected by Trivy) from this:
```
quay.io/cephcsi/cephcsi:canary (redhat 8.6)

Total: 42 (UNKNOWN: 0, LOW: 1, MEDIUM: 38, HIGH: 3, CRITICAL: 0)
```
to
```
quay.io/cephcsi/cephcsi:canary (redhat 8.6)

Total: 8 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 2, CRITICAL: 0)
```

## Is there anything that requires special attention ##

Do you have any questions? No

Is the change backward compatible? Yes

Are there concerns around backward compatibility? No

Provide any external context for the change, if any.

* The ceph/cephcsi image uses the ceph/ceph image as base
* The ceph/ceph image uses the centos/centos:stream8 image as base
* That CentOS 8 image was last updated 4 months ago and contains several vulnerable packages that have updates available that address the vulnerabilities
* This installs all the available updates at build time to address the problem of outdated base images

## Related issues ##

Related: #3538 (It does not fully fix it, but significantly reduce the issues found)
Related: ceph/ceph-container#2074 - A similar fix  in the immediate base image

## Future concerns ##

The package vulnerabilities not fixed is unexpected - this might be due to Trivy using a RHEL patch database instead of a CentOS stream one.

The vulnerabilities in the Go portion should also be addressed.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
