### PR TITLE
ci: use CentOS Stream 9 for Jenkins Jobs Builder image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 RUN true \
  && dnf -y install git make python3-pip \


### PR DESCRIPTION
CentOS Stream 8 does not provide a module named 'dataclasses'. It seems current versions of Jenkins Jobs Builder require that. Python 3.7 offers the module by default, so using a new base distribution with Python 3.9 has the module too.

See-also: #3909

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
