### PR TITLE
ci: exclude branches from the testing matrix for `ok-to-test` comments

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -21,19 +21,30 @@ jobs:
         branch: [release-v3.8, release-v3.9, devel]
         k8s: ["1.25", "1.26", "1.27", "1.28"]
         exclude:
+          # The exclude items below are dynamically constructed. If the
+          # base_ref matches the given branch, it will be excluded from the
+          # test matrix.
+
           # the next Ceph-CSI version will not be tested with old Kubernetes
           - k8s: "1.25"
-            branch: devel
+            branch: >
+              ${{ "devel" == github.base_ref
+              && github.base_ref || "no-exclude" }}
+
           # Ceph-CSI <= 3.9 was released before Kubernetes 1.28
           - k8s: "1.28"
-            branch: release-v3.8
+            branch: >
+              ${{ "release-v3.8" == github.base_ref
+              && github.base_ref || "no-exclude" }}
           - k8s: "1.28"
-            branch: release-v3.9
+            branch: >
+              ${{ "release-v3.9" == github.base_ref
+              && github.base_ref || "no-exclude" }}
 
+    # watch out, matrix.branch can not be used in this if-statement :-/
     if: >
       (github.event.label.name == 'ok-to-test' &&
-      github.event.pull_request.merged != true &&
-      github.base_ref == matrix.branch)
+      github.event.pull_request.merged != true)
 
     steps:
       - name: >


### PR DESCRIPTION
It seems that `matrix.*` parameters can not be used in the if-statement for a job. Now using the `exclude:` parameter with a more dynamically constructed value for the branch. If the value for the branch is not part of the initial branch list, the value will not be excluded, so the jobs are expected to run.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
