### PR TITLE
helm: add annotations for ceph-csi-rbd secret

### DIFF
--- a/charts/ceph-csi-cephfs/templates/secret.yaml
+++ b/charts/ceph-csi-cephfs/templates/secret.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ .Values.secret.name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secret.annotations }}
+  annotations: {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ include "ceph-csi-cephfs.name" . }}
     chart: {{ include "ceph-csi-cephfs.chart" . }}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -288,6 +288,7 @@ secret:
   # Specifies whether the secret should be created
   create: false
   name: csi-cephfs-secret
+  annotations: {}
   # Key values correspond to a user name and its key, as defined in the
   # ceph cluster. User ID should have required access to the 'pool'
   # specified in the storage class

--- a/charts/ceph-csi-rbd/templates/secret.yaml
+++ b/charts/ceph-csi-rbd/templates/secret.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ .Values.secret.name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secret.annotations }}
+  annotations: {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ include "ceph-csi-rbd.name" . }}
     chart: {{ include "ceph-csi-rbd.chart" . }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -480,6 +480,7 @@ secret:
   # Specifies whether the secret should be created
   create: false
   name: csi-rbd-secret
+  annotations: {}
   # Key values correspond to a user name and its key, as defined in the
   # ceph cluster. User ID should have required access to the 'pool'
   # specified in the storage class


### PR DESCRIPTION
To use mutating webhook to modify secrets.
For example banzaicloud vault webhook:
https://bank-vaults.dev/docs/mutating-webhook/annotations/

