### PR TITLE
build: remove urllib3 downgrade in jjb container, use timeout instead

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,9 +1,8 @@
 FROM quay.io/centos/centos:stream9
 
-# FIXME #3946: jenkins-job-builder does not seem to work with urllib3 2.x
 RUN true \
  && dnf -y install git make python3-pip \
- && pip3 install jenkins-job-builder 'urllib3>=1.26.15,<2' \
+ && pip3 install jenkins-job-builder \
  && dnf -y clean all \
  && true
 

--- a/deploy/jjb-config.yaml
+++ b/deploy/jjb-config.yaml
@@ -11,3 +11,4 @@ data:
     user=ndevos-admin-edit-view
     password=<token-from-user-config-in-webui>
     url=https://jenkins-ceph-csi.apps.ci.centos.org/
+    timeout=120


### PR DESCRIPTION
The upstream reported issue suggests adding a `timeout` value in the Jenkins Jobs Builder configuration. This looks like a nicer workaround than downgrading urllib3.

Fixes: #3946
See-also: https://storyboard.openstack.org/#!/story/2010752

**Note:** the `timeout=120` value was manually added in the ConfigMap of the current deployment.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
