### PR TITLE
build: disable ceph-iscsi repository

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -4,6 +4,11 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE} as updated_base
 
+# TODO: remove the following cmd, when issue
+# https://github.com/ceph/ceph-container/issues/2034 is fixed.
+RUN dnf config-manager --disable \
+    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi || true
+
 RUN dnf -y update \
        && dnf clean all \
        && rm -rf /var/cache/yum
@@ -28,11 +33,6 @@ RUN source /build.env && \
 
 # test if the downloaded version of Golang works (different arch?)
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
-
-# TODO: remove the following cmd, when issue
-# https://github.com/ceph/ceph-container/issues/2034 is fixed.
-RUN dnf config-manager --disable \
-    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch || true
 
 RUN dnf -y install --nodocs \
 	librados-devel librbd-devel \


### PR DESCRIPTION
The ceph-iscsi repository seems to provide broken metadata or packages. Ceph-CSI does not need to install them, so disable the repository for now.

It seems that other repositories gave issues before too, but these repositories were disabled after installing all available updates. For ceph-iscsi updating fails already, so disable the repositories before updating.

Updates: #2034

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
