### PR TITLE
ci: use `github.event.label.name` for check in pull-request-commenter

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   add-comment:
     if: >
-      (github.event.pull_request.label == 'ok-to-test' &&
+      (github.event.label.name == 'ok-to-test' &&
       github.event.pull_request.merged != true) ||
       (github.event.pull_request.action == 'opened' &&
       contains(github.event.pull_request.labels.*.name,'ok-to-test'))


### PR DESCRIPTION
The `github.event.label.name` was replaced by
`github.event.pull_request.label` in PR #3862. It seems that the value always is `null`, which causes the pull-request-commenter to skip the events for `ok-to-test` label additions. By using the original `github.event.label.name`, things work again as expected.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
