### PR TITLE
util: include request-IDs in all gRPC calls for the Controller

### DIFF
--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -97,7 +97,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, srv Servers) {
 		klog.Fatalf("Failed to listen: %v", err)
 	}
 
-	server := grpc.NewServer()
+	server := grpc.NewServer(NewMiddlewareServerOption(false))
 	s.server = server
 
 	if srv.IS != nil {


### PR DESCRIPTION
Snapshot procedures do not seem to contain the `Req-ID:` prefix in the
logs anymore (or weren't they there at all?) for some reason. This adds
them back.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
