### PR TITLE
ci: checkout the local mergify-merge-queue-labels-copier

### DIFF
--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -11,6 +11,9 @@ jobs:
   mergify-merge-queue-labels-copier:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repository to get the local action
+        uses: actions/checkout@v3
+
       - name: Copying labels
         # FIXME: using local instead of Mergifyio/gha-mergify-merge-queue-labels-copier@main
         uses: ./actions/gha-mergify-merge-queue-labels-copier/


### PR DESCRIPTION
Without checking out the repository, it is not possible to run the local action.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
