### PR TITLE
ci: add GitHub Workflow to copy labels in Mergify created PRs

### DIFF
--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -1,0 +1,16 @@
+---
+name: Mergify merge-queue labels copier
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  mergify-merge-queue-labels-copier:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copying labels
+        uses: Mergifyio/gha-mergify-merge-queue-labels-copier@main
+#        with:
+#          labels: comma,separated,lists,of,labels,to,copy


### PR DESCRIPTION
When Mergify creates a PR, the `ok-to-test` label needs to be added before CI runs. Not all PRs need complete testing, and they may have some `ci/skip/..` labels too. With this new GitHub Workflow, the labels get copied from the original PR into the newly created PR.

See-also: https://github.com/Mergifyio/mergify/discussions/5088

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
