### PR TITLE
deploy: Update provisioner image repository

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -216,7 +216,7 @@ provisioner:
 
   provisioner:
     image:
-      repository: gcr.io/k8s-staging-sig-storage/csi-provisioner
+      repository: registry.k8s.io/sig-storage/csi-provisioner
       tag: v3.5.0
       pullPolicy: IfNotPresent
     resources: {}


### PR DESCRIPTION
Update ceph-csi-rbd helm chart to use the released image repo for csi-provisioner instead of the staging repo.

Fixes: #3976