### PR TITLE
ci: remove deprecated `rebase_fallback` from .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,6 @@ defaults:
       # credentials of users with write access to repo to rebase prs.
       name: default
       method: rebase
-      rebase_fallback: merge
       update_method: rebase
       # For rebasing Mergify uses the author of the PR. Ideally we use the
       # ceph-csi-bot for that, but this is a feature that needs a paid


### PR DESCRIPTION
This commit removes the deprecated `rebase_fallback` option from .mergify.yml .

refer: https://docs.mergify.com/actions/merge/#options

Signed-off-by: Rakshith R <rar@redhat.com>
