### PR TITLE
ci: do not add `ok-to-test` if CentOS jobs were successful

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -52,6 +52,8 @@ pull_request_rules:
       - "check-pending=Queue: Embarked in merge train"
       - not:
           check-pending~=^ci/centos
+      - not:
+          status-success~=^ci/centos
     actions:
       label:
         add:


### PR DESCRIPTION
Mergify does not add the `ok-to-test` label immediately anymore. But once the CentOS CI jobs have finished, the label still gets added. With the additional check, this should not be the case anymore.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
