### PR TITLE
ci: fix syntax error in `pull-request-commenter` GitHub Workflow

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -11,10 +11,9 @@ on:
       - opened
 jobs:
   add-comment:
-    # yamllint disable-line rule:line-length
-    if: (github.event.pull_request.label == ok-to-test && \
+    if: (github.event.pull_request.label == 'ok-to-test' && \
          github.event.pull_request.merged != 'true') || \
-        (github.event.pull_request.action == opened && \
+        (github.event.pull_request.action == 'opened' && \
          contains(github.event.pull_request.labels.*.name,'ok-to-test'))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The `ok-to-test` label does not work anymore, and the GitHub Workflow contains the following error:

    The workflow is not valid.
    .github/workflows/pull-request-commentor.yaml (Line: 15, Col: 9):
    Unrecognized named-value: 'ok-to-test'.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
