### PR TITLE
CephFS: Update fetchIP() to add support for IPv6 address

### DIFF
--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -212,9 +212,12 @@ func (ac *activeClient) fetchIP() (string, error) {
 	clientInfo := ac.Inst
 	parts := strings.Fields(clientInfo)
 	if len(parts) >= 2 {
-		ip := strings.Split(parts[1], ":")[0]
-
-		return ip, nil
+		lastColonIndex := strings.LastIndex(parts[1], ":")
+		firstPart := parts[1][:lastColonIndex]
+		ip := net.ParseIP(firstPart)
+		if ip != nil {
+			return ip.String(), nil
+		}
 	}
 
 	return "", fmt.Errorf("failed to extract IP address, incorrect format: %s", clientInfo)

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -69,6 +69,11 @@ func TestFetchIP(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			clientInfo:  "client.4305 2001:0db8:85a3:0000:0000:8a2e:0370:7334:0/422650892",
+			expectedIP:  "2001:db8:85a3::8a2e:370:7334",
+			expectedErr: false,
+		},
+		{
 			clientInfo:  "",
 			expectedIP:  "",
 			expectedErr: true,


### PR DESCRIPTION
the current fetchIP() function works for IPv4 addresses, this commit updates the same to support IPv6 too.
fixes: #4192 