### PR TITLE
fixed all potential crashing when decoding volume ID(CSI identifier) failed

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -243,7 +243,11 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	defer rs.VolumeLocks.Release(volumeID)
 
 	rbdVol, err := corerbd.GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	defer func() {
+		if rbdVol != nil {
+			rbdVol.Destroy()
+		}
+	}()
 	if err != nil {
 		switch {
 		case errors.Is(err, corerbd.ErrImageNotFound):
@@ -305,7 +309,11 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	defer rs.VolumeLocks.Release(volumeID)
 
 	rbdVol, err := corerbd.GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	defer func() {
+		if rbdVol != nil {
+			rbdVol.Destroy()
+		}
+	}()
 	if err != nil {
 		switch {
 		case errors.Is(err, corerbd.ErrImageNotFound):
@@ -376,7 +384,11 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	defer rs.VolumeLocks.Release(volumeID)
 
 	rbdVol, err := corerbd.GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	defer func() {
+		if rbdVol != nil {
+			rbdVol.Destroy()
+		}
+	}()
 	if err != nil {
 		switch {
 		case errors.Is(err, corerbd.ErrImageNotFound):
@@ -472,7 +484,11 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	defer rs.VolumeLocks.Release(volumeID)
 
 	rbdVol, err := corerbd.GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	defer func() {
+		if rbdVol != nil {
+			rbdVol.Destroy()
+		}
+	}()
 	if err != nil {
 		switch {
 		case errors.Is(err, corerbd.ErrImageNotFound):
@@ -585,7 +601,11 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 	rbdVol, err := corerbd.GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	defer func() {
+		if rbdVol != nil {
+			rbdVol.Destroy()
+		}
+	}()
 	if err != nil {
 		switch {
 		case errors.Is(err, corerbd.ErrImageNotFound):
@@ -798,7 +818,11 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 	rbdVol, err := corerbd.GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	defer func() {
+		if rbdVol != nil {
+			rbdVol.Destroy()
+		}
+	}()
 	if err != nil {
 		switch {
 		case errors.Is(err, corerbd.ErrImageNotFound):

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1082,7 +1082,11 @@ func (cs *ControllerServer) CreateSnapshot(
 
 	// Fetch source volume information
 	rbdVol, err := GenVolFromVolID(ctx, req.GetSourceVolumeId(), cr, req.GetSecrets())
-	defer rbdVol.Destroy()
+	defer func() {
+		if rbdVol != nil {
+			rbdVol.Destroy()
+		}
+	}()
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrImageNotFound):


### PR DESCRIPTION
# Describe what this PR does #

csi-rbdplugin will crash when decoding volume ID failed due to nil pointer, similar to #4099 

## Related issues ##

#4098 #4099 #4107
