### PR TITLE
cephfs: add support for VolumeCondition in NodeGetVolumeStats operation

### DIFF
--- a/docs/design/proposals/volume-condition.md
+++ b/docs/design/proposals/volume-condition.md
@@ -1,0 +1,25 @@
+# Suport for CSI `VolumeCondition` aka Volume Health Checker
+
+## health-checker API
+
+Under `internal/health-checker`  the Manager for health-checking is
+implemented. The Manager can start a checking process for a given path, return
+the (un)healthy state and stop the checking process when the volume is not
+needed anymore.
+
+The Manager is responsible for creating a suitble checker for the requested
+path. If the path a s block-device, the BlockChecker should be created. For a
+filesystem path (directory), the FileChecker is appropriate.
+
+## CephFS
+
+The health-checker writes to the file `csi-volume-condition.ts` in the root of
+the volume. This file containse a JSON formatted timestamp.
+
+A new `data` directory is introduced for newly created volumes. During the
+`NodeStageVolume` call the root of the volume is mounted, and the `data`
+directory is bind-mounted inside the container when `NodePublishVolume` is
+called.
+
+The `data` directory makes it possible to place Ceph-CSI internal files in the
+root of the volume, without that the user/application has access to it.

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -40,6 +40,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// defaultDataRoot is a directory on the volume that will be mounted inside the
+// container during NodePublishVolume. The parent directory od defaultDataRoot
+// will be mounted during NodeStageVolume, and is available for Ceph-CSI
+// internal consumption,
+const defaultDataRoot = "data"
+
 // ControllerServer struct of CEPH CSI driver with supported methods of CSI
 // controller server spec.
 type ControllerServer struct {
@@ -365,6 +371,12 @@ func (cs *ControllerServer) CreateVolume(
 		volumeContext := k8s.RemoveCSIPrefixedParameters(req.GetParameters())
 		volumeContext["subvolumeName"] = vID.FsSubvolName
 		volumeContext["subvolumePath"] = volOptions.RootPath
+
+		if volOptions.DataRoot == "" {
+			volOptions.DataRoot = defaultDataRoot
+		}
+		volumeContext["dataRoot"] = volOptions.DataRoot
+
 		volume := &csi.Volume{
 			VolumeId:      vID.VolumeID,
 			CapacityBytes: volOptions.Size,
@@ -456,6 +468,12 @@ func (cs *ControllerServer) CreateVolume(
 	volumeContext := k8s.RemoveCSIPrefixedParameters(req.GetParameters())
 	volumeContext["subvolumeName"] = vID.FsSubvolName
 	volumeContext["subvolumePath"] = volOptions.RootPath
+
+	if volOptions.DataRoot == "" {
+		volOptions.DataRoot = defaultDataRoot
+	}
+	volumeContext["dataRoot"] = volOptions.DataRoot
+
 	volume := &csi.Volume{
 		VolumeId:      vID.VolumeID,
 		CapacityBytes: volOptions.Size,

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -25,6 +25,7 @@ import (
 	casceph "github.com/ceph/ceph-csi/internal/csi-addons/cephfs"
 	csiaddons "github.com/ceph/ceph-csi/internal/csi-addons/server"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	hc "github.com/ceph/ceph-csi/internal/health-checker"
 	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -82,6 +83,7 @@ func NewNodeServer(
 		VolumeLocks:        util.NewVolumeLocks(),
 		kernelMountOptions: kernelMountOptions,
 		fuseMountOptions:   fuseMountOptions,
+		healthChecker:      hc.NewHealthCheckManager(),
 	}
 }
 

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -71,6 +71,12 @@ type VolumeOptions struct {
 
 	ProvisionVolume bool `json:"provisionVolume"`
 	BackingSnapshot bool `json:"backingSnapshot"`
+
+	// DataRoot is set to the directory that is bind-mounted into the
+	// container. The parent directory of the DataRoot is not available for
+	// the end-user, but Ceph-CSI can use it for storing state, doing
+	// health-checks and the like.
+	DataRoot string `json:dataRoot`
 }
 
 // Connect a CephFS volume to the Ceph cluster.
@@ -263,6 +269,10 @@ func NewVolumeOptions(
 	}
 
 	if err = extractOptionalOption(&backingSnapshotBool, "backingSnapshot", volOptions); err != nil {
+		return nil, err
+	}
+
+	if err = extractOptionalOption(&opts.DataRoot, "dataRoot", volOptions); err != nil {
 		return nil, err
 	}
 

--- a/internal/health-checker/filechecker.go
+++ b/internal/health-checker/filechecker.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2023 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecker
+
+import (
+	"errors"
+	"os"
+	"path"
+	"time"
+)
+
+// command is what is sent through the channel to terminate the go routine.
+type command string
+
+const (
+	// stopCommand is sent through the channel to stop checking.
+	stopCommand = command("STOP")
+)
+
+type fileChecker struct {
+	// filename contains the filename that is used for checking.
+	filename string
+
+	// interval contains the time to sleep between health checks.
+	interval time.Duration
+
+	// current status
+	healthy    bool
+	err        error
+	isRunning  bool
+	lastUpdate time.Time
+
+	// commands is the channel to read commands from; when to stop.
+	commands chan command
+}
+
+func newFileChecker(dir string) ConditionChecker {
+	return &fileChecker{
+		filename:   path.Join(dir, "csi-volume-condition.ts"),
+		healthy:    true,
+		interval:   120 * time.Second,
+		lastUpdate: time.Now(),
+		commands:   make(chan command),
+	}
+}
+
+// runChecker is an endless loop that writes a timestamp and reads it back from
+// a file.
+func (fc *fileChecker) runChecker() {
+	fc.isRunning = true
+
+	for {
+		if fc.shouldStop() {
+			fc.isRunning = false
+
+			return
+		}
+
+		now := time.Now()
+
+		err := fc.writeTimestamp(now)
+		if err != nil {
+			fc.healthy = false
+			fc.err = err
+
+			continue
+		}
+
+		ts, err := fc.readTimestamp()
+		if err != nil {
+			fc.healthy = false
+			fc.err = err
+
+			continue
+		}
+
+		// verify that the written timestamp is read back
+		if now.Compare(ts) != 0 {
+			fc.healthy = false
+			fc.err = errors.New("timestamp read from file does not match what was written")
+
+			continue
+		}
+
+		// run health check, write a timestamp to a file, read it back
+		fc.healthy = true
+		fc.err = nil
+		fc.lastUpdate = ts
+	}
+}
+
+func (fc *fileChecker) shouldStop() bool {
+	start := time.Now()
+
+	for {
+		// check if we slept long enough to run a next check
+		slept := time.Since(start)
+		if slept >= fc.interval {
+			break
+		}
+
+		select {
+		case <-fc.commands:
+			// a command was reveived, need to stop checking
+			return true
+		default:
+			// continue with checking
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	return false
+}
+
+func (fc *fileChecker) start() {
+	go fc.runChecker()
+}
+
+func (fc *fileChecker) stop() {
+	fc.commands <- stopCommand
+}
+
+func (fc *fileChecker) isHealthy() (bool, error) {
+	// check for the last update, it should be within a certain number of
+	//
+	//   lastUpdate + (N x fc.interval)
+	//
+	// Without such a check, a single slow write/read could trigger actions
+	// to recover an unhealthy volume already.
+	//
+	// It is required to check, in case the write or read in the go routine
+	// is blocked.
+	return fc.healthy, fc.err
+}
+
+// readTimestamp reads the JSON formatted timestamp from the file.
+func (fc *fileChecker) readTimestamp() (time.Time, error) {
+	var ts time.Time
+
+	data, err := os.ReadFile(fc.filename)
+	if err != nil {
+		return ts, err
+	}
+
+	err = ts.UnmarshalJSON(data)
+
+	return ts, err
+}
+
+// writeTimestamp writes the timestamp to the file in JSON format.
+func (fc *fileChecker) writeTimestamp(ts time.Time) error {
+	data, err := ts.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(fc.filename, data, 0644)
+}

--- a/internal/health-checker/filechecker.go
+++ b/internal/health-checker/filechecker.go
@@ -48,14 +48,22 @@ type fileChecker struct {
 	commands chan command
 }
 
-func newFileChecker(dir string) ConditionChecker {
+func newFileChecker(dir string) (ConditionChecker, error) {
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0755)
+	}
+	if err != nil {
+		return nil, err
+	}
+
 	return &fileChecker{
 		filename:   path.Join(dir, "csi-volume-condition.ts"),
 		healthy:    true,
 		interval:   120 * time.Second,
 		lastUpdate: time.Now(),
 		commands:   make(chan command),
-	}
+	}, nil
 }
 
 // runChecker is an endless loop that writes a timestamp and reads it back from

--- a/internal/health-checker/filechecker_test.go
+++ b/internal/health-checker/filechecker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package healthchecker
 
 import (
+	"path"
 	"testing"
 	"time"
 )
@@ -24,8 +25,12 @@ import (
 func TestFileChecker(t *testing.T) {
 	t.Parallel()
 
-	volumePath := t.TempDir()
-	fc := newFileChecker(volumePath)
+	volumePath := path.Join(t.TempDir(), "csi-health-check.d")
+	fc, err := newFileChecker(volumePath)
+	if err != nil {
+		t.Fatalf("failed to create FileChecker: %v", err)
+	}
+
 	checker := fc.(*fileChecker)
 	checker.interval = time.Second * 5
 
@@ -55,12 +60,16 @@ func TestFileChecker(t *testing.T) {
 func TestWriteReadTimestamp(t *testing.T) {
 	t.Parallel()
 
-	volumePath := t.TempDir()
-	fc := newFileChecker(volumePath)
+	volumePath := path.Join(t.TempDir(), "csi-health-check.d")
+	fc, err := newFileChecker(volumePath)
+	if err != nil {
+		t.Fatalf("failed to create FileChecker: %v", err)
+	}
+
 	checker := fc.(*fileChecker)
 	ts := time.Now()
 
-	err := checker.writeTimestamp(ts)
+	err = checker.writeTimestamp(ts)
 	if err != nil {
 		t.Fatalf("failed to write timestamp: %v", err)
 	}

--- a/internal/health-checker/filechecker_test.go
+++ b/internal/health-checker/filechecker_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFileChecker(t *testing.T) {
+	t.Parallel()
+
+	volumePath := t.TempDir()
+	fc := newFileChecker(volumePath)
+	checker := fc.(*fileChecker)
+	checker.interval = time.Second * 5
+
+	// start the checker
+	checker.start()
+
+	// wait a second to get the go routine running
+	time.Sleep(time.Second)
+	if !checker.isRunning {
+		t.Error("checker failed to start")
+	}
+
+	for i := 0; i < 10; i++ {
+		// check health, should be healthy
+		healthy, msg := checker.isHealthy()
+		if !healthy || msg != nil {
+			t.Error("volume is unhealthy")
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	// stop the checker
+	checker.stop()
+}
+
+func TestWriteReadTimestamp(t *testing.T) {
+	t.Parallel()
+
+	volumePath := t.TempDir()
+	fc := newFileChecker(volumePath)
+	checker := fc.(*fileChecker)
+	ts := time.Now()
+
+	err := checker.writeTimestamp(ts)
+	if err != nil {
+		t.Fatalf("failed to write timestamp: %v", err)
+	}
+
+	_, err = checker.readTimestamp()
+	if err != nil {
+		t.Fatalf("failed to read timestamp: %v", err)
+	}
+}

--- a/internal/health-checker/manager.go
+++ b/internal/health-checker/manager.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecker
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Manager provides the API for getting the health status of a volume. The main
+// usage is requesting the health status by path.
+//
+// When the Manager detects that a new path is used for checking, a new
+// instance of a ConditionChecker is created  for the path, and started.
+//
+// Once the path is not active anymore (when NodeUnstageVolume is called), the
+// ConditionChecker needs to be stopped, which can be done by
+// Manager.StopChecker().
+type Manager interface {
+	StartChecker(path string) error
+	StopChecker(path string)
+	IsHealthy(path string) (bool, error)
+}
+
+// ConditionChecker describes the interface that a health status reporter needs
+// to implement. It is used internally by the Manager only.
+type ConditionChecker interface {
+	// start runs a the health checking function in a new go routine.
+	start()
+
+	// stop terminates a the health checking function that runs in a go
+	// routine.
+	stop()
+
+	// isHealthy returns the status of the volume, without blocking.
+	isHealthy() (bool, error)
+}
+
+type healthCheckManager struct {
+	checkers sync.Map // map[path]ConditionChecker
+}
+
+func NewHealthCheckManager() Manager {
+	return &healthCheckManager{
+		checkers: sync.Map{},
+	}
+}
+
+func (hcm *healthCheckManager) StartChecker(path string) error {
+	cc := newFileChecker(path)
+
+	// load the 'old' ConditionChecker if it exists, otherwuse store 'cc'
+	old, ok := hcm.checkers.LoadOrStore(path, cc)
+	if ok {
+		// 'old' was loaded, cast it to ConditionChecker
+		cc = old.(ConditionChecker)
+	} else {
+		// 'cc' was stored, start it only once
+		cc.start()
+	}
+
+	return nil
+}
+
+func (hcm *healthCheckManager) StopChecker(path string) {
+	old, ok := hcm.checkers.LoadAndDelete(path)
+	if !ok {
+		// nothing was loaded, nothing to do
+		return
+	}
+
+	// 'old' was loaded, cast it to ConditionChecker
+	cc := old.(ConditionChecker)
+	cc.stop()
+}
+
+func (hcm *healthCheckManager) IsHealthy(path string) (bool, error) {
+	// load the 'old' ConditionChecker if it exists
+	old, ok := hcm.checkers.Load(path)
+	if !ok {
+		return true, fmt.Errorf("no ConditionChecker for path: %s", path)
+	}
+
+	// 'old' was loaded, cast it to ConditionChecker
+	cc := old.(ConditionChecker)
+
+	return cc.isHealthy()
+}

--- a/internal/health-checker/manager.go
+++ b/internal/health-checker/manager.go
@@ -61,7 +61,10 @@ func NewHealthCheckManager() Manager {
 }
 
 func (hcm *healthCheckManager) StartChecker(path string) error {
-	cc := newFileChecker(path)
+	cc, err := newFileChecker(path)
+	if err != nil {
+		return err
+	}
 
 	// load the 'old' ConditionChecker if it exists, otherwuse store 'cc'
 	old, ok := hcm.checkers.LoadOrStore(path, cc)

--- a/internal/health-checker/manager_test.go
+++ b/internal/health-checker/manager_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecker
+
+import (
+	"testing"
+)
+
+func TestManager(t *testing.T) {
+	t.Parallel()
+
+	volumePath := t.TempDir()
+	mgr := NewHealthCheckManager()
+
+	// expected to have an error in msg
+	healthy, msg := mgr.IsHealthy(volumePath)
+	if !(healthy && msg != nil) {
+		t.Error("ConditionChecker was not started yet, did not get an error")
+	}
+
+	t.Log("start the checker")
+	err := mgr.StartChecker(volumePath)
+	if err != nil {
+		t.Fatalf("ConditionChecker could not get started: %v", err)
+	}
+
+	t.Log("check health, should be healthy")
+	healthy, msg = mgr.IsHealthy(volumePath)
+	if !healthy || err != nil {
+		t.Error("volume is unhealthy")
+	}
+
+	t.Log("stop the checker")
+	mgr.StopChecker(volumePath)
+}


### PR DESCRIPTION
This is my work-in-progress state for supporting `VOLUME_CONDITION`, starting with CephFS.

Updates: #1356

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
