### PR TITLE
ci: update images for mirroring

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -7,6 +7,10 @@
 #
 
 # ceph-csi devel
+docker.io/rook/ceph:v1.12.1      rook/ceph:v1.12.1
+quay.io/ceph/ceph:v18            quay.io/ceph/ceph:v18
+
+# ceph-csi v3.9
 docker.io/rook/ceph:v1.10.9      rook/ceph:v1.10.9
 
 # ceph-csi v3.7


### PR DESCRIPTION
As we need to move to the latest Rook and Ceph releases in the devel branch updating mirroring images to push the latest images to the internal registry.

