### PR TITLE
helm: Include seLinuxMount only if KubeVersion greater or equal of 1.25

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -6,4 +6,6 @@ spec:
   attachRequired: false
   podInfoOnMount: false
   fsGroupPolicy: {{ default "File" .Values.CSIDriver.fsGroupPolicy }}
+{{- if semverCompare ">= 1.25.x" .Capabilities.KubeVersion.Version }}
   seLinuxMount: true
+{{- end }}

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -6,4 +6,6 @@ spec:
   attachRequired: true
   podInfoOnMount: false
   fsGroupPolicy: File
+{{- if semverCompare ">= 1.25.x" .Capabilities.KubeVersion.Version }}
   seLinuxMount: true
+{{- end }}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Fix chart to be compatible with kube version lower then 1.25.0

## Is there anything that requires special attention ##

Do you have any questions?
Yes, I don't see where to bounce helm chart version, `version: 3-canary` looks not legit

Is the change backward compatible?
Yes

Are there concerns around backward compatibility?
No

Provide any external context for the change, if any.
Desribed in issue #4474

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #4474 
Fixes: #4437

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
