### PR TITLE
build: create /etc/selinux/config in case it is missing

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -10,6 +10,8 @@ FROM ${BASE_IMAGE} as updated_base
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN dnf -y update --nobest \
        && dnf -y install nfs-utils \
        && dnf clean all \

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -23,6 +23,8 @@ RUN source /build.env \
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN dnf -y install \
 	git \
 	make \

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -23,6 +23,8 @@ ENV \
 
 COPY build.env /
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN source /build.env \
     && \
     ( test -n "${GOARCH}" && exit 0; echo -e "\n\nMissing GOARCH argument for building image, install Golang or run: make containerized-test GOARCH=amd64\n\n"; exit 1 ) \


### PR DESCRIPTION
Sometimes the Ceph container images seem to have a broken scriptlet
while installing/updating Ceph packages. It is relatively common for
them to fail when `/etc/selinux/config` does not exist. By ensuring the
file directory and file exist (even if empty), the package installation
or upgrades succeed.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
(cherry picked from commit 24d6b5fe3fa9aa54a138a6ef91dede253902ee76)
