### PR TITLE
ci: run `tickgit` after merging a PR in the devel branch

### DIFF
--- a/.github/workflows/tickgit.yaml
+++ b/.github/workflows/tickgit.yaml
@@ -1,0 +1,18 @@
+---
+name: List TODO's
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - devel
+
+permissions:
+  contents: read
+
+jobs:
+  tickgit:
+    name: tickgit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make containerized-test TARGET=tickgit

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,10 @@ check-env:
 
 codespell:
 	codespell --config scripts/codespell.conf
+
+tickgit:
+	tickgit $(CURDIR)
+
 #
 # commitlint will do a rebase on top of GIT_SINCE when REBASE=1 is passed.
 #

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -56,6 +56,7 @@ RUN source /build.env \
     && npm install @commitlint/cli@"${COMMITLINT_VERSION}" \
     && popd \
     && git config --global --add safe.directory ${CEPHCSIPATH} \
+    && go install github.com/augmentable-dev/tickgit/cmd/tickgit@latest \
     && true
 
 WORKDIR ${CEPHCSIPATH}


### PR DESCRIPTION
The `tickgit.com` webservice seems to not update itself anymore, but having a list of TODO's is very useful. Use the tickgit project to gather the TODO's, bit in a GitHub Workflow.

Developers can also run `make containerized-test TARGET=tickgit` to get the result locally.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
