### PR TITLE
rbd: remove topologyConstrainedPools parameter

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -240,8 +240,7 @@ func (cs *ControllerServer) parseVolCreateRequest(
 }
 
 func buildCreateVolumeResponse(req *csi.CreateVolumeRequest, rbdVol *rbdVolume) *csi.CreateVolumeResponse {
-	// remove kubernetes csi prefixed parameters.
-	volumeContext := k8s.RemoveCSIPrefixedParameters(req.GetParameters())
+	volumeContext := util.GetVolumeContext(req.GetParameters())
 	volumeContext["pool"] = rbdVol.Pool
 	volumeContext["journalPool"] = rbdVol.JournalPool
 	volumeContext["imageName"] = rbdVol.RbdImageName

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -363,7 +364,7 @@ func attachRBDImage(ctx context.Context, volOptions *rbdVolume, device string, c
 }
 
 func appendNbdDeviceTypeAndOptions(cmdArgs []string, userOptions, cookie string) []string {
-	isUnmap := util.CheckSliceContains(cmdArgs, "unmap")
+	isUnmap := slices.Contains(cmdArgs, "unmap")
 	if !isUnmap {
 		if !strings.Contains(userOptions, useNbdNetlink) {
 			cmdArgs = append(cmdArgs, "--"+useNbdNetlink)

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -353,7 +353,6 @@ func attachRBDImage(ctx context.Context, volOptions *rbdVolume, device string, c
 		}
 
 		err = waitForrbdImage(ctx, backoff, volOptions)
-
 		if err != nil {
 			return "", err
 		}
@@ -364,7 +363,7 @@ func attachRBDImage(ctx context.Context, volOptions *rbdVolume, device string, c
 }
 
 func appendNbdDeviceTypeAndOptions(cmdArgs []string, userOptions, cookie string) []string {
-	isUnmap := CheckSliceContains(cmdArgs, "unmap")
+	isUnmap := util.CheckSliceContains(cmdArgs, "unmap")
 	if !isUnmap {
 		if !strings.Contains(userOptions, useNbdNetlink) {
 			cmdArgs = append(cmdArgs, "--"+useNbdNetlink)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2071,17 +2071,6 @@ func getCephClientLogFileName(id, logDir, prefix string) string {
 	return fmt.Sprintf("%s/%s-%s.log", logDir, prefix, id)
 }
 
-// CheckSliceContains checks the slice for string.
-func CheckSliceContains(options []string, opt string) bool {
-	for _, o := range options {
-		if o == opt {
-			return true
-		}
-	}
-
-	return false
-}
-
 // strategicActionOnLogFile act on log file based on cephLogStrategy.
 func strategicActionOnLogFile(ctx context.Context, logStrategy, logFile string) {
 	var err error

--- a/internal/util/topology.go
+++ b/internal/util/topology.go
@@ -30,6 +30,9 @@ import (
 const (
 	keySeparator   rune   = '/'
 	labelSeparator string = ","
+
+	// topologyPoolsParam is the parameter name used to pass topology constrained pools.
+	topologyPoolsParam = "topologyConstrainedPools"
 )
 
 // GetTopologyFromDomainLabels returns the CSI topology map, determined from
@@ -129,7 +132,7 @@ func GetTopologyFromRequest(
 	var topologyPools []TopologyConstrainedPool
 
 	// check if parameters have pool configuration pertaining to topology
-	topologyPoolsStr := req.GetParameters()["topologyConstrainedPools"]
+	topologyPoolsStr := req.GetParameters()[topologyPoolsParam]
 	if topologyPoolsStr == "" {
 		return nil, nil, nil
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -383,17 +383,6 @@ func CallStack() string {
 	return string(stack)
 }
 
-// CheckSliceContains checks the slice for string.
-func CheckSliceContains(options []string, opt string) bool {
-	for _, o := range options {
-		if o == opt {
-			return true
-		}
-	}
-
-	return false
-}
-
 // GetVolumeContext filters out parameters that are not required in volume context.
 func GetVolumeContext(parameters map[string]string) map[string]string {
 	volumeContext := map[string]string{}
@@ -403,7 +392,7 @@ func GetVolumeContext(parameters map[string]string) map[string]string {
 		topologyPoolsParam,
 	}
 	for k, v := range parameters {
-		if !CheckSliceContains(notRequiredParams, k) {
+		if !slices.Contains(notRequiredParams, k) {
 			volumeContext[k] = v
 		}
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"golang.org/x/sys/unix"
@@ -380,4 +381,35 @@ func CallStack() string {
 	_ = runtime.Stack(stack, false)
 
 	return string(stack)
+}
+
+// CheckSliceContains checks the slice for string.
+func CheckSliceContains(options []string, opt string) bool {
+	for _, o := range options {
+		if o == opt {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetVolumeContext filters out parameters that are not required in volume context.
+func GetVolumeContext(parameters map[string]string) map[string]string {
+	volumeContext := map[string]string{}
+
+	// parameters that are not required in the volume context
+	notRequiredParams := []string{
+		topologyPoolsParam,
+	}
+	for k, v := range parameters {
+		if !CheckSliceContains(notRequiredParams, k) {
+			volumeContext[k] = v
+		}
+	}
+
+	// remove kubernetes csi prefixed parameters.
+	volumeContext = k8s.RemoveCSIPrefixedParameters(volumeContext)
+
+	return volumeContext
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit removes the `topologyConstrainedPools` parameter from PV volumeAttributes as it is not required.

## Related issues ##

Fixes: #4497 

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
