### PR TITLE
added permission to get nodes for rbd

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-clusterrole.yaml
@@ -11,9 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
-{{- if and .Values.readAffinity .Values.readAffinity.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
-{{- end }}
 {{- end -}}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -11,11 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
-{{- if .Values.topology.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
-{{- end }}
   # allow to read Vault Token and connection options from the Tenants namespace
   - apiGroups: [""]
     resources: ["secrets"]

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -125,7 +125,7 @@ func (r *Driver) Run(conf *util.Config) {
 			})
 	}
 
-	if k8s.RunsOnKubernetes() {
+	if k8s.RunsOnKubernetes() && conf.IsNodeServer {
 		nodeLabels, err = k8s.GetNodeLabels(conf.NodeID)
 		if err != nil {
 			log.FatalLogMsg(err.Error())


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Based on the implementation in rbd driver the nodeplugin should have by default permission to get nodes in order to retrieve the node labels

## Is there anything that requires special attention ##

* Related rbd driver implementation can be found [here](https://github.com/ceph/ceph-csi/blob/devel/internal/rbd/driver/driver.go#L128C1-L133C3)

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
