### PR TITLE
ci: add CSI_UPGRADE_VERSION var to build.env

### DIFF
--- a/build.env
+++ b/build.env
@@ -11,6 +11,9 @@
 # cephcsi image version
 CSI_IMAGE_VERSION=canary
 
+# cephcsi upgrade version
+CSI_UPGRADE_VERSION=v3.9.0
+
 # Ceph version to use
 BASE_IMAGE=quay.io/ceph/ceph:v17
 CEPH_VERSION=quincy


### PR DESCRIPTION
# Describe what this PR does #

Currently, upgrade version for upgrade tests
need to be set in ci/centos branch.
This commit adds a variable in build.env,
so that we have the flexibility to use
this value instead.

Upgrade tests are failing in https://github.com/ceph/ceph-csi/pull/4005.

Depends-on: #4007 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
