### PR TITLE
e2e: Fixing the TODO in createCephfsStorageClass

### DIFF
--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -66,11 +66,6 @@ func createCephfsStorageClass(
 	if err != nil {
 		return err
 	}
-	// TODO: remove this once the ceph-csi driver release-v3.9 is completed
-	// and upgrade tests are done from v3.9 to devel.
-	// The mountOptions from previous are not compatible with NodeStageVolume
-	// request.
-	sc.MountOptions = []string{}
 
 	sc.Parameters["fsName"] = fileSystemName
 	sc.Parameters["csi.storage.k8s.io/provisioner-secret-namespace"] = cephCSINamespace


### PR DESCRIPTION
Fixing the TODO from createCephfsStorageClass()
since v3.9 is released and upgrade tests will be
run from v3.9 to devel.
https://github.com/ceph/ceph-csi/pull/3994

Fixes: #3911