### PR TITLE
build: disable ceph-iscsi repository for test-container builds too

### DIFF
--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -17,6 +17,11 @@ RUN source /build.env \
     && mkdir -p /usr/local/go \
     && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
+# TODO: remove the following cmd, when issue
+# https://github.com/ceph/ceph-container/issues/2034 is fixed.
+RUN dnf config-manager --disable \
+    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi || true
+
 RUN dnf -y install \
 	git \
 	make \


### PR DESCRIPTION
The ceph-iscsi repository seems to provide broken metadata or packages. Ceph-CSI does not need to install them, so disable the repository for now.

It seems that other repositories gave issues before too, but these repositories were disabled after installing all available updates. For ceph-iscsi updating fails already, so disable the repositories before updating.

Updates: 0efe8e4711

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
