### PR TITLE
Add support & e2e for mountOptions & efficient selinux relabelling support

### DIFF
--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -14,3 +14,4 @@ spec:
   attachRequired: false
   podInfoOnMount: false
   fsGroupPolicy: File
+  seLinuxMount: true

--- a/deploy/nfs/kubernetes/csidriver.yaml
+++ b/deploy/nfs/kubernetes/csidriver.yaml
@@ -13,5 +13,6 @@ metadata:
 spec:
   attachRequired: false
   fsGroupPolicy: File
+  seLinuxMount: true
   volumeLifecycleModes:
     - Persistent

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -13,4 +13,5 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  seLinuxMount: true
   fsGroupPolicy: File

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -318,6 +318,25 @@ var _ = Describe(cephfsType, func() {
 					}
 				})
 			}
+
+			By("verify mountOptions support", func() {
+				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
+				if err != nil {
+					framework.Failf("failed to create CephFS storageclass: %v", err)
+				}
+
+				err = verifySeLinuxMountOption(f, pvcPath, appPath,
+					cephFSDeamonSetName, cephFSContainerName, cephCSINamespace)
+				if err != nil {
+					framework.Failf("failed to verify mount options: %v", err)
+				}
+
+				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					framework.Failf("failed to delete CephFS storageclass: %v", err)
+				}
+			})
+
 			By("verify generic ephemeral volume support", func() {
 				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
 				if err != nil {

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -66,6 +66,12 @@ func createCephfsStorageClass(
 	if err != nil {
 		return err
 	}
+	// TODO: remove this once the ceph-csi driver release-v3.9 is completed
+	// and upgrade tests are done from v3.9 to devel.
+	// The mountOptions from previous are not compatible with NodeStageVolume
+	// request.
+	sc.MountOptions = []string{}
+
 	sc.Parameters["fsName"] = fileSystemName
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-name"] = cephFSProvisionerSecretName

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -43,6 +43,7 @@ var (
 	nfsRookCephNFS     = "rook-nfs.yaml"
 	nfsDeploymentName  = "csi-nfsplugin-provisioner"
 	nfsDeamonSetName   = "csi-nfsplugin"
+	nfsContainerName   = "csi-nfsplugin"
 	nfsDirPath         = "../deploy/nfs/kubernetes/"
 	nfsExamplePath     = examplePath + "nfs/"
 	nfsPoolName        = ".nfs"
@@ -360,6 +361,24 @@ var _ = Describe("nfs", func() {
 				err := waitForDaemonSets(nfsDeamonSetName, cephCSINamespace, f.ClientSet, deployTimeout)
 				if err != nil {
 					framework.Failf("timeout waiting for daemonset %s: %v", nfsDeamonSetName, err)
+				}
+			})
+
+			By("verify mountOptions support", func() {
+				err := createNFSStorageClass(f.ClientSet, f, false, nil)
+				if err != nil {
+					framework.Failf("failed to create NFS storageclass: %v", err)
+				}
+
+				err = verifySeLinuxMountOption(f, pvcPath, appPath,
+					nfsDeamonSetName, nfsContainerName, cephCSINamespace)
+				if err != nil {
+					framework.Failf("failed to verify mount options: %v", err)
+				}
+
+				err = deleteResource(nfsExamplePath + "storageclass.yaml")
+				if err != nil {
+					framework.Failf("failed to delete NFS storageclass: %v", err)
 				}
 			})
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -51,6 +51,7 @@ var (
 	e2eTemplatesPath   = "../e2e/templates/"
 	rbdDeploymentName  = "csi-rbdplugin-provisioner"
 	rbdDaemonsetName   = "csi-rbdplugin"
+	rbdContainerName   = "csi-rbdplugin"
 	defaultRBDPool     = "replicapool"
 	erasureCodedPool   = "ec-pool"
 	noDataPool         = ""
@@ -442,6 +443,14 @@ var _ = Describe("RBD", func() {
 					}
 				})
 			}
+
+			By("verify mountOptions support", func() {
+				err := verifySeLinuxMountOption(f, pvcPath, appPath,
+					rbdDaemonsetName, rbdContainerName, cephCSINamespace)
+				if err != nil {
+					framework.Failf("failed to verify mount options: %v", err)
+				}
+			})
 
 			By("create a PVC and check PVC/PV metadata on RBD image", func() {
 				pvc, err := loadPVC(pvcPath)

--- a/examples/cephfs/storageclass.yaml
+++ b/examples/cephfs/storageclass.yaml
@@ -65,5 +65,5 @@ parameters:
 
 reclaimPolicy: Delete
 allowVolumeExpansion: true
-mountOptions:
-  - debug
+# mountOptions:
+#   - context="system_u:object_r:container_file_t:s0:c0,c1"

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -292,11 +292,18 @@ func (ns *NodeServer) mount(
 
 	log.DebugLog(ctx, "cephfs: mounting volume %s with %s", volID, mnt.Name())
 
+	var mountOptions []string
+	if m := volCap.GetMount(); m != nil {
+		mountOptions = m.GetMountFlags()
+	}
+
 	switch mnt.(type) {
 	case *mounter.FuseMounter:
 		volOptions.FuseMountOptions = util.MountOptionsAdd(volOptions.FuseMountOptions, ns.fuseMountOptions)
+		volOptions.FuseMountOptions = util.MountOptionsAdd(volOptions.FuseMountOptions, mountOptions...)
 	case *mounter.KernelMounter:
 		volOptions.KernelMountOptions = util.MountOptionsAdd(volOptions.KernelMountOptions, ns.kernelMountOptions)
+		volOptions.KernelMountOptions = util.MountOptionsAdd(volOptions.KernelMountOptions, mountOptions...)
 	}
 
 	const readOnly = "ro"

--- a/scripts/k8s-storage/sc-cephfs.yaml.in
+++ b/scripts/k8s-storage/sc-cephfs.yaml.in
@@ -15,5 +15,3 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
 reclaimPolicy: Delete
 allowVolumeExpansion: true
-mountOptions:
-  - debug


### PR DESCRIPTION
- pv.Spec.MountOptions will now be added during NodePublish as well as NodeStage Request.
- `SeLinuxMount: true` option is set in csidriver object. 
- e2e testcases is added to test presence of mountOptions during mounting by all three csidriver nodeplugins.

Note: 
- refer comment https://github.com/ceph/ceph-csi/issues/757#issuecomment-1590758956
- Automatic addition of selinux context in mountOptions cannot be tested in ci since minikube
is not selinux enabled.
- Added e2e closely mimics the selinux context that kublet would've passed. https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/csi_mock/csi_selinux_mount.go#L77


refer: https://kubernetes.io/blog/2023/04/18/kubernetes-1-27-efficient-selinux-relabeling-beta/

Resolves: #3855 #757 