### PR TITLE
cleanup: fix the pre-commit-golang repo link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-signoff
 
   # Catch gofmt issues, if any.
-  - repo: git://github.com/dnephin/pre-commit-golang
+  - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.3.5
     hooks:
       - id: go-fmt


### PR DESCRIPTION
Initialization of pre-commit-golang environment is failing when using the git://github.com/dnephin/pre-commit-golang repo link. Changing it to https://github.com/dnephin/pre-commit-golang fixed the issue.

Depends-on: #3762
Fixes: #3760