### PR TITLE
rebase: pin dynamic-resource-allocation to v0.26.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ go-test-api: check-env
 mod-check: check-env
 	@echo 'running: go mod verify'
 	@go mod verify && [ "$(shell sha512sum go.mod)" = "`sha512sum go.mod`" ] || ( echo "ERROR: go.mod was modified by 'go mod verify'" && false )
+	@echo 'running: go list -mod=readonly -m all'
+	@go list -mod=readonly -m all 1> /dev/null
 
 scripts/golangci.yml: scripts/golangci.yml.in
 	rm -f scripts/golangci.yml.buildtags.in

--- a/go.mod
+++ b/go.mod
@@ -186,6 +186,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.26.1
 	k8s.io/cri-api => k8s.io/cri-api v0.26.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.1
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.1
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.1
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.1
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1375,6 +1375,7 @@ sigs.k8s.io/yaml
 # k8s.io/controller-manager => k8s.io/controller-manager v0.26.1
 # k8s.io/cri-api => k8s.io/cri-api v0.26.1
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.1
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.1
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.1
 # k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.1
 # k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.1


### PR DESCRIPTION
ping dynamic-resource-allocation dependency to v0.26.1 as the offline build sometimes fails with the below error message

```
[🎩︎]mrajanna@fedora ceph-csi $]go list -mod=readonly -m all
go: k8s.io/dynamic-resource-allocation@v0.0.0: invalid version: unknown revision v0.0.0
```

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

