### PR TITLE
cleanup: set pid limit only for nodeserver

### DIFF
--- a/docs/design/proposals/rbd-mirror.md
+++ b/docs/design/proposals/rbd-mirror.md
@@ -47,7 +47,6 @@ csi:
   volumeAttributes:
     clusterID: rook-ceph
     imageFeatures: layering
-    imageFormat: "2"
     imageName: csi-vol-0c23de1c-18fb-11eb-a903-0242ac110005
     journalPool: replicapool
     pool: replicapool


### PR DESCRIPTION
setting pod limit only for node server for below reasons

* We dont execute any commands  with CLI anymore in the controller service
* Controller deployment is not privileged enough to set the PID limits.

Added one more commit for doc cleanup

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>