### PR TITLE
doc: update release notes for grpc metrics

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,4 +2,6 @@
 
 ## Breaking Changes
 
+- Removed the deprecated grpc metrics flag's in [PR](https://github.com/ceph/ceph-csi/pull/4225)
+
 ## Features

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -17,10 +17,11 @@ RUN source /build.env \
     && mkdir -p /usr/local/go \
     && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
 
-# TODO: remove the following cmd, when issue
-# https://github.com/ceph/ceph-container/issues/2034 is fixed.
+# TODO: remove the following cmd, when issues
+# https://github.com/ceph/ceph-container/issues/2034
+# https://github.com/ceph/ceph-container/issues/2141 are fixed.
 RUN dnf config-manager --disable \
-    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi || true
+    tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
 RUN dnf -y install \
 	git \


### PR DESCRIPTION
updating the PendingReleaseNotes.md to mark the grpc flag removal.

