### PR TITLE
ci: update pr-commentor and mergify rules for v3.10

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -18,16 +18,16 @@ jobs:
 
     strategy:
       matrix:
-        branch: [release-v3.8, release-v3.9, devel]
+        branch: [release-v3.9, release-v3.10, devel]
         k8s: ["1.25", "1.26", "1.27", "1.28"]
         exclude:
           # the next Ceph-CSI version will not be tested with old Kubernetes
           - k8s: "1.25"
             branch: "devel"
+          - k8s: "1.25"
+            branch: "release-v3.10"
 
           # Ceph-CSI <= 3.9 was released before Kubernetes 1.28
-          - k8s: "1.28"
-            branch: "release-v3.8"
           - k8s: "1.28"
             branch: "release-v3.9"
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -284,15 +284,6 @@ pull_request_rules:
         name: default
       delete_head_branch: {}
 
-  - name: backport patches to release-v3.8 branch
-    conditions:
-      - base=devel
-      - label=backport-to-release-v3.8
-    actions:
-      backport:
-        branches:
-          - release-v3.8
-
   - name: backport patches to release-v3.9 branch
     conditions:
       - base=devel
@@ -301,6 +292,15 @@ pull_request_rules:
       backport:
         branches:
           - release-v3.9
+
+  - name: backport patches to release-v3.10 branch
+    conditions:
+      - base=devel
+      - label=backport-to-release-v3.10
+    actions:
+      backport:
+        branches:
+          - release-v3.10
 
   - name: remove outdated approvals on ci/centos
     conditions:

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,20 +1,7 @@
-# v3.10 Pending Release Notes
+# v3.11 Pending Release Notes
 
 ## Breaking Changes
 
-- Removed the deprecated grpc metrics flag's in [PR](https://github.com/ceph/ceph-csi/pull/4225)
-
-- Support for pre-creation of cephFS subvolumegroup before creating subvolume
-  is removed in [PR](https://github.com/ceph/ceph-csi/pull/4195)
-
 ## Features
 
-- Support for configuring read affinity for individuals cluster within the ceph-csi-config
-  ConfigMap in [PR](https://github.com/ceph/ceph-csi/pull/4165)
-
-- Support for CephFS kernel and fuse mount options per cluster in [PR](https://github.com/ceph/ceph-csi/pull/4245)
-
 ## NOTE
-
-- Support is limited to only the active Ceph releases. Support for EOLed Ceph
-  releases are removed [PR](https://github.com/ceph/ceph-csi/pull/4262)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

- ci: modify mergiy rules for new release-v3.10
    
    This commit adds support for v3.10 backports
    and removes support for v3.8 backports.
    

- ci: update pr-commentor rules matrix
    
    This commit adds rules for release-v3.10
    and removes rules for release-v3.8.