### PR TITLE
build: make sure `nfs-utils` is installed

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
 RUN dnf -y update --nobest \
+       && dnf -y install nfs-utils \
        && dnf clean all \
        && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Ceph is minimizing their container-images, which can cause the
`nfs-utils` package to be dropped. As Ceph-CSI supports mounting NFS, it
needs the `/sbin/mount.nfs` executable, so install the package (or a
no-op if it is installed already).

See-also: https://rook-io.slack.com/archives/C46Q5UC05/p1699188662893109
Signed-off-by: Niels de Vos <ndevos@ibm.com>
