### PR TITLE
ci: fix pull-request-commentor workflow

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -12,7 +12,10 @@ on:
 jobs:
   add-comment:
     # yamllint disable-line rule:line-length
-    if: github.event.label.name == 'ok-to-test' && github.event.pull_request.merged != 'true'
+    if: (github.event.pull_request.label == ok-to-test && \
+         github.event.pull_request.merged != 'true') || \
+        (github.event.pull_request.action == opened && \
+         contains(github.event.pull_request.labels.*.name,'ok-to-test'))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Fix if condition in workflow to account
for ok-to-test label on newly created prs.

refer: 
- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
- https://docs.github.com/en/actions/learn-github-actions/expressions#example-using-an-object-filter