### PR TITLE
ci: run versioned k8s jobs only on selected branches

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -8,111 +8,70 @@ on:
       - "release-v*"
     types:
       - labeled
+
+permissions:
+  pull-requests: write
+
 jobs:
-  add-comment:
+  branch-k8s-selection:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [release-v3.8, release-v3.9, devel]
+        k8s: ["1.25", "1.26", "1.27", "1.28"]
+        exclude:
+          # the next Ceph-CSI version will not be tested with old Kubernetes
+          - k8s: "1.25"
+            branch: devel
+          # Ceph-CSI <= 3.9 was released before Kubernetes 1.28
+          - k8s: "1.28"
+            branch: release-v3.8
+          - k8s: "1.28"
+            branch: release-v3.9
+
+    if: >
+      (github.event.label.name == 'ok-to-test' &&
+      github.event.pull_request.merged != true &&
+      github.base_ref == matrix.branch)
+
+    steps:
+      - name: >
+          Add comment to trigger external storage tests for Kubernetes
+          ${{ matrix.k8s }}
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/k8s-e2e-external-storage/${{ matrix.k8s }}
+
+      - name: >
+          Add comment to trigger helm E2E tests for Kubernetes
+          ${{ matrix.k8s }}
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e-helm/k8s-${{ matrix.k8s }}
+
+      - name: Add comment to trigger E2E tests for Kubernetes ${{ matrix.k8s }}
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/mini-e2e/k8s-${{ matrix.k8s }}
+
+  any-branch-k8s-version:
+    runs-on: ubuntu-latest
+
     if: >
       (github.event.label.name == 'ok-to-test' &&
       github.event.pull_request.merged != true)
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
+
     steps:
-      - name: Add comment to trigger external storage tests for Kubernetes 1.25
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.25
-
-      - name: Add comment to trigger external storage tests for Kubernetes 1.26
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.26
-
-      - name: Add comment to trigger external storage tests for Kubernetes 1.27
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.27
-
-      - name: Add comment to trigger external storage tests for Kubernetes 1.28
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.28
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.25
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.25
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.26
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.26
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.27
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.27
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.28
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.28
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.25
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.25
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.26
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.26
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.27
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.27
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.28
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.28
-
       - name: Add comment to trigger cephfs upgrade tests
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -129,6 +88,19 @@ jobs:
           body: |
             /test ci/centos/upgrade-tests-rbd
 
+  remove-label:
+    runs-on: ubuntu-latest
+
+    # run after the other jobs
+    needs:
+      - branch-k8s-selection
+      - any-branch-k8s-version
+
+    if: >
+      (github.event.label.name == 'ok-to-test' &&
+      github.event.pull_request.merged != true)
+
+    steps:
       - name: remove ok-to-test-label after commenting
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
By using a matrix strategy with excluding certain branches and Kubernetes versions, the number of CI jobs per PullRequest should stay limited.

Closes: #4060

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
