### PR TITLE
doc: added note about monitor ips update during failover

### DIFF
--- a/docs/design/proposals/clusterid-mapping.md
+++ b/docs/design/proposals/clusterid-mapping.md
@@ -178,3 +178,10 @@ operation from the primary cluster to a remote cluster. The existing volumes
 that are created on the remote cluster does not require any mapping as the
 volumeHandle already contains the required information about the local cluster (
 clusterID, poolID etc).
+
+**Note:-** To use a mirrored and promoted RBD image on a secondary site during a
+failover, you need to replace the primary monitor addresses with the IP
+addresses of the secondary cluster in the ceph-csi-config. Otherwise, Ceph-CSI
+won't be able to use the volumes, and application pods will become stuck in the
+`ContainerCreating` state. Thus, during failover, both clusters will have the
+same monitor IP addresses.


### PR DESCRIPTION
Docs update: IP addresses in csi-config-map needs to be changed after failover to secondary site. Without this change, applications can't use mirrored rbd images.

## Is there anything that requires special attention ##

Only documentation update.

## Related issues ##

Fixes: #4493

## Future concerns ##

No future concerns

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
