### PR TITLE
doc: add pending release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,6 +34,20 @@ Fixes: #issue_number
 List items that are not part of the PR and do not impact it's
 functionality, but are work items that can be taken up subsequently.
 
+**Checklist:**
+
+* [ ] **Commit Message Formatting**: Commit titles and messages follow
+  guidelines in the [developer
+  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
+* [ ] Reviewed the developer guide on [Submitting a Pull
+  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
+* [ ] [Pending release
+  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
+  updated with breaking and/or notable changes for the next major release.
+* [ ] Documentation has been updated, if necessary.
+* [ ] Unit tests have been added, if necessary.
+* [ ] Integration tests have been added, if necessary.
+
 ---
 
 <details>
@@ -42,7 +56,7 @@ functionality, but are work items that can be taken up subsequently.
 These commands are normally not required, but in case of issues, leave any of
 the following bot commands in an otherwise empty comment in this PR:
 
-- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
+* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
   failure (please report the failure too!)
 
 </details>

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,0 +1,5 @@
+# v3.10 Pending Release Notes
+
+## Breaking Changes
+
+## Features


### PR DESCRIPTION
Keeping track of changes between releases and fetching that information during release is difficult, Adding a doc to keep track of the changes between major releases helps during release.

