### PR TITLE
ci: remove `ok-to-test` label after commenting

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -113,3 +113,14 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/upgrade-tests-rbd
+
+      - name: remove ok-to-test-label after commenting
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: github.event.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ["ok-to-test"]
+            })

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -73,9 +73,6 @@ pull_request_rules:
         message: "This pull request now has conflicts with the target branch.
         Could you please resolve conflicts and force push the corrected
         changes? 🙏"
-      label:
-        remove:
-          - ok-to-test
 
   - name: update dependencies by dependabot (skip commitlint)
     conditions:
@@ -108,9 +105,6 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
-      label:
-        remove:
-          - ok-to-test
 
   - name: dismiss review of merged pull request
     conditions:
@@ -118,9 +112,6 @@ pull_request_rules:
       - merged
     actions:
       dismiss_reviews: {}
-      label:
-        remove:
-          - ok-to-test
 
   - name: automatic merge
     conditions:
@@ -153,9 +144,6 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
-      label:
-        remove:
-          - ok-to-test
 
   - name: automatic merge PR having ready-to-merge label
     conditions:
@@ -187,9 +175,6 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
-      label:
-        remove:
-          - ok-to-test
 
   - name: backport patches to release-v3.6 branch
     conditions:
@@ -247,9 +232,6 @@ pull_request_rules:
       queue:
         name: default
       delete_head_branch: {}
-      label:
-        remove:
-          - ok-to-test
 
   ##
   ## Automatically set/remove labels


### PR DESCRIPTION
Once the comments have been added, the `ok-to-test` label can be removed. This makes it possible to simplify the Mergify configuration.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
