### PR TITLE
ci: `bot_account` is not available for our Mergify usage

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,9 +9,13 @@ defaults:
       method: rebase
       rebase_fallback: merge
       update_method: rebase
-    rebase:
+      # For rebasing Mergify uses the author of the PR. Ideally we use the
+      # ceph-csi-bot for that, but this is a feature that needs a paid
+      # subscription.
+      #
+      # rebase:
       # Use ceph-csi-bot for rebasing, not the account of the PR owner.
-      bot_account: ceph-csi-bot
+      # bot_account: ceph-csi-bot
 
 queue_rules:
   - name: default


### PR DESCRIPTION
`bot_account` is a feature that is part of the paid subscription. The Ceph organization does not have that.

Mergify will use the author of the PR for rebasing by default. This isn't very nice, but we can't change it at the moment.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
