### PR TITLE
cleanup: no need for disabling the apache-arrow-centor repository anymore

### DIFF
--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -17,11 +17,6 @@ RUN source /build.env \
     && mkdir -p /usr/local/go \
     && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
-# FIXME: Ceph does not need Apache Arrow anymore, some container images may
-# still have the repository enabled. Disabling the repository can be removed in
-# the future, see https://github.com/ceph/ceph-container/pull/1990 .
-RUN dnf config-manager --disable apache-arrow-centos || true
-
 RUN dnf -y install \
 	git \
 	make \


### PR DESCRIPTION
The apache-arrow-centor repository is not available in current Ceph container-images, there is no need to try to disable the repository anymore.

See-also: https://github.com/ceph/ceph-container/pull/1990

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
