### PR TITLE
build: update golang to 1.19.8

### DIFF
--- a/build.env
+++ b/build.env
@@ -16,7 +16,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v17
 CEPH_VERSION=quincy
 
 # standard Golang options
-GOLANG_VERSION=1.19.5
+GOLANG_VERSION=1.19.8
 GO111MODULE=on
 
 # commitlint version


### PR DESCRIPTION
CephCSI may be vulnerable to
https://github.com/advisories/GHSA-8v5j-pwr7-w5f8. Update golang to 1.19.8 since it contains
fixes for mentioned CVE.
