### PR TITLE
ci: skip `./api/vendor` in codespell runs

### DIFF
--- a/scripts/codespell.conf
+++ b/scripts/codespell.conf
@@ -1,5 +1,5 @@
 [codespell]
 # TODO: enable codespell on retest folder except vendor
-skip = .git,./vendor,./docs/design/proposals/images,./actions/retest/*,go.sum
+skip = .git,./vendor,./docs/design/proposals/images,./actions/retest/*,./api/vendor,go.sum
 ignore-words-list = ExtraVersion,extraversion,ba
 check-filenames = true


### PR DESCRIPTION
The `./api/vendor` directory seems to have spellcheck problems while running locally. For some reason the CI jobs running in GitHub do not seem to be affected.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
