### PR TITLE
ci: do not run commitlint GitHub Action on dependabot PRs

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   commitlint:
     name: commitlint
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-retest-action.yaml
+++ b/.github/workflows/test-retest-action.yaml
@@ -4,6 +4,9 @@ name: test-retest-action
 on:
   pull_request:
     branches: [devel]
+    paths:
+      - 'actions/retest/**'
+      - '.github/workflows/test-retest-action.yaml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently commitlint is only skipped for PR at the time dependabot creates them. Once Mergify rebases them, commitlint is started anyway. This causes failed CI runs, which then need to be ignored. It is cleaner to not run commitlint on any PR that dependabot owns.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
