### PR TITLE
ci: Update csi_upgrade_version

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -6,7 +6,7 @@
     test_type:
       - 'cephfs'
       - 'rbd'
-    csi_upgrade_version: 'v3.7.2'
+    csi_upgrade_version: 'v3.9.0'
     jobs:
       - 'upgrade-tests-{test_type}'
 


### PR DESCRIPTION
Point the csi_upgrade_version from v3.7.2 to the
latest release v3.9.0.

Updates: #3911
