### PR TITLE
cleanup: don't return an internal type from VolumeGroupJournal.Connect()

### DIFF
--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -36,7 +36,7 @@ type VolumeGroupJournal interface {
 	Connect(
 		monitors,
 		namespace string,
-		cr *util.Credentials) (*volumeGroupJournalConfig, error)
+		cr *util.Credentials) error
 	// Destroy frees any resources and invalidates the journal connection.
 	Destroy()
 	// SetNamespace sets the namespace for the journal.
@@ -115,14 +115,14 @@ func (sgj *volumeGroupJournalConfig) Connect(
 	monitors,
 	namespace string,
 	cr *util.Credentials,
-) (*volumeGroupJournalConfig, error) {
+) error {
 	conn, err := sgj.Config.Connect(monitors, namespace, cr)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	sgj.Connection = conn
 
-	return sgj, nil
+	return nil
 }
 
 func (sgj *volumeGroupJournalConfig) Destroy() {


### PR DESCRIPTION
The VolumeGroupJournal interface does not need to return anything except for a potential error. Any instance that implements the VolumeGroupJournal interface can be used to call all functions.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
