### PR TITLE
revert: revert template changes done for v3.8.1 release

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.8.1
+CSI_IMAGE_VERSION=v3.8-canary
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.7.2

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -94,7 +94,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.8.1
+      tag: v3.8-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -117,7 +117,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.8.1
+      tag: v3.8-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -95,7 +95,7 @@ spec:
               mountPath: /csi
         - name: csi-cephfsplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -143,7 +143,7 @@ spec:
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -49,7 +49,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -116,7 +116,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -88,7 +88,7 @@ spec:
               mountPath: /csi
         - name: csi-nfsplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -120,7 +120,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -49,7 +49,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -117,7 +117,7 @@ spec:
               mountPath: /csi
         - name: csi-rbdplugin
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -174,7 +174,7 @@ spec:
               readOnly: true
         - name: csi-rbdplugin-controller
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -195,7 +195,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -51,7 +51,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -135,7 +135,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.8.1
+          image: quay.io/cephcsi/cephcsi:v3.8-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
# Describe what this PR does #

This commit revert the changes made for 3.8.1 release back to v3.8-canary tagging.

refer: https://github.com/ceph/ceph-csi/releases/tag/v3.8.1

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
