### PR TITLE
ci: group golang.org/x/ under golang dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       golang-dependencies:
         patterns:
           - "github.com/golang*"
+          - "golang.org/x/*"
       k8s-dependencies:
         patterns:
           - "k8s.io*"


### PR DESCRIPTION
Golang dependencies are already grouped, but they only contain packages
from `github.com/golang*`. There are more Golang standard packages that
are located at `golang.org/x/*`. Because of the tight relationship
between these packages, it is more efficient to group updates together.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
