### PR TITLE
deploy: use release repository for csi-resizer

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -198,7 +198,7 @@ provisioner:
     name: resizer
     enabled: true
     image:
-      repository: gcr.io/k8s-staging-sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.9.2
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -248,7 +248,7 @@ provisioner:
     name: resizer
     enabled: true
     image:
-      repository: gcr.io/k8s-staging-sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.9.2
       pullPolicy: IfNotPresent
     resources: {}

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -62,7 +62,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:v1.9.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -57,7 +57,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:v1.9.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -99,7 +99,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:v1.9.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

According to https://github.com/kubernetes-csi/external-resizer/releases/tag/v1.9.2 `registry.k8s.io/sig-storage/csi-resizer` is the release repository for the csi-resizer image. I'm guessing that #4132 used the staging repo because the image tag was not yet pushed to the release repo.

## Is there anything that requires special attention ##

I've verified that it is exactly the same image digest in both the staging and release repository, so this is basically a cosmetic change only.

## Related issues ##

#4132 introduced the staging repo.

## Future concerns ##

none afaics

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
