### PR TITLE
ci: allow Mergify to merge PRs that modify the mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,6 +16,11 @@ defaults:
       # Use ceph-csi-bot for rebasing, not the account of the PR owner.
       # bot_account: ceph-csi-bot
 
+      # by default Mergify requires manual merging of PRs that modify its own
+      # configuration (this file), allowing this makes it easier to prepare for
+      # releases (new branches added here)
+      allow_merging_configuration_change: true
+
 queue_rules:
   - name: default
     conditions:


### PR DESCRIPTION
The new `allow_merging_configuration_change` option can be enabled to

> Allow merging Mergify configuration change.

Which is useful for a more automated process when preparing for a
release.

See-also: https://docs.mergify.com/workflow/actions/merge/#parameters
Signed-off-by: Niels de Vos <ndevos@ibm.com>
