### PR TITLE
ci: strip quay.io from mirrored ceph/ceph:v18 image

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -8,7 +8,7 @@
 
 # ceph-csi devel
 docker.io/rook/ceph:v1.12.1      rook/ceph:v1.12.1
-quay.io/ceph/ceph:v18            quay.io/ceph/ceph:v18
+quay.io/ceph/ceph:v18            ceph/ceph:v18
 
 # ceph-csi v3.9
 docker.io/rook/ceph:v1.10.9      rook/ceph:v1.10.9


### PR DESCRIPTION
CI jobs pull the ceph/ceph:v18 image (without `quay.io`). If the mirroring includes the registry host, the image can not be found.

Updates: #4030

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
