### PR TITLE
ci: fix author=mergify[bot]

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -58,7 +58,7 @@ pull_request_rules:
           status-success~=^ci/centos
       - or:
           - "check-pending=Queue: Embarked in merge train"
-          - author=mergify
+          - author=mergify[bot]
     actions:
       label:
         add:


### PR DESCRIPTION
Author of mergifyio created pr is mergify[bot].
It needs the suffix `[bot]` for the condition
to be evaluated to true.

The .mergifyio config settings can be tinkered here https://dashboard.mergify.com/github/ceph/repo/ceph-csi/config-editor?pullRequestNumber=3813 and checked.

![Screenshot from 2023-05-15 11-07-23](https://github.com/ceph/ceph-csi/assets/31369230/190192d6-a791-43f0-9532-47388cb22c96)
