### PR TITLE
ci: remove kubernetes 1.23 support

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -2,8 +2,6 @@
 - project:
     name: k8s-e2e-external-storage
     k8s_version:
-      - '1.23':
-          only_run_on_request: true
       - '1.24':
           only_run_on_request: true
       - '1.25':

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,6 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.23':
-          only_run_on_request: true
       - '1.24':
           only_run_on_request: true
       - '1.25':


### PR DESCRIPTION
removed the ability to run tests with kubernetes 1.23 as its no longer a maintained version.

fixes: #3636

