### PR TITLE
rbd: include trashed parent images while calculating the clone depth

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1255,6 +1255,7 @@ func (cs *ControllerServer) CreateSnapshot(
 
 	// Update the metadata on snapshot not on the original image
 	rbdVol.RbdImageName = rbdSnap.RbdSnapName
+	rbdVol.ImageID = vol.ImageID
 	rbdVol.ClusterName = cs.ClusterName
 
 	defer func() {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -636,7 +636,9 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			rbdVol.Monitors,
 			rbdVol.RbdImageName,
 			cr)
-		if err != nil {
+		if errors.Is(err, rbderrors.ErrFlattenInProgress) {
+			return status.Error(codes.Aborted, err.Error())
+		} else if err != nil {
 			return status.Error(codes.Internal, err.Error())
 		}
 
@@ -1087,7 +1089,7 @@ func cleanupRBDImage(ctx context.Context,
 	if inUse {
 		log.ErrorLog(ctx, "rbd %s is still being used", rbdVol)
 
-		return nil, status.Errorf(codes.Aborted, "rbd %s is still being used", rbdVol.RbdImageName)
+		return nil, status.Errorf(codes.FailedPrecondition, "rbd %s is still being used", rbdVol.RbdImageName)
 	}
 
 	// delete the temporary rbd image created as part of volume clone during
@@ -1250,7 +1252,7 @@ func (cs *ControllerServer) CreateSnapshot(
 	}()
 
 	vol, err := cs.doSnapshotClone(ctx, rbdVol, rbdSnap, cr)
-	if err != nil {
+	if err != nil && !errors.Is(err, rbderrors.ErrFlattenInProgress) {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1099,9 +1099,10 @@ func cleanupRBDImage(ctx context.Context,
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// Deleting rbd image
+	// Deleting rbd image, it isn't a failure if the image was deleted already.
 	log.DebugLog(ctx, "deleting image %s", rbdVol.RbdImageName)
-	if err = rbdVol.Delete(ctx); err != nil {
+	err = rbdVol.Delete(ctx)
+	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v",
 			rbdVol, err)
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -600,7 +600,7 @@ func flattenImageBeforeMapping(
 		if err != nil {
 			return err
 		}
-		depth, err = volOptions.getCloneDepth(ctx)
+		depth, err = volOptions.getCloneDepth()
 		if err != nil {
 			return err
 		}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -600,7 +600,7 @@ func flattenImageBeforeMapping(
 		if err != nil {
 			return err
 		}
-		depth, err = volOptions.getCloneDepth()
+		depth, err = volOptions.getCloneDepth(rbdHardMaxCloneDepth + 1)
 		if err != nil {
 			return err
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -812,7 +812,10 @@ func (ri *rbdImage) getCloneDepth(maxDepth uint) (uint, error) {
 	// Close this image, it is not used anymore. Using defer to close it
 	// and replacing the image with an other image can result in resource
 	// leaks according to golangci-lint.
-	image.Close()
+	cErr := image.Close()
+	if cErr != nil {
+		log.WarningLogMsg("failed to close image %s: %v", ri, cErr)
+	}
 
 	for {
 		if errors.Is(err, librbd.ErrNotFound) {
@@ -840,7 +843,8 @@ func (ri *rbdImage) getCloneDepth(maxDepth uint) (uint, error) {
 
 		// open the parent image, so that the for-loop can continue
 		// with checking for the parent of the parent
-		image, err = librbd.OpenImageByIdReadOnly(ri.ioctx, info.Image.ImageID, librbd.NoSnapshot)
+		imageID := info.Image.ImageID
+		image, err = librbd.OpenImageByIdReadOnly(ri.ioctx, imageID, librbd.NoSnapshot)
 		if err != nil && errors.Is(err, librbd.ErrNotFound) {
 			// parent image does not exist, no parent after all
 			break
@@ -858,7 +862,10 @@ func (ri *rbdImage) getCloneDepth(maxDepth uint) (uint, error) {
 
 		// Using defer in a for loop seems to be problematic. Just
 		// always close the image.
-		image.Close()
+		cErr = image.Close()
+		if cErr != nil {
+			log.WarningLogMsg("failed to close image with id %s: %v", imageID, cErr)
+		}
 	}
 
 	return depth, nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -788,49 +788,65 @@ func (rv *rbdVolume) DeleteTempImage(ctx context.Context) error {
 	return nil
 }
 
-func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
-	var depth uint
-	vol := rbdVolume{}
+// getCloneDepth walks the parents of the image and returns the number of
+// images in the chain.
+//
+// This function reuses the ioctx of the image to open all images in the
+// chain. There is no need to open new ioctx's for every image.
+func (ri *rbdImage) getCloneDepth() (uint, error) {
+	var (
+		depth uint
+		info  *librbd.ParentInfo
+	)
 
-	vol.Pool = ri.Pool
-	vol.Monitors = ri.Monitors
-	vol.RbdImageName = ri.RbdImageName
-	vol.ImageID = ri.ImageID
-	vol.RadosNamespace = ri.RadosNamespace
-	vol.conn = ri.conn.Copy()
+	image, err := ri.open()
+	if err != nil {
+		return 0, fmt.Errorf("failed to open image %s: %w", ri, err)
+	}
+
+	// get the librbd.ImageSpec of the parent
+	info, err = image.GetParent()
+
+	// Close this image, it is not used anymore. Using defer to close it
+	// and replacing the image with an other image can result in resource
+	// leaks according to golangci-lint.
+	image.Close()
 
 	for {
-		if vol.RbdImageName == "" {
-			return depth, nil
-		}
-		err := vol.openIoctx()
-		if err != nil {
-			return depth, err
+		if errors.Is(err, librbd.ErrNotFound) {
+			// image does not have more parents
+			break
+		} else if err != nil {
+			return 0, fmt.Errorf("failed to get parent of image %s at depth %d: %w", ri, depth, err)
 		}
 
-		err = vol.getImageInfo()
-		// FIXME: create and destroy the vol inside the loop.
-		// see https://github.com/ceph/ceph-csi/pull/1838#discussion_r598530807
-		vol.ioctx.Destroy()
-		vol.ioctx = nil
-		if err != nil {
-			// if the parent image is moved to trash the name will be present
-			// in rbd image info but the image will be in trash, in that case
-			// return the found depth
-			if errors.Is(err, rbderrors.ErrImageNotFound) {
-				return depth, nil
+		// if there is a parent, count it to the depth
+		depth++
+
+		// open the parent image, so that the for-loop can continue
+		// with checking for the parent of the parent
+		image, err = librbd.OpenImageById(ri.ioctx, info.Image.ImageID, info.Snap.SnapName)
+		if errors.Is(err, librbd.ErrNotFound) {
+			// image does not have more parents
+			break
+		} else if err != nil {
+			imageSpec := info.Image.ImageID
+			if info.Snap.SnapName != librbd.NoSnapshot {
+				imageSpec += "@" + info.Snap.SnapName
 			}
-			log.ErrorLog(ctx, "failed to check depth on image %s: %s", &vol, err)
 
-			return depth, err
+			return 0, fmt.Errorf("failed to open parent image ID %q, at depth %d: %w", imageSpec, depth, err)
 		}
-		if vol.ParentName != "" {
-			depth++
-		}
-		vol.RbdImageName = vol.ParentName
-		vol.ImageID = vol.ParentID
-		vol.Pool = vol.ParentPool
+
+		info, err = image.GetParent()
+		// info and err checking is done in the top of the for loop
+
+		// Using defer in a for loop seems to be problematic. Just
+		// always close the image.
+		image.Close()
 	}
+
+	return depth, nil
 }
 
 func flattenClonedRbdImages(
@@ -875,7 +891,7 @@ func (ri *rbdImage) flattenRbdImage(
 
 	// skip clone depth check if request is for force flatten
 	if !forceFlatten {
-		depth, err = ri.getCloneDepth(ctx)
+		depth, err = ri.getCloneDepth()
 		if err != nil {
 			return err
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -123,6 +123,8 @@ type rbdImage struct {
 	NamePrefix  string
 	// ParentName represents the parent image name of the image.
 	ParentName string
+	// ParentID represents the parent image ID of the image.
+	ParentID string
 	// Parent Pool is the pool that contains the parent image.
 	ParentPool string
 	// Cluster name
@@ -793,6 +795,7 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 	vol.Pool = ri.Pool
 	vol.Monitors = ri.Monitors
 	vol.RbdImageName = ri.RbdImageName
+	vol.ImageID = ri.ImageID
 	vol.RadosNamespace = ri.RadosNamespace
 	vol.conn = ri.conn.Copy()
 
@@ -825,6 +828,7 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 			depth++
 		}
 		vol.RbdImageName = vol.ParentName
+		vol.ImageID = vol.ParentID
 		vol.Pool = vol.ParentPool
 	}
 }
@@ -946,6 +950,9 @@ func (ri *rbdImage) getParentName() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	ri.ParentName = parentInfo.Image.ImageName
+	ri.ParentID = parentInfo.Image.ImageID
 
 	return parentInfo.Image.ImageName, nil
 }
@@ -1717,6 +1724,11 @@ func (ri *rbdImage) getImageInfo() error {
 	// TODO: can rv.VolSize not be a uint64? Or initialize it to -1?
 	ri.VolSize = int64(imageInfo.Size)
 
+	ri.ImageID, err = image.GetId()
+	if err != nil {
+		return err
+	}
+
 	features, err := image.GetFeatures()
 	if err != nil {
 		return err
@@ -1730,11 +1742,13 @@ func (ri *rbdImage) getImageInfo() error {
 		// the parent is an error or not.
 		if errors.Is(err, librbd.ErrNotFound) {
 			ri.ParentName = ""
+			ri.ParentID = ""
 		} else {
 			return err
 		}
 	} else {
 		ri.ParentName = parentInfo.Image.ImageName
+		ri.ParentID = parentInfo.Image.ImageID
 		ri.ParentPool = parentInfo.Image.PoolName
 		ri.ParentInTrash = parentInfo.Image.Trash
 	}
@@ -1769,6 +1783,7 @@ func (ri *rbdImage) getParent() (*rbdImage, error) {
 	parentImage.Pool = ri.ParentPool
 	parentImage.RadosNamespace = ri.RadosNamespace
 	parentImage.RbdImageName = ri.ParentName
+	parentImage.ImageID = ri.ParentID
 
 	err = parentImage.getImageInfo()
 	if err != nil {
@@ -1826,6 +1841,7 @@ type rbdImageMetadataStash struct {
 	Pool           string `json:"pool"`
 	RadosNamespace string `json:"radosNamespace"`
 	ImageName      string `json:"image"`
+	ImageID        string `json:"imageID"`
 	UnmapOptions   string `json:"unmapOptions"`
 	NbdAccess      bool   `json:"accessType"`
 	Encrypted      bool   `json:"encrypted"`
@@ -1855,6 +1871,7 @@ func stashRBDImageMetadata(volOptions *rbdVolume, metaDataPath string) error {
 		Pool:           volOptions.Pool,
 		RadosNamespace: volOptions.RadosNamespace,
 		ImageName:      volOptions.RbdImageName,
+		ImageID:        volOptions.ImageID,
 		Encrypted:      volOptions.isBlockEncrypted(),
 		UnmapOptions:   volOptions.UnmapOptions,
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -789,11 +789,13 @@ func (rv *rbdVolume) DeleteTempImage(ctx context.Context) error {
 }
 
 // getCloneDepth walks the parents of the image and returns the number of
-// images in the chain.
+// images in the chain. The `maxDepth` argument to the function is used to
+// specify a limit of the depth to check. When `maxDepth` depth is reached, no
+// further traversing of the depth is required.
 //
 // This function reuses the ioctx of the image to open all images in the
 // chain. There is no need to open new ioctx's for every image.
-func (ri *rbdImage) getCloneDepth() (uint, error) {
+func (ri *rbdImage) getCloneDepth(maxDepth uint) (uint, error) {
 	var (
 		depth uint
 		info  *librbd.ParentInfo
@@ -814,20 +816,33 @@ func (ri *rbdImage) getCloneDepth() (uint, error) {
 
 	for {
 		if errors.Is(err, librbd.ErrNotFound) {
-			// image does not have more parents
+			// image does not have a parent
 			break
 		} else if err != nil {
 			return 0, fmt.Errorf("failed to get parent of image %s at depth %d: %w", ri, depth, err)
 		}
 
+		// if the parent is in trash, return maxDepth to trigger
+		// flattening
+		if info.Image.Trash {
+			return maxDepth, nil
+		}
+
 		// if there is a parent, count it to the depth
 		depth++
 
+		// if maxDepth (usually hard-limit) is reached, further
+		// traversing parents is not needed, some action (flattening)
+		// will be triggered regardless of deeper depth
+		if depth == maxDepth {
+			break
+		}
+
 		// open the parent image, so that the for-loop can continue
 		// with checking for the parent of the parent
-		image, err = librbd.OpenImageById(ri.ioctx, info.Image.ImageID, info.Snap.SnapName)
-		if errors.Is(err, librbd.ErrNotFound) {
-			// image does not have more parents
+		image, err = librbd.OpenImageByIdReadOnly(ri.ioctx, info.Image.ImageID, librbd.NoSnapshot)
+		if err != nil && errors.Is(err, librbd.ErrNotFound) {
+			// parent image does not exist, no parent after all
 			break
 		} else if err != nil {
 			imageSpec := info.Image.ImageID
@@ -891,7 +906,7 @@ func (ri *rbdImage) flattenRbdImage(
 
 	// skip clone depth check if request is for force flatten
 	if !forceFlatten {
-		depth, err = ri.getCloneDepth()
+		depth, err = ri.getCloneDepth(hardlimit)
 		if err != nil {
 			return err
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -902,7 +902,9 @@ func (ri *rbdImage) flattenRbdImage(
 	_, err = ta.AddFlatten(admin.NewImageSpec(ri.Pool, ri.RadosNamespace, ri.RbdImageName))
 	rbdCephMgrSupported, knownErr := isCephMgrSupported(ctx, ri.ClusterID, err)
 	if rbdCephMgrSupported {
-		if err != nil {
+		// it is not possible to flatten an image that is in trash (ErrNotFound)
+		switch {
+		case err != nil && !errors.Is(err, rados.ErrNotFound):
 			// discard flattening error if the image does not have any parent
 			rbdFlattenNoParent := fmt.Sprintf("Image %s/%s does not have a parent", ri.Pool, ri.RbdImageName)
 			if strings.Contains(err.Error(), rbdFlattenNoParent) {
@@ -911,11 +913,11 @@ func (ri *rbdImage) flattenRbdImage(
 			log.ErrorLog(ctx, "failed to add task flatten for %s : %v", ri, err)
 
 			return err
-		}
-		if forceFlatten || depth >= hardlimit {
+		case forceFlatten || depth >= hardlimit:
 			return fmt.Errorf("%w: flatten is in progress for image %s", rbderrors.ErrFlattenInProgress, ri.RbdImageName)
+		default:
+			log.DebugLog(ctx, "successfully added task to flatten image %q", ri)
 		}
-		log.DebugLog(ctx, "successfully added task to flatten image %q", ri)
 	}
 	if !rbdCephMgrSupported && knownErr != nil {
 		log.ErrorLog(

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -536,7 +536,14 @@ func (ri *rbdImage) open() (*librbd.Image, error) {
 		return nil, err
 	}
 
-	image, err := librbd.OpenImage(ri.ioctx, ri.RbdImageName, librbd.NoSnapshot)
+	var image *librbd.Image
+
+	// try to open by id, that works for images in trash too
+	if ri.ImageID != "" {
+		image, err = librbd.OpenImageById(ri.ioctx, ri.ImageID, librbd.NoSnapshot)
+	} else {
+		image, err = librbd.OpenImage(ri.ioctx, ri.RbdImageName, librbd.NoSnapshot)
+	}
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {
 			err = fmt.Errorf("Failed as %w (internal %w)", rbderrors.ErrImageNotFound, err)


### PR DESCRIPTION
The `getCloneDepth()` function did not account for images that are in
the trash. A trashed image can only be opened by the image-id, and not
by name anymore.

Closes: #4013
Depends-on: #4064 #4273

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
