### PR TITLE
ci: use `podman` for simple GitHub workflows

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: codespell
-        run: CONTAINER_CMD=docker make containerized-test TARGET=codespell
+        run: make containerized-test TARGET=codespell

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -19,4 +19,4 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: commitlint
         # yamllint disable-line rule:line-length
-        run: make containerized-test CONTAINER_CMD=docker TARGET=commitlint GIT_SINCE="origin/${GITHUB_BASE_REF}"
+        run: make containerized-test TARGET=commitlint GIT_SINCE="origin/${GITHUB_BASE_REF}"

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: go-test
-        run: CONTAINER_CMD=docker make containerized-test TARGET=go-test
+        run: make containerized-test TARGET=go-test
   go-test-api:
     name: go-test-api
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: go-test-api
-        run: CONTAINER_CMD=docker make containerized-test TARGET=go-test-api
+        run: make containerized-test TARGET=go-test-api

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
-        run: CONTAINER_CMD=docker make containerized-test TARGET=go-lint
+        run: make containerized-test TARGET=go-lint

--- a/.github/workflows/lint-extras.yaml
+++ b/.github/workflows/lint-extras.yaml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: lint-extras
-        run: CONTAINER_CMD=docker make containerized-test TARGET=lint-extras
+        run: make containerized-test TARGET=lint-extras

--- a/.github/workflows/mod-check.yaml
+++ b/.github/workflows/mod-check.yaml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: mod-check
-        run: CONTAINER_CMD=docker make containerized-test TARGET=mod-check
+        run: make containerized-test TARGET=mod-check


### PR DESCRIPTION
`podman` is installed by default on the Ubuntu runners. Podman is recommended for developers and contributors, as there are no elevated privileges required to run it. Docker requires extra permissions to build and or run container images, and contributors to Ceph-CSI should not need to spend time working with that (several developers run the `docker` command with `sudo`, which is discouraged).

Only the multi-arch Workflows require Docker, for the time being.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
