### PR TITLE
ci: update minikube to v1.32.0

### DIFF
--- a/build.env
+++ b/build.env
@@ -44,7 +44,7 @@ HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 HELM_VERSION=v3.10.1
 
 # minikube settings
-MINIKUBE_VERSION=v1.31.2
+MINIKUBE_VERSION=v1.32.0
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 


### PR DESCRIPTION
No major changes that affect Ceph-CSI testing, see the linked release notes for details.

See-also: https://github.com/kubernetes/minikube/releases/tag/v1.32.0

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
