### PR TITLE
update centos ci jobs for kubernetes 1.28 

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -8,6 +8,8 @@
           only_run_on_request: true
       - '1.27':
           only_run_on_request: true
+      - '1.28':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -8,6 +8,8 @@
           only_run_on_request: true
       - '1.27':
           only_run_on_request: true
+      - '1.28':
+          only_run_on_request: true
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.25'
+    k8s_version: '1.27'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
Update templates to allow running kubernetes 1.28 jobs and also make use of kubernetes version v1.27 for the upgrade test

updates #4052