### PR TITLE
cephFS: fix fetchIP to support more formats

### DIFF
--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -74,6 +74,11 @@ func TestFetchIP(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			clientInfo:  "client.24152 v1:100.64.0.7:0/3658550259",
+			expectedIP:  "100.64.0.7",
+			expectedErr: false,
+		},
+		{
 			clientInfo:  "",
 			expectedIP:  "",
 			expectedErr: true,


### PR DESCRIPTION
the output of` ceph tell mds.0 client ls`  returns inst to be prefixed by v1 or similar.
So adding the support for same in FetchIP, so that it can fetch correct IP from the inst of that format.

example - clientInfo:  "client.24152 v1:100.64.0.7:0/3658550259"
			expectedIP:  "100.64.0.7"