### PR TITLE
ci: add CSI_UPGRADE_VERSION var to build.env

### DIFF
--- a/build.env
+++ b/build.env
@@ -11,6 +11,9 @@
 # cephcsi image version
 CSI_IMAGE_VERSION=v3.9-canary
 
+# cephcsi upgrade version
+CSI_UPGRADE_VERSION=v3.8.1
+
 # Ceph version to use
 BASE_IMAGE=quay.io/ceph/ceph:v17
 CEPH_VERSION=quincy


### PR DESCRIPTION
Currently, upgrade version for upgrade tests
need to be set in ci/centos branch.
This commit adds a variable in build.env,
so that we have the flexibility to use
this value instead.

> Backport of: https://github.com/ceph/ceph-csi/pull/4008