### PR TITLE
ci: include ci/skip/.. labels for copying into merge queue PRs

### DIFF
--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -13,5 +13,5 @@ jobs:
       - name: Copying labels
         uses: Mergifyio/gha-mergify-merge-queue-labels-copier@main
         with:
-          # labels: comma,separated,lists,of,labels,to,copy
-          labels: ""
+          # FIXME: empty labels should copy all, that does not work?
+          labels: ci/skip/e2e,ci/skip/multi-arch-build


### PR DESCRIPTION
Setting an empty `labels:` fails to work as intended, no labels get copied ad all. Now setting the `ci/skip/..` labels, as those are most important for speeding up merging.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
