### PR TITLE
ci: replace inline `dsl:` script by Groovy files

### DIFF
--- a/jjb-deploy.groovy
+++ b/jjb-deploy.groovy
@@ -1,0 +1,16 @@
+node {
+  stage('build-images') {
+    parallel jjb: {
+      sh "oc start-build --follow jjb"
+    },
+    mirror_images: {
+      sh 'oc start-build --follow mirror-images'
+    }
+  }
+  stage('checkout ci repository') {
+    git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
+  }
+  stage('deployment') {
+    sh "./deploy/jjb.sh --cmd deploy --GIT_REF ${GIT_BRANCH} --GIT_REPO ${GIT_REPO}"
+  }
+}

--- a/jjb-validate.groovy
+++ b/jjb-validate.groovy
@@ -1,0 +1,14 @@
+if (params.ghprbPullId != null) {
+    GIT_BRANCH = "pull/${ghprbPullId}/merge"
+}
+
+node {
+  stage('checkout ci repository') {
+    checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
+      userRemoteConfigs: [[url: "${GIT_REPO}",
+        refspec: "${GIT_BRANCH}"]]])
+  }
+  stage('validation') {
+    sh "./deploy/jjb.sh --cmd validate --GIT_REF ${GIT_BRANCH} --GIT_REPO ${GIT_REPO}"
+  }
+}

--- a/jobs/build-images.yaml
+++ b/jobs/build-images.yaml
@@ -15,9 +15,9 @@
         git:
           url: https://github.com/ceph/ceph-csi
           branches:
-            - ci/devel
+            - ci/centos
       script-path: build-images.groovy
-      lightweight-checkout: true
+      lightweight-checkout: false
     scm:
       - git:
           name: origin

--- a/jobs/jjb-deploy.yaml
+++ b/jobs/jjb-deploy.yaml
@@ -18,24 +18,14 @@
       - build-discarder:
           days-to-keep: 7
           artifact-days-to-keep: 7
-    dsl: |
-      node {
-        stage('build-images') {
-          parallel jjb: {
-            sh "oc start-build --follow jjb"
-          },
-          mirror_images: {
-            sh 'oc start-build --follow mirror-images'
-          }
-        }
-        stage('checkout ci repository') {
-          git url: "${GIT_REPO}", branch: "${GIT_BRANCH}", changelog: false
-        }
-        stage('deployment') {
-          sh "./deploy/jjb.sh --cmd deploy \
-              --GIT_REF ${GIT_BRANCH} --GIT_REPO ${GIT_REPO}"
-        }
-      }
+    pipeline-scm:
+      scm:
+        git:
+          url: https://github.com/ceph/ceph-csi
+          branches:
+            - ci/centos
+      script-path: jjb-deploy.groovy
+      lightweight-checkout: false
     scm:
       - git:
           name: origin

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -18,22 +18,14 @@
       - build-discarder:
           days-to-keep: 7
           artifact-days-to-keep: 7
-    dsl: |
-      if (params.ghprbPullId != null) {
-          GIT_BRANCH = "pull/${ghprbPullId}/merge"
-      }
-
-      node {
-        stage('checkout ci repository') {
-          checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
-            userRemoteConfigs: [[url: "${GIT_REPO}",
-              refspec: "${GIT_BRANCH}"]]])
-        }
-        stage('validation') {
-          sh "./deploy/jjb.sh --cmd validate \
-              --GIT_REF ${GIT_BRANCH} --GIT_REPO ${GIT_REPO}"
-        }
-      }
+    pipeline-scm:
+      scm:
+        git:
+          url: https://github.com/ceph/ceph-csi
+          branches:
+            - ci/centos
+      script-path: jjb-validate.groovy
+      lightweight-checkout: false
     triggers:
       - github-pull-request:
           status-url: ${RUN_DISPLAY_URL}


### PR DESCRIPTION
Jenkins Jobs Builder does not like the inline `dsl:` scripts anymore, so
replace them by Groovy files in the main directory, similar to other
jobs.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
