### PR TITLE
cleanup: correct typo in `NewCSIVolumeroupJournal()` function

### DIFF
--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -84,8 +84,8 @@ type volumeGroupJournalConfig struct {
 	*Connection
 }
 
-// NewCSIVolumeroupJournal returns an instance of VolumeGroupJournal for groups.
-func NewCSIVolumeroupJournal(suffix string) VolumeGroupJournal {
+// NewCSIVolumeGroupJournal returns an instance of VolumeGroupJournal for groups.
+func NewCSIVolumeGroupJournal(suffix string) VolumeGroupJournal {
 	return &volumeGroupJournalConfig{
 		Config: &Config{
 			csiDirectory:            "csi.groups." + suffix,
@@ -105,7 +105,7 @@ func (sgj *volumeGroupJournalConfig) SetNamespace(ns string) {
 // NewCSIVolumeGroupJournalWithNamespace returns an instance of VolumeGroupJournal for
 // volume groups using a predetermined namespace value.
 func NewCSIVolumeGroupJournalWithNamespace(suffix, ns string) VolumeGroupJournal {
-	j := NewCSIVolumeroupJournal(suffix)
+	j := NewCSIVolumeGroupJournal(suffix)
 	j.SetNamespace(ns)
 
 	return j


### PR DESCRIPTION
The name of the function should be `NewCSIVolumeGroupJournal()`.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
