### PR TITLE
release/v3.10.1 canary

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -18,16 +18,16 @@ jobs:
 
     strategy:
       matrix:
-        branch: [release-v3.8, release-v3.9, devel]
+        branch: [release-v3.9, release-v3.10, devel]
         k8s: ["1.25", "1.26", "1.27", "1.28"]
         exclude:
           # the next Ceph-CSI version will not be tested with old Kubernetes
           - k8s: "1.25"
             branch: "devel"
+          - k8s: "1.25"
+            branch: "release-v3.10"
 
           # Ceph-CSI <= 3.9 was released before Kubernetes 1.28
-          - k8s: "1.28"
-            branch: "release-v3.8"
           - k8s: "1.28"
             branch: "release-v3.9"
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,19 +2,6 @@
 
 ## Breaking Changes
 
-- Removed the deprecated grpc metrics flag's in [PR](https://github.com/ceph/ceph-csi/pull/4225)
-
-- Support for pre-creation of cephFS subvolumegroup before creating subvolume
-  is removed in [PR](https://github.com/ceph/ceph-csi/pull/4195)
-
 ## Features
 
-- Support for configuring read affinity for individuals cluster within the ceph-csi-config
-  ConfigMap in [PR](https://github.com/ceph/ceph-csi/pull/4165)
-
-- Support for CephFS kernel and fuse mount options per cluster in [PR](https://github.com/ceph/ceph-csi/pull/4245)
-
 ## NOTE
-
-- Support is limited to only the active Ceph releases. Support for EOLed Ceph
-  releases are removed [PR](https://github.com/ceph/ceph-csi/pull/4262)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ environments.
 
 | Ceph CSI Version | Container Orchestrator Name | Version Tested     |
 | -----------------| --------------------------- | -------------------|
+| v3.10.1          | Kubernetes                  | v1.26, v1.27, v1.28|
 | v3.10.0          | Kubernetes                  | v1.26, v1.27, v1.28|
 | v3.9.0           | Kubernetes                  | v1.25, v1.26, v1.27|
 
@@ -128,6 +129,7 @@ in the Kubernetes documentation.
 | Ceph CSI Release/Branch | Container image name         | Image Tag |
 | ----------------------- | ---------------------------- | --------- |
 | devel (Branch)          | quay.io/cephcsi/cephcsi      | canary    |
+| v3.10.1 (Release)       | quay.io/cephcsi/cephcsi      | v3.10.1   |
 | v3.10.0 (Release)       | quay.io/cephcsi/cephcsi      | v3.10.0   |
 | v3.9.0 (Release)        | quay.io/cephcsi/cephcsi      | v3.9.0    |
 

--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.10-canary
+CSI_IMAGE_VERSION=v3.10.1
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.9.0

--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.10.1
+CSI_IMAGE_VERSION=v3.10-canary
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.9.0

--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.10.0
+CSI_IMAGE_VERSION=v3.10-canary
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.9.0

--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=canary
+CSI_IMAGE_VERSION=v3.10.0
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.9.0

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-clusterrole.yaml
@@ -11,9 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
-{{- if and .Values.readAffinity .Values.readAffinity.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
-{{- end }}
 {{- end -}}

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -86,7 +86,7 @@ spec:
 {{- if .Values.nodeplugin.profiling.enabled }}
             - "--enableprofiling={{ .Values.nodeplugin.profiling.enabled }}"
 {{- end }}
-            - "--enable-read-affinity={{ and .Values.readAffinity .Values.readAffinity.enabled }}"
+            - "--enable-read-affinity={{ and .Values.readAffinity .Values.readAffinity.enabled | default false }}"
 {{- if and .Values.readAffinity .Values.readAffinity.enabled }}
             - "--crush-location-labels={{ .Values.readAffinity.crushLocationLabels | join "," }}"
 {{- end }}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -99,7 +99,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.10.0
+      tag: v3.10.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -198,7 +198,7 @@ provisioner:
     name: resizer
     enabled: true
     image:
-      repository: gcr.io/k8s-staging-sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.9.2
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -99,7 +99,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: canary
+      tag: v3.10.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -99,7 +99,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.10.1
+      tag: v3.10-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -11,11 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
-{{- if .Values.topology.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
-{{- end }}
   # allow to read Vault Token and connection options from the Tenants namespace
   - apiGroups: [""]
     resources: ["secrets"]

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -87,7 +87,7 @@ spec:
 {{- if .Values.nodeplugin.profiling.enabled }}
             - "--enableprofiling={{ .Values.nodeplugin.profiling.enabled }}"
 {{- end }}
-            - "--enable-read-affinity={{ and .Values.readAffinity .Values.readAffinity.enabled }}"
+            - "--enable-read-affinity={{ and .Values.readAffinity .Values.readAffinity.enabled | default false }}"
 {{- if and .Values.readAffinity .Values.readAffinity.enabled }}
             - "--crush-location-labels={{ .Values.readAffinity.crushLocationLabels | join "," }}"
 {{- end }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -127,7 +127,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.10.0
+      tag: v3.10.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -248,7 +248,7 @@ provisioner:
     name: resizer
     enabled: true
     image:
-      repository: gcr.io/k8s-staging-sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.9.2
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -127,7 +127,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: canary
+      tag: v3.10.0
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -127,7 +127,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.10.1
+      tag: v3.10-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -10,6 +10,8 @@ FROM ${BASE_IMAGE} as updated_base
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN dnf -y update --nobest \
        && dnf -y install nfs-utils \
        && dnf clean all \

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -94,7 +94,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -142,7 +142,7 @@ spec:
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -62,7 +62,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:v1.9.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -94,7 +94,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -142,7 +142,7 @@ spec:
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -94,7 +94,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -142,7 +142,7 @@ spec:
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -94,8 +94,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin
-          # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -143,7 +142,7 @@ spec:
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -124,7 +124,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -48,8 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -125,7 +124,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -124,7 +124,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -124,7 +124,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -88,7 +88,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -120,7 +120,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -57,7 +57,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:v1.9.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -88,8 +88,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-nfsplugin
-          # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -121,7 +120,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -88,7 +88,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -120,7 +120,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -88,7 +88,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -120,7 +120,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -48,8 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -116,7 +116,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -172,7 +172,7 @@ spec:
               mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--type=controller"
             - "--v=5"
@@ -193,7 +193,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -99,7 +99,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:v1.9.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -116,7 +116,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -172,7 +172,7 @@ spec:
               mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -193,7 +193,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -116,8 +116,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin
-          # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -173,8 +172,7 @@ spec:
               mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-rbdplugin-controller
-          # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--type=controller"
             - "--v=5"
@@ -195,7 +193,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -116,7 +116,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -172,7 +172,7 @@ spec:
               mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -193,7 +193,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -134,7 +134,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10-canary
+          image: quay.io/cephcsi/cephcsi:v3.10.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -134,7 +134,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,8 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          # for stable functionality replace canary with latest release version
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -135,7 +134,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:canary
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -134,7 +134,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.0
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/internal/csi-addons/cephfs/network_fence.go
+++ b/internal/csi-addons/cephfs/network_fence.go
@@ -71,7 +71,7 @@ func (fcs *FenceControllerServer) FenceClusterNetwork(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	cr, err := util.NewUserCredentials(req.GetSecrets())
+	cr, err := util.NewAdminCredentials(req.GetSecrets())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -100,7 +100,7 @@ func (fcs *FenceControllerServer) UnfenceClusterNetwork(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	cr, err := util.NewUserCredentials(req.GetSecrets())
+	cr, err := util.NewAdminCredentials(req.GetSecrets())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -74,6 +74,11 @@ func TestFetchIP(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			clientInfo:  "client.24152 v1:100.64.0.7:0/3658550259",
+			expectedIP:  "100.64.0.7",
+			expectedErr: false,
+		},
+		{
 			clientInfo:  "",
 			expectedIP:  "",
 			expectedErr: true,

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -125,7 +125,7 @@ func (r *Driver) Run(conf *util.Config) {
 			})
 	}
 
-	if k8s.RunsOnKubernetes() {
+	if k8s.RunsOnKubernetes() && conf.IsNodeServer {
 		nodeLabels, err = k8s.GetNodeLabels(conf.NodeID)
 		if err != nil {
 			log.FatalLogMsg(err.Error())

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -23,6 +23,8 @@ RUN source /build.env \
 RUN dnf config-manager --disable \
     tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN dnf -y install \
 	git \
 	make \

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -23,6 +23,8 @@ ENV \
 
 COPY build.env /
 
+RUN mkdir /etc/selinux || true && touch /etc/selinux/config
+
 RUN source /build.env \
     && \
     ( test -n "${GOARCH}" && exit 0; echo -e "\n\nMissing GOARCH argument for building image, install Golang or run: make containerized-test GOARCH=amd64\n\n"; exit 1 ) \


### PR DESCRIPTION
- deploy: update templates to v3.10.0
- ci: update pr-commentor rules matrix
- revert: revert to 3.10-canary
- helm: add default false value for --enable-read-affinity
- helm: update node plugin cluster role
- rbd: updated node labels fetching logic
- cephfs: fix network fencing admin id
- deploy: use release repository for csi-resizer
- build: create /etc/selinux/config in case it is missing
- cephfs: fix fetchIP to support more formats
- deploy: update templates to v3.10.1
- revert: use v3.10-canary as work-in-progress version again
