### PR TITLE
ci: `github.event.pull_request.merged` is a boolean, not a string

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -13,7 +13,7 @@ jobs:
   add-comment:
     if: >
       (github.event.pull_request.label == 'ok-to-test' &&
-      github.event.pull_request.merged != 'true') ||
+      github.event.pull_request.merged != true) ||
       (github.event.pull_request.action == 'opened' &&
       contains(github.event.pull_request.labels.*.name,'ok-to-test'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
With the updates to the pull-request-commenter, all strings were placed within `'` to prevent syntax issues. It seems that `github.event.pull_request.merged` really is a boolean (or `null`), and not a string.

Doc: https://docs.github.com/en/webhooks-and-events/ ("payloads" section)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
