### PR TITLE
ci: use dependabot group feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,26 @@
 ---
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"
+    groups:
+      golang-dependencies:
+        patterns:
+          - "github.com/golang*"
+      k8s-dependencies:
+        patterns:
+          - "k8s.io*"
+          - "sigs.k8s.io*"
+      github-dependencies:
+        patterns:
+          - "github.com*"
+        exclude-patterns:
+          - "github.com/golang*"
+          - "github.com/container-storage-interface/spec"
     labels:
       - rebase
     commit-message:
@@ -53,6 +68,19 @@ updates:
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"
+    groups:
+      golang-dependencies:
+        patterns:
+          - "github.com/golang*"
+      k8s-dependencies:
+        patterns:
+          - "k8s.io*"
+          - "sigs.k8s.io*"
+      github-dependencies:
+        patterns:
+          - "github.com*"
+        exclude-patterns:
+          - "github.com/golang*"
     labels:
       - rebase
       - ci/skip/e2e


### PR DESCRIPTION
enable dependabot raising PR by groups to reduce PR and save CI resources.
This uses the  beta groups feature of dependabot. More details here https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

