### PR TITLE
ci: install Helm with script located on GitHub

### DIFF
--- a/build.env
+++ b/build.env
@@ -34,6 +34,9 @@ SNAPSHOT_VERSION=v6.1.0
 #TEST_COVERAGE=html
 #GO_COVER_DIR=_output/
 
+# URL for the script to install Helm
+HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+
 # helm chart generation, testing and publishing
 HELM_VERSION=v3.10.1
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -104,7 +104,7 @@ CSI_CHARTS_DIR=$(mktemp -d)
 
 pushd "${CSI_CHARTS_DIR}" >/dev/null
 
-curl -L https://git.io/get_helm.sh | bash -s -- --version "${HELM_VERSION}"
+curl -L "${HELM_SCRIPT}" | bash -s -- --version "${HELM_VERSION}"
 
 build_step "cloning ceph/csi-charts repository"
 git clone https://github.com/ceph/csi-charts

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -50,7 +50,7 @@ RUN source /build.env \
        | tar xzf - -C ${GOROOT} --strip-components=1 \
     && curl -sf "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_VERSION}/install.sh" \
        | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
-    && curl -L https://git.io/get_helm.sh | bash -s -- --version "${HELM_VERSION}" \
+    && curl -L "${HELM_SCRIPT}" | bash -s -- --version "${HELM_VERSION}" \
     && mkdir /opt/commitlint && pushd /opt/commitlint \
     && npm init -y \
     && npm install @commitlint/cli@"${COMMITLINT_VERSION}" \


### PR DESCRIPTION
Installing Helm fails often in the CI. The Helm documentation does not point to `https://git.io/get_helm.sh` anymore, but to a location on GitHub. To make it easier to update the location in the future, it has now been added to `build.env`, just like the `HELM_VERSION`.

See-also: https://helm.sh/docs/intro/install/

The failures in CI jobs would look like this:
![image](https://github.com/ceph/ceph-csi/assets/400257/0a2e499d-94f2-48f9-a6c4-2d15cd4a24aa)

Installing `golangci-lint` succeeds, the next `curl` command fails.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
