### PR TITLE
ci: retry pulling container images up to 10x

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -38,8 +38,28 @@ def create_duffy_config() {
 // pulling from the destination registry.
 //
 // Images need to be pre-pushed into the source registry, though.
+//
+// On occasion pulling images is not stable due to a broken proxy in the CI
+// environment. For that, try pulling the image up to 10x.
 def podman_pull(source, destination, image) {
-	ssh "podman pull --authfile=~/.podman-auth.json ${source}/${image} && podman tag ${source}/${image} ${image} ${destination}/${image}"
+	def failed = null
+
+	for (i in 0..9) {
+		try {
+			ssh "podman pull --authfile=~/.podman-auth.json ${source}/${image} && podman tag ${source}/${image} ${image} ${destination}/${image}"
+			failed = null
+			break
+		}
+		catch (err) {
+			failed = err
+			// failed to pull image, but try again
+		}
+	}
+
+	// if the last pull failed, throw the error
+	if (failed != null) {
+		throw failed
+	}
 }
 
 node('cico-workspace') {


### PR DESCRIPTION
There seems to be some failing network component in the CI environment
that prevents pulling container images. Even pulling it from the
registry to my laptop fails often, but with a few retries everything
gets pulled eventually.

This PR is a test to see if the logic in Groovy is correct. If it works, I'll update other CI jobs with this as well.