### PR TITLE
cephfs: remove snapshot protect/unprotect

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -830,7 +830,7 @@ func (cs *ControllerServer) CreateSnapshot(
 	}
 	defer cs.VolumeLocks.Release(sourceVolID)
 	snapName := req.GetName()
-	sid, _, err := store.CheckSnapExists(ctx, parentVolOptions, cephfsSnap, cs.ClusterName, cs.SetMetadata, cr)
+	sid, err := store.CheckSnapExists(ctx, parentVolOptions, cephfsSnap, cs.ClusterName, cs.SetMetadata, cr)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/cephfs/errors/errors.go
+++ b/internal/cephfs/errors/errors.go
@@ -46,9 +46,6 @@ var (
 	// statically provisioned.
 	ErrNonStaticVolume = coreError.New("volume not static")
 
-	// ErrSnapProtectionExist is returned when the snapshot is already protected.
-	ErrSnapProtectionExist = coreError.New("snapshot  protection already exists")
-
 	// ErrSnapNotFound is returned when snap name passed is not found in the list
 	// of snapshots for the given image.
 	ErrSnapNotFound = coreError.New("snapshot not found")

--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -398,11 +398,11 @@ func CheckSnapExists(
 	clusterName string,
 	setMetadata bool,
 	cr *util.Credentials,
-) (*SnapshotIdentifier, *core.SnapshotInfo, error) {
+) (*SnapshotIdentifier, error) {
 	// Connect to cephfs' default radosNamespace (csi)
 	j, err := SnapJournal.Connect(volOptions.Monitors, fsutil.RadosNamespace, cr)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer j.Destroy()
 
@@ -411,10 +411,10 @@ func CheckSnapExists(
 	snapData, err := j.CheckReservation(
 		ctx, volOptions.MetadataPool, snap.RequestName, snap.NamePrefix, volOptions.VolID, kmsID, encryptionType)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if snapData == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 	sid := &SnapshotIdentifier{}
 	snapUUID := snapData.ImageUUID
@@ -428,10 +428,10 @@ func CheckSnapExists(
 			err = j.UndoReservation(ctx, volOptions.MetadataPool,
 				volOptions.MetadataPool, snapID, snap.RequestName)
 
-			return nil, nil, err
+			return nil, err
 		}
 
-		return nil, nil, err
+		return nil, err
 	}
 
 	defer func() {
@@ -455,10 +455,10 @@ func CheckSnapExists(
 	sid.SnapshotID, err = util.GenerateVolID(ctx, volOptions.Monitors, cr, volOptions.FscID,
 		"", volOptions.ClusterID, snapUUID, fsutil.VolIDVersion)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	log.DebugLog(ctx, "Found existing snapshot (%s) with subvolume name (%s) for request (%s)",
 		snapData.ImageAttributes.RequestName, volOptions.VolID, sid.FsSnapshotName)
 
-	return sid, &snapInfo, nil
+	return sid, nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit eliminates the code for protecting and unprotecting
snapshots, as the functionality to protect and unprotect snapshots
is being deprecated.

## Is there anything that requires special attention ##

Is the change backward compatible? Yes

Are there concerns around backward compatibility? No

Fixes: #4169 