### PR TITLE
allow modify fsGroupPolicy for csidriver

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: false
-  fsGroupPolicy: File
+  fsGroupPolicy: {{ default "File" .Values.CSIDriver.fsGroupPolicy }}
   seLinuxMount: true

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -41,6 +41,23 @@ logLevel: 5
 # sidecarLogLevel is the variable for Kubernetes sidecar container's log level
 sidecarLogLevel: 1
 
+# Set fsGroupPolicy for CSI Driver object spec
+# https://kubernetes-csi.github.io/docs/support-fsgroup.html
+# The following modes are supported:
+# - None: Indicates that volumes will be mounted with no modifications, as the
+#   CSI volume driver does not support these operations.
+# - File: Indicates that the CSI volume driver supports volume ownership and
+#   permission change via fsGroup, and Kubernetes may use fsGroup to change
+#   permissions and ownership of the volume to match user requested fsGroup in
+#   the pod's SecurityPolicy regardless of fstype or access mode.
+# - ReadWriteOnceWithFSType: Indicates that volumes will be examined to
+#   determine if volume ownership and permissions should be modified to match
+#   the pod's security policy.
+# Changes will only occur if the fsType is defined and the persistent volume's
+# accessModes contains ReadWriteOnce.
+CSIDriver:
+  fsGroupPolicy: "File"
+
 nodeplugin:
   name: nodeplugin
   # if you are using ceph-fuse client set this value to OnDelete


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
Hello!
This PR allows to modify parameter fsGroupPolicy in cephfs-csi driver.
It is useful for closing bugs like this
https://bugzilla.redhat.com/show_bug.cgi?id=2059248
For example, I faced a problem when I tried to mount the existing CephFS volume to our application with the next security parameters
```
securityContext:
  fsGroup: 82
  runAsGroup: 82
  runAsUser: 82
```
Since there are more than 1 million files in this volume it tries to chown all of them, as I understand it, and the pods get stuck in the ContainerCreating state for a very long time.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?
Yes.
Are there concerns around backward compatibility?
No.
Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
