### PR TITLE
ci: update github actions for k8s 1.27

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -37,6 +37,13 @@ jobs:
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.26
 
+      - name: Add comment to trigger external storage tests for Kubernetes 1.27
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/k8s-e2e-external-storage/1.27
+
       - name: Add comment to trigger helm E2E tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -58,6 +65,13 @@ jobs:
           body: |
             /test ci/centos/mini-e2e-helm/k8s-1.26
 
+      - name: Add comment to trigger helm E2E tests for Kubernetes 1.27
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e-helm/k8s-1.27
+
       - name: Add comment to trigger E2E tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -78,6 +92,13 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e/k8s-1.26
+
+      - name: Add comment to trigger E2E tests for Kubernetes 1.27
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e/k8s-1.27
 
       - name: Add comment to trigger cephfs upgrade tests
         uses: peter-evans/create-or-update-comment@v3


### PR DESCRIPTION
This commit updates the github actions to test against kubernetes 1.27

Depends-on: #3734