### PR TITLE
rebase: replace MetricsBindAddress with Metrics

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	clientConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 // Manager is the interface that will wrap Add function.
@@ -62,7 +63,7 @@ func Start(config Config) error {
 	opts := manager.Options{
 		LeaderElection: true,
 		// disable metrics
-		MetricsBindAddress:         "0",
+		Metrics:                    metricsserver.Options{BindAddress: "0"},
 		LeaderElectionNamespace:    config.Namespace,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaderElectionID:           electionID,


### PR DESCRIPTION
MetricsBindAddress is replaced by Metrics in the
controller-runtime manager options in version 0.16.0 as part of
https://github.com/kubernetes-sigs/controller-runtime/commit/e59161ee8f41b2f24953419533dca84d30262c21 Updating the same here.