### PR TITLE
cleanup: do not pass EncodingVersion to `GenerateVolID()`

### DIFF
--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -192,7 +192,7 @@ func CheckVolExists(ctx context.Context,
 
 	// found a volume already available, process and return it!
 	vid.VolumeID, err = util.GenerateVolID(ctx, volOptions.Monitors, cr, volOptions.FscID,
-		"", volOptions.ClusterID, imageUUID, fsutil.VolIDVersion)
+		"", volOptions.ClusterID, imageUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +299,7 @@ func ReserveVol(ctx context.Context, volOptions *VolumeOptions, secret map[strin
 	volOptions.VolID = vid.FsSubvolName
 	// generate the volume ID to return to the CO system
 	vid.VolumeID, err = util.GenerateVolID(ctx, volOptions.Monitors, cr, volOptions.FscID,
-		"", volOptions.ClusterID, imageUUID, fsutil.VolIDVersion)
+		"", volOptions.ClusterID, imageUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func ReserveSnap(
 
 	// generate the snapshot ID to return to the CO system
 	vid.SnapshotID, err = util.GenerateVolID(ctx, volOptions.Monitors, cr, volOptions.FscID,
-		"", volOptions.ClusterID, imageUUID, fsutil.VolIDVersion)
+		"", volOptions.ClusterID, imageUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +453,7 @@ func CheckSnapExists(
 
 	// found a snapshot already available, process and return it!
 	sid.SnapshotID, err = util.GenerateVolID(ctx, volOptions.Monitors, cr, volOptions.FscID,
-		"", volOptions.ClusterID, snapUUID, fsutil.VolIDVersion)
+		"", volOptions.ClusterID, snapUUID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cephfs/util/util.go
+++ b/internal/cephfs/util/util.go
@@ -20,9 +20,6 @@ package util
 type VolumeID string
 
 const (
-	// VolIDVersion is the version number of volume ID encoding scheme.
-	VolIDVersion uint16 = 1
-
 	// RadosNamespace to store CSI specific objects and keys.
 	RadosNamespace = "csi"
 )

--- a/internal/rbd/globals.go
+++ b/internal/rbd/globals.go
@@ -22,11 +22,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/journal"
 )
 
-const (
-	// volIDVersion is the version number of volume ID encoding scheme.
-	volIDVersion uint16 = 1
-)
-
 var (
 	// CSIInstanceID is the instance ID that is unique to an instance of CSI, used when sharing
 	// ceph clusters across CSI instances, to differentiate omap names per CSI instance.

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -192,7 +192,7 @@ func checkSnapCloneExists(
 	rbdSnap.VolSize = vol.VolSize
 	// found a snapshot already available, process and return its information
 	rbdSnap.VolID, err = util.GenerateVolID(ctx, rbdSnap.Monitors, cr, snapData.ImagePoolID, rbdSnap.Pool,
-		rbdSnap.ClusterID, snapUUID, volIDVersion)
+		rbdSnap.ClusterID, snapUUID)
 	if err != nil {
 		return false, err
 	}
@@ -328,7 +328,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 
 	// found a volume already available, process and return it!
 	rv.VolID, err = util.GenerateVolID(ctx, rv.Monitors, rv.conn.Creds, imageData.ImagePoolID, rv.Pool,
-		rv.ClusterID, rv.ReservedID, volIDVersion)
+		rv.ClusterID, rv.ReservedID)
 	if err != nil {
 		return false, err
 	}
@@ -405,7 +405,7 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 	}
 
 	rbdSnap.VolID, err = util.GenerateVolID(ctx, rbdSnap.Monitors, cr, imagePoolID, rbdSnap.Pool,
-		rbdSnap.ClusterID, rbdSnap.ReservedID, volIDVersion)
+		rbdSnap.ClusterID, rbdSnap.ReservedID)
 	if err != nil {
 		return err
 	}
@@ -482,7 +482,7 @@ func reserveVol(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnapshot, cr
 	}
 
 	rbdVol.VolID, err = util.GenerateVolID(ctx, rbdVol.Monitors, cr, imagePoolID, rbdVol.Pool,
-		rbdVol.ClusterID, rbdVol.ReservedID, volIDVersion)
+		rbdVol.ClusterID, rbdVol.ReservedID)
 	if err != nil {
 		return err
 	}
@@ -640,7 +640,7 @@ func RegenerateJournal(
 		}
 		// As the omap already exists for this image ID return nil.
 		rbdVol.VolID, err = util.GenerateVolID(ctx, rbdVol.Monitors, cr, imagePoolID, rbdVol.Pool,
-			rbdVol.ClusterID, rbdVol.ReservedID, volIDVersion)
+			rbdVol.ClusterID, rbdVol.ReservedID)
 		if err != nil {
 			return "", err
 		}
@@ -665,7 +665,7 @@ func RegenerateJournal(
 		}
 	}()
 	rbdVol.VolID, err = util.GenerateVolID(ctx, rbdVol.Monitors, cr, imagePoolID, rbdVol.Pool,
-		rbdVol.ClusterID, rbdVol.ReservedID, volIDVersion)
+		rbdVol.ClusterID, rbdVol.ReservedID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -286,7 +286,6 @@ func GenerateVolID(
 	cr *Credentials,
 	locationID int64,
 	pool, clusterID, objUUID string,
-	volIDVersion uint16,
 ) (string, error) {
 	var err error
 
@@ -299,10 +298,9 @@ func GenerateVolID(
 
 	// generate the volume ID to return to the CO system
 	vi := CSIIdentifier{
-		LocationID:      locationID,
-		EncodingVersion: volIDVersion,
-		ClusterID:       clusterID,
-		ObjectUUID:      objUUID,
+		LocationID: locationID,
+		ClusterID:  clusterID,
+		ObjectUUID: objUUID,
 	}
 
 	volID, err := vi.ComposeCSIID()

--- a/internal/util/volid_test.go
+++ b/internal/util/volid_test.go
@@ -34,7 +34,7 @@ var testData = []testTuple{
 	{
 		vID: CSIIdentifier{
 			LocationID:      0xffff,
-			EncodingVersion: 0xffff,
+			encodingVersion: 0xffff,
 			ClusterID:       "01616094-9d93-4178-bf45-c7eac19e8b15",
 			ObjectUUID:      "00000000-1111-2222-bbbb-cacacacacaca",
 		},


### PR DESCRIPTION
The only encoding version that exists is `1`. There is no need to have multiple constants for that version across different packages. Because there is only one version, `GenerateVolID()` does not really require it, and it can use a default version.

If there is a need in the future to support an other encoding version, this can be revisited with a cleaner solution.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
