### PR TITLE
ci: update mirroring container-images job for new OCP

### DIFF
--- a/mirror/mirror-buildconfig.yaml
+++ b/mirror/mirror-buildconfig.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: mirror-images
@@ -9,7 +9,7 @@ spec:
   tags:
     - name: latest
 ---
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: mirror-images

--- a/mirror/mirror-cronjob.yaml
+++ b/mirror/mirror-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: mirror-images
@@ -33,4 +33,11 @@ spec:
                     secretKeyRef:
                       name: container-registry-auth
                       key: passwd
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
           restartPolicy: OnFailure


### PR DESCRIPTION
The new OpenShift cluster complained about deprecated types and missing options in the yaml files.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
