### PR TITLE
ci: use modified gha-mergify-merge-queue-labels-copier Action

### DIFF
--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: Mergify merge-queue labels copier
 # yamllint disable-line rule:truthy
 on:
@@ -11,7 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Copying labels
-        uses: Mergifyio/gha-mergify-merge-queue-labels-copier@main
-        with:
-          # FIXME: empty labels should copy all, that does not work?
-          labels: ci/skip/e2e,ci/skip/multi-arch-build
+        # FIXME: using local instead of Mergifyio/gha-mergify-merge-queue-labels-copier@main
+        uses: ./actions/gha-mergify-merge-queue-labels-copier.yaml

--- a/actions/gha-mergify-merge-queue-labels-copier.yaml
+++ b/actions/gha-mergify-merge-queue-labels-copier.yaml
@@ -1,0 +1,33 @@
+---
+# yamllint disable rule:line-length
+#
+# Fork of Mergifyio/gha-mergify-merge-queue-labels-copier@main with modified
+# startsWith() check.
+#
+# See: https://docs.github.com/en/actions/learn-github-actions/expressions#startswith
+#
+name: 'mergify-merge-queue-labels-copier'
+description: 'Mergify: copies pull request labels to merge queue draft PRs'
+inputs:
+  labels:
+    description: 'Comma separated list of labels to copy (all if empty)'
+    required: true
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Copying labels
+      shell: bash
+      if: startsWith(github.head_ref, 'mergify/merge queue/')
+      env:
+        REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+        MERGE_QUEUE_PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh pr view --json body -q ".body" $MERGE_QUEUE_PR_URL | sed -n -e '/```yaml/,/```/p' | sed -e '1d;$d' | yq '.pull_requests[]|.number' | while read pr_number ; do
+          gh pr view --json labels -q '.labels[]|.name' ${REPOSITORY_URL}/pull/$pr_number | while read label ; do
+            if [[ -z "$labels" ]] || [[ ",$labels," =~ ",$label," ]]; then
+              gh pr edit --add-label "$label" $MERGE_QUEUE_PR_URL
+            if
+          done
+        done


### PR DESCRIPTION
The original Mergifyio/gha-mergify-merge-queue-labels-copier@main contains `startsWith()` that has the arguments reversed. This prevents the action from working as intended.

See-also: https://docs.github.com/en/actions/learn-github-actions/expressions#startswith

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
