### PR TITLE
revert: rollback commits to build v3.9.0 tags

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -4,11 +4,6 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE} as updated_base
 
-# TODO: remove the following cmd, when issue
-# https://github.com/ceph/ceph-container/issues/2034 is fixed.
-RUN dnf config-manager --disable \
-    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi || true
-
 RUN dnf -y update \
        && dnf clean all \
        && rm -rf /var/cache/yum
@@ -33,6 +28,11 @@ RUN source /build.env && \
 
 # test if the downloaded version of Golang works (different arch?)
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
+
+# TODO: remove the following cmd, when issue
+# https://github.com/ceph/ceph-container/issues/2034 is fixed.
+RUN dnf config-manager --disable \
+    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch || true
 
 RUN dnf -y install --nodocs \
 	librados-devel librbd-devel \

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -512,14 +512,6 @@ func resizeNodeStagePath(ctx context.Context,
 		if err != nil {
 			return status.Error(codes.Internal, err.Error())
 		}
-
-		// If this is a AccessType=Block volume, do not attempt
-		// filesystem resize. The application is in charge of the data
-		// on top of the raw block-device, we can not assume there is a
-		// filesystem at all.
-		if isBlock {
-			return nil
-		}
 	}
 	// check stagingPath needs resize.
 	ok, err = resizer.NeedResize(devicePath, stagingTargetPath)

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -17,11 +17,6 @@ RUN source /build.env \
     && mkdir -p /usr/local/go \
     && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
-# TODO: remove the following cmd, when issue
-# https://github.com/ceph/ceph-container/issues/2034 is fixed.
-RUN dnf config-manager --disable \
-    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi || true
-
 RUN dnf -y install \
 	git \
 	make \


### PR DESCRIPTION
# Describe what this PR does #

This commit reverts a couple of changes from release v3.9 branch.
Since template changes were not done pointing image tag to 3.9-canary, v3.9.0 images were
overwritten.
This revert is done in order to restore v3.9.0 tagged image.

https://quay.io/repository/cephcsi/cephcsi?tab=history

---

This will be followed by another pr to restore the commits and point templates to 3.9-canary.
