### PR TITLE
ci: remove `\` from GitHub Workflow if condition

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -11,10 +11,11 @@ on:
       - opened
 jobs:
   add-comment:
-    if: (github.event.pull_request.label == 'ok-to-test' && \
-         github.event.pull_request.merged != 'true') || \
-        (github.event.pull_request.action == 'opened' && \
-         contains(github.event.pull_request.labels.*.name,'ok-to-test'))
+    if: >
+      (github.event.pull_request.label == 'ok-to-test' &&
+      github.event.pull_request.merged != 'true') ||
+      (github.event.pull_request.action == 'opened' &&
+      contains(github.event.pull_request.labels.*.name,'ok-to-test'))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Backslashes (`\`) cause issues in the `if` statment with GitHub Workflows.

    Unexpected symbol: '\'. Located at position 53 within expression:
    (github.event.pull_request.label == 'ok-to-test' && \

Using the `>` YAML syntax to replace linebreaks with spaces should address this problem.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
