### PR TITLE
fix: ErrWaitTimeout is deprecated in k8s 1.27

### DIFF
--- a/e2e/deployment.go
+++ b/e2e/deployment.go
@@ -175,7 +175,7 @@ func waitForDeploymentComplete(clientSet kubernetes.Interface, name, ns string, 
 		return false, nil
 	})
 
-	if errors.Is(err, wait.ErrWaitTimeout) {
+	if wait.Interrupted(err) {
 		err = fmt.Errorf("%s", reason)
 	}
 	if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1912,7 +1912,7 @@ var _ = Describe("RBD", func() {
 					return true, nil
 				})
 
-				if errors.Is(err, wait.ErrWaitTimeout) {
+				if wait.Interrupted(err) {
 					framework.Failf("timed out waiting for the rbd-nbd process: %s", reason)
 				}
 				if err != nil {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1047,7 +1047,7 @@ func waitToRemoveImagesFromTrash(f *framework.Framework, poolName string, t int)
 		return false, nil
 	})
 
-	if errors.Is(err, wait.ErrWaitTimeout) {
+	if wait.Interrupted(err) {
 		err = errReason
 	}
 

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -509,7 +509,7 @@ func waitForrbdImage(ctx context.Context, backoff wait.Backoff, volOptions *rbdV
 		return !used, nil
 	})
 	// return error if rbd image has not become available for the specified timeout
-	if errors.Is(err, wait.ErrWaitTimeout) {
+	if wait.Interrupted(err) {
 		return fmt.Errorf("rbd image %s is still being used", imagePath)
 	}
 	// return error if any other errors were encountered during waiting for the image to become available


### PR DESCRIPTION
replaced ErrWaitTimeout with Interrupted
