### PR TITLE
build: use Go 1.20 as Kubernetes 1.27 requires it

### DIFF
--- a/build.env
+++ b/build.env
@@ -16,7 +16,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v17
 CEPH_VERSION=quincy
 
 # standard Golang options
-GOLANG_VERSION=1.19.8
+GOLANG_VERSION=1.20.4
 GO111MODULE=on
 
 # commitlint version

--- a/build.env
+++ b/build.env
@@ -23,7 +23,7 @@ GO111MODULE=on
 COMMITLINT_VERSION=latest
 
 # static checks and linters
-GOLANGCI_VERSION=v1.47.3
+GOLANGCI_VERSION=v1.53.0
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
-	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:golint // e2e uses By() and other Ginkgo functions
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -47,7 +47,7 @@ func deployVault(c kubernetes.Interface, deployTimeout int) {
 		"cm",
 		"ceph-csi-encryption-kms-config",
 		"--ignore-not-found=true")
-	Expect(err).Should(BeNil())
+	Expect(err).ShouldNot(HaveOccurred())
 
 	createORDeleteVault(kubectlCreate)
 	opt := metav1.ListOptions{
@@ -55,11 +55,11 @@ func deployVault(c kubernetes.Interface, deployTimeout int) {
 	}
 
 	pods, err := c.CoreV1().Pods(cephCSINamespace).List(context.TODO(), opt)
-	Expect(err).Should(BeNil())
-	Expect(len(pods.Items)).Should(Equal(1))
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(pods.Items).Should(HaveLen(1))
 	name := pods.Items[0].Name
 	err = waitForPodInRunningState(name, cephCSINamespace, c, deployTimeout, noError)
-	Expect(err).Should(BeNil())
+	Expect(err).ShouldNot(HaveOccurred())
 }
 
 func deleteVault() {
@@ -123,7 +123,7 @@ func createTenantServiceAccount(c kubernetes.Interface, ns string) error {
 // were created with createTenantServiceAccount.
 func deleteTenantServiceAccount(ns string) {
 	err := createORDeleteTenantServiceAccount(kubectlDelete, ns)
-	Expect(err).Should(BeNil())
+	Expect(err).ShouldNot(HaveOccurred())
 }
 
 // createORDeleteTenantServiceAccount is a helper that reads the tenant-sa.yaml

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/onsi/gomega" // nolint
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"

--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:golint // e2e uses Expect() and other Gomega functions
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"

--- a/e2e/errors_test.go
+++ b/e2e/errors_test.go
@@ -21,8 +21,9 @@ import (
 	"testing"
 )
 
-//nolint:lll // error string cannot be split into multiple lines as is a
 // output from kubectl.
+//
+//nolint:lll // error string cannot be split into multiple lines as is a
 func TestGetStdErr(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/e2e/errors_test.go
+++ b/e2e/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-// nolint:lll // error string cannot be split into multiple lines as is a
+//nolint:lll // error string cannot be split into multiple lines as is a
 // output from kubectl.
 func TestGetStdErr(t *testing.T) {
 	t.Parallel()

--- a/e2e/kms.go
+++ b/e2e/kms.go
@@ -122,8 +122,9 @@ func (vc *vaultConfig) canGetPassphrase() bool {
 
 // getPassphrase method will execute few commands to try read the secret for
 // specified key from inside the vault container:
-//  * authenticate with vault and ignore any stdout (we do not need output)
-//  * issue get request for particular key
+//   - authenticate with vault and ignore any stdout (we do not need output)
+//   - issue get request for particular key
+//
 // resulting in stdOut (first entry in tuple) - output that contains the key
 // or stdErr (second entry in tuple) - error getting the key.
 func (vc *vaultConfig) getPassphrase(f *framework.Framework, key string) (string, string) {

--- a/e2e/migration.go
+++ b/e2e/migration.go
@@ -30,7 +30,7 @@ import (
 // composeIntreeMigVolID create a volID similar to intree migration volID
 // the migration volID format looks like below
 // mig-mons-<hash>-image-<UUID_<poolhash>
-// nolint:lll    // ex: "mig_mons-b7f67366bb43f32e07d8a261a7840da9_image-e0b45b52-7e09-47d3-8f1b-806995fa4412_706f6f6c5f7265706c6963615f706f6f6c
+//nolint:lll    // ex: "mig_mons-b7f67366bb43f32e07d8a261a7840da9_image-e0b45b52-7e09-47d3-8f1b-806995fa4412_706f6f6c5f7265706c6963615f706f6f6c
 func composeIntreeMigVolID(mons, rbdImageName string) string {
 	poolField := hex.EncodeToString([]byte(defaultRBDPool))
 	monsField := monsPrefix + getMonsHash(mons)

--- a/e2e/migration.go
+++ b/e2e/migration.go
@@ -30,6 +30,7 @@ import (
 // composeIntreeMigVolID create a volID similar to intree migration volID
 // the migration volID format looks like below
 // mig-mons-<hash>-image-<UUID_<poolhash>
+//
 //nolint:lll    // ex: "mig_mons-b7f67366bb43f32e07d8a261a7840da9_image-e0b45b52-7e09-47d3-8f1b-806995fa4412_706f6f6c5f7265706c6963615f706f6f6c
 func composeIntreeMigVolID(mons, rbdImageName string) string {
 	poolField := hex.EncodeToString([]byte(defaultRBDPool))

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:golint // e2e uses By() and other Ginkgo functions
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
-	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -420,7 +420,7 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 	})
 }
 
-// nolint:unparam // currently skipNotFound is always false, this can change in the future
+//nolint:unparam // currently skipNotFound is always false, this can change in the future
 func deletePodWithLabel(label, ns string, skipNotFound bool) error {
 	err := retryKubectlArgs(
 		ns,

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/ceph/ceph-csi/internal/util"
 
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:golint // e2e uses By() and other Ginkgo functions
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/ceph/ceph-csi/internal/util"
 
-	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -204,7 +204,7 @@ func checkGetKeyError(err error, stdErr string) bool {
 }
 
 // checkClusternameInMetadata check for cluster name metadata on RBD image.
-// nolint:nilerr // intentionally returning nil on error in the retry loop.
+//nolint:nilerr // intentionally returning nil on error in the retry loop.
 func checkClusternameInMetadata(f *framework.Framework, ns, pool, image string) {
 	t := time.Duration(deployTimeout) * time.Minute
 	var (

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -204,6 +204,7 @@ func checkGetKeyError(err error, stdErr string) bool {
 }
 
 // checkClusternameInMetadata check for cluster name metadata on RBD image.
+//
 //nolint:nilerr // intentionally returning nil on error in the retry loop.
 func checkClusternameInMetadata(f *framework.Framework, ns, pool, image string) {
 	t := time.Duration(deployTimeout) * time.Minute

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -75,6 +75,7 @@ var deepFlattenSupport = []util.KernelVersion{
 
 // To use `io-timeout=0` we need
 // www.mail-archive.com/linux-block@vger.kernel.org/msg38060.html
+//
 //nolint:gomnd // numbers specify Kernel versions.
 var nbdZeroIOtimeoutSupport = []util.KernelVersion{
 	{

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-// nolint:gomnd // numbers specify Kernel versions.
+//nolint:gomnd // numbers specify Kernel versions.
 var nbdResizeSupport = []util.KernelVersion{
 	{
 		Version:      5,
@@ -49,7 +49,7 @@ var nbdResizeSupport = []util.KernelVersion{
 	}, // standard 5.3+ versions
 }
 
-// nolint:gomnd // numbers specify Kernel versions.
+//nolint:gomnd // numbers specify Kernel versions.
 var fastDiffSupport = []util.KernelVersion{
 	{
 		Version:      5,
@@ -61,7 +61,7 @@ var fastDiffSupport = []util.KernelVersion{
 	}, // standard 5.3+ versions
 }
 
-// nolint:gomnd // numbers specify Kernel versions.
+//nolint:gomnd // numbers specify Kernel versions.
 var deepFlattenSupport = []util.KernelVersion{
 	{
 		Version:      5,
@@ -75,7 +75,7 @@ var deepFlattenSupport = []util.KernelVersion{
 
 // To use `io-timeout=0` we need
 // www.mail-archive.com/linux-block@vger.kernel.org/msg38060.html
-// nolint:gomnd // numbers specify Kernel versions.
+//nolint:gomnd // numbers specify Kernel versions.
 var nbdZeroIOtimeoutSupport = []util.KernelVersion{
 	{
 		Version:      5,

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -792,6 +792,8 @@ func sparsifyBackingRBDImage(f *framework.Framework, pvc *v1.PersistentVolumeCla
 func deletePool(name string, cephFS bool, f *framework.Framework) error {
 	cmds := []string{}
 	if cephFS {
+		//nolint:dupword // "ceph osd pool delete" requires the pool 2x
+		//
 		// ceph fs fail
 		// ceph fs rm myfs --yes-i-really-mean-it
 		// ceph osd pool delete myfs-metadata myfs-metadata
@@ -803,6 +805,8 @@ func deletePool(name string, cephFS bool, f *framework.Framework) error {
 			fmt.Sprintf("ceph osd pool delete %s-metadata %s-metadata --yes-i-really-really-mean-it", name, name),
 			fmt.Sprintf("ceph osd pool delete %s-replicated %s-replicated --yes-i-really-really-mean-it", name, name))
 	} else {
+		//nolint:dupword // "ceph osd pool delete" requires the pool 2x
+		//
 		// ceph osd pool delete replicapool replicapool
 		// --yes-i-really-mean-it
 		cmds = append(cmds, fmt.Sprintf("ceph osd pool delete %s %s --yes-i-really-really-mean-it", name, name))

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega" // nolint
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -45,7 +45,7 @@ func expandPVCSize(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, size s
 	_, err = c.CoreV1().
 		PersistentVolumeClaims(updatedPVC.Namespace).
 		Update(context.TODO(), updatedPVC, metav1.UpdateOptions{})
-	Expect(err).Should(BeNil())
+	Expect(err).ShouldNot(HaveOccurred())
 
 	start := time.Now()
 	framework.Logf("Waiting up to %v to be in Resized state", pvc)

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:golint // e2e uses Expect() and other Gomega functions
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -23,7 +23,7 @@ import (
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	snapclient "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned/typed/volumesnapshot/v1"
-	. "github.com/onsi/gomega" // nolint
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -293,7 +293,7 @@ func getVolumeSnapshotContent(namespace, snapshotName string) (*snapapi.VolumeSn
 	return volumeSnapshotContent, nil
 }
 
-// nolint:gocyclo,cyclop // reduce complexity
+//nolint:gocyclo,cyclop // reduce complexity
 func validateBiggerPVCFromSnapshot(f *framework.Framework,
 	pvcPath,
 	appPath,

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -23,7 +23,7 @@ import (
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	snapclient "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned/typed/volumesnapshot/v1"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:golint // e2e uses Expect() and other Gomega functions
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -35,7 +35,7 @@ import (
 func getSnapshotClass(path string) snapapi.VolumeSnapshotClass {
 	sc := snapapi.VolumeSnapshotClass{}
 	err := unmarshal(path, &sc)
-	Expect(err).Should(BeNil())
+	Expect(err).ShouldNot(HaveOccurred())
 
 	return sc
 }
@@ -43,7 +43,7 @@ func getSnapshotClass(path string) snapapi.VolumeSnapshotClass {
 func getSnapshot(path string) snapapi.VolumeSnapshot {
 	sc := snapapi.VolumeSnapshot{}
 	err := unmarshal(path, &sc)
-	Expect(err).Should(BeNil())
+	Expect(err).ShouldNot(HaveOccurred())
 
 	return sc
 }

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -322,7 +322,7 @@ func validateRBDStaticMigrationPVC(f *framework.Framework, appPath, scName strin
 	return err
 }
 
-// nolint:gocyclo,cyclop // reduce complexity
+//nolint:gocyclo,cyclop // reduce complexity
 func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) error {
 	opt := make(map[string]string)
 	var (

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/upgrade-cephfs.go
+++ b/e2e/upgrade-cephfs.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:golint // e2e uses By() and other Ginkgo functions
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/upgrade-rbd.go
+++ b/e2e/upgrade-rbd.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:golint // e2e uses By() and other Ginkgo functions
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1529,13 +1529,14 @@ func validateController(
 	return deleteResource(rbdExamplePath + "storageclass.yaml")
 }
 
-//nolint:deadcode,unused // Unused code will be used in future.
 // k8sVersionGreaterEquals checks the ServerVersion of the Kubernetes cluster
 // and compares it to the major.minor version passed. In case the version of
 // the cluster is equal or higher to major.minor, `true` is returned, `false`
 // otherwise.
 // If fetching the ServerVersion of the Kubernetes cluster fails, the calling
 // test case is marked as `FAILED` and gets aborted.
+//
+//nolint:deadcode,unused // Unused code will be used in future.
 func k8sVersionGreaterEquals(c kubernetes.Interface, major, minor int) bool {
 	v, err := c.Discovery().ServerVersion()
 	if err != nil {
@@ -1681,6 +1682,7 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 // retryKubectlArgs takes a namespace and action telling kubectl what to do
 // with the passed arguments. This function retries until no error occurred, or
 // the timeout passed.
+//
 //nolint:unparam // retryKubectlArgs will be used with kubectlDelete arg later on.
 func retryKubectlArgs(namespace string, action kubectlAction, t int, args ...string) error {
 	timeout := time.Duration(t) * time.Minute

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -852,7 +852,7 @@ func writeDataAndCalChecksum(app *v1.Pod, opt *metav1.ListOptions, f *framework.
 	return checkSum, nil
 }
 
-// nolint:gocyclo,gocognit,nestif,cyclop // reduce complexity
+//nolint:gocyclo,gocognit,nestif,cyclop // reduce complexity
 func validatePVCClone(
 	totalCount int,
 	sourcePvcPath, sourceAppPath, clonePvcPath, clonePvcAppPath,
@@ -1067,7 +1067,7 @@ func validatePVCClone(
 	validateRBDImageCount(f, 0, defaultRBDPool)
 }
 
-// nolint:gocyclo,gocognit,nestif,cyclop // reduce complexity
+//nolint:gocyclo,gocognit,nestif,cyclop // reduce complexity
 func validatePVCSnapshot(
 	totalCount int,
 	pvcPath, appPath, snapshotPath, pvcClonePath, appClonePath string,
@@ -1529,7 +1529,7 @@ func validateController(
 	return deleteResource(rbdExamplePath + "storageclass.yaml")
 }
 
-// nolint:deadcode,unused // Unused code will be used in future.
+//nolint:deadcode,unused // Unused code will be used in future.
 // k8sVersionGreaterEquals checks the ServerVersion of the Kubernetes cluster
 // and compares it to the major.minor version passed. In case the version of
 // the cluster is equal or higher to major.minor, `true` is returned, `false`
@@ -1681,7 +1681,7 @@ func retryKubectlFile(namespace string, action kubectlAction, filename string, t
 // retryKubectlArgs takes a namespace and action telling kubectl what to do
 // with the passed arguments. This function retries until no error occurred, or
 // the timeout passed.
-// nolint:unparam // retryKubectlArgs will be used with kubectlDelete arg later on.
+//nolint:unparam // retryKubectlArgs will be used with kubectlDelete arg later on.
 func retryKubectlArgs(namespace string, action kubectlAction, t int, args ...string) error {
 	timeout := time.Duration(t) * time.Minute
 	args = append([]string{string(action)}, args...)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi
 
-go 1.19
+go 1.20
 
 require (
 	github.com/IBM/keyprotect-go-client v0.10.0

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -241,6 +241,7 @@ func checkValidCreateVolumeRequest(
 }
 
 // CreateVolume creates a reservation and the volume in backend, if it is not already present.
+//
 //nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
 func (cs *ControllerServer) CreateVolume(
 	ctx context.Context,
@@ -730,6 +731,7 @@ func (cs *ControllerServer) ControllerExpandVolume(
 
 // CreateSnapshot creates the snapshot in backend and stores metadata
 // in store
+//
 //nolint:gocognit,gocyclo,cyclop // golangci-lint did not catch this earlier, needs to get fixed late
 func (cs *ControllerServer) CreateSnapshot(
 	ctx context.Context,
@@ -986,6 +988,7 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 
 // DeleteSnapshot deletes the snapshot in backend and removes the
 // snapshot metadata from store.
+//
 //nolint:gocyclo,cyclop // TODO: reduce complexity
 func (cs *ControllerServer) DeleteSnapshot(
 	ctx context.Context,

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -241,7 +241,7 @@ func checkValidCreateVolumeRequest(
 }
 
 // CreateVolume creates a reservation and the volume in backend, if it is not already present.
-// nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
+//nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
 func (cs *ControllerServer) CreateVolume(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
@@ -730,7 +730,7 @@ func (cs *ControllerServer) ControllerExpandVolume(
 
 // CreateSnapshot creates the snapshot in backend and stores metadata
 // in store
-// nolint:gocognit,gocyclo,cyclop // golangci-lint did not catch this earlier, needs to get fixed late
+//nolint:gocognit,gocyclo,cyclop // golangci-lint did not catch this earlier, needs to get fixed late
 func (cs *ControllerServer) CreateSnapshot(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest,
@@ -986,7 +986,7 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 
 // DeleteSnapshot deletes the snapshot in backend and removes the
 // snapshot metadata from store.
-// nolint:gocyclo,cyclop // TODO: reduce complexity
+//nolint:gocyclo,cyclop // TODO: reduce complexity
 func (cs *ControllerServer) DeleteSnapshot(
 	ctx context.Context,
 	req *csi.DeleteSnapshotRequest,

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -49,6 +49,8 @@ type Subvolume struct {
 
 // SubVolumeClient is the interface that holds the signature of subvolume methods
 // that interacts with CephFS subvolume API's.
+//
+//nolint:interfacebloat // SubVolumeClient has more than 10 methods, that is ok.
 type SubVolumeClient interface {
 	// GetVolumeRootPathCeph returns the root path of the subvolume.
 	GetVolumeRootPathCeph(ctx context.Context) (string, error)

--- a/internal/cephfs/fuserecovery.go
+++ b/internal/cephfs/fuserecovery.go
@@ -96,18 +96,18 @@ func validateFsType(mountpoint, fsType string, mis []mountutil.MountInfo) bool {
 // volume moutpoints inside the NodePublishVolume call.
 //
 // Restoration is performed in following steps:
-// 1. Detection: staging target path must be a working mountpoint, and target
-//    path must not be a corrupted mountpoint (see getMountState()). If either
-//    of those checks fail, mount recovery is performed.
-// 2. Recovery preconditions:
-//    * NodeStageMountinfo is present for this volume,
-//    * if staging target path and target path are mountpoints, they must be
-//      managed by ceph-fuse,
-//    * VolumeOptions.Mounter must evaluate to "fuse".
-// 3. Recovery:
-//    * staging target path is unmounted and mounted again using ceph-fuse,
-//    * target path is only unmounted; NodePublishVolume is then expected to
-//      continue normally.
+//  1. Detection: staging target path must be a working mountpoint, and target
+//     path must not be a corrupted mountpoint (see getMountState()). If either
+//     of those checks fail, mount recovery is performed.
+//  2. Recovery preconditions:
+//     * NodeStageMountinfo is present for this volume,
+//     * if staging target path and target path are mountpoints, they must be
+//     managed by ceph-fuse,
+//     * VolumeOptions.Mounter must evaluate to "fuse".
+//  3. Recovery:
+//     * staging target path is unmounted and mounted again using ceph-fuse,
+//     * target path is only unmounted; NodePublishVolume is then expected to
+//     continue normally.
 func (ns *NodeServer) tryRestoreFuseMountsInNodePublish(
 	ctx context.Context,
 	volID fsutil.VolumeID,

--- a/internal/cephfs/mounter/volumemounter.go
+++ b/internal/cephfs/mounter/volumemounter.go
@@ -31,7 +31,7 @@ import (
 var (
 	availableMounters []string
 
-	// nolint:gomnd // numbers specify Kernel versions.
+	//nolint:gomnd // numbers specify Kernel versions.
 	quotaSupport = []util.KernelVersion{
 		{
 			Version:      4,

--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -71,7 +71,7 @@ because, the order of omap creation and deletion are inverse of each other, and 
 request name lock, and hence any stale omaps are leftovers from incomplete transactions and are
 hence safe to garbage collect.
 */
-// nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
+//nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
 func CheckVolExists(ctx context.Context,
 	volOptions,
 	parentVolOpt *VolumeOptions,

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -210,7 +210,7 @@ func fmtBackingSnapshotOptionMismatch(optName, expected, actual string) error {
 
 // NewVolumeOptions generates a new instance of volumeOptions from the provided
 // CSI request parameters.
-// nolint:gocyclo,cyclop // TODO: reduce complexity
+//nolint:gocyclo,cyclop // TODO: reduce complexity
 func NewVolumeOptions(
 	ctx context.Context,
 	requestName,
@@ -348,7 +348,7 @@ func IsVolumeCreateRO(caps []*csi.VolumeCapability) bool {
 
 // newVolumeOptionsFromVolID generates a new instance of volumeOptions and VolumeIdentifier
 // from the provided CSI VolumeID.
-// nolint:gocyclo,cyclop // TODO: reduce complexity
+//nolint:gocyclo,cyclop // TODO: reduce complexity
 func NewVolumeOptionsFromVolID(
 	ctx context.Context,
 	volID string,

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -210,6 +210,7 @@ func fmtBackingSnapshotOptionMismatch(optName, expected, actual string) error {
 
 // NewVolumeOptions generates a new instance of volumeOptions from the provided
 // CSI request parameters.
+//
 //nolint:gocyclo,cyclop // TODO: reduce complexity
 func NewVolumeOptions(
 	ctx context.Context,
@@ -348,6 +349,7 @@ func IsVolumeCreateRO(caps []*csi.VolumeCapability) bool {
 
 // newVolumeOptionsFromVolID generates a new instance of volumeOptions and VolumeIdentifier
 // from the provided CSI VolumeID.
+//
 //nolint:gocyclo,cyclop // TODO: reduce complexity
 func NewVolumeOptionsFromVolID(
 	ctx context.Context,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -69,6 +69,8 @@ func NewCSIDriver(name, v, nodeID string) *CSIDriver {
 
 // ValidateControllerServiceRequest validates the controller
 // plugin capabilities.
+//
+//nolint:interfacer // c can be of type fmt.Stringer, but that does not make the API clearer
 func (d *CSIDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapability_RPC_Type) error {
 	if c == csi.ControllerServiceCapability_RPC_UNKNOWN {
 		return nil

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -82,7 +82,7 @@ func (d *CSIDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapa
 		}
 	}
 
-	return status.Error(codes.InvalidArgument, fmt.Sprintf("%s", c)) //nolint
+	return status.Error(codes.InvalidArgument, fmt.Sprintf("%s", c))
 }
 
 // AddControllerServiceCapabilities stores the controller capabilities

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -17,8 +17,6 @@ limitations under the License.
 package csicommon
 
 import (
-	"fmt"
-
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -82,7 +80,7 @@ func (d *CSIDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapa
 		}
 	}
 
-	return status.Error(codes.InvalidArgument, fmt.Sprintf("%s", c))
+	return status.Error(codes.InvalidArgument, c.String())
 }
 
 // AddControllerServiceCapabilities stores the controller capabilities

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -279,9 +279,9 @@ NOTE: As the function manipulates omaps, it should be called with a lock against
 held, to prevent parallel operations from modifying the state of the omaps for this request name.
 
 Return values:
-	- ImageData: which contains the UUID,Pool,PoolID and ImageAttributes that were reserved for the
-     passed in reqName, empty if there was no reservation found
-	- error: non-nil in case of any errors
+  - ImageData: which contains the UUID,Pool,PoolID and ImageAttributes that were reserved for the
+    passed in reqName, empty if there was no reservation found
+  - error: non-nil in case of any errors
 */
 func (conn *Connection) CheckReservation(ctx context.Context,
 	journalPool, reqName, namePrefix, snapParentName, kmsConfig string,
@@ -431,9 +431,9 @@ NOTE: As the function manipulates omaps, it should be called with a lock against
 held, to prevent parallel operations from modifying the state of the omaps for this request name.
 
 Input arguments:
-	- csiJournalPool: Pool name that holds the CSI request name based journal
-	- volJournalPool: Pool name that holds the image/subvolume and the per-image journal (may be
-	  different if image is created in a topology constrained pool)
+  - csiJournalPool: Pool name that holds the CSI request name based journal
+  - volJournalPool: Pool name that holds the image/subvolume and the per-image journal (may be
+    different if image is created in a topology constrained pool)
 */
 func (conn *Connection) UndoReservation(ctx context.Context,
 	csiJournalPool, volJournalPool, volName, reqName string,
@@ -537,24 +537,24 @@ NOTE: As the function manipulates omaps, it should be called with a lock against
 held, to prevent parallel operations from modifying the state of the omaps for this request name.
 
 Input arguments:
-	- journalPool: Pool where the CSI journal is stored (maybe different than the pool where the
-	  image/subvolume is created due to topology constraints)
-	- journalPoolID: pool ID of the journalPool
-	- imagePool: Pool where the image/subvolume is created
-	- imagePoolID: pool ID of the imagePool
-	- reqName: Name of the volume request received
-	- namePrefix: Prefix to use when generating the image/subvolume name (suffix is an auto-generated UUID)
-	- parentName: Name of the parent image/subvolume if reservation is for a snapshot (optional)
-	- kmsConf: Name of the key management service used to encrypt the image (optional)
-	- encryptionType: Type of encryption used when kmsConf is set (optional)
-	- volUUID: UUID need to be reserved instead of auto-generating one (this is useful for mirroring and metro-DR)
-	- owner: the owner of the volume (optional)
-	- backingSnapshotID: ID of the snapshot on which the CephFS snapshot-backed volume is based (optional)
+  - journalPool: Pool where the CSI journal is stored (maybe different than the pool where the
+    image/subvolume is created due to topology constraints)
+  - journalPoolID: pool ID of the journalPool
+  - imagePool: Pool where the image/subvolume is created
+  - imagePoolID: pool ID of the imagePool
+  - reqName: Name of the volume request received
+  - namePrefix: Prefix to use when generating the image/subvolume name (suffix is an auto-generated UUID)
+  - parentName: Name of the parent image/subvolume if reservation is for a snapshot (optional)
+  - kmsConf: Name of the key management service used to encrypt the image (optional)
+  - encryptionType: Type of encryption used when kmsConf is set (optional)
+  - volUUID: UUID need to be reserved instead of auto-generating one (this is useful for mirroring and metro-DR)
+  - owner: the owner of the volume (optional)
+  - backingSnapshotID: ID of the snapshot on which the CephFS snapshot-backed volume is based (optional)
 
 Return values:
-	- string: Contains the UUID that was reserved for the passed in reqName
-	- string: Contains the image name that was reserved for the passed in reqName
-	- error: non-nil in case of any errors
+  - string: Contains the UUID that was reserved for the passed in reqName
+  - string: Contains the image name that was reserved for the passed in reqName
+  - error: non-nil in case of any errors
 */
 func (conn *Connection) ReserveName(ctx context.Context,
 	journalPool string, journalPoolID int64,

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -61,11 +61,11 @@ var (
 
 // GetKMS returns an instance of Key Management System.
 //
-// - tenant is the owner of the Volume, used to fetch the Vault Token from the
-//   Kubernetes Namespace where the PVC lives
-// - kmsID is the service name of the KMS configuration
-// - secrets contain additional details, like TLS certificates to connect to
-//   the KMS
+//   - tenant is the owner of the Volume, used to fetch the Vault Token from the
+//     Kubernetes Namespace where the PVC lives
+//   - kmsID is the service name of the KMS configuration
+//   - secrets contain additional details, like TLS certificates to connect to
+//     the KMS
 func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, error) {
 	if kmsID == "" || kmsID == DefaultKMSType {
 		return GetDefaultKMS(secrets)

--- a/internal/kms/secretskms_test.go
+++ b/internal/kms/secretskms_test.go
@@ -53,7 +53,7 @@ func TestGenerateNonce(t *testing.T) {
 
 func TestGenerateCipher(t *testing.T) {
 	t.Parallel()
-	// nolint:gosec // this passphrase is intentionally hardcoded
+	//nolint:gosec // this passphrase is intentionally hardcoded
 	passphrase := "my-cool-luks-passphrase"
 	salt := "unique-id-for-the-volume"
 

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -123,7 +123,7 @@ func setConfigString(option *string, config map[string]interface{}, key string) 
 // these settings will be used when connecting to the Vault service with
 // vc.connectVault().
 //
-// nolint:gocyclo,cyclop // iterating through many config options, not complex at all.
+//nolint:gocyclo,cyclop // iterating through many config options, not complex at all.
 func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 	vaultConfig := make(map[string]interface{})
 	keyContext := make(map[string]string)

--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -44,29 +44,30 @@ ServiceAccount from the Tenant that owns the volume to store/retrieve the
 encryption passphrase of volumes.
 
 Example JSON structure in the KMS config is,
-{
-    "vault-tenant-sa": {
-        "encryptionKMSType": "vaulttenantsa",
-        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
-        "vaultBackendPath": "secret/",
-        "vaultTLSServerName": "vault.default.svc.cluster.local",
-        "vaultCAFromSecret": "vault-ca",
-        "vaultClientCertFromSecret": "vault-client-cert",
-        "vaultClientCertKeyFromSecret": "vault-client-cert-key",
-        "vaultCAVerify": "false",
-        "tenantConfigName": "ceph-csi-kms-config",
-        "tenantSAName": "ceph-csi-vault-sa",
-        "tenants": {
-            "my-app": {
-                "vaultAddress": "https://vault.example.com",
-                "vaultCAVerify": "true"
-            },
-            "an-other-app": {
-                "tenantSAName": "encryped-storage-sa"
-            }
-	},
-	...
-}.
+
+	{
+	    "vault-tenant-sa": {
+	        "encryptionKMSType": "vaulttenantsa",
+	        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+	        "vaultBackendPath": "secret/",
+	        "vaultTLSServerName": "vault.default.svc.cluster.local",
+	        "vaultCAFromSecret": "vault-ca",
+	        "vaultClientCertFromSecret": "vault-client-cert",
+	        "vaultClientCertKeyFromSecret": "vault-client-cert-key",
+	        "vaultCAVerify": "false",
+	        "tenantConfigName": "ceph-csi-kms-config",
+	        "tenantSAName": "ceph-csi-vault-sa",
+	        "tenants": {
+	            "my-app": {
+	                "vaultAddress": "https://vault.example.com",
+	                "vaultCAVerify": "true"
+	            },
+	            "an-other-app": {
+	                "tenantSAName": "encryped-storage-sa"
+	            }
+		},
+		...
+	}.
 */
 type vaultTenantSA struct {
 	vaultTenantConnection

--- a/internal/kms/vault_tokens.go
+++ b/internal/kms/vault_tokens.go
@@ -160,30 +160,31 @@ VaultTokens represents a Hashicorp Vault KMS configuration that provides a
 Token per tenant.
 
 Example JSON structure in the KMS config is,
-{
-    "vault-with-tokens": {
-        "encryptionKMSType": "vaulttokens",
-        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
-        "vaultBackend": "kv-v2",
-        "vaultBackendPath": "secret/",
-        "vaultTLSServerName": "vault.default.svc.cluster.local",
-        "vaultCAFromSecret": "vault-ca",
-        "vaultClientCertFromSecret": "vault-client-cert",
-        "vaultClientCertKeyFromSecret": "vault-client-cert-key",
-        "vaultCAVerify": "false",
-        "tenantConfigName": "ceph-csi-kms-config",
-        "tenantTokenName": "ceph-csi-kms-token",
-        "tenants": {
-            "my-app": {
-                "vaultAddress": "https://vault.example.com",
-                "vaultCAVerify": "true"
-            },
-            "an-other-app": {
-                "tenantTokenName": "storage-encryption-token"
-            }
-	},
-	...
-}.
+
+	{
+	    "vault-with-tokens": {
+	        "encryptionKMSType": "vaulttokens",
+	        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+	        "vaultBackend": "kv-v2",
+	        "vaultBackendPath": "secret/",
+	        "vaultTLSServerName": "vault.default.svc.cluster.local",
+	        "vaultCAFromSecret": "vault-ca",
+	        "vaultClientCertFromSecret": "vault-client-cert",
+	        "vaultClientCertKeyFromSecret": "vault-client-cert-key",
+	        "vaultCAVerify": "false",
+	        "tenantConfigName": "ceph-csi-kms-config",
+	        "tenantTokenName": "ceph-csi-kms-token",
+	        "tenants": {
+	            "my-app": {
+	                "vaultAddress": "https://vault.example.com",
+	                "vaultCAVerify": "true"
+	            },
+	            "an-other-app": {
+	                "tenantTokenName": "storage-encryption-token"
+	            }
+		},
+		...
+	}.
 */
 type vaultTenantConnection struct {
 	vaultConnection

--- a/internal/kms/vault_tokens.go
+++ b/internal/kms/vault_tokens.go
@@ -353,7 +353,7 @@ func (kms *vaultTokensKMS) setTokenName(config map[string]interface{}) error {
 // initCertificates updates the kms.vaultConfig with the options from config
 // it calls the kubernetes secrets and get the required data.
 
-// nolint:gocyclo,cyclop // iterating through many config options, not complex at all.
+//nolint:gocyclo,cyclop // iterating through many config options, not complex at all.
 func (vtc *vaultTenantConnection) initCertificates(config map[string]interface{}) error {
 	vaultConfig := make(map[string]interface{})
 

--- a/internal/nfs/controller/volume.go
+++ b/internal/nfs/controller/volume.go
@@ -270,14 +270,14 @@ func (nv *NFSVolume) getNFSCluster() (string, error) {
 	fs := fscore.NewFileSystem(nv.conn)
 	fsName, err := fs.GetFsName(nv.ctx, nv.fscID)
 	if err != nil && errors.Is(err, util.ErrPoolNotFound) {
-		return "", fmt.Errorf("%w for ID %x: %v", ErrFilesystemNotFound, nv.fscID, err)
+		return "", fmt.Errorf("%w for ID %x: %w", ErrFilesystemNotFound, nv.fscID, err)
 	} else if err != nil {
 		return "", fmt.Errorf("failed to get filesystem name for ID %x: %w", nv.fscID, err)
 	}
 
 	mdPool, err := fs.GetMetadataPool(nv.ctx, fsName)
 	if err != nil && errors.Is(err, util.ErrPoolNotFound) {
-		return "", fmt.Errorf("metadata pool for %q %w: %v", fsName, ErrNotFound, err)
+		return "", fmt.Errorf("metadata pool for %q %w: %w", fsName, ErrNotFound, err)
 	} else if err != nil {
 		return "", fmt.Errorf("failed to get metadata pool for %q: %w", fsName, err)
 	}
@@ -291,7 +291,7 @@ func (nv *NFSVolume) getNFSCluster() (string, error) {
 
 	clusterName, err := j.FetchAttribute(nv.ctx, mdPool, nv.objectUUID, clusterNameKey)
 	if err != nil && errors.Is(err, util.ErrPoolNotFound) || errors.Is(err, util.ErrKeyNotFound) {
-		return "", fmt.Errorf("cluster name for %q %w: %v", nv.objectUUID, ErrNotFound, err)
+		return "", fmt.Errorf("cluster name for %q %w: %w", nv.objectUUID, ErrNotFound, err)
 	} else if err != nil {
 		return "", fmt.Errorf("failed to get cluster name for %q: %w", nv.objectUUID, err)
 	}
@@ -308,14 +308,14 @@ func (nv *NFSVolume) setNFSCluster(clusterName string) error {
 	fs := fscore.NewFileSystem(nv.conn)
 	fsName, err := fs.GetFsName(nv.ctx, nv.fscID)
 	if err != nil && errors.Is(err, util.ErrPoolNotFound) {
-		return fmt.Errorf("%w for ID %x: %v", ErrFilesystemNotFound, nv.fscID, err)
+		return fmt.Errorf("%w for ID %x: %w", ErrFilesystemNotFound, nv.fscID, err)
 	} else if err != nil {
 		return fmt.Errorf("failed to get filesystem name for ID %x: %w", nv.fscID, err)
 	}
 
 	mdPool, err := fs.GetMetadataPool(nv.ctx, fsName)
 	if err != nil && errors.Is(err, util.ErrPoolNotFound) {
-		return fmt.Errorf("metadata pool for %q %w: %v", fsName, ErrNotFound, err)
+		return fmt.Errorf("metadata pool for %q %w: %w", fsName, ErrNotFound, err)
 	} else if err != nil {
 		return fmt.Errorf("failed to get metadata pool for %q: %w", fsName, err)
 	}

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -232,7 +232,7 @@ func (ns *NodeServer) mountNFS(
 		volumeID, source, mountPoint, mountOptions)
 	if netNamespaceFilePath != "" {
 		_, stderr, err = util.ExecuteCommandWithNSEnter(
-			ctx, netNamespaceFilePath, "mount", args[:]...)
+			ctx, netNamespaceFilePath, "mount", args...)
 	} else {
 		err = ns.Mounter.Mount(source, mountPoint, "nfs", mountOptions)
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1060,7 +1060,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 }
 
 // CreateSnapshot creates the snapshot in backend and stores metadata in store.
-// nolint:gocyclo,cyclop // TODO: reduce complexity.
+//nolint:gocyclo,cyclop // TODO: reduce complexity.
 func (cs *ControllerServer) CreateSnapshot(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest,

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1060,6 +1060,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 }
 
 // CreateSnapshot creates the snapshot in backend and stores metadata in store.
+//
 //nolint:gocyclo,cyclop // TODO: reduce complexity.
 func (cs *ControllerServer) CreateSnapshot(
 	ctx context.Context,

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -308,8 +308,8 @@ func (cs *ControllerServer) CreateVolume(
 		return nil, err
 	}
 
-	// TODO: create/get a connection from the the ConnPool, and do not pass
-	// the credentials to any of the utility functions.
+	// TODO: create/get a connection from the ConnPool, and do not pass the
+	// credentials to any of the utility functions.
 
 	cr, err := util.NewUserCredentialsWithMigration(req.GetSecrets())
 	if err != nil {

--- a/internal/rbd/migration_test.go
+++ b/internal/rbd/migration_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -78,7 +78,7 @@ var (
 	kernelRelease = ""
 	// deepFlattenSupport holds the list of kernel which support mapping rbd
 	// image with deep-flatten image feature
-	// nolint:gomnd // numbers specify Kernel versions.
+	//nolint:gomnd // numbers specify Kernel versions.
 	deepFlattenSupport = []util.KernelVersion{
 		{
 			Version:      5,
@@ -114,7 +114,7 @@ var (
 
 // parseBoolOption checks if parameters contain option and parse it. If it is
 // empty or not set return default.
-// nolint:unparam // currently defValue is always false, this can change in the future
+//nolint:unparam // currently defValue is always false, this can change in the future
 func parseBoolOption(ctx context.Context, parameters map[string]string, optionName string, defValue bool) bool {
 	boolVal := defValue
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1023,7 +1023,7 @@ func (ns *NodeServer) NodeUnstageVolume(
 		}
 
 		// It was not mounted and image metadata is also missing, we are done as the last step in
-		// in the staging transaction is complete
+		// the staging transaction is complete
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -114,6 +114,7 @@ var (
 
 // parseBoolOption checks if parameters contain option and parse it. If it is
 // empty or not set return default.
+//
 //nolint:unparam // currently defValue is always false, this can change in the future
 func parseBoolOption(ctx context.Context, parameters map[string]string, optionName string, defValue bool) bool {
 	boolVal := defValue

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -538,6 +538,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 // Generate new volume Handler
 // The volume handler won't remain same as its contains poolID,clusterID etc
 // which are not same across clusters.
+//
 //nolint:gocyclo,cyclop,nestif // TODO: reduce complexity
 func RegenerateJournal(
 	volumeAttributes map[string]string,

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -538,7 +538,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 // Generate new volume Handler
 // The volume handler won't remain same as its contains poolID,clusterID etc
 // which are not same across clusters.
-// nolint:gocyclo,cyclop,nestif // TODO: reduce complexity
+//nolint:gocyclo,cyclop,nestif // TODO: reduce complexity
 func RegenerateJournal(
 	volumeAttributes map[string]string,
 	claimName,

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -567,7 +567,7 @@ func RegenerateJournal(
 
 	err = vi.DecomposeCSIID(rbdVol.VolID)
 	if err != nil {
-		return "", fmt.Errorf("%w: error decoding volume ID (%s) (%s)",
+		return "", fmt.Errorf("%w: error decoding volume ID (%w) (%s)",
 			ErrInvalidVolID, err, rbdVol.VolID)
 	}
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1175,7 +1175,7 @@ func GenVolFromVolID(
 
 	err := vi.DecomposeCSIID(volumeID)
 	if err != nil {
-		return vol, fmt.Errorf("%w: error decoding volume ID (%s) (%s)",
+		return vol, fmt.Errorf("%w: error decoding volume ID (%w) (%s)",
 			ErrInvalidVolID, err, volumeID)
 	}
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1197,6 +1197,7 @@ func GenVolFromVolID(
 			return rbdVol, vErr
 		}
 	}
+
 	return vol, err
 }
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1161,7 +1161,7 @@ func generateVolumeFromVolumeID(
 // GenVolFromVolID generates a rbdVolume structure from the provided identifier, updating
 // the structure with elements from on-disk image metadata as well.
 //
-// nolint // returns non-exported *rbdVolume, which is fine
+
 func GenVolFromVolID(
 	ctx context.Context,
 	volumeID string,
@@ -1702,7 +1702,7 @@ func (ri *rbdImageMetadataStash) String() string {
 func stashRBDImageMetadata(volOptions *rbdVolume, metaDataPath string) error {
 	imgMeta := rbdImageMetadataStash{
 		// there are no checks for this at present
-		Version:        3, // nolint:gomnd // number specifies version.
+		Version:        3, //nolint:gomnd // number specifies version.
 		Pool:           volOptions.Pool,
 		RadosNamespace: volOptions.RadosNamespace,
 		ImageName:      volOptions.RbdImageName,

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1161,7 +1161,7 @@ func generateVolumeFromVolumeID(
 // GenVolFromVolID generates a rbdVolume structure from the provided identifier, updating
 // the structure with elements from on-disk image metadata as well.
 //
-
+//nolint:golint // TODO: returning unexported rbdVolume type, use an interface instead.
 func GenVolFromVolID(
 	ctx context.Context,
 	volumeID string,

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -297,7 +297,7 @@ func TestStrategicActionOnLogFile(t *testing.T) {
 			var err error
 			switch tt.args.logStrategy {
 			case "compress":
-				newExt := strings.Replace(tt.args.logFile, ".log", ".gz", -1)
+				newExt := strings.ReplaceAll(tt.args.logFile, ".log", ".gz")
 				if _, err = os.Stat(newExt); os.IsNotExist(err) {
 					t.Errorf("compressed logFile (%s) not found: %v", newExt, err)
 				}

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/conn_pool_test.go
+++ b/internal/util/conn_pool_test.go
@@ -73,7 +73,7 @@ func (cp *ConnPool) fakeGet(monitors, user, keyfile string) (*rados.Conn, string
 	return conn, unique, nil
 }
 
-// nolint:paralleltest // these tests cannot run in parallel
+//nolint:paralleltest // these tests cannot run in parallel
 func TestConnPool(t *testing.T) {
 	cp := NewConnPool(interval, expiry)
 	defer cp.Destroy()

--- a/internal/util/credentials_test.go
+++ b/internal/util/credentials_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/crushlocation.go
+++ b/internal/util/crushlocation.go
@@ -64,7 +64,7 @@ func getCrushLocationMap(crushLocationLabels string, nodeLabels map[string]strin
 			crushLocationType = "host"
 		}
 		// replace "." with "-" to satisfy ceph crush map.
-		value = strings.Replace(strings.TrimSpace(value), ".", "-", -1)
+		value = strings.ReplaceAll(strings.TrimSpace(value), ".", "-")
 		crushLocationMap[crushLocationType] = value
 	}
 

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -67,7 +67,7 @@ type ClusterInfo struct {
 }
 
 // Expected JSON structure in the passed in config file is,
-// nolint:godot // example json content should not contain unwanted dot.
+//nolint:godot // example json content should not contain unwanted dot.
 /*
 [{
 	"clusterID": "<cluster-id>",

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -24,6 +24,8 @@ func ValidateURL(c *Config) error {
 func StartMetricsServer(c *Config) {
 	addr := net.JoinHostPort(c.MetricsIP, strconv.Itoa(c.MetricsPort))
 	http.Handle(c.MetricsPath, promhttp.Handler())
+
+	//nolint:gosec // TODO: add support for passing timeouts
 	err := http.ListenAndServe(addr, nil)
 	if err != nil {
 		log.FatalLogMsg("failed to listen on address %v: %s", addr, err)

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/k8s/parameters_test.go
+++ b/internal/util/k8s/parameters_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/log/log_utils.go
+++ b/internal/util/log/log_utils.go
@@ -29,7 +29,7 @@ func GzipLogFile(pathToFile string) error {
 	}
 
 	// Replace .log extension with .gz extension.
-	newExt := strings.Replace(pathToFile, ".log", ".gz", -1)
+	newExt := strings.ReplaceAll(pathToFile, ".log", ".gz")
 
 	// Open file for writing.
 	gf, err := os.OpenFile(newExt, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644) // #nosec:G304,G302, file inclusion & perms

--- a/internal/util/log/log_utils_test.go
+++ b/internal/util/log/log_utils_test.go
@@ -37,7 +37,7 @@ func TestGzipLogFile(t *testing.T) {
 		t.Errorf("GzipLogFile failed: %v", err)
 	}
 
-	newExt := strings.Replace(logFile.Name(), ".log", ".gz", -1)
+	newExt := strings.ReplaceAll(logFile.Name(), ".log", ".gz")
 	if _, err = os.Stat(newExt); errors.Is(err, os.ErrNotExist) {
 		t.Errorf("compressed logFile (%s) not found: %v", newExt, err)
 	}

--- a/internal/util/reftracker/errors/errors.go
+++ b/internal/util/reftracker/errors/errors.go
@@ -70,7 +70,7 @@ func TryRADOSAborted(opErr error) error {
 		return opErr
 	}
 
-	// nolint:errorlint // Can't use errors.As() because rados.radosError is private.
+	//nolint:errorlint // Can't use errors.As() because rados.radosError is private.
 	errnoErr, ok := radosOpErr.OpError.(interface{ ErrorCode() int })
 	if !ok {
 		return opErr

--- a/internal/util/reftracker/reftype/reftype.go
+++ b/internal/util/reftracker/reftype/reftype.go
@@ -54,7 +54,7 @@ func FromBytes(bs []byte) (RefType, error) {
 	}
 
 	num := RefType(bs[0])
-	switch num { // nolint:exhaustive // reftype.Unknown is handled in default case.
+	switch num { //nolint:exhaustive // reftype.Unknown is handled in default case.
 	case Normal, Mask:
 		return num, nil
 	default:

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -66,7 +66,7 @@ func GetTopologyFromDomainLabels(domainLabels, nodeName, driverName string) (map
 	// driverName is validated, and we are adding a lowercase "topology." to it, so no validation for conformance
 
 	// Convert passed in labels to a map, and check for uniqueness
-	labelsToRead := strings.SplitN(domainLabels, labelSeparator, -1)
+	labelsToRead := strings.Split(domainLabels, labelSeparator)
 	log.DefaultLog("passed in node labels for processing: %+v", labelsToRead)
 
 	labelsIn := make(map[string]bool)
@@ -158,7 +158,7 @@ func GetTopologyFromRequest(
 	}
 
 	// extract topology based pools configuration
-	err := json.Unmarshal([]byte(strings.Replace(topologyPoolsStr, "\n", " ", -1)), &topologyPools)
+	err := json.Unmarshal([]byte(strings.ReplaceAll(topologyPoolsStr, "\n", " ")), &topologyPools)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"failed to parse JSON encoded topology constrained pools parameter (%s): %w",

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/util/volid.go
+++ b/internal/util/volid.go
@@ -32,15 +32,15 @@ The CSI identifier is composed as elaborated in the comment against ComposeCSIID
 DecomposeCSIID is the inverse of the same function.
 
 The CSIIdentifier structure carries the following fields,
-- LocationID: 64 bit integer identifier determining the location of the volume on the Ceph cluster.
-  It is the ID of the poolname or fsname, for RBD or CephFS backed volumes respectively.
-- EncodingVersion: Carries the version number of the encoding scheme used to encode the CSI ID,
-  and is preserved for any future proofing w.r.t changes in the encoding scheme, and to retain
-  ability to parse backward compatible encodings.
-- ClusterID: Is a unique ID per cluster that the CSI instance is serving and is restricted to
-  lengths that can be accommodated in the encoding scheme.
-- ObjectUUID: Is the on-disk uuid of the object (image/snapshot) name, for the CSI volume that
-  corresponds to this CSI ID.
+  - LocationID: 64 bit integer identifier determining the location of the volume on the Ceph cluster.
+    It is the ID of the poolname or fsname, for RBD or CephFS backed volumes respectively.
+  - EncodingVersion: Carries the version number of the encoding scheme used to encode the CSI ID,
+    and is preserved for any future proofing w.r.t changes in the encoding scheme, and to retain
+    ability to parse backward compatible encodings.
+  - ClusterID: Is a unique ID per cluster that the CSI instance is serving and is restricted to
+    lengths that can be accommodated in the encoding scheme.
+  - ObjectUUID: Is the on-disk uuid of the object (image/snapshot) name, for the CSI volume that
+    corresponds to this CSI ID.
 */
 type CSIIdentifier struct {
 	LocationID      int64
@@ -60,6 +60,7 @@ const (
 /*
 ComposeCSIID composes a CSI ID from passed in parameters.
 Version 1 of the encoding scheme is as follows,
+
 	[csi_id_version=1:4byte] + [-:1byte]
 	[length of clusterID=1:4byte] + [-:1byte]
 	[clusterID:36bytes (MAX)] + [-:1byte]

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -158,6 +158,11 @@ linters-settings:
     max-blank-identifiers: 3
   nestif:
     min-complexity: 7
+  revive:
+    rules:
+      # dot-imports is already checked by golint
+      - name: dot-imports
+        disabled: true
 
 linters:
   enable-all: true

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -163,6 +163,10 @@ linters-settings:
       # dot-imports is already checked by golint
       - name: dot-imports
         disabled: true
+  stylecheck:
+    checks:
+      # "should not use dot imports" is handled by golint
+      - "-ST1001"
 
 linters:
   enable-all: true

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -126,6 +126,8 @@ linters-settings:
       - wrapperFunc
       - unnamedResult
       - dupImport  # https://github.com/go-critic/go-critic/issues/845
+      # TODO: uncheckedInlineErr gives many false-positives
+      - uncheckedInlineErr
   unused:
     # treat code as a program (not a library) and report unused exported
     # identifiers; default is false.
@@ -195,5 +197,5 @@ linters:
     - maintidx
     - exhaustruct
     - containedctx
-    # TODO: depguard requires a list of (un)acceptible imports
+    # TODO: depguard requires a list of (un)acceptable imports
     - depguard

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -195,3 +195,5 @@ linters:
     - maintidx
     - exhaustruct
     - containedctx
+    # TODO: depguard requires a list of (un)acceptible imports
+    - depguard


### PR DESCRIPTION
# Describe what this PR does #

Go 1.20 is a requirement for building some of the Kubernetes packages that Ceph-CSI consumes.

## Is there anything that requires special attention ##

The golangci-lint version that was used, did not support Go 1.20. So golangci-lint was updated to the latest version too.

## Related issues ##

Updating the Kubernetes dependencies to 1.27 requires this PR. 

Updates: #3848 #3752

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
