### PR TITLE
rbd: update snap RbdImageName in createSnapshot

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1340,8 +1340,6 @@ func (cs *ControllerServer) doSnapshotClone(
 		return nil, err
 	}
 
-	// update rbd image name
-	rbdSnap.RbdImageName = cloneRbd.RbdImageName
 	err = cloneRbd.createSnapshot(ctx, rbdSnap)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create snapshot %s: %v", rbdSnap, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1411,6 +1411,7 @@ func (ri *rbdImage) hasSnapshotFeature() bool {
 }
 
 func (ri *rbdImage) createSnapshot(ctx context.Context, pOpts *rbdSnapshot) error {
+	pOpts.RbdImageName = ri.RbdImageName
 	log.DebugLog(ctx, "rbd: snap create %s using mon %s", pOpts, pOpts.Monitors)
 	image, err := ri.open()
 	if err != nil {


### PR DESCRIPTION
# Describe what this PR does
This PR updates the snapshot RbdImageName in
`createSnapshot` method. This resolves the
incorrect statement logged during snapshot creation.

Fixes: #4151 

    Instead of logging `rbdSnap`, why not log `cloneRbd`?
    Or, would it not be cleaner to set  `RbdImageName` inside `cloneRbd.createSnapshot()`?

_Originally posted by @nixpanic in https://github.com/ceph/ceph-csi/pull/4152#discussion_r1339919511_
            
            

