### PR TITLE
doc: use the Ceph Slack instance and not our silo'ed own one

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ welcome and encouraged to join.
 
 Please use the following to reach members of the community:
 
-- Slack: Join our [slack channel](https://cephcsi.slack.com) to discuss
-  anything related to this project. You can join the slack by
-  this [invite link](https://bit.ly/2MeS4KY )
+- Slack: Join our [Slack channel](https://ceph-storage.slack.com) to discuss
+  anything related to this project. You can join the Slack by this [invite
+  link](https://bit.ly/40FQu7u)
 - Forums: [ceph-csi](https://groups.google.com/forum/#!forum/ceph-csi)
 - Twitter: [@CephCsi](https://twitter.com/CephCsi)

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -327,7 +327,7 @@ are certain about the flaky test failure behavior, then comment on the PR
 indicating the logs about a particular test that went flaky and use the
 appropriate command to retrigger the job[s].
 If you are uncertain about the CI failure, we prefer that you ping us on
-[Slack channel #ci](https://cephcsi.slack.com) with more details on
+[Slack channel #ceph-csi](https://ceph-storage.slack.com) with more details on
 failures before retriggering the jobs, we will be happy to help.
 
 ### Retesting failed Jobs


### PR DESCRIPTION
Currently the Ceph-CSI community is on the 'free' Slack instance at https://cephcsi.slack.com. The Ceph project uses a Slack instance that we can use for Ceph-CSI as well. In order to integrate more with other Ceph projects, we should ideally be active on the same Slack instance.

For now, we have `#ceph-csi` as only channel on the https://ceph-storage-slack.com, we can add more channels if needed.

See-also: https://ceph.io/en/community/connect/

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
