### PR TITLE
Bug 2246388 - [GGS][ODF 4.13.3] MountVolume.MountDevice failed - invalid encryption kms configuration: missing encryption passphrase in secrets 

### DIFF
--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"strconv"
 
 	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -341,7 +342,8 @@ func ParseEncryptionOpts(
 		encrypted, kmsID string
 	)
 	encrypted, ok = volOptions["encrypted"]
-	if !ok {
+	val, _ := strconv.ParseBool(encrypted)
+	if !ok || !val{
 		return "", util.EncryptionTypeNone, nil
 	}
 	ok, err = strconv.ParseBool(encrypted)

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"strconv"
 
 	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -343,7 +342,7 @@ func ParseEncryptionOpts(
 	)
 	encrypted, ok = volOptions["encrypted"]
 	val, _ := strconv.ParseBool(encrypted)
-	if !ok || !val{
+	if !ok || !val {
 		return "", util.EncryptionTypeNone, nil
 	}
 	ok, err = strconv.ParseBool(encrypted)


### PR DESCRIPTION
fix: Invalid "invalid encryption kms configuration" error

