### PR TITLE
ci: remove k8s 1.24 support

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -2,8 +2,6 @@
 - project:
     name: k8s-e2e-external-storage
     k8s_version:
-      - '1.24':
-          only_run_on_request: true
       - '1.25':
           only_run_on_request: true
       - '1.26':

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,8 +2,6 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.24':
-          only_run_on_request: true
       - '1.25':
           only_run_on_request: true
       - '1.26':


### PR DESCRIPTION
K8s 1.24 will be End of Life on 2023-07-28.
Therefore, this commit removes support
for k8s 1.24.

refer:
https://kubernetes.io/releases/#release-v1-24