### PR TITLE
ci: disable addons after cluster creation

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -255,8 +255,6 @@ up)
         install_podman_wrapper
     fi
 
-    disable_storage_addons
-
     #  get kubernetes version we are operating on and accordingly enable feature gates
     KUBE_MAJOR=$(kube_version 1)
     KUBE_MINOR=$(kube_version 2)
@@ -283,6 +281,7 @@ up)
     if [[ "${VM_DRIVER}" = "podman" ]]; then
         ${minikube} ssh "sudo mount -oremount,rw /sys"
     fi
+    disable_storage_addons
     ${minikube} kubectl -- cluster-info
     ;;
 down)

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -2,8 +2,7 @@
 
 ROOK_VERSION=${ROOK_VERSION:-"v1.6.2"}
 ROOK_DEPLOY_TIMEOUT=${ROOK_DEPLOY_TIMEOUT:-300}
-ROOK_URL="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/"
-ROOK_DEPLOYMENT_PATH="cluster/examples/kubernetes/ceph"
+ROOK_URL="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/deploy/examples"
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}
 ROOK_BLOCK_EC_POOL_NAME=${ROOK_BLOCK_EC_POOL_NAME:-"ec-pool"}
 
@@ -30,31 +29,10 @@ function log_errors() {
 	exit 1
 }
 
-rook_version() {
-	echo "${ROOK_VERSION#v}" | cut -d'.' -f"${1}"
-}
-
-function update_rook_url() {
-	ROOK_MAJOR=$(rook_version 1)
-	ROOK_MINOR=$(rook_version 2)
-
-	# If rook version is => 1.8 update deployment path.
-	if [ "${ROOK_MAJOR}" -eq 1 ] && [ "${ROOK_MINOR}" -ge 8 ]; then
-		ROOK_DEPLOYMENT_PATH="deploy/examples"
-	fi
-	ROOK_URL+=${ROOK_DEPLOYMENT_PATH}
-}
-
 function deploy_rook() {
 	kubectl_retry create -f "${ROOK_URL}/common.yaml"
+	kubectl_retry create -f "${ROOK_URL}/crds.yaml"
 
-	ROOK_MAJOR=$(rook_version 1)
-	ROOK_MINOR=$(rook_version 2)
-
-	# If rook version is > 1.5 , we will apply CRDs.
-	if [ "${ROOK_MAJOR}" -eq 1 ] && [ "${ROOK_MINOR}" -ge 5 ]; then
-		kubectl_retry create -f "${ROOK_URL}/crds.yaml"
-	fi
 	TEMP_DIR="$(mktemp -d)"
 	curl -o "${TEMP_DIR}/operator.yaml" "${ROOK_URL}/operator.yaml"
 	# disable rook deployed csi drivers
@@ -106,12 +84,8 @@ function teardown_rook() {
 	kubectl delete -f "${ROOK_URL}/toolbox.yaml"
 	kubectl delete -f "${ROOK_URL}/cluster-test.yaml"
 	kubectl delete -f "${ROOK_URL}/operator.yaml"
-	ROOK_MAJOR=$(rook_version 1)
-	ROOK_MINOR=$(rook_version 2)
-	if [ "${ROOK_MAJOR}" -eq 1 ] && [ "${ROOK_MINOR}" -ge 5 ]; then
-		kubectl delete -f "${ROOK_URL}/crds.yaml"
-	fi
 	kubectl delete -f "${ROOK_URL}/common.yaml"
+	kubectl delete -f "${ROOK_URL}/crds.yaml"
 }
 
 function create_block_pool() {
@@ -251,9 +225,6 @@ function check_rbd_stat() {
 	fi
 	echo ""
 }
-
-# update rook URL before doing any operation.
-update_rook_url
 
 case "${1:-}" in
 deploy)

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -E
 
-ROOK_VERSION=${ROOK_VERSION:-"v1.6.2"}
+ROOK_VERSION=${ROOK_VERSION:-"v1.12.5"}
 ROOK_DEPLOY_TIMEOUT=${ROOK_DEPLOY_TIMEOUT:-300}
 ROOK_URL="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/deploy/examples"
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}


### PR DESCRIPTION
* Disabling add-on pre-cluster creation is not working, Moving the disable addons to post-cluster creation.
* I added 2nd commit to remove support for the older version of Rook as well.

Current script output

```
[🎩︎]mrajanna@li-2cfbef4c-22d9-11b2-a85c-a3e4a93c405f ceph-csi $]./scripts/minikube.sh up
😄  minikube v1.31.0 on Fedora 38
    ▪ KUBECONFIG=/home/mrajanna/workspace/src/github.com/JohnStrunk/k8s-cluster/kubeconfig
    ▪ MINIKUBE_VERSION=v1.31.2
❗  minikube skips various validations when --force is supplied; this may lead to unexpected behavior
🎉  minikube 1.31.2 is available! Download it: https://github.com/kubernetes/minikube/releases/tag/v1.31.2
💡  To disable this notice, run: 'minikube config set WantUpdateNotification false'

✨  Using the kvm2 driver based on user configuration
👍  Starting control plane node minikube in cluster minikube
🔥  Creating kvm2 VM (CPUs=12, Memory=4096MB, Disk=32768MB) ...
🐳  Preparing Kubernetes v1.27.2 on Docker 24.0.4 ...
    ▪ kubelet.resolv-conf=/run/systemd/resolve/resolv.conf
    ▪ kubelet.read-only-port=10255
    ▪ Generating certificates and keys ...
    ▪ Booting up control plane ...
    ▪ Configuring RBAC rules ...
🔗  Configuring bridge CNI (Container Networking Interface) ...
    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
root        2113    2057 44 11:06 ?        00:00:12 kube-apiserver --advertise-address=192.168.39.66 --allow-privileged=true --authorization-mode=Node,RBAC --client-ca-file=/var/lib/minikube/certs/ca.crt --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota --enable-bootstrap-token-auth=true --etcd-cafile=/var/lib/minikube/certs/etcd/ca.crt --etcd-certfile=/var/lib/minikube/certs/apiserver-etcd-client.crt --etcd-keyfile=/var/lib/minikube/certs/apiserver-etcd-client.key --etcd-servers=https://127.0.0.1:2379 --feature-gates=ReadWriteOncePod=true,RecoverVolumeExpansionFailure=true --kubelet-client-certificate=/var/lib/minikube/certs/apiserver-kubelet-client.crt --kubelet-client-key=/var/lib/minikube/certs/apiserver-kubelet-client.key --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --proxy-client-cert-file=/var/lib/minikube/certs/front-proxy-client.crt --proxy-client-key-file=/var/lib/minikube/certs/front-proxy-client.key --requestheader-allowed-names=front-proxy-client --requestheader-client-ca-file=/var/lib/minikube/certs/front-proxy-ca.crt --requestheader-extra-headers-prefix=X-Remote-Extra- --requestheader-group-headers=X-Remote-Group --requestheader-username-headers=X-Remote-User --secure-port=8443 --service-account-issuer=https://kubernetes.default.svc.cluster.local --service-account-key-file=/var/lib/minikube/certs/sa.pub --service-account-signing-key-file=/var/lib/minikube/certs/sa.key --service-cluster-ip-range=10.96.0.0/12 --tls-cert-file=/var/lib/minikube/certs/apiserver.crt --tls-private-key-file=/var/lib/minikube/certs/apiserver.key
root        4195       1 53 11:07 ?        00:00:00 /var/lib/minikube/binaries/v1.27.2/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime-endpoint=unix:///var/run/cri-dockerd.sock --feature-gates=ReadWriteOncePod=true,RecoverVolumeExpansionFailure=true --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.39.66 --read-only-port=10255 --resolv-conf=/run/systemd/resolve/resolv.conf --v=4
docker      4289    4270  0 11:07 pts/0    00:00:00 bash -c ps -Af |grep kubelet
docker      4291    4289  0 11:07 pts/0    00:00:00 grep kubelet
Kubernetes control plane is running at https://192.168.39.66:8443
CoreDNS is running at https://192.168.39.66:8443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

[🎩︎]mrajanna@li-2cfbef4c-22d9-11b2-a85c-a3e4a93c405f ceph-csi $]minikube addons list
|-----------------------------|----------|--------------|--------------------------------|
|         ADDON NAME          | PROFILE  |    STATUS    |           MAINTAINER           |
|-----------------------------|----------|--------------|--------------------------------|
| ambassador                  | minikube | disabled     | 3rd party (Ambassador)         |
| auto-pause                  | minikube | disabled     | minikube                       |
| cloud-spanner               | minikube | disabled     | Google                         |
| csi-hostpath-driver         | minikube | disabled     | Kubernetes                     |
| dashboard                   | minikube | disabled     | Kubernetes                     |
| default-storageclass        | minikube | enabled ✅   | Kubernetes                     |
| efk                         | minikube | disabled     | 3rd party (Elastic)            |
| freshpod                    | minikube | disabled     | Google                         |
| gcp-auth                    | minikube | disabled     | Google                         |
| gvisor                      | minikube | disabled     | minikube                       |
| headlamp                    | minikube | disabled     | 3rd party (kinvolk.io)         |
| helm-tiller                 | minikube | disabled     | 3rd party (Helm)               |
| inaccel                     | minikube | disabled     | 3rd party (InAccel             |
|                             |          |              | [info@inaccel.com])            |
| ingress                     | minikube | disabled     | Kubernetes                     |
| ingress-dns                 | minikube | disabled     | minikube                       |
| inspektor-gadget            | minikube | disabled     | 3rd party                      |
|                             |          |              | (inspektor-gadget.io)          |
| istio                       | minikube | disabled     | 3rd party (Istio)              |
| istio-provisioner           | minikube | disabled     | 3rd party (Istio)              |
| kong                        | minikube | disabled     | 3rd party (Kong HQ)            |
| kubevirt                    | minikube | disabled     | 3rd party (KubeVirt)           |
| logviewer                   | minikube | disabled     | 3rd party (unknown)            |
| metallb                     | minikube | disabled     | 3rd party (MetalLB)            |
| metrics-server              | minikube | disabled     | Kubernetes                     |
| nvidia-driver-installer     | minikube | disabled     | 3rd party (Nvidia)             |
| nvidia-gpu-device-plugin    | minikube | disabled     | 3rd party (Nvidia)             |
| olm                         | minikube | disabled     | 3rd party (Operator Framework) |
| pod-security-policy         | minikube | disabled     | 3rd party (unknown)            |
| portainer                   | minikube | disabled     | 3rd party (Portainer.io)       |
| registry                    | minikube | disabled     | minikube                       |
| registry-aliases            | minikube | disabled     | 3rd party (unknown)            |
| registry-creds              | minikube | disabled     | 3rd party (UPMC Enterprises)   |
| storage-provisioner         | minikube | enabled ✅   | minikube                       |
| storage-provisioner-gluster | minikube | disabled     | 3rd party (Gluster)            |
| volumesnapshots             | minikube | disabled     | Kubernetes                     |
|-----------------------------|----------|--------------|--------------------------------|
```
