### PR TITLE
rbd: (lastSyncInfo)handle last sync duration being empty case

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -814,9 +814,9 @@ func getLastSyncInfo(description string) (*replication.GetVolumeReplicationInfoR
 		return nil, fmt.Errorf("no snapshot details: %w", corerbd.ErrLastSyncTimeNotFound)
 	}
 	type localStatus struct {
-		LocalSnapshotTime    int64 `json:"local_snapshot_timestamp"`
-		LastSnapshotBytes    int64 `json:"last_snapshot_bytes"`
-		LastSnapshotDuration int64 `json:"last_snapshot_sync_seconds"`
+		LocalSnapshotTime    int64  `json:"local_snapshot_timestamp"`
+		LastSnapshotBytes    int64  `json:"last_snapshot_bytes"`
+		LastSnapshotDuration *int64 `json:"last_snapshot_sync_seconds"`
 	}
 
 	var localSnapInfo localStatus
@@ -830,12 +830,10 @@ func getLastSyncInfo(description string) (*replication.GetVolumeReplicationInfoR
 	if localSnapInfo.LocalSnapshotTime == 0 {
 		return nil, fmt.Errorf("empty local snapshot timestamp: %w", corerbd.ErrLastSyncTimeNotFound)
 	}
-	if localSnapInfo.LastSnapshotDuration == 0 {
-		response.LastSyncDuration = nil
-	} else {
+	if localSnapInfo.LastSnapshotDuration != nil {
 		// converts localSnapshotDuration of type int64 to string format with
 		// appended `s` seconds required  for time.ParseDuration
-		lastDurationTime := fmt.Sprintf("%ds", localSnapInfo.LastSnapshotDuration)
+		lastDurationTime := fmt.Sprintf("%ds", *localSnapInfo.LastSnapshotDuration)
 		// parse Duration from the lastDurationTime string
 		lastDuration, err := time.ParseDuration(lastDurationTime)
 		if err != nil {

--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -513,6 +513,18 @@ func TestValidateLastSyncInfo(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name: "description with last_snapshot_sync_seconds = 0",
+			//nolint:lll // sample output cannot be split into multiple lines.
+			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_sync_seconds":0,
+			"last_snapshot_bytes":81920,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
+			info: &replication.GetVolumeReplicationInfoResponse{
+				LastSyncDuration: durationpb.New(time.Duration(0)),
+				LastSyncTime:     timestamppb.New(time.Unix(1684675261, 0)),
+				LastSyncBytes:    81920,
+			},
+			expectedErr: "",
+		},
+		{
 			name: "description with invalid JSON",
 			//nolint:lll // sample output cannot be split into multiple lines.
 			description: `replaying,{"bytes_per_second":0.0,"last_snapshot_bytes":81920","bytes_per_snapshot":149504.0","remote_snapshot_timestamp":1662655501`,


### PR DESCRIPTION
This commit modifies code to handle last sync duration being empty & 0,returning nil & 0 on encountering it respectively. Earlier both case returned 0. Test case is added for the same too.
