### PR TITLE
ci: Mergify copy-labels requires empty `labels:` value

### DIFF
--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -12,5 +12,6 @@ jobs:
     steps:
       - name: Copying labels
         uses: Mergifyio/gha-mergify-merge-queue-labels-copier@main
-#        with:
-#          labels: comma,separated,lists,of,labels,to,copy
+        with:
+          # labels: comma,separated,lists,of,labels,to,copy
+          labels:


### PR DESCRIPTION
Mergify copy-labels requires empty `labels:` value.

See-also: Mergifyio/mergify#5088

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
