### PR TITLE
ci: do not include go-ceph in generic GitHub package rebases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
         patterns:
           - "github.com*"
         exclude-patterns:
+          - "github.com/ceph/*"
           - "github.com/golang*"
           - "github.com/container-storage-interface/spec"
     labels:


### PR DESCRIPTION
go-ceph is an important package that we consume.  It is better to have that as separate rebase PR from Dependabot and not include it in the general GitHub package group.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
