### PR TITLE
doc: remove `/retest all` command for Jenkins jobs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,7 +44,5 @@ the following bot commands in an otherwise empty comment in this PR:
 
 - `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
   failure (please report the failure too!)
-- `/retest all`: run this in case the CentOS CI failed to start/report any test
-  progress or results
 
 </details>

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -300,12 +300,6 @@ opening fresh PRs, rebase of PRs and force pushing changes to existing PRs.
 
 Right now, we also have below commands to manually retrigger the CI jobs
 
-1. To retrigger all the CI jobs, comment the PR with command: `/retest all`
-
-   **Note**:
-
-   This will rerun all the jobs including the jobs which are already passed
-
 1. To retrigger a specific CI job, comment the PR with command: `/retest <job-name>`
 
    example:


### PR DESCRIPTION
`/retest all` causes a spike in resource consumption in Jenkins and the OpenShift cluster kills the Pod. That means tests are not fully running yet, and results never arrive back in the PR. Instead of `/retest all`, the `ok-to-test` label can be used to trigger required tests with a slight delay between each command.

Depends-on: #3965

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
