### PR TITLE
ci: use `context.issue.number` for removing `ok-to-test`

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           script: |
             github.rest.issues.removeLabel({
-              issue_number: github.event.pull_request.number,
+              issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: ["ok-to-test"]


### PR DESCRIPTION
`github.event.pull_request.number` does not seem to be valid as a script object/variable.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
