### PR TITLE
ci: add gosec for golang security scanning

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -1,0 +1,19 @@
+---
+name: Run Gosec
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - devel
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...


### PR DESCRIPTION
Adding gosec security scanning as a CI job to run on each PR to ensure we are good with security problems.

More details at https://github.com/securego/gosec


@nixpanic @Rakshith-R @yati1998 @iPraveenParihar Do you guys prefer to run it on each PR or as a cronjob?

Note:-
Based on above response need to modify mergify rules