### PR TITLE
ci: override csi_upgrade_version from build.env

### DIFF
--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -183,6 +183,17 @@ node('cico-workspace') {
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
 		}
+		stage("set csi-upgrade-version from build.env") {
+			def build_env_csi_upgrade_version = sh(
+				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${CSI_UPGRADE_VERSION}\'',
+				returnStdout: true
+			).trim()
+
+			if (build_env_csi_upgrade_version != '') {
+				// override csi_upgrade_version with CSI_UPGRADE_VERSION value from build.env.
+				csi_upgrade_version= build_env_csi_upgrade_version
+			}
+		}
 		stage("run ${test_type} upgrade tests") {
 			timeout(time: 120, unit: 'MINUTES') {
 				upgrade_args = "--test-cephfs=false --test-rbd=true --upgrade-testing=true"


### PR DESCRIPTION
This commit enables overriding csi_upgrade_version used for upgrade testing with CSI_UPGRADE_VERSION
value from build.env.

Upgrade tests are failing in https://github.com/ceph/ceph-csi/pull/4005.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
