### PR TITLE
ci: prepare Jenkins jobs for Kubernetes 1.30

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -12,6 +12,8 @@
           only_run_on_request: true
       - '1.29':
           only_run_on_request: true
+      - '1.30':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -12,6 +12,8 @@
           only_run_on_request: true
       - '1.29':
           only_run_on_request: true
+      - '1.30':
+          only_run_on_request: true
     test_type:
       - 'cephfs'
       - 'rbd'


### PR DESCRIPTION
Kubernetes 1.30 is in Alpha state, it should be usable for testing
Ceph-CSI against now.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
