### PR TITLE
doc: adding empty storageClassName in static pvc

### DIFF
--- a/docs/static-pvc.md
+++ b/docs/static-pvc.md
@@ -108,6 +108,7 @@ metadata:
   name: fs-static-pvc
   namespace: default
 spec:
+  storageClassName: ""
   accessModes:
   # ReadWriteMany is only supported for Block PVC
   - ReadWriteOnce


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

we need to add `storageClassName: ""` in static pvc yaml other we'll get error
```
Cannot bind to requested volume "fs-static-pv": storageClassName does not match
```

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1

* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
