### PR TITLE
ci: check for `mergify/merge-queue/` string, with `-`

### DIFF
--- a/actions/gha-mergify-merge-queue-labels-copier/action.yaml
+++ b/actions/gha-mergify-merge-queue-labels-copier/action.yaml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Copying labels
       shell: bash
-      if: startsWith(github.head_ref, 'mergify/merge queue/')
+      if: startsWith(github.head_ref, 'mergify/merge-queue/')
       env:
         REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
         MERGE_QUEUE_PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}


### PR DESCRIPTION
It seems that the `-` in `mergify/merge-queue/` was dropped somehow :-(

![image](https://github.com/ceph/ceph-csi/assets/400257/aadb88b7-489c-43fd-86d7-7b8f5c9f2743)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
