### PR TITLE
ci: the order of `--allow-empty-variables` for `jenkins-jobs` is important

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -2,7 +2,7 @@ WORKDIR ?= $(CURDIR)/../
 OUTPUT ?= $(WORKDIR)/_output/
 
 test:
-	cd $(WORKDIR) && jenkins-jobs test --allow-empty-variables -o $(OUTPUT) jobs
+	cd $(WORKDIR) && jenkins-jobs --allow-empty-variables test -o $(OUTPUT) jobs
 
 deploy:
-	cd $(WORKDIR) && jenkins-jobs update --allow-empty-variables --delete-old jobs
+	cd $(WORKDIR) && jenkins-jobs --allow-empty-variables update --delete-old jobs


### PR DESCRIPTION
Jenkins Jobs Builder fails like this, indicating the order of the
parameters is important:

```
$ jenkins-jobs update --allow-empty-variables --delete-old jobs
usage: jenkins-jobs [-h] [--conf CONF] [-l LOG_LEVEL] [--ignore-cache]
                    [--flush-cache] [--version] [--allow-empty-variables]
                    [--server SECTION] [--user USER] [--password PASSWORD]
                    {delete,delete-all,get-plugins-info,list,test,update} ...
jenkins-jobs: error: unrecognized arguments: --allow-empty-variables
```

Signed-off-by: Niels de Vos <ndevos@ibm.com>
