### PR TITLE
doc: update documentation for v3.8.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ environments.
 | Ceph CSI Version | Container Orchestrator Name | Version Tested|
 | -----------------| --------------------------- | --------------|
 | v3.9.0 | Kubernetes | v1.25, v1.26, v1.27|
+| v3.8.1 | Kubernetes | v1.25, v1.26, v1.27|
 | v3.8.0 | Kubernetes | v1.24, v1.25, v1.26, v1.27|
 
 There is work in progress to make this CO-independent and thus
@@ -129,6 +130,7 @@ in the Kubernetes documentation.
 | ----------------------- | ---------------------------- | --------- |
 | devel (Branch)          | quay.io/cephcsi/cephcsi      | canary    |
 | v3.9.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.9.0    |
+| v3.8.1 (Release)        | quay.io/cephcsi/cephcsi      | v3.8.1    |
 | v3.8.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.8.0    |
 
 | Deprecated Ceph CSI Release/Branch | Container image name | Image Tag |


### PR DESCRIPTION
# Describe what this PR does #

This commit updates readme doc for v3.8.1 release.

## Related issues ##

Depends-on: #4005 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
