### PR TITLE
ci: migrate to new OpenShift cluster running on AWS

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -9,7 +9,7 @@ def git_since = 'ci/centos'
 def base = ''
 def doc_change = 0
 // private, internal container image repository
-def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def ci_registry = 'registry-ceph-csi.apps.ocp.cloud.ci.centos.org'
 def cached_image = 'ceph-csi'
 def use_pulled_image = 'USE_PULLED_IMAGE=yes'
 

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -9,7 +9,7 @@ def git_since = 'devel'
 def workdir = '/opt/build/go/src/github.com/ceph/ceph-csi'
 def doc_change = 0
 // private, internal container image repository
-def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def ci_registry = 'registry-ceph-csi.apps.ocp.cloud.ci.centos.org'
 def cached_image = "ceph-csi"
 def use_test_image = 'USE_PULLED_IMAGE=yes'
 def use_build_image = 'USE_PULLED_IMAGE=yes'

--- a/deploy/ceph-csi-buildconfig.yaml
+++ b/deploy/ceph-csi-buildconfig.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: ceph-csi-canary
@@ -21,11 +21,11 @@ spec:
   output:
     to:
       kind: DockerImage
-      name: registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi:canary
+      name: registry-ceph-csi.apps.ocp.cloud.ci.centos.org/ceph-csi:canary
     pushSecret:
       name: container-registry-auth
 ---
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: ceph-csi-test
@@ -47,11 +47,11 @@ spec:
   output:
     to:
       kind: DockerImage
-      name: registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi:test
+      name: registry-ceph-csi.apps.ocp.cloud.ci.centos.org/ceph-csi:test
     pushSecret:
       name: container-registry-auth
 ---
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: ceph-csi-devel
@@ -73,6 +73,6 @@ spec:
   output:
     to:
       kind: DockerImage
-      name: registry-ceph-csi.apps.ocp.ci.centos.org/ceph-csi:devel
+      name: registry-ceph-csi.apps.ocp.cloud.ci.centos.org/ceph-csi:devel
     pushSecret:
       name: container-registry-auth

--- a/deploy/checkout-repo.sh
+++ b/deploy/checkout-repo.sh
@@ -11,7 +11,7 @@ fail() {
 # exit in case a command fails
 set -e
 
-git config --global --add safe.directory ${PWD}
+git config --global --add safe.directory "${PWD}"
 git init .
 git remote add origin "${GIT_REPO}"
 git fetch origin "${GIT_REF}"

--- a/deploy/container-registry.yaml
+++ b/deploy/container-registry.yaml
@@ -21,7 +21,7 @@ stringData:
   config.json: |-
     {
       "auths": {
-        "registry-ceph-csi.apps.ocp.ci.centos.org": {
+        "registry-ceph-csi.apps.ocp.cloud.ci.centos.org": {
           "auth": "@@SOME_B64ENCODED_STRING@@"
         }
       }
@@ -61,7 +61,7 @@ spec:
       volumes:
         - name: container-images
           persistentVolumeClaim:
-            claimName: ceph-csi-image-registry
+            claimName: image-registry
         - name: htpasswd
           secret:
             secretName: container-registry-auth

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -10,7 +10,7 @@ def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
 def namespace = 'k8s-e2e-storage-' + UUID.randomUUID().toString().split('-')[-1]
-def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def ci_registry = 'registry-ceph-csi.apps.ocp.cloud.ci.centos.org'
 def failure = null
 
 def ssh(cmd) {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -9,7 +9,7 @@ def git_since = "devel"
 def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
-def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def ci_registry = 'registry-ceph-csi.apps.ocp.cloud.ci.centos.org'
 def namespace = 'cephcsi-e2e-' + UUID.randomUUID().toString().split('-')[-1]
 def failure = null
 

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -9,7 +9,7 @@ def git_since = 'devel'
 def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
-def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def ci_registry = 'registry-ceph-csi.apps.ocp.cloud.ci.centos.org'
 def failure = null
 
 def ssh(cmd) {

--- a/mirror/mirror-images.sh
+++ b/mirror/mirror-images.sh
@@ -9,7 +9,7 @@
 # registry.
 #
 
-CI_REGISTRY='registry-ceph-csi.apps.ocp.ci.centos.org'
+CI_REGISTRY='registry-ceph-csi.apps.ocp.cloud.ci.centos.org'
 
 # get_image_entries returns the contents of images.txt without comments or empty lines
 function get_image_entries() {

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -9,7 +9,7 @@ def git_since = 'devel'
 def skip_e2e = 0
 def doc_change = 0
 def k8s_release = 'latest'
-def ci_registry = 'registry-ceph-csi.apps.ocp.ci.centos.org'
+def ci_registry = 'registry-ceph-csi.apps.ocp.cloud.ci.centos.org'
 def failure = null
 
 def ssh(cmd) {


### PR DESCRIPTION
The CentOS CI environment we're using is being replaced by an OpenShift cluster running on AWS. The move to the new infrastructure should be done by the end of the month.

Hopefully everything is migrated with this PR. The new Jenkins environment is running at https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/

See-also: https://lists.centos.org/pipermail/ci-users/2023-January/005908.html

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
