### PR TITLE
ci: add sudo prefix for status commands

### DIFF
--- a/system-status.sh
+++ b/system-status.sh
@@ -36,11 +36,11 @@ log minikube logs
 log minikube_ssh top -b -c -n1 -w
 
 # get the logs from the VM
-log minikube_ssh journalctl --boot
+log minikube_ssh sudo journalctl --boot
 
 # get kubelet status
-log minikube_ssh systemctl status kubelet
-log minikube_ssh journalctl -xeu kubelet
+log minikube_ssh sudo systemctl status kubelet
+log minikube_ssh sudo journalctl -xeu kubelet
 
 # filesystem status for host and VM
 log df -hT


### PR DESCRIPTION
few commands are getting permission denied error adding sudo is fixing the problem

```
Warning: Permanently added '192.168.49.2' (ECDSA) to the
list of known hosts.
Hint: You are currently not seeing messages from other
users and the system.
Users in the 'systemd-journal' group can see all messages.
Pass -q to turn off this notice.
No journal files were opened due to insufficient permissions.
```
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

