### PR TITLE
rbd: use ImageID where possible, add ParentID to prevent confusion

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1017,9 +1017,10 @@ func cleanupRBDImage(ctx context.Context,
 		}
 	}
 
-	// Deleting rbd image
+	// Deleting rbd image, it isn't a failure if the image was deleted already.
 	log.DebugLog(ctx, "deleting image %s", rbdVol.RbdImageName)
-	if err = rbdVol.deleteImage(ctx); err != nil {
+	err = rbdVol.deleteImage(ctx)
+	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		log.ErrorLog(ctx, "failed to delete rbd image: %s with error: %v",
 			rbdVol, err)
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1173,6 +1173,7 @@ func (cs *ControllerServer) CreateSnapshot(
 
 	// Update the metadata on snapshot not on the original image
 	rbdVol.RbdImageName = rbdSnap.RbdSnapName
+	rbdVol.ImageID = vol.ImageID
 	rbdVol.ClusterName = cs.ClusterName
 
 	defer func() {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -505,7 +505,14 @@ func (ri *rbdImage) open() (*librbd.Image, error) {
 		return nil, err
 	}
 
-	image, err := librbd.OpenImage(ri.ioctx, ri.RbdImageName, librbd.NoSnapshot)
+	var image *librbd.Image
+
+	// try to open by id, that works for images in trash too
+	if ri.ImageID != "" {
+		image, err = librbd.OpenImageById(ri.ioctx, ri.ImageID, librbd.NoSnapshot)
+	} else {
+		image, err = librbd.OpenImage(ri.ioctx, ri.RbdImageName, librbd.NoSnapshot)
+	}
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {
 			err = util.JoinErrors(ErrImageNotFound, err)

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -107,6 +107,8 @@ func generateVolFromSnap(rbdSnap *rbdSnapshot) *rbdVolume {
 	vol.JournalPool = rbdSnap.JournalPool
 	vol.RadosNamespace = rbdSnap.RadosNamespace
 	vol.RbdImageName = rbdSnap.RbdSnapName
+	vol.ParentName = rbdSnap.ParentName
+	vol.ParentID = rbdSnap.ParentID
 
 	// /!\ WARNING /!\
 	//

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -107,7 +107,15 @@ func generateVolFromSnap(rbdSnap *rbdSnapshot) *rbdVolume {
 	vol.JournalPool = rbdSnap.JournalPool
 	vol.RadosNamespace = rbdSnap.RadosNamespace
 	vol.RbdImageName = rbdSnap.RbdSnapName
-	vol.ImageID = rbdSnap.ImageID
+
+	// /!\ WARNING /!\
+	//
+	// Do not set the ImageID to the ID of the snapshot, a new image will
+	// be created based on the returned rbdVolume. If the ImageID is set to
+	// the ID of the snapshot, accessing the new image by ID will actually
+	// access the snapshot!
+	// vol.ImageID = rbdSnap.ImageID
+
 	// copyEncryptionConfig cannot be used here because the volume and the
 	// snapshot will have the same volumeID which cases the panic in
 	// copyEncryptionConfig function.


### PR DESCRIPTION
`librbd.OpenImageById()` works if the image is in the trash, so it makes
it possible to get the parent of the image.

When a new volume is not created yet, the ImageID should not be set to
the ID of the snapshot.

In some places the ImageID is used as the ID of the parent. That is very
confusing and prone to errors. Instead, fetch the right ImageID where
possible, and set ParentID for referencing to parent images.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
