### PR TITLE
rename configmaps to match the csi type (rbd or cephfs), fix for 3652

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -314,10 +314,10 @@ kubeletDir: /var/lib/kubelet
 # Name of the csi-driver
 driverName: cephfs.csi.ceph.com
 # Name of the configmap used for state
-configMapName: ceph-csi-config
+configMapName: ceph-csi-config-cephfs
 # Key to use in the Configmap if not config.json
 # configMapKey:
 # Use an externally provided configmap
 externallyManagedConfigmap: false
 # Name of the configmap used for ceph.conf
-cephConfConfigMapName: ceph-config
+cephConfConfigMapName: ceph-config-cephfs

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -462,12 +462,12 @@ cephLogDirHostPath: /var/log/ceph
 # Name of the csi-driver
 driverName: rbd.csi.ceph.com
 # Name of the configmap used for state
-configMapName: ceph-csi-config
+configMapName: ceph-csi-config-rbd
 # Key to use in the Configmap if not config.json
 # configMapKey:
 # Use an externally provided configmap
 externallyManagedConfigmap: false
 # Name of the configmap used for ceph.conf
-cephConfConfigMapName: ceph-config
+cephConfConfigMapName: ceph-config-rbd
 # Name of the configmap used for encryption kms configuration
 kmsConfigMapName: ceph-csi-encryption-kms-config


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
rename configmaps to match the csi type (rbd or cephfs)

This fixes bug https://github.com/ceph/ceph-csi/issues/3652

## Related issues ##

Fixes: #3652 


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
