### PR TITLE
ci: correct the format of `pipeline-scm.scm`

### DIFF
--- a/jobs/build-images.yaml
+++ b/jobs/build-images.yaml
@@ -12,10 +12,10 @@
           artifact-days-to-keep: 7
     pipeline-scm:
       scm:
-        git:
-          url: https://github.com/ceph/ceph-csi
-          branches:
-            - ci/centos
+        - git:
+            url: https://github.com/ceph/ceph-csi
+            branches:
+              - ci/centos
       script-path: build-images.groovy
       lightweight-checkout: false
     scm:

--- a/jobs/jjb-deploy.yaml
+++ b/jobs/jjb-deploy.yaml
@@ -20,10 +20,10 @@
           artifact-days-to-keep: 7
     pipeline-scm:
       scm:
-        git:
-          url: https://github.com/ceph/ceph-csi
-          branches:
-            - ci/centos
+        - git:
+            url: https://github.com/ceph/ceph-csi
+            branches:
+              - ci/centos
       script-path: jjb-deploy.groovy
       lightweight-checkout: false
     scm:

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -20,10 +20,10 @@
           artifact-days-to-keep: 7
     pipeline-scm:
       scm:
-        git:
-          url: https://github.com/ceph/ceph-csi
-          branches:
-            - ci/centos
+        - git:
+            url: https://github.com/ceph/ceph-csi
+            branches:
+              - ci/centos
       script-path: jjb-validate.groovy
       lightweight-checkout: false
     triggers:


### PR DESCRIPTION
It seems the `git` component of `pipeline-scm.scm` needs to be a list.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
