### PR TITLE
cleanup: use real version for k8s.io/pod-security-admission instead of v0.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/kubernetes v1.29.2
 	k8s.io/mount-utils v0.29.2
-	k8s.io/pod-security-admission v0.0.0
+	k8s.io/pod-security-admission v0.29.2
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.17.2
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1576,7 +1576,7 @@ k8s.io/kubernetes/test/utils/kubeconfig
 # k8s.io/mount-utils v0.29.2 => k8s.io/mount-utils v0.29.2
 ## explicit; go 1.21
 k8s.io/mount-utils
-# k8s.io/pod-security-admission v0.0.0 => k8s.io/pod-security-admission v0.29.2
+# k8s.io/pod-security-admission v0.29.2 => k8s.io/pod-security-admission v0.29.2
 ## explicit; go 1.21
 k8s.io/pod-security-admission/api
 k8s.io/pod-security-admission/policy


### PR DESCRIPTION
The version v0.0.0 looks incorrect in go.mod, use the latest version
like all other Kubernetes modules.

There are no changes in code or vendored files, only in comments.