### PR TITLE
revert: use v3.10-canary as work-in-progress version again

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.10.1
+CSI_IMAGE_VERSION=v3.10-canary
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.9.0

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -99,7 +99,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.10.1
+      tag: v3.10-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -127,7 +127,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.10.1
+      tag: v3.10-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -94,7 +94,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -142,7 +142,7 @@ spec:
             - name: ceph-csi-encryption-kms-config
               mountPath: /etc/ceph-csi-encryption-kms-config/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -124,7 +124,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -88,7 +88,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -120,7 +120,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10.0
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -116,7 +116,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -172,7 +172,7 @@ spec:
               mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -193,7 +193,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -134,7 +134,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.10.1
+          image: quay.io/cephcsi/cephcsi:v3.10-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
v3.10.1 has been released, we should not update the built
container-images with the same version. Use v3.10-canary for everything
that is merged in the release-v3.10 branch before we release a next
version.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
