### PR TITLE
build: use urllib3 < 2 with Jenkins jobs Builder

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,9 @@
 FROM quay.io/centos/centos:stream9
 
+# FIXME #3946: jenkins-job-builder does not seem to work with urllib3 2.x
 RUN true \
  && dnf -y install git make python3-pip \
- && pip3 install jenkins-job-builder \
+ && pip3 install jenkins-job-builder 'urllib3>=1.26.15,<2' \
  && dnf -y clean all \
  && true
 


### PR DESCRIPTION
jenkins-job-builder does not seem to work with urllib3 2.x, force using version 1.x as a workaround.

Updates: #3946 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
