### PR TITLE
ci: allow missing `RUN_DISPLAY_URL` variable in Jenkins Jobs

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -2,7 +2,7 @@ WORKDIR ?= $(CURDIR)/../
 OUTPUT ?= $(WORKDIR)/_output/
 
 test:
-	cd $(WORKDIR) && jenkins-jobs test -o $(OUTPUT) jobs
+	cd $(WORKDIR) && jenkins-jobs test --allow-empty-variables -o $(OUTPUT) jobs
 
 deploy:
-	cd $(WORKDIR) && jenkins-jobs update --delete-old jobs
+	cd $(WORKDIR) && jenkins-jobs update --allow-empty-variables --delete-old jobs


### PR DESCRIPTION
The `RUN_DISPLAY_URL` is automatically set by Jenkins, but it seems the
latest Jenkins Jobs Builder update does not detect it automatically.
Run the JJB commands with `--allow-empty-variables`.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
