### PR TITLE
ci: update install-snapshot script to deploy newer version of snapshotter

### DIFF
--- a/build.env
+++ b/build.env
@@ -30,7 +30,7 @@ GOLANGCI_VERSION=v1.54.1
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases
-SNAPSHOT_VERSION=v6.2.2
+SNAPSHOT_VERSION=v7.0.1
 
 # "go test" configuration
 # set to stdout or html to enable coverage reporting, disabled by default

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -37,19 +37,19 @@ function install_snapshot_controller() {
 
     create_or_delete_resource "create" "${namespace}"
 
-    pod_ready=$(kubectl_retry get pods -l app=snapshot-controller -n "${namespace}" -o jsonpath='{.items[0].status.containerStatuses[0].ready}')
+    pod_ready=$(kubectl_retry get pods -l app.kubernetes.io/name=snapshot-controller -n "${namespace}" -o jsonpath='{.items[0].status.containerStatuses[0].ready}')
     INC=0
     until [[ "${pod_ready}" == "true" || $INC -gt 20 ]]; do
         sleep 10
         ((++INC))
-        pod_ready=$(kubectl_retry get pods -l app=snapshot-controller -n "${namespace}" -o jsonpath='{.items[0].status.containerStatuses[0].ready}')
+        pod_ready=$(kubectl_retry get pods -l app.kubernetes.io/name=snapshot-controller -n "${namespace}" -o jsonpath='{.items[0].status.containerStatuses[0].ready}')
         echo "snapshotter pod status: ${pod_ready}"
     done
 
     if [ "${pod_ready}" != "true" ]; then
         echo "snapshotter controller creation failed"
-        kubectl_retry get pods -l app=snapshot-controller -n "${namespace}"
-        kubectl_retry describe po -l app=snapshot-controller -n "${namespace}"
+        kubectl_retry get pods -l app.kubernetes.io/name=snapshot-controller -n "${namespace}"
+        kubectl_retry describe po -l app.kubernetes.io/name=snapshot-controller -n "${namespace}"
         exit 1
     fi
 

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -98,12 +98,6 @@ function create_or_delete_resource() {
     kubectl "${operation}" -f "${VOLUME_SNAPSHOT}"
 }
 
-function delete_snapshot_crd() {
-    kubectl delete -f "${SNAPSHOTCLASS}" --ignore-not-found
-    kubectl delete -f "${VOLUME_SNAPSHOT_CONTENT}" --ignore-not-found
-    kubectl delete -f "${VOLUME_SNAPSHOT}" --ignore-not-found
-}
-
 case "${1:-}" in
 install)
     install_snapshot_controller "$2"

--- a/scripts/install-snapshot.sh
+++ b/scripts/install-snapshot.sh
@@ -71,7 +71,7 @@ function create_or_delete_resource() {
     curl -o "${temp_snap_controller}" "${SNAPSHOT_CONTROLLER}"
     sed -i "s/namespace: kube-system/namespace: ${namespace}/g" "${temp_rbac}"
     sed -i "s/namespace: kube-system/namespace: ${namespace}/g" "${temp_snap_controller}"
-    sed -i "s/canary/${SNAPSHOT_VERSION}/g" "${temp_snap_controller}"
+    sed -i -E "s/(image: registry\.k8s\.io\/sig-storage\/snapshot-controller:).*$/\1$SNAPSHOT_VERSION/g" "${temp_snap_controller}"
 
     if [ "${operation}" == "create" ]; then
         # Argument to add/update


### PR DESCRIPTION
Updated the `install-snapshot.sh`  to support installing of new snapshotter version and also to enable volumegroupsnapshot flag during installation. Used `kubectl_retry` helper to retry if there is any failure.

updates #4435 