### PR TITLE
cephfs: remove subvolume during clone

### DIFF
--- a/internal/cephfs/core/clone.go
+++ b/internal/cephfs/core/clone.go
@@ -157,7 +157,9 @@ func (s *subVolumeClient) CreateCloneFromSnapshot(
 			}
 		}
 	}()
-	cloneState, err := s.GetCloneState(ctx)
+	var cloneState cephFSCloneState
+	// avoid err variable shadowing
+	cloneState, err = s.GetCloneState(ctx)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to get clone state: %v", err)
 


### PR DESCRIPTION
If any operations like resizing or deleting the snapshot fail, we need to remove both the snapshot and the clone to avoid resource leaks.

closes: #4218

