### PR TITLE
cephfs: Add CSI-Addons NetworkFence support to CephFS

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -197,6 +197,11 @@ func (fs *Driver) setupCSIAddonsServer(conf *util.Config) error {
 	is := casceph.NewIdentityServer(conf)
 	fs.cas.RegisterService(is)
 
+	if conf.IsControllerServer {
+		fcs := casceph.NewFenceControllerServer()
+		fs.cas.RegisterService(fcs)
+	}
+
 	// start the server, this does not block, it runs a new go-routine
 	err = fs.cas.Start()
 	if err != nil {

--- a/internal/csi-addons/cephfs/identity.go
+++ b/internal/csi-addons/cephfs/identity.go
@@ -77,6 +77,12 @@ func (is *IdentityServer) GetCapabilities(
 						Type: identity.Capability_Service_CONTROLLER_SERVICE,
 					},
 				},
+			}, &identity.Capability{
+				Type: &identity.Capability_NetworkFence_{
+					NetworkFence: &identity.Capability_NetworkFence{
+						Type: identity.Capability_NetworkFence_NETWORK_FENCE,
+					},
+				},
 			})
 	}
 

--- a/internal/csi-addons/cephfs/network_fence.go
+++ b/internal/csi-addons/cephfs/network_fence.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2023 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"context"
+	"errors"
+
+	nf "github.com/ceph/ceph-csi/internal/csi-addons/networkfence"
+	"github.com/ceph/ceph-csi/internal/util"
+
+	"github.com/csi-addons/spec/lib/go/fence"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FenceControllerServer struct of cephFS CSI driver with supported methods
+// of CSI-Addons networkfence controller service spec.
+type FenceControllerServer struct {
+	*fence.UnimplementedFenceControllerServer
+}
+
+// NewFenceControllerServer creates a new FenceControllerServer which handles
+// the FenceController Service requests from the CSI-Addons specification.
+func NewFenceControllerServer() *FenceControllerServer {
+	return &FenceControllerServer{}
+}
+
+// RegisterService registers the FenceControllerServer's service
+// with the gRPC server.
+func (fcs *FenceControllerServer) RegisterService(server grpc.ServiceRegistrar) {
+	fence.RegisterFenceControllerServer(server, fcs)
+}
+
+// validateFenceClusterNetworkReq checks the sanity of FenceClusterNetworkRequest.
+func validateNetworkFenceReq(fenceClients []*fence.CIDR, options map[string]string) error {
+	if len(fenceClients) == 0 {
+		return errors.New("CIDR block cannot be empty")
+	}
+
+	if value, ok := options["clusterID"]; !ok || value == "" {
+		return errors.New("missing or empty clusterID")
+	}
+
+	return nil
+}
+
+// FenceClusterNetwork blocks access to a CIDR block by creating a network fence.
+// It evicts the IP addresses of clients, which are in CIDR block.
+func (fcs *FenceControllerServer) FenceClusterNetwork(
+	ctx context.Context,
+	req *fence.FenceClusterNetworkRequest,
+) (*fence.FenceClusterNetworkResponse, error) {
+	err := validateNetworkFenceReq(req.GetCidrs(), req.Parameters)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	cr, err := util.NewUserCredentials(req.GetSecrets())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	nwFence, err := nf.NewNetworkFence(ctx, cr, req.Cidrs, req.GetParameters())
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	err = nwFence.AddClientEviction(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fence CIDR block %q: %s", nwFence.Cidr, err.Error())
+	}
+
+	return &fence.FenceClusterNetworkResponse{}, nil
+}

--- a/internal/csi-addons/cephfs/network_fence.go
+++ b/internal/csi-addons/cephfs/network_fence.go
@@ -89,3 +89,32 @@ func (fcs *FenceControllerServer) FenceClusterNetwork(
 
 	return &fence.FenceClusterNetworkResponse{}, nil
 }
+
+// UnfenceClusterNetwork unblocks the access to a CIDR block by removing the network fence.
+func (fcs *FenceControllerServer) UnfenceClusterNetwork(
+	ctx context.Context,
+	req *fence.UnfenceClusterNetworkRequest,
+) (*fence.UnfenceClusterNetworkResponse, error) {
+	err := validateNetworkFenceReq(req.GetCidrs(), req.Parameters)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	cr, err := util.NewUserCredentials(req.GetSecrets())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	nwFence, err := nf.NewNetworkFence(ctx, cr, req.Cidrs, req.GetParameters())
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	err = nwFence.RemoveNetworkFence(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to unfence CIDR block %q: %s", nwFence.Cidr, err.Error())
+	}
+
+	return &fence.UnfenceClusterNetworkResponse{}, nil
+}

--- a/internal/csi-addons/cephfs/network_fence_test.go
+++ b/internal/csi-addons/cephfs/network_fence_test.go
@@ -20,9 +20,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/csi-addons/spec/lib/go/fence"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestFenceClusterNetwork is a minimal test for the FenceClusterNetwork()

--- a/internal/csi-addons/cephfs/network_fence_test.go
+++ b/internal/csi-addons/cephfs/network_fence_test.go
@@ -42,3 +42,19 @@ func TestFenceClusterNetwork(t *testing.T) {
 	_, err := controller.FenceClusterNetwork(context.TODO(), req)
 	assert.Error(t, err)
 }
+
+// TestUnfenceClusterNetwork is a minimal test for the UnfenceClusterNetwork()
+// procedure. During unit-testing, there is no Ceph cluster available, so actual
+// operations can not be performed.
+func TestUnfenceClusterNetwork(t *testing.T) {
+	t.Parallel()
+	controller := NewFenceControllerServer()
+
+	req := &fence.UnfenceClusterNetworkRequest{
+		Parameters: map[string]string{},
+		Secrets:    nil,
+		Cidrs:      nil,
+	}
+	_, err := controller.UnfenceClusterNetwork(context.TODO(), req)
+	assert.Error(t, err)
+}

--- a/internal/csi-addons/cephfs/network_fence_test.go
+++ b/internal/csi-addons/cephfs/network_fence_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/csi-addons/spec/lib/go/fence"
+)
+
+// TestFenceClusterNetwork is a minimal test for the FenceClusterNetwork()
+// procedure. During unit-testing, there is no Ceph cluster available, so
+// actual operations can not be performed.
+func TestFenceClusterNetwork(t *testing.T) {
+	t.Parallel()
+
+	controller := NewFenceControllerServer()
+
+	req := &fence.FenceClusterNetworkRequest{
+		Parameters: map[string]string{},
+		Secrets:    nil,
+		Cidrs:      nil,
+	}
+
+	_, err := controller.FenceClusterNetwork(context.TODO(), req)
+	assert.Error(t, err)
+}

--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -224,7 +224,6 @@ func (ac *activeClient) fetchID() (int, error) {
 	}
 
 	return 0, fmt.Errorf("failed to extract client ID, incorrect format: %s", clientInfo)
-
 }
 
 // AddClientEviction blocks access for all the IPs in the CIDR block

--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -1,9 +1,12 @@
 /*
-Copyright 2022 The Ceph-CSI Authors.
+Copyright 2023 The Ceph-CSI Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +18,13 @@ package networkfence
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -29,6 +35,8 @@ import (
 const (
 	blocklistTime     = "157784760"
 	invalidCommandStr = "invalid command"
+	// we can always use mds rank 0, since all the clients have a session with rank-0.
+	mdsRank = "0"
 )
 
 // NetworkFence contains the CIDR blocks to be blocked.
@@ -36,6 +44,11 @@ type NetworkFence struct {
 	Cidr     []string
 	Monitors string
 	cr       *util.Credentials
+}
+
+// activeClient represents the structure of an active client.
+type activeClient struct {
+	Inst string `json:"inst"`
 }
 
 // NewNetworkFence returns a networkFence struct object from the Network fence/unfence request.
@@ -122,6 +135,148 @@ func (nf *NetworkFence) AddNetworkFence(ctx context.Context) error {
 
 		// add ceph blocklist for each IP in the range mentioned by the CIDR
 		for _, host := range hosts {
+			err = nf.addCephBlocklist(ctx, host, false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func listActiveClients(ctx context.Context) ([]activeClient, error) {
+	// FIXME: replace the ceph command with go-ceph API in future
+	cmd := []string{"tell", fmt.Sprintf("mds.%s", mdsRank), "client", "ls"}
+	stdout, stdErr, err := util.ExecCommandWithTimeout(ctx, 2*time.Minute, "ceph", cmd...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list active clients: %w, stderr: %q", err, stdErr)
+	}
+
+	var activeClients []activeClient
+	if err := json.Unmarshal([]byte(stdout), &activeClients); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return activeClients, nil
+}
+
+func evictCephFSClient(ctx context.Context, clientID int) error {
+	// FIXME: replace the ceph command with go-ceph API in future
+	cmd := []string{"tell", fmt.Sprintf("mds.%s", mdsRank), "client", "evict", fmt.Sprintf("id=%d", clientID)}
+	_, stdErr, err := util.ExecCommandWithTimeout(ctx, 2*time.Minute, "ceph", cmd...)
+	if err != nil {
+		return fmt.Errorf("failed to evict client %d: %w, stderr: %q", clientID, err, stdErr)
+	}
+	log.DebugLog(ctx, "client %s has been evicted from CephFS\n", clientID)
+
+	return nil
+}
+
+func isIPInCIDR(ctx context.Context, ip, cidr string) bool {
+	// Parse the CIDR block
+	_, ipCidr, err := net.ParseCIDR(cidr)
+	if err != nil {
+		log.ErrorLog(ctx, "error parsing CIDR block %s: %w\n", cidr, err)
+
+		return false
+	}
+
+	// Parse the IP address
+	ipAddress := net.ParseIP(ip)
+	if ipAddress == nil {
+		log.ErrorLog(ctx, "error parsing IP address %s\n", ip)
+
+		return false
+	}
+
+	// Check if the IP address is within the CIDR block
+	return ipCidr.Contains(ipAddress)
+}
+
+func (ac *activeClient) fetchIP() (string, error) {
+	// example: "inst": "client.4305 172.21.9.34:0/422650892",
+	// then returning value will be 172.21.9.34
+	clientInfo := ac.Inst
+	parts := strings.Fields(clientInfo)
+	if len(parts) >= 2 {
+		ip := strings.Split(parts[1], ":")[0]
+
+		return ip, nil
+	}
+
+	return "", fmt.Errorf("failed to extract IP address, incorrect format: %s", clientInfo)
+}
+
+func (ac *activeClient) fetchID() (int, error) {
+	// example: "inst": "client.4305 172.21.9.34:0/422650892",
+	// then returning value will be 4305
+	clientInfo := ac.Inst
+	parts := strings.Fields(clientInfo)
+	if len(parts) >= 1 {
+		clientIDStr := strings.TrimPrefix(parts[0], "client.")
+		clientID, err := strconv.Atoi(clientIDStr)
+		if err != nil {
+			return 0, fmt.Errorf("failed to convert client ID to int: %w", err)
+		}
+
+		return clientID, nil
+	}
+
+	return 0, fmt.Errorf("failed to extract client ID, incorrect format: %s", clientInfo)
+
+}
+
+// AddClientEviction blocks access for all the IPs in the CIDR block
+// using client eviction.
+// blocks the active clients listed in cidr, and the IPs
+// for whom there is no active client present too.
+func (nf *NetworkFence) AddClientEviction(ctx context.Context) error {
+	evictedIPs := make(map[string]bool)
+	// fetch active clients
+	activeClients, err := listActiveClients(ctx)
+	if err != nil {
+		return err
+	}
+	// iterate through CIDR blocks and check if any active client matches
+	for _, cidr := range nf.Cidr {
+		for _, client := range activeClients {
+			clientIP, err := client.fetchIP()
+			if err != nil {
+				return fmt.Errorf("error fetching client IP: %w", err)
+			}
+			// check if the clientIP is in the CIDR block
+			if isIPInCIDR(ctx, clientIP, cidr) {
+				clientID, err := client.fetchID()
+				if err != nil {
+					return fmt.Errorf("error fetching client ID: %w", err)
+				}
+				// evict the client
+				err = evictCephFSClient(ctx, clientID)
+				if err != nil {
+					return fmt.Errorf("error evicting client %d: %w", clientID, err)
+				}
+				log.DebugLog(ctx, "client %d has been evicted\n", clientID)
+				// add the CIDR to the list of blocklisted IPs
+				evictedIPs[clientIP] = true
+			}
+		}
+	}
+
+	// blocklist the IPs in CIDR without any active clients
+	for _, cidr := range nf.Cidr {
+		// check if the CIDR is evicted
+		// fetch the list of IPs from a CIDR block
+		hosts, err := getIPRange(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to convert CIDR block %s to corresponding IP range: %w", cidr, err)
+		}
+
+		// add ceph blocklist for each IP in the range mentioned by the CIDR
+		for _, host := range hosts {
+			if evictedIPs[host] {
+				continue
+			}
 			err = nf.addCephBlocklist(ctx, host, false)
 			if err != nil {
 				return err

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -1,9 +1,12 @@
 /*
-Copyright 2022 The Ceph-CSI Authors.
+Copyright 2023 The Ceph-CSI Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -94,3 +94,41 @@ func TestFetchIP(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		clientInfo  string
+		expectedID  int
+		expectedErr bool
+	}{
+		{
+			clientInfo:  "client.4305 172.21.9.34:0/422650892",
+			expectedID:  4305,
+			expectedErr: false,
+		},
+		{
+			clientInfo:  "",
+			expectedID:  0,
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		ts := tt
+		t.Run(ts.clientInfo, func(t *testing.T) {
+			t.Parallel()
+			ac := &activeClient{Inst: ts.clientInfo}
+			actualID, actualErr := ac.fetchID()
+
+			if (actualErr != nil) != ts.expectedErr {
+				t.Errorf("expected error %v but got %v", ts.expectedErr, actualErr)
+			}
+
+			if actualID != ts.expectedID {
+				t.Errorf("expected ID %d but got %d", ts.expectedID, actualID)
+			}
+		})
+	}
+}

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -54,3 +54,43 @@ func TestGetIPRange(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		clientInfo  string
+		expectedIP  string
+		expectedErr bool
+	}{
+		{
+			clientInfo:  "client.4305 172.21.9.34:0/422650892",
+			expectedIP:  "172.21.9.34",
+			expectedErr: false,
+		},
+		{
+			clientInfo:  "",
+			expectedIP:  "",
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		ts := tt
+
+		t.Run(ts.clientInfo, func(t *testing.T) {
+			t.Parallel()
+
+			client := activeClient{Inst: ts.clientInfo}
+			ip, actualErr := client.fetchIP()
+
+			if (actualErr != nil) != ts.expectedErr {
+				t.Errorf("expected error %v but got %v", ts.expectedErr, actualErr)
+			}
+
+			if ip != ts.expectedIP {
+				t.Errorf("expected IP %s but got %s", ts.expectedIP, ip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
-  adds client eviction to cephfs, based
on the IPs in cidr block, it evicts those IPs from
the network.

updates: https://github.com/ceph/ceph-csi/issues/3969 