### PR TITLE
ci: use latest minikube version (v1.31.2)

### DIFF
--- a/build.env
+++ b/build.env
@@ -44,7 +44,7 @@ HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 HELM_VERSION=v3.10.1
 
 # minikube settings
-MINIKUBE_VERSION=v1.31.0
+MINIKUBE_VERSION=v1.31.2
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 


### PR DESCRIPTION
Use the latest minikube version that contains minor changes and bugfixes.

See-also: https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
