### PR TITLE
ci: add ci bot for auto assigning issue

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,0 +1,20 @@
+---
+name: Assign issue to contributor
+# yamllint disable-line rule:truthy
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  assign:
+    name: Run self assign job
+    runs-on: ubuntu-latest
+    steps:
+      - name: take the issue
+        uses: bdougie/take-action@main
+        with:
+          message: >
+            Thanks for taking this issue!
+            Let us know if you have any questions!
+          trigger: /assign
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this will auto assign the issue to the user who
commented /assign

Similar to https://github.com/rook/rook/blob/master/.github/workflows/auto-assign.yaml 

Fixes: #4277 