### PR TITLE
e2e: remove extra check for snapshot count

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -1944,8 +1944,6 @@ var _ = Describe(cephfsType, func() {
 					framework.Failf("failed to delete PVC or application: %v", err)
 				}
 
-				validateCephFSSnapshotCount(f, 0, subvolumegroup, pv)
-
 				err = deletePVCAndApp("", f, pvc, app)
 				if err != nil {
 					framework.Failf("failed to delete PVC or application: %v", err)


### PR DESCRIPTION
snapshot count validation has already done for this test, after the deletion of snapshot
