### PR TITLE
cephfs: make fsName as optional for static PVC

### DIFF
--- a/docs/static-pvc.md
+++ b/docs/static-pvc.md
@@ -202,9 +202,10 @@ spec:
       # node stage secret namespace where above secret is created
       namespace: default
     volumeAttributes:
+      # optional file system to be mounted
+      "fsName": "myfs"
       # Required options from storageclass parameters need to be added in volumeAttributes
       "clusterID": "ba68226a-672f-4ba5-97bc-22840318b2ec"
-      "fsName": "myfs"
       "staticVolume": "true"
       "rootPath": /volumes/testGroup/testSubVolume
     # volumeHandle can be anything, need not to be same
@@ -228,7 +229,7 @@ static CephFS PV
 |  Attributes  |                                                                     Description                                                                      | Required |
 | :----------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: | :------: |
 |  clusterID   | The clusterID is used by the CSI plugin to uniquely identify and use a Ceph cluster (this is the key in configmap created duing ceph-csi deployment) |   Yes    |
-|    fsName    |                                      CephFS filesystem name into which the subvolume should be created/present                                       |   Yes    |
+|    fsName    |                                      CephFS filesystem name to be mounted. Not passing this option mounts the default file system.                                       |   No    |
 | staticVolume |                                           Value must be set to `true` to mount and unmount static cephFS PVC                                         |   Yes    |
 |   rootPath   |                     Actual path of the subvolume in ceph cluster, can be retrieved by issuing getpath command as described above                     |   Yes    |
 

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -474,11 +474,19 @@ var _ = Describe(cephfsType, func() {
 				}
 			})
 
-			By("check static PVC", func() {
+			By("check static PVC with FsName", func() {
 				scPath := cephFSExamplePath + "secret.yaml"
-				err := validateCephFsStaticPV(f, appPath, scPath)
+				err := validateCephFsStaticPV(f, appPath, scPath, fileSystemName)
 				if err != nil {
-					framework.Failf("failed to validate CephFS static pv: %v", err)
+					framework.Failf("failed to validate CephFS static pv with filesystem name: %v", err)
+				}
+			})
+
+			By("check static PVC with without FsName", func() {
+				scPath := cephFSExamplePath + "secret.yaml"
+				err := validateCephFsStaticPV(f, appPath, scPath, "")
+				if err != nil {
+					framework.Failf("failed to validate CephFS static pv without filesystem name: %v", err)
 				}
 			})
 

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -323,7 +323,7 @@ func validateRBDStaticMigrationPVC(f *framework.Framework, appPath, scName strin
 }
 
 //nolint:gocyclo,cyclop // reduce complexity
-func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) error {
+func validateCephFsStaticPV(f *framework.Framework, appPath, scPath, fsName string) error {
 	opt := make(map[string]string)
 	var (
 		cephFsVolName = "testSubVol"
@@ -406,7 +406,9 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath string) erro
 	}
 
 	opt["clusterID"] = fsID
-	opt["fsName"] = fileSystemName
+	if fsName != "" {
+		opt["fsName"] = fsName
+	}
 	opt["staticVolume"] = strconv.FormatBool(true)
 	opt["rootPath"] = rootPath
 	pv := getStaticPV(

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -697,7 +697,7 @@ func NewVolumeOptionsFromStaticVolume(
 		return nil, nil, err
 	}
 
-	if err = extractOption(&opts.FsName, "fsName", options); err != nil {
+	if err = extractOptionalOption(&opts.FsName, "fsName", options); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
consider fsName optional for static volume as it is not required to be set during mount operation with fuse and kernel client.


fixes: #4311 