### PR TITLE
ci: add `ok-to-test` label to all PRs in the merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -49,14 +49,16 @@ queue_rules:
               - "status-success=ci/centos/jjb-validate"
 
 pull_request_rules:
-  - name: start CI jobs for merge queue PRs by Mergify
+  - name: start CI jobs for PRs in the merge queue
     conditions:
       - base~=^(devel)|(release-.+)$
-      - author=mergify
       - not:
           check-pending~=^ci/centos
       - not:
           status-success~=^ci/centos
+      - or:
+          - "check-pending=Queue: Embarked in merge train"
+          - author=mergify
     actions:
       label:
         add:


### PR DESCRIPTION
It seems that some PRs still get rebased by Mergify, whereas others get tested for the **merge queue** by creating a new temporary PR. In both cases the `ok-to-test` label should get set automatically.

Fixes: c4d372e (ci: automatically add `ok-to-test` to PRs created by Mergify)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
