### PR TITLE
ci: use the "ceph-csi-bot" account for commenting on PRs

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Add comment to trigger external storage tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.24
@@ -30,6 +31,7 @@ jobs:
       - name: Add comment to trigger external storage tests for Kubernetes 1.25
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.25
@@ -37,6 +39,7 @@ jobs:
       - name: Add comment to trigger external storage tests for Kubernetes 1.26
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.26
@@ -44,6 +47,7 @@ jobs:
       - name: Add comment to trigger external storage tests for Kubernetes 1.27
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.27
@@ -51,6 +55,7 @@ jobs:
       - name: Add comment to trigger helm E2E tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e-helm/k8s-1.24
@@ -58,6 +63,7 @@ jobs:
       - name: Add comment to trigger helm E2E tests for Kubernetes 1.25
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e-helm/k8s-1.25
@@ -65,6 +71,7 @@ jobs:
       - name: Add comment to trigger helm E2E tests for Kubernetes 1.26
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e-helm/k8s-1.26
@@ -72,6 +79,7 @@ jobs:
       - name: Add comment to trigger helm E2E tests for Kubernetes 1.27
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e-helm/k8s-1.27
@@ -79,6 +87,7 @@ jobs:
       - name: Add comment to trigger E2E tests for Kubernetes 1.24
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e/k8s-1.24
@@ -86,6 +95,7 @@ jobs:
       - name: Add comment to trigger E2E tests for Kubernetes 1.25
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e/k8s-1.25
@@ -93,6 +103,7 @@ jobs:
       - name: Add comment to trigger E2E tests for Kubernetes 1.26
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e/k8s-1.26
@@ -100,6 +111,7 @@ jobs:
       - name: Add comment to trigger E2E tests for Kubernetes 1.27
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/mini-e2e/k8s-1.27
@@ -107,6 +119,7 @@ jobs:
       - name: Add comment to trigger cephfs upgrade tests
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/upgrade-tests-cephfs
@@ -114,6 +127,7 @@ jobs:
       - name: Add comment to trigger rbd upgrade tests
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/upgrade-tests-rbd
@@ -121,6 +135,7 @@ jobs:
       - name: remove ok-to-test-label after commenting
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           script: |
             github.rest.issues.removeLabel({
               issue_number: context.issue.number,


### PR DESCRIPTION
By default the `GITHUB_TOKEN` is used for the actions, and the name of the account that comments is "github-actions[bot]". It is a nice touch to use the Ceph-CSI Bot account instead.

**Note:** The pull-request-commenter will only run with updated configuration once this PR is merged.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
