### PR TITLE
ci: only add `ok-to-test` if there are no pending CentOS jobs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -50,6 +50,8 @@ pull_request_rules:
     conditions:
       - base~=^(devel)|(release-.+)$
       - "check-pending=Queue: Embarked in merge train"
+      - not:
+          check-pending~=^ci/centos
     actions:
       label:
         add:


### PR DESCRIPTION
After the `ok-to-test` label was added, the commenter will remove the label again. There is no need for Mergify to re-add the label while CI jobs are still running.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
