### PR TITLE
util: remove metrics argument from NewMiddlewareServerOption

### DIFF
--- a/internal/csi-addons/server/server.go
+++ b/internal/csi-addons/server/server.go
@@ -87,7 +87,7 @@ func (cas *CSIAddonsServer) RegisterService(svc CSIAddonsService) {
 // returned.
 func (cas *CSIAddonsServer) Start() error {
 	// create the gRPC server and register services
-	cas.server = grpc.NewServer(csicommon.NewMiddlewareServerOption(false))
+	cas.server = grpc.NewServer(csicommon.NewMiddlewareServerOption())
 
 	for _, svc := range cas.services {
 		svc.RegisterService(cas.server)

--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -97,7 +97,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, srv Servers) {
 		klog.Fatalf("Failed to listen: %v", err)
 	}
 
-	server := grpc.NewServer(NewMiddlewareServerOption(false))
+	server := grpc.NewServer(NewMiddlewareServerOption())
 	s.server = server
 
 	if srv.IS != nil {

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -93,12 +92,8 @@ func NewControllerServiceCapability(ctrlCap csi.ControllerServiceCapability_RPC_
 
 // NewMiddlewareServerOption creates a new grpc.ServerOption that configures a
 // common format for log messages and other gRPC related handlers.
-func NewMiddlewareServerOption(withMetrics bool) grpc.ServerOption {
+func NewMiddlewareServerOption() grpc.ServerOption {
 	middleWare := []grpc.UnaryServerInterceptor{contextIDInjector, logGRPC, panicHandler}
-
-	if withMetrics {
-		middleWare = append(middleWare, grpc_prometheus.UnaryServerInterceptor)
-	}
 
 	return grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(middleWare...))
 }


### PR DESCRIPTION
This commit removes metrics argument from NewMiddlewareServerOption as it always set to false.

              we can remove `metrics` argument from `NewMiddlewareServerOption` as it always set to false but it can be in separate PR.

_Originally posted by @Madhu-1 in https://github.com/ceph/ceph-csi/pull/4263#discussion_r1395809088_
            