### PR TITLE
ci: add `/api` to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,17 @@ updates:
       - ci/skip/e2e
     commit-message:
       prefix: "rebase"
+  - package-ecosystem: "gomod"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    labels:
+      - rebase
+      - ci/skip/e2e
+      - ci/skip/multi-arch-build
+    commit-message:
+      prefix: "rebase"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,7 @@ updates:
     labels:
       - rebase
       - ci/skip/e2e
+      - ci/skip/multi-arch-build
     commit-message:
       prefix: "rebase"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
PR #3669 has been created for `/api`, but does not follow our PR description and commit guidelines. Dependabot needs to take `/api` into account as well.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
