### PR TITLE
cleanup: remove left-overs of ReplicationServer in csi-common

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -166,8 +166,6 @@ func (fs *Driver) Run(conf *util.Config) {
 		IS: fs.is,
 		CS: fs.cs,
 		NS: fs.ns,
-		// passing nil for replication server as cephFS does not support mirroring.
-		RS: nil,
 	}
 	server.Start(conf.Endpoint, srv)
 

--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/csi-addons/spec/lib/go/replication"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 )
@@ -46,7 +45,6 @@ type Servers struct {
 	IS csi.IdentityServer
 	CS csi.ControllerServer
 	NS csi.NodeServer
-	RS replication.ControllerServer
 }
 
 // NewNonBlockingGRPCServer return non-blocking GRPC.
@@ -110,9 +108,6 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, srv Servers) {
 	}
 	if srv.NS != nil {
 		csi.RegisterNodeServer(server, srv.NS)
-	}
-	if srv.RS != nil {
-		replication.RegisterControllerServer(server, srv.RS)
 	}
 
 	log.DefaultLog("Listening for connections on address: %#v", listener.Addr())


### PR DESCRIPTION
The ReplicationServer is not used anymore, the functionality has moved
to CSI-Addons and the `internal/csi-addons/rbd` package. These last
references were not activated anywhere, so can be removed without any
impact.

See-also: #3314
