### PR TITLE
ci: add capability to run specific e2e tests

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -10,6 +10,10 @@
           only_run_on_request: true
       - '1.28':
           only_run_on_request: true
+    test_type:
+      - 'cephfs'
+      - 'rbd'
+      - 'nfs'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'
@@ -32,6 +36,10 @@
           name: k8s_version
           default: '{k8s_version}'
           description: Kubernetes version to deploy in the test cluster.
+      - string:
+          name: test_type
+          default: '{test_type}'
+          description: Mentions whether tests run for rbd/cephfs/nfs.
     pipeline-scm:
       scm:
         - git:
@@ -46,7 +54,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version})?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}-{test_type})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
@@ -73,6 +81,11 @@
           name: k8s_version
           default: '{k8s_version}'
           description: Kubernetes version to deploy in the test cluster.
+      - string:
+          name: test_type
+          default: '{test_type}'
+          description: Mentions whether tests run for rbd/cephfs/nfs.
+
     pipeline-scm:
       scm:
         - git:
@@ -87,7 +100,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version})?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version}-{test_type})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -38,7 +38,7 @@
           description: Kubernetes version to deploy in the test cluster.
       - string:
           name: test_type
-          default: '{test_type}'
+          default: ''
           description: Mentions whether tests run for rbd/cephfs/nfs.
     pipeline-scm:
       scm:
@@ -54,7 +54,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}-{test_type})?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}(/test_type-{test_type})?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
@@ -83,7 +83,7 @@
           description: Kubernetes version to deploy in the test cluster.
       - string:
           name: test_type
-          default: '{test_type}'
+          default: ''
           description: Mentions whether tests run for rbd/cephfs/nfs.
 
     pipeline-scm:
@@ -100,7 +100,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version}-{test_type})?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version}(/test_type-{test_type})?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -198,7 +198,15 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {
-				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='--delete-namespace-on-failure=false --deploy-cephfs=false --deploy-rbd=false --helm-test=true'"
+				test_type = "--test-rbd=true --test-cephfs=true --test-nfs=true"
+				if ("${test_type}" == "cephfs"){
+					test_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"
+				} else if ("${test_type}" == "rbd"){
+					test_type = "--test-rbd=true --test-cephfs=false --test-nfs=false"
+				} else if ("${test_type}" == "nfs"){
+					test_type = "--test-nfs=true --test-cephfs=false --test-rbd=false"
+				}
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='--delete-namespace-on-failure=false --deploy-cephfs=false --deploy-rbd=false --helm-test=true ${test_type}'"
 			}
 		}
 		stage('cleanup ceph-csi deployment') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -185,7 +185,15 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {
-				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS="--delete-namespace-on-failure=false"'
+				test_type = "--test-rbd=true --test-cephfs=true --test-nfs=true"
+				if ("${test_type}" == "cephfs"){
+					test_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"
+				} else if ("${test_type}" == "rbd"){
+					test_type = "--test-rbd=true --test-cephfs=false --test-nfs=false"
+				} else if ("${test_type}" == "nfs"){
+					test_type = "--test-nfs=true --test-cephfs=false --test-rbd=false"
+				}
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS='--delete-namespace-on-failure=false ${test_type}'"
 			}
 		}
 	}


### PR DESCRIPTION
The current e2e test runs will trigger all 3 types of tests which takes a lot of time to complete. If the patch impacts only a single type, then having an option to trigger only that particular e2e test can save
considerable amount of time based on the test type.

This can also help in reducing the time in testing when a patch failed on a particular e2e test type and triggering only that e2e with the fix for the failure or re-trigger only that test again to check for false positives.
