### PR TITLE
ci: only add `/test ..` comment if the branch for the PR matches

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -21,25 +21,15 @@ jobs:
         branch: [release-v3.8, release-v3.9, devel]
         k8s: ["1.25", "1.26", "1.27", "1.28"]
         exclude:
-          # The exclude items below are dynamically constructed. If the
-          # base_ref matches the given branch, it will be excluded from the
-          # test matrix.
-
           # the next Ceph-CSI version will not be tested with old Kubernetes
           - k8s: "1.25"
-            branch: >
-              ${{ "devel" == github.base_ref
-              && github.base_ref || "no-exclude" }}
+            branch: "devel"
 
           # Ceph-CSI <= 3.9 was released before Kubernetes 1.28
           - k8s: "1.28"
-            branch: >
-              ${{ "release-v3.8" == github.base_ref
-              && github.base_ref || "no-exclude" }}
+            branch: "release-v3.8"
           - k8s: "1.28"
-            branch: >
-              ${{ "release-v3.9" == github.base_ref
-              && github.base_ref || "no-exclude" }}
+            branch: "release-v3.9"
 
     # watch out, matrix.branch can not be used in this if-statement :-/
     if: >
@@ -50,6 +40,7 @@ jobs:
       - name: >
           Add comment to trigger external storage tests for Kubernetes
           ${{ matrix.k8s }}
+        if: ${{ github.base_ref == matrix.branch }}
         uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
@@ -60,6 +51,7 @@ jobs:
       - name: >
           Add comment to trigger helm E2E tests for Kubernetes
           ${{ matrix.k8s }}
+        if: ${{ github.base_ref == matrix.branch }}
         uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
@@ -69,6 +61,7 @@ jobs:
 
       - name: Add comment to trigger E2E tests for Kubernetes ${{ matrix.k8s }}
         uses: peter-evans/create-or-update-comment@v3
+        if: ${{ github.base_ref == matrix.branch }}
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
By adding an if-statement for each step of the matrix job, only those steps are executed where the base ref of the PR matches the branch in the matrix parameters.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
