### PR TITLE
rebase: use Helm client 3.14.1 for generating charts

### DIFF
--- a/build.env
+++ b/build.env
@@ -41,7 +41,7 @@ SNAPSHOT_VERSION=v7.0.1
 HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 
 # helm chart generation, testing and publishing
-HELM_VERSION=v3.10.1
+HELM_VERSION=v3.14.1
 
 # minikube settings
 MINIKUBE_VERSION=v1.32.0


### PR DESCRIPTION
By using version 3.14.1 of the client for generating Helm charts, users
are prevented to run into a security issue when they manually create the
charts.

The automatically generated Helm charts are not affected by this issue.

Fixes: CVE-2024-25620