### PR TITLE
ci: automatically add `ok-to-test` to PRs created by Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -49,10 +49,10 @@ queue_rules:
               - "status-success=ci/centos/jjb-validate"
 
 pull_request_rules:
-  - name: start CI jobs for queued PR
+  - name: start CI jobs for merge queue PRs by Mergify
     conditions:
       - base~=^(devel)|(release-.+)$
-      - "check-pending=Queue: Embarked in merge train"
+      - author=mergify
       - not:
           check-pending~=^ci/centos
       - not:


### PR DESCRIPTION
Mergify does not automatically rebase PRs that are queued for merging (anymore?). Instead, it creates a new draft PR that is expected to get tested by the CI. At the moment someone needs to add the `ok-to-test` label to the PR. This is cumbersome and can cause delays in the merge process.

The configuration for Mergify now includes a rule that any PR created by Mergify, will automatically get the `ok-to-test` label. This should make it easier to get PR merged.

See-also: #3796

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
