### PR TITLE
ci: fix pr-commentor for merge queue draft pr

### DIFF
--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -15,3 +15,4 @@ jobs:
         uses: Mergifyio/gha-mergify-merge-queue-labels-copier@main
         with:
           additional-labels: 'ok-to-test'
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}

--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -8,14 +8,11 @@ on:
       - "release-v*"
     types:
       - labeled
-      - opened
 jobs:
   add-comment:
     if: >
       (github.event.label.name == 'ok-to-test' &&
-      github.event.pull_request.merged != true) ||
-      (github.event.pull_request.action == 'opened' &&
-      contains(github.event.pull_request.labels.*.name,'ok-to-test'))
+      github.event.pull_request.merged != true)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
The mergify label copier used github-actions bot
to add labels. Actions performed by github-actions bot do not trigger a workflow and hence
pull-request-commentor was not working as expected. This commit modifies mergify label copier to use
Cephcsi-bot to copy labels which then will be
able to trigger action to add pr comments.

refer: https://github.com/Mergifyio/gha-mergify-merge-queue-labels-copier/pull/6