### PR TITLE
ci: trigger `Add comment` workflow for "opened" prs

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -8,6 +8,7 @@ on:
       - "release-v*"
     types:
       - labeled
+      - opened
 jobs:
   add-comment:
     # yamllint disable-line rule:line-length


### PR DESCRIPTION
# Describe what this PR does #

The `Add comment` workflow was triggered only
when labels were added to the pr and failed
to be run on prs which were created with the
required label.
This commit makes sure the workflow is triggered
on pr creation too.

refer the manual label removal and addition to
trigger workflow right below the pr description https://github.com/ceph/ceph-csi/pull/3857#issue-1727005811

