### PR TITLE
doc: remove use of `XXX` in example descriptions

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,10 +14,10 @@ GITHUB_EMAIL=${GITHUB_EMAIL:-"ceph-csi-bot@users.noreply.github.com"}
 
 # Build and push images. Steps as below:
 # 1. get base image from ./build.env (BASE_IMAGE=ceph/ceph:v14.2)
-# 2. parse manifest to get image digest per arch (sha256:XXX, sha256:YYY)
-# 3. patch Dockerfile with amd64 base image (FROM ceph/ceph:v14.2@sha256:XXX)
+# 2. parse manifest to get image digest per arch (sha256:XYZ, sha256:ZYX)
+# 3. patch Dockerfile with amd64 base image (FROM ceph/ceph:v14.2@sha256:XYZ)
 # 4. build and push amd64 image
-# 5. patch Dockerfile with arm64 base image (FROM ceph/ceph:v14.2@sha256:YYY)
+# 5. patch Dockerfile with arm64 base image (FROM ceph/ceph:v14.2@sha256:ZYX)
 # 6. build and push arm64 image
 build_push_images() {
 	# "docker manifest" requires experimental feature enabled
@@ -29,11 +29,11 @@ build_push_images() {
 	# get image digest per architecture
 	# {
 	#   "arch": "amd64",
-	#   "digest": "sha256:XXX"
+	#   "digest": "sha256:XYZ"
 	# }
 	# {
 	#   "arch": "arm64",
-	#   "digest": "sha256:YYY"
+	#   "digest": "sha256:ZYX"
 	# }
 	manifests=$(docker manifest inspect "${baseimg}" | jq '.manifests[] | {arch: .platform.architecture, digest: .digest}')
 	# qemu-user-static is to enable an execution of different multi-architecture containers by QEMU

--- a/scripts/build-multi-arch-image.sh
+++ b/scripts/build-multi-arch-image.sh
@@ -16,11 +16,11 @@ baseimg=$(awk -F = '/^BASE_IMAGE=/ {print $NF}' "${build_env}")
 # get image digest per architecture
 # {
 #   "arch": "amd64",
-#   "digest": "sha256:XXX"
+#   "digest": "sha256:XYZ"
 # }
 # {
 #   "arch": "arm64",
-#   "digest": "sha256:YYY"
+#   "digest": "sha256:ZYX"
 # }
 manifests=$(docker manifest inspect "${baseimg}" | jq '.manifests[] | {arch: .platform.architecture, digest: .digest}')
 # qemu-user-static is to enable an execution of different multi-architecture containers by QEMU


### PR DESCRIPTION
tickgit.com identifies `XXX` as label for TODO's. There is no need to
list the `digest` hash examples in the TODO list, so  replace the `XXX`
and `YYY` examples with `XYZ` and `ZYX`.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
