### PR TITLE
cephfs: Fix cephfs PVC sizing

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -67,9 +67,9 @@ func RoundOffCephFSVolSize(bytes int64) int64 {
 		return 4 * helpers.MiB
 	}
 
-	floatbytes := float64(bytes) / helpers.MiB
+	bytesInFloat := float64(bytes) / helpers.MiB
 
-	bytes = int64(math.Ceil(floatbytes/4) * 4)
+	bytes = int64(math.Ceil(bytesInFloat/4) * 4)
 
 	return RoundOffBytes(bytes * helpers.MiB)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -67,9 +67,9 @@ func RoundOffCephFSVolSize(bytes int64) int64 {
 		return 4 * helpers.MiB
 	}
 
-	bytes /= helpers.MiB
+	floatbytes := float64(bytes) / helpers.MiB
 
-	bytes = int64(math.Ceil(float64(bytes)/4) * 4)
+	bytes = int64(math.Ceil(floatbytes/4) * 4)
 
 	return RoundOffBytes(bytes * helpers.MiB)
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -376,6 +376,16 @@ func TestRoundOffCephFSVolSize(t *testing.T) {
 			4194304, // 4 MiB
 		},
 		{
+			"101MB conversion",
+			101000000,
+			104857600, // 100MiB
+		},
+		{
+			"500MB conversion",
+			500000000,
+			503316480, // 480MiB
+		},
+		{
 			"1023MiB conversion",
 			1072693248,
 			1073741824, // 1024 MiB


### PR DESCRIPTION
Issue:
The RoundOffCephFSVolSize() function omits the fractional part when calculating the size for cephfs volumes, leading to the created volume capacity to be lesser than the requested volume capacity.

Fix:
Consider the fractional part during the size calculation so the rounded off volume size will be greater than or equal to the requested volume size.


Fixes: #4179