### PR TITLE
ci: remove Kubernetes 1.23 from github action

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -16,13 +16,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Add comment to trigger external storage tests for Kubernetes 1.23
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.23
-
       - name: Add comment to trigger external storage tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -44,13 +37,6 @@ jobs:
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.26
 
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.23
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.23
-
       - name: Add comment to trigger helm E2E tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -71,13 +57,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e-helm/k8s-1.26
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.23
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.23
 
       - name: Add comment to trigger E2E tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3


### PR DESCRIPTION
Removed Kubernetes 1.23 from GitHub action as 1.23 is not supported anymore.

Updates: #3636 