### PR TITLE
fix when rbdVol is nil, panic occurred

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1078,7 +1078,9 @@ func (cs *ControllerServer) CreateSnapshot(
 
 	// Fetch source volume information
 	rbdVol, err := GenVolFromVolID(ctx, req.GetSourceVolumeId(), cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	if rbdVol != nil {
+		defer rbdVol.Destroy()
+	}
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrImageNotFound):


### PR DESCRIPTION

![image](https://github.com/ceph/ceph-csi/assets/116237787/02ab30f1-2197-4b31-b6e8-db5c7ad8907d)
When rbdVol is nil, panic occurred
add if  rbdVol != nil