### PR TITLE
util: Limit cryptsetup PBKDF memory usage

### DIFF
--- a/internal/util/cryptsetup.go
+++ b/internal/util/cryptsetup.go
@@ -20,8 +20,12 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 )
+
+// Limit memory used by Argon2i PBKDF to 32 MiB.
+const cryptsetupPBKDFMemoryLimit = 32 << 10 // 32768 KiB
 
 // LuksFormat sets up volume as an encrypted LUKS partition.
 func LuksFormat(devicePath, passphrase string) (string, string, error) {
@@ -33,6 +37,8 @@ func LuksFormat(devicePath, passphrase string) (string, string, error) {
 		"luks2",
 		"--hash",
 		"sha256",
+		"--pbkdf-memory",
+		strconv.Itoa(cryptsetupPBKDFMemoryLimit),
 		devicePath,
 		"-d",
 		"/dev/stdin")


### PR DESCRIPTION
# Describe what this PR does #

By default, `cryptsetup luksFormat` uses Argon2i as Password-Based Key Derivation Function (PBKDF), which not only has a CPU cost, but also a memory cost (to make brute-force attacks harder).

The memory cost is based on the available system memory by default, which in the context of Ceph CSI can be a problem for two reasons:

1. Pods can have a memory limit (much lower that the memory available on the node, usually) which isn't taken into account by `cryptsetup`, so it can get OOM-killed when formating a new volume;
2. The amount of memory that was used during `cryptsetup luksFormat` will then be needed for `cryptsetup luksOpen`, so if the volume was formated on a node with a lot of memory, but then needs to be opened on a different node with less memory, `cryptsetup` will get OOM-killed.

This commit sets the PBKDF memory limit to a fixed value to ensure consistent memory usage regardless of the specifications of the nodes where the volume happens to be formatted in the first place.

The limit is set to a relatively low value (32 MiB) so that the `csi-rbdplugin` container in the `nodeplugin` pod doesn't require an extravagantly high memory limit in order to format/open volumes (particularly with operations happening in parallel), while at the same time not being so low as to render it completely pointless.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

## Context ##

Prior to this change, `cryptsetup` would get OOM-killed unless we set a memory limit larger than 1GiB, which was way too much to dedicate to a container that otherwise barely needs any.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
