### PR TITLE
doc: Clarify default values for mountOptions and mkfsOptions in storageclass example

### DIFF
--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -44,7 +44,7 @@ parameters:
    #
    # The default options depend on the csi.storage.k8s.io/fstype setting:
    # - ext4: "-m0 -Enodiscard,lazy_itable_init=1,lazy_journal_init=1"
-   # - xfs: "-onouuid -K"
+   # - xfs: "-K"
    #
    # mkfsOptions: "-m0 -Ediscard -i1024"
 
@@ -163,5 +163,7 @@ parameters:
    # objectSize: <>
 reclaimPolicy: Delete
 allowVolumeExpansion: true
+
+# If filesystem is xfs, nouuid will be automatically added to mountOptions
 mountOptions:
    - discard


### PR DESCRIPTION
# Describe what this PR does #

I thought the example comments are a bit misleading in case of mountOptions and mkfsOptions. I tried to clarify it based on the code in [here](https://github.com/ceph/ceph-csi/blob/5ff0607360815cd2c9ba8a420ceacbd2ce298ff5/internal/rbd/nodeserver.go#L105)

## Is there anything that requires special attention ##

Do you have any questions? No

Is the change backward compatible? Yes

Are there concerns around backward compatibility? No

## Related issues ##
N/A

## Future concerns ##
N/A
