### PR TITLE
ci: make minikube.sh work on macOS M1 with the qemu2 driver

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -200,7 +200,7 @@ if [[ "${VM_DRIVER}" == "kvm2" ]]; then
     DISK="vda1"
 fi
 
-if [[ "${VM_DRIVER}" == "kvm2" ]] || [[ "${VM_DRIVER}" == "hyperkit" ]]; then
+if [[ "${VM_DRIVER}" == "kvm2" ]] || [[ "${VM_DRIVER}" == "hyperkit" ]] || [[ "${VM_DRIVER}" == "qemu2" ]]; then
     # adding extra disks is only supported on kvm2 and hyperkit
     DISK_CONFIG=${DISK_CONFIG:-" --extra-disks=${NUM_DISKS} --disk-size=${DISK_SIZE} "}
 else
@@ -219,7 +219,7 @@ K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-""}
 
 # kubelet.resolv-conf needs to point to a file, not a symlink
 # the default minikube VM has /etc/resolv.conf -> /run/systemd/resolve/resolv.conf
-RESOLV_CONF='/run/systemd/resolve/resolv.conf'
+RESOLV_CONF="${RESOLV_CONF:-/run/systemd/resolve/resolv.conf}"
 if { [[ "${VM_DRIVER}" == "none" ]] || [[ "${VM_DRIVER}" == "podman" ]]; } && [[ ! -e "${RESOLV_CONF}" ]]; then
 	# in case /run/systemd/resolve/resolv.conf does not exist, use the
 	# standard /etc/resolv.conf (with symlink resolved)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This PR makes scripts/minikube.sh work on macOS M1 with the qemu2 driver.

To utilize minikube on macOS M1, the qemu2 VM driver is currently the only viable option. Therefore, the following modifications have been implemented:
* the RESOLV_CONF variable has been made configurable because it needs to be overridden as /etc/resolv.conf when using the qemu2 driver.
* adding additional disks when using the qemu2 driver.

Also, **the GNU sed should be used**.

Here is the usage example:

```bash
export KUBE_VERSION=v1.28.3    # it's the latest version supported by minikube v1.32.0.
export MINIKUBE_ARCH=arm64
export VM_DRIVER=qemu2         # hyperkit is unavailable for arm64, so qemu2 is the only option for macOS M1
export CNI=auto
export RESOLV_CONF=/etc/resolv.conf
export CPUS=4                  # "nproc" is unavailable on macOS, so explicitly set a number
export MEMORY=4096
export DISK_SIZE=20

./scripts/minikube.sh up
./scripts/minikube.sh deploy-rook
```

## Related issues ##

No.

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
