### PR TITLE
rbd: do not execute rbd sparsify when volume is in use

### DIFF
--- a/internal/rbd/errors.go
+++ b/internal/rbd/errors.go
@@ -63,4 +63,6 @@ var (
 	ErrFetchingMirroringInfo = errors.New("failed to get mirroring info of image")
 	// ErrResyncImageFailed is returned when the operation to resync the image fails.
 	ErrResyncImageFailed = errors.New("failed to resync image")
+	// ErrImageInUse is returned when the image is in use.
+	ErrImageInUse = errors.New("image is in use")
 )


### PR DESCRIPTION

# Describe what this PR does #

This commit makes sure sparsify() is not run when rbd image is in use.
Running rbd sparsify with workload doing io and too frequently is not desirable.
When a image is in use fstrim is run and sparsify will be run only when image is not mapped.

Too many frequent rbd sparsify calls has been seen to cause mounted pod to be stuck.

Logs when PVC is not mounted to a Pod:
```
I0711 07:05:45.339456       1 utils.go:195] ID: 21 GRPC call: /reclaimspace.ReclaimSpaceController/ControllerReclaimSpace
I0711 07:05:45.339635       1 utils.go:206] ID: 21 GRPC request: {"parameters":{"clusterID":"rook-ceph","imageFeatures":"layering","imageFormat":"2","imageName":"csi-vol-9890e517-0f58-4b63-b7b6-5d2b6379ab1b","journalPool":"replicapool","pool":"replicapool","storage.kubernetes.io/csiProvisionerIdentity":"1689058250740-1371-rook-ceph.rbd.csi.ceph.com"},"secrets":"***stripped***","volume_id":"0001-0009-rook-ceph-0000000000000001-9890e517-0f58-4b63-b7b6-5d2b6379ab1b"}
I0711 07:05:45.348794       1 omap.go:88] ID: 21 got omap values: (pool="replicapool", namespace="", name="csi.volume.9890e517-0f58-4b63-b7b6-5d2b6379ab1b"): map[csi.imageid:138a8a79d1db csi.imagename:csi-vol-9890e517-0f58-4b63-b7b6-5d2b6379ab1b csi.volname:pvc-9949853a-3899-4cde-b2b1-8ee8fe908708 csi.volume.owner:rook-ceph]
I0711 07:05:46.034081       1 utils.go:212] ID: 21 GRPC response: {}
```

Logs when PVC is mounted to a Pod:
```
I0711 07:05:09.953239       1 utils.go:195] ID: 20 GRPC call: /reclaimspace.ReclaimSpaceController/ControllerReclaimSpace
I0711 07:05:09.956137       1 utils.go:206] ID: 20 GRPC request: {"parameters":{"clusterID":"rook-ceph","imageFeatures":"layering","imageFormat":"2","imageName":"csi-vol-9890e517-0f58-4b63-b7b6-5d2b6379ab1b","journalPool":"replicapool","pool":"replicapool","storage.kubernetes.io/csiProvisionerIdentity":"1689058250740-1371-rook-ceph.rbd.csi.ceph.com"},"secrets":"***stripped***","volume_id":"0001-0009-rook-ceph-0000000000000001-9890e517-0f58-4b63-b7b6-5d2b6379ab1b"}
I0711 07:05:09.992341       1 omap.go:88] ID: 20 got omap values: (pool="replicapool", namespace="", name="csi.volume.9890e517-0f58-4b63-b7b6-5d2b6379ab1b"): map[csi.imageid:138a8a79d1db csi.imagename:csi-vol-9890e517-0f58-4b63-b7b6-5d2b6379ab1b csi.volname:pvc-9949853a-3899-4cde-b2b1-8ee8fe908708 csi.volume.owner:rook-ceph]
I0711 07:05:10.051898       1 reclaimspace.go:76] ID: 20 volume with ID "0001-0009-rook-ceph-0000000000000001-9890e517-0f58-4b63-b7b6-5d2b6379ab1b" is in use, skipping sparsify operation
I0711 07:05:10.052064       1 utils.go:212] ID: 20 GRPC response: {}
```

cc @idryomov 
---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
