### PR TITLE
build: use Go 1.21.5

### DIFF
--- a/build.env
+++ b/build.env
@@ -19,7 +19,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v18
 CEPH_VERSION=reef
 
 # standard Golang options
-GOLANG_VERSION=1.20.4
+GOLANG_VERSION=1.21.5
 GO111MODULE=on
 
 # commitlint version

--- a/build.env
+++ b/build.env
@@ -26,7 +26,7 @@ GO111MODULE=on
 COMMITLINT_VERSION=latest
 
 # static checks and linters
-GOLANGCI_VERSION=v1.53.0
+GOLANGCI_VERSION=v1.54.1
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -10,6 +10,8 @@ FROM ${BASE_IMAGE} as updated_base
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN dnf -y update --nobest \
        && dnf -y install nfs-utils \
        && dnf clean all \

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -23,6 +23,8 @@ RUN source /build.env \
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN dnf -y install \
 	git \
 	make \

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -23,6 +23,8 @@ ENV \
 
 COPY build.env /
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN source /build.env \
     && \
     ( test -n "${GOARCH}" && exit 0; echo -e "\n\nMissing GOARCH argument for building image, install Golang or run: make containerized-test GOARCH=amd64\n\n"; exit 1 ) \


### PR DESCRIPTION
The package k8s.io/kubernetes/pkg/features requires Go 1.21 now, so
let's use that while building.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
