### PR TITLE
rbd: Dont depend on image state to issue resync

### DIFF
--- a/internal/cephfs/util/mountinfo.go
+++ b/internal/cephfs/util/mountinfo.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	// google.golang.org/protobuf/encoding doesn't offer MessageV2().
-	"github.com/golang/protobuf/proto" //nolint:staticcheck // See comment above.
+	"github.com/golang/protobuf/proto" //nolint:all // See comment above.
 	"google.golang.org/protobuf/encoding/protojson"
 )
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1558,6 +1558,19 @@ func (rv *rbdVolume) setImageOptions(ctx context.Context, options *librbd.ImageO
 	return nil
 }
 
+// GetImageCreationTime returns the creation time of the image. if the image
+// creation time is not set, it queries the image info and returns the creation time.
+func (ri *rbdImage) GetImageCreationTime() (*timestamppb.Timestamp, error) {
+	if ri.CreatedAt != nil {
+		return ri.CreatedAt, nil
+	}
+	if err := ri.getImageInfo(); err != nil {
+		return nil, err
+	}
+
+	return ri.CreatedAt, nil
+}
+
 // getImageInfo queries rbd about the given image and returns its metadata, and returns
 // ErrImageNotFound if provided image is not found.
 func (ri *rbdImage) getImageInfo() error {


### PR DESCRIPTION
Previously we were dependent on the image mirror state to issue the resync command, What we came to know is that we cannot depend on the image mirror state as the state can change anytime from one to another, We are following the below steps to fix this problem.

* During the Demote volume store the image creation timestamp. 
* During Resync do the below operation
    * Check the image creation timestamp stored during the Demote operation and the current creation timestamp during Resync and check both are equal and it for force resync then issue resync
    * If the image on both sides is not in the unknown state, check last_snapshot_timestamp on the local mirror description,  if it's present send volumeReady as false, or else return an error message.
    * If both the images are in up+unknown the send volumeReady as true.

Storing the image creation timestamp on the rbd image as metadata and it gets cleaned up when the image is recreated as it gets synced up from the primary cluster.