### PR TITLE
deploy: fix a bug of ceph-csi helm chart rendered duplicate affinities in rbd and cephfs

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -48,6 +48,14 @@ spec:
                     values:
                       - {{ .Values.provisioner.name }}
               topologyKey: "kubernetes.io/hostname"
+{{- if .Values.provisioner.affinity }}
+{{ toYaml .Values.provisioner.affinity | indent 8 -}}
+{{- end -}}
+{{- else -}}
+{{- if .Values.provisioner.affinity }}
+      affinity:
+{{ toYaml .Values.provisioner.affinity | indent 8 -}}
+{{- end -}}
 {{- end }}
       serviceAccountName: {{ include "ceph-csi-cephfs.serviceAccountName.provisioner" . }}
       hostNetwork: {{ .Values.provisioner.enableHostNetwork }}
@@ -228,10 +236,6 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
-{{- if .Values.provisioner.affinity }}
-      affinity:
-{{ toYaml .Values.provisioner.affinity | indent 8 -}}
-{{- end -}}
 {{- if .Values.provisioner.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.provisioner.nodeSelector | indent 8 -}}

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -48,6 +48,14 @@ spec:
                     values:
                       - {{ .Values.provisioner.name }}
               topologyKey: "kubernetes.io/hostname"
+{{- if .Values.provisioner.affinity }}
+{{ toYaml .Values.provisioner.affinity | indent 8 -}}
+{{- end -}}
+{{- else -}}
+{{- if .Values.provisioner.affinity }}
+      affinity:
+{{ toYaml .Values.provisioner.affinity | indent 8 -}}
+{{- end -}}
 {{- end }}
       serviceAccountName: {{ include "ceph-csi-rbd.serviceAccountName.provisioner" . }}
       hostNetwork: {{ .Values.provisioner.enableHostNetwork }}
@@ -309,10 +317,6 @@ spec:
                   path: oidc-token
                   expirationSeconds: 3600
                   audience: ceph-csi-kms
-{{- if .Values.provisioner.affinity }}
-      affinity:
-{{ toYaml .Values.provisioner.affinity | indent 8 -}}
-{{- end -}}
 {{- if .Values.provisioner.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.provisioner.nodeSelector | indent 8 -}}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

When I try to deploy the ceph-csi-rbd chart with value provisioner.affinity, there will be two affinities field in deployment provisioner.


## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #3750

