### PR TITLE
ci: prevent always removing `ok-to-test` label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -63,9 +63,6 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
-      label:
-        remove:
-          - ok-to-test
 
   - name: ask to resolve conflict
     conditions:


### PR DESCRIPTION
The check for a rebase always hits, but the actions for that inspect the event for a real rebase. Removing the `ok-to-test` label is not suitable in the Mergify check, as the label action does not inspect the event. This caused the `ok-to-test` label to be removed on every Mergify validation of the PR.

Fixes: ba68ce6 (ci: drop `ok-to-test` label when a PR is rebased)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
