### PR TITLE
ci: fix trigger command for `ci/centos/mini-e2e-helm` jobs

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -85,7 +85,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test (ci/centos/mini-e2e-helm(/k8s-{k8s_version})?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true


### PR DESCRIPTION
The `/test ci/centos/mini-e2e-helm` has been broken with the last change where `/test all` was removed. A remaining '(' makes the regular expression invalid, and jobs fail to get started.

Fixes: f9f3bb9 ("ci: remove `/retest all` command for Jenkins jobs")

**Note:** The jobs in Jenkins have manually been modified so that triggering works again.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
