### PR TITLE
ci: remove `/retest all` command for Jenkins jobs

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -41,7 +41,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/k8s-e2e-external-storage/{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/k8s-e2e-external-storage(/{k8s_version})?))'
+          trigger-phrase: '/(re)?test ci/centos/k8s-e2e-external-storage(/{k8s_version})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -44,7 +44,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e(/k8s-{k8s_version})?))'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
@@ -85,7 +85,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/mini-e2e-helm(/k8s-{k8s_version})?))'
+          trigger-phrase: '/(re)?test (ci/centos/mini-e2e-helm(/k8s-{k8s_version})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -52,7 +52,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/upgrade-tests-{test_type}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ((all)|(ci/centos/upgrade-tests(-{test_type})?))'
+          trigger-phrase: '/(re)?test ci/centos/upgrade-tests(-{test_type})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true


### PR DESCRIPTION
`/retest all` causes a spike in resource consumption in Jenkins and the OpenShift cluster kills the Pod. That means tests are not fully running yet, and results never arrive back in the PR. Instead of `/retest all`, the `ok-to-test` label can be used to trigger required tests with a slight delay between each command.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
