### PR TITLE
mergify: add support for 3.9 backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -200,6 +200,15 @@ pull_request_rules:
         branches:
           - release-v3.8
 
+  - name: backport patches to release-v3.9 branch
+    conditions:
+      - base=devel
+      - label=backport-to-release-v3.9
+    actions:
+      backport:
+        branches:
+          - release-v3.9
+
   - name: remove outdated approvals on ci/centos
     conditions:
       - base=ci/centos

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -182,15 +182,6 @@ pull_request_rules:
         name: default
       delete_head_branch: {}
 
-  - name: backport patches to release-v3.7 branch
-    conditions:
-      - base=devel
-      - label=backport-to-release-v3.7
-    actions:
-      backport:
-        branches:
-          - release-v3.7
-
   - name: backport patches to release-v3.8 branch
     conditions:
       - base=devel


### PR DESCRIPTION
- ci: remove mergify rules for release-v3.7
    
 >   This commit removes mergify rules to backport PR
    to release-v3.7 branch.   
 
-    ci: add mergify rules for release-v3.9
    
>    This commit adds mergify rules to backport PR
    to release-v3.9 branch.