### PR TITLE
e2e: add timeout for pvc deletion in ephemeral e2e

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -395,11 +395,19 @@ var _ = Describe(cephfsType, func() {
 				}
 				validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
 				validateOmapCount(f, 1, cephfsType, metadataPool, volumesType)
+				pvcName := app.Spec.Volumes[0].Name
 				// delete pod
 				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 				if err != nil {
 					framework.Failf("failed to delete application: %v", err)
 				}
+
+				// wait for the associated PVC to be deleted
+				err = waitForPVCToBeDeleted(f.ClientSet, app.Namespace, pvcName, deployTimeout)
+				if err != nil {
+					framework.Failf("failed to wait for PVC deletion: %v", err)
+				}
+
 				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
 				validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
 				err = deleteResource(cephFSExamplePath + "storageclass.yaml")

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -813,10 +813,18 @@ var _ = Describe("RBD", func() {
 				// validate created backend rbd images
 				validateRBDImageCount(f, 1, defaultRBDPool)
 				validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+				pvcName := app.Spec.Volumes[0].Name
 				err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 				if err != nil {
 					framework.Failf("failed to delete application: %v", err)
 				}
+
+				// wait for the associated PVC to be deleted
+				err = waitForPVCToBeDeleted(f.ClientSet, app.Namespace, pvcName, deployTimeout)
+				if err != nil {
+					framework.Failf("failed to wait for PVC deletion: %v", err)
+				}
+
 				// validate created backend rbd images
 				validateRBDImageCount(f, 0, defaultRBDPool)
 				validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)


### PR DESCRIPTION
this commit adds the timeout to wait for pvc
deletion after the deletion of pod in a test.

fixes: #3910 