### PR TITLE
ci: run registry garbage collection every week

### DIFF
--- a/deploy/docker-gc.yaml
+++ b/deploy/docker-gc.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: docker-gc
+  labels:
+    app: docker-gc
+spec:
+  schedule: '@weekly'
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: docker-gc
+        spec:
+          containers:
+            - name: docker-gc
+              image: docker.io/library/registry:2
+              args:
+                - registry
+                - garbage-collect
+                - /config/config.yml
+                - --delete-untagged
+              volumeMounts:
+                - name: container-images
+                  mountPath: /var/lib/registry
+                - name: config
+                  mountPath: /config
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+          volumes:
+            - name: container-images
+              persistentVolumeClaim:
+                claimName: ceph-csi-image-registry
+            - name: config
+              secret:
+                secretName: container-registry-config
+          restartPolicy: OnFailure


### PR DESCRIPTION
In the old OpenShift cluster the registry consumer 800+ GB of data. Once running the garbage collection manually, the consumption reduced to a little over 8GB. Let's be nice users of the infrastructure and run garbage collection weekly.

**Note:** the CronJob has already been pushed to the OCP cluster, this is just for archiving.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
