### PR TITLE
doc: adding empty storageClassName in static pvc

### DIFF
--- a/docs/static-pvc.md
+++ b/docs/static-pvc.md
@@ -257,6 +257,7 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  storageClassName: ""
   volumeMode: Filesystem
   # volumeName should be same as PV name
   volumeName: cephfs-static-pv


### PR DESCRIPTION
we need to add `storageClassName: ""` in cephfs static pvc similar what was done for rbd static pvc in #4010.

Kubernetes links that explain why the change is required
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1


---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
