### PR TITLE
rebase: update k8s external-snapshotter to v6.2.2

### DIFF
--- a/build.env
+++ b/build.env
@@ -27,7 +27,7 @@ GOLANGCI_VERSION=v1.47.3
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases
-SNAPSHOT_VERSION=v6.1.0
+SNAPSHOT_VERSION=v6.2.2
 
 # "go test" configuration
 # set to stdout or html to enable coverage reporting, disabled by default


### PR DESCRIPTION
A full changelog is at
https://github.com/kubernetes-csi/external-snapshotter/blob/release-6.2/CHANGELOG/CHANGELOG-6.2.md

All PRs are listed here:
https://github.com/kubernetes-csi/external-snapshotter/compare/v6.1.0...v6.2.2

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
