### PR TITLE
fscrypt: create a new blank key sized according to the passphrase

### DIFF
--- a/internal/util/fscrypt/fscrypt.go
+++ b/internal/util/fscrypt/fscrypt.go
@@ -58,6 +58,11 @@ var policyV2Support = []util.KernelVersion{
 	},
 }
 
+// error values
+var (
+	ErrBadAuth = errors.New("key authentication check failed")
+)
+
 func AppendEncyptedSubdirectory(dir string) string {
 	return path.Join(dir, FscryptSubdir)
 }
@@ -97,6 +102,10 @@ func createKeyFuncFromVolumeEncryption(
 	volID string,
 ) (func(fscryptactions.ProtectorInfo, bool) (*fscryptcrypto.Key, error), error) {
 	keyFunc := func(info fscryptactions.ProtectorInfo, retry bool) (*fscryptcrypto.Key, error) {
+		if retry {
+			return nil, ErrBadAuth
+		}
+
 		passphrase, err := getPassphrase(ctx, encryption, volID)
 		if err != nil {
 			return nil, err
@@ -375,7 +384,7 @@ func Unlock(
 		return err
 	}
 
-	// A proper set up fscrypy directory requires metadata and a kernel policy:
+	// A proper set up fscrypt directory requires metadata and a kernel policy:
 
 	// 1. Do we have a metadata directory (.fscrypt) set up?
 	metadataDirExists := false


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

Padding a passphrase with null chars to arrive at a 32-byte length
later forces a user to also pass null chars via the term when
attempting to manually unlock a subvolume via the fscrypt cli tools.

This also had a side-effect of truncating any longer length passphrase
down to a shorter 32-byte length.

fixup for:
https://github.com/ceph/ceph-csi/commit/cfea8d756231e7eda5150e33a7f5711cfcf3aafb
https://github.com/ceph/ceph-csi/commit/dd0e1988c08e75ce9564854eab93bb0826a9532d


## Is there anything that requires special attention ##

Backward compatibility is provided to unlock subvolumes that might have been created using the old style null-padded passphrase

This PR also includes an additional fix for a related issue where fscrypt was allowed to indefinitely retry the `keyFn` after an auth failure, which can block subsequent requests to the ceph csi driver.

## Related issues ##

n/a

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
