### PR TITLE
rbd: VolumeGroupSnapshot support

### DIFF
--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -199,6 +199,7 @@ func NewCSISnapshotJournal(suffix string) *Config {
 		cephSnapSourceKey:       "csi.source",
 		namespace:               "",
 		csiImageIDKey:           "csi.imageid",
+		csiGroupIDKey:           "csi.groupid",
 		encryptKMSKey:           "csi.volume.encryptKMS",
 		encryptionType:          "csi.volume.encryptionType",
 		ownerKey:                "csi.volume.owner",
@@ -805,7 +806,8 @@ func (conn *Connection) StoreAttribute(ctx context.Context, pool, reservedUUID, 
 
 // StoreGroupID stores an groupID in omap.
 func (conn *Connection) StoreGroupID(ctx context.Context, pool, reservedUUID, groupID string) error {
-	err := conn.StoreAttribute(ctx, pool, reservedUUID, conn.config.csiGroupIDKey, groupID)
+	err := setOMapKeys(ctx, conn, pool, conn.config.namespace, conn.config.cephUUIDDirectoryPrefix+reservedUUID,
+		map[string]string{conn.config.csiGroupIDKey: groupID})
 	if err != nil {
 		return fmt.Errorf("failed to store groupID %w", err)
 	}

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -25,6 +25,7 @@ import (
 	csiaddons "github.com/ceph/ceph-csi/internal/csi-addons/server"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/rbd"
+	"github.com/ceph/ceph-csi/internal/rbd/features"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -123,6 +124,19 @@ func (r *Driver) Run(conf *util.Config) {
 				csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
 				csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
 			})
+
+		// GroupSnapGetInfo is used within the VolumeGroupSnapshot implementation
+		vgsSupported, vgsErr := features.SupportsGroupSnapGetInfo()
+		if vgsSupported {
+			r.cd.AddGroupControllerServiceCapabilities([]csi.GroupControllerServiceCapability_RPC_Type{
+				csi.GroupControllerServiceCapability_RPC_CREATE_DELETE_GET_VOLUME_GROUP_SNAPSHOT,
+			})
+		} else {
+			log.DefaultLog("not enabling VolumeGroupSnapshot service capability")
+		}
+		if vgsErr != nil {
+			log.ErrorLogMsg("failed detecting VolumeGroupSnapshot support: %v", vgsErr)
+		}
 	}
 
 	if k8s.RunsOnKubernetes() && conf.IsNodeServer {
@@ -178,6 +192,7 @@ func (r *Driver) Run(conf *util.Config) {
 		IS: r.ids,
 		CS: r.cs,
 		NS: r.ns,
+		GS: r.cs,
 	}
 	s.Start(conf.Endpoint, srv, csicommon.MiddlewareServerOptionConfig{
 		LogSlowOpInterval: conf.LogSlowOpInterval,

--- a/internal/rbd/group.go
+++ b/internal/rbd/group.go
@@ -44,6 +44,7 @@ func (rv *rbdVolume) AddToGroup(ctx context.Context, vg types.VolumeGroup) error
 	if err != nil {
 		return fmt.Errorf("failed to open image %q: %w", rv, err)
 	}
+	defer image.Close()
 
 	info, err := image.GetGroup()
 	if err != nil {

--- a/internal/rbd/group/group_snapshot.go
+++ b/internal/rbd/group/group_snapshot.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2024 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+// volumeGroupSnapshot handles all requests for 'rbd group snap' operations.
+type volumeGroupSnapshot struct {
+	commonVolumeGroup
+
+	// snapshots is a list of rbd-images that are part of the group. The ID
+	// of each snapshot is stored in the journal.
+	snapshots []types.Snapshot
+
+	// snapshotsToFree contains Snapshots that were resolved during
+	// GetVolumeGroupSnapshot.
+	snapshotsToFree []types.Snapshot
+}
+
+// verify that volumeGroupSnapshot implements the VolumeGroupSnapshot interface.
+var _ types.VolumeGroupSnapshot = &volumeGroupSnapshot{}
+
+// GetVolumeGroupSnapshot initializes a new VolumeGroupSnapshot object that can
+// be used to inspect and delete a group of snapshots that was created by a
+// VolumeGroup.
+func GetVolumeGroupSnapshot(
+	ctx context.Context,
+	id string,
+	csiDriver string,
+	creds *util.Credentials,
+	snapshotResolver types.SnapshotResolver,
+) (types.VolumeGroupSnapshot, error) {
+	cleanVGS := true
+
+	vgs := &volumeGroupSnapshot{}
+	err := vgs.initCommonVolumeGroup(ctx, id, csiDriver, creds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize volume group snapshot with id %q: %w", id, err)
+	}
+	defer func() {
+		if cleanVGS {
+			vgs.Destroy(ctx)
+		}
+	}()
+
+	attrs, err := vgs.getVolumeGroupAttributes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get volume attributes for id %q: %w", vgs, err)
+	}
+
+	var snapshots []types.Snapshot
+	// it is needed to free the previously allocated snapshots in case of an error
+	defer func() {
+		// snapshotsToFree is empty in case of an error, let .Destroy() handle it otherwise
+		if len(vgs.snapshotsToFree) > 0 {
+			return
+		}
+
+		for _, s := range snapshots {
+			s.Destroy(ctx)
+		}
+	}()
+	for snapID := range attrs.VolumeMap {
+		snap, err := snapshotResolver.GetSnapshotByID(ctx, snapID)
+		if err != nil {
+			// free the previously allocated snapshots
+			for _, s := range snapshots {
+				s.Destroy(ctx)
+			}
+
+			return nil, fmt.Errorf("failed to resolve snapshot image %q for volume group snapshot %q: %w", snapID, vgs, err)
+		}
+
+		log.DebugLog(ctx, "resolved snapshot id %q to snapshot %q", snapID, snap)
+
+		snapshots = append(snapshots, snap)
+	}
+
+	vgs.snapshots = snapshots
+	// all allocated snapshots need to be free'd at Destroy() time
+	vgs.snapshotsToFree = snapshots
+
+	cleanVGS = false
+	log.DebugLog(ctx, "GetVolumeGroupSnapshot(%s) returns %+v", id, *vgs)
+
+	return vgs, nil
+}
+
+// NewVolumeGroupSnapshot creates a new VolumeGroupSnapshot object with the
+// given slice of Snapshots and adds the objectmapping to the journal.
+func NewVolumeGroupSnapshot(
+	ctx context.Context,
+	id string,
+	csiDriver string,
+	creds *util.Credentials,
+	snapshots []types.Snapshot,
+) (types.VolumeGroupSnapshot, error) {
+	cleanupVGS := true
+
+	vgs := &volumeGroupSnapshot{}
+	err := vgs.initCommonVolumeGroup(ctx, id, csiDriver, creds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize volume group snapshot with id %q: %w", id, err)
+	}
+	defer func() {
+		if cleanupVGS {
+			vgs.Destroy(ctx)
+		}
+	}()
+
+	vgs.snapshots = snapshots
+	vgs.snapshotsToFree = snapshots
+
+	_ /* attrs */, err = vgs.getVolumeGroupAttributes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get volume attributes for id %q: %w", vgs, err)
+	}
+
+	volumeMap := make(map[string]string, len(snapshots))
+
+	// add the CSI handles of each snapshot to the journal
+	for _, snapshot := range snapshots {
+		handle, snapErr := snapshot.GetID(ctx)
+		if snapErr != nil {
+			return nil, fmt.Errorf("failed to get ID for snapshot %q of volume group snapshot %q: %w", snapshot, vgs, snapErr)
+		}
+
+		name, snapErr := snapshot.GetName(ctx)
+		if snapErr != nil {
+			return nil, fmt.Errorf("failed to get name for snapshot %q of volume group snapshot %q: %w", snapshot, vgs, snapErr)
+		}
+
+		volumeMap[handle] = name
+	}
+
+	j, err := vgs.getJournal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = j.AddVolumesMapping(ctx, vgs.pool, vgs.objectUUID, volumeMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add volume mapping for volume group snapshot %q: %w", vgs, err)
+	}
+
+	// all done successfully, no need to cleanup the returned vgs
+	cleanupVGS = false
+
+	return vgs, nil
+}
+
+// ToCSI creates a CSI type for the VolumeGroupSnapshot.
+func (vgs *volumeGroupSnapshot) ToCSI(ctx context.Context) (*csi.VolumeGroupSnapshot, error) {
+	snapshots, err := vgs.ListSnapshots(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list snapshots for volume group %q: %w", vgs, err)
+	}
+
+	csiSnapshots := make([]*csi.Snapshot, len(snapshots))
+	for i, snap := range snapshots {
+		csiSnapshots[i], err = snap.ToCSI(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert snapshot %q to CSI type: %w", snap, err)
+		}
+	}
+
+	id, err := vgs.GetID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get id for volume group snapshot %q: %w", vgs, err)
+	}
+
+	ct, err := vgs.GetCreationTime(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get creation time for volume group snapshot %q: %w", vgs, err)
+	}
+
+	return &csi.VolumeGroupSnapshot{
+		GroupSnapshotId: id,
+		Snapshots:       csiSnapshots,
+		CreationTime:    timestamppb.New(*ct),
+		ReadyToUse:      true,
+	}, nil
+}
+
+// Destroy frees the resources used by the volumeGroupSnapshot.
+func (vgs *volumeGroupSnapshot) Destroy(ctx context.Context) {
+	// free the volumes that were allocated in GetVolumeGroup()
+	if len(vgs.snapshotsToFree) > 0 {
+		for _, volume := range vgs.snapshotsToFree {
+			volume.Destroy(ctx)
+		}
+		vgs.snapshotsToFree = make([]types.Snapshot, 0)
+	}
+
+	vgs.commonVolumeGroup.Destroy(ctx)
+}
+
+// Delete removes all snapshots and eventually the volume group snapshot.
+func (vgs *volumeGroupSnapshot) Delete(ctx context.Context) error {
+	for _, snapshot := range vgs.snapshots {
+		log.DebugLog(ctx, "deleting snapshot image %q for volume group snapshot %q", snapshot, vgs)
+
+		err := snapshot.Delete(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to delete snapshot %q as part of volume groups snapshot %q: %w", snapshot, vgs, err)
+		}
+	}
+
+	return vgs.commonVolumeGroup.Delete(ctx)
+}
+
+func (vgs *volumeGroupSnapshot) ListSnapshots(ctx context.Context) ([]types.Snapshot, error) {
+	return vgs.snapshots, nil
+}

--- a/internal/rbd/group/group_snapshot.go
+++ b/internal/rbd/group/group_snapshot.go
@@ -155,6 +155,12 @@ func NewVolumeGroupSnapshot(
 		}
 
 		volumeMap[handle] = name
+
+		// store the CSI ID of the group in the snapshot attributes
+		snapErr = snapshot.SetVolumeGroup(ctx, creds, vgs.id)
+		if snapErr != nil {
+			return nil, fmt.Errorf("failed to set volume group ID %q for snapshot %q: %w", vgs.id, name, snapErr)
+		}
 	}
 
 	j, err := vgs.getJournal(ctx)

--- a/internal/rbd/group/util.go
+++ b/internal/rbd/group/util.go
@@ -57,13 +57,16 @@ type commonVolumeGroup struct {
 	pool      string
 	namespace string
 
+	// csiDriver is the CSI drivername that is required to connect the journal
+	csiDriver string
+	// use getJournal() to make sure the journal is connected
 	journal journal.VolumeGroupJournal
 }
 
 func (cvg *commonVolumeGroup) initCommonVolumeGroup(
 	ctx context.Context,
 	id string,
-	j journal.VolumeGroupJournal,
+	csiDriver string,
 	creds *util.Credentials,
 ) error {
 	csiID := util.CSIIdentifier{}
@@ -87,7 +90,7 @@ func (cvg *commonVolumeGroup) initCommonVolumeGroup(
 		return fmt.Errorf("failed to get pool for volume group id %q: %w", id, err)
 	}
 
-	cvg.journal = j
+	cvg.csiDriver = csiDriver
 	cvg.credentials = creds
 	cvg.id = id
 	cvg.clusterID = csiID.ClusterID
@@ -113,18 +116,27 @@ func (cvg *commonVolumeGroup) Destroy(ctx context.Context) {
 	}
 
 	if cvg.credentials != nil {
-		cvg.credentials.DeleteCredentials()
+		// credentials should only be removed with DeleteCredentials()
+		// by the caller that allocated them
 		cvg.credentials = nil
 	}
 
-	log.DebugLog(ctx, "destroyed volume group instance with id %q", cvg.id)
+	if cvg.journal != nil {
+		cvg.journal.Destroy()
+		cvg.journal = nil
+	}
 }
 
 // getVolumeGroupAttributes fetches the attributes from the journal, sets some
 // of the common values for the VolumeGroup and returns the attributes struct
 // for further consumption (like checking the VolumeMap).
 func (cvg *commonVolumeGroup) getVolumeGroupAttributes(ctx context.Context) (*journal.VolumeGroupAttributes, error) {
-	attrs, err := cvg.journal.GetVolumeGroupAttributes(ctx, cvg.pool, cvg.objectUUID)
+	j, err := cvg.getJournal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs, err := j.GetVolumeGroupAttributes(ctx, cvg.pool, cvg.objectUUID)
 	if err != nil {
 		if !errors.Is(err, util.ErrKeyNotFound) && !errors.Is(err, util.ErrPoolNotFound) {
 			return nil, fmt.Errorf("failed to get attributes for volume group id %q: %w", cvg.id, err)
@@ -197,6 +209,12 @@ func (cvg *commonVolumeGroup) getConnection(ctx context.Context) (*util.ClusterC
 		return cvg.conn, nil
 	}
 
+	if cvg.credentials == nil {
+		log.DebugLog(ctx, "missing credentials for common volume group %q: %s", cvg, util.CallStack())
+
+		return nil, errors.New("can not connect to cluster without credentials")
+	}
+
 	conn := &util.ClusterConnection{}
 	err := conn.Connect(cvg.monitors, cvg.credentials)
 	if err != nil {
@@ -207,6 +225,29 @@ func (cvg *commonVolumeGroup) getConnection(ctx context.Context) (*util.ClusterC
 	log.DebugLog(ctx, "connection established for volume group %q", cvg.id)
 
 	return conn, nil
+}
+
+func (cvg *commonVolumeGroup) getJournal(ctx context.Context) (journal.VolumeGroupJournal, error) {
+	if cvg.journal != nil {
+		return cvg.journal, nil
+	}
+
+	if cvg.credentials == nil {
+		log.DebugLog(ctx, "missing credentials for common volume group %q: %s", cvg, util.CallStack())
+
+		return nil, errors.New("can not connect the journal without credentials")
+	}
+
+	journalConfig := journal.NewCSIVolumeGroupJournalWithNamespace(cvg.csiDriver, cvg.namespace)
+
+	j, err := journalConfig.Connect(cvg.monitors, cvg.namespace, cvg.credentials)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to journal: %w", err)
+	}
+
+	cvg.journal = j
+
+	return j, nil
 }
 
 // GetIOContext returns the IOContext for the volume group if it exists,
@@ -254,7 +295,12 @@ func (cvg *commonVolumeGroup) Delete(ctx context.Context) error {
 		return fmt.Errorf("failed to get pool for volume group %q: %w", cvg, err)
 	}
 
-	err = cvg.journal.UndoReservation(ctx, pool, name, csiID)
+	j, err := cvg.getJournal(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = j.UndoReservation(ctx, pool, name, csiID)
 	if err != nil /* TODO? !errors.Is(..., err) */ {
 		return fmt.Errorf("failed to undo the reservation for volume group %q: %w", cvg, err)
 	}

--- a/internal/rbd/group/util.go
+++ b/internal/rbd/group/util.go
@@ -34,6 +34,9 @@ type commonVolumeGroup struct {
 	// is used to find the group in the journal.
 	id string
 
+	// requestName is passed by the caller when a group is created.
+	requestName string
+
 	// name is used in RBD API calls as the name of this object
 	name string
 
@@ -130,6 +133,7 @@ func (cvg *commonVolumeGroup) getVolumeGroupAttributes(ctx context.Context) (*jo
 		attrs = &journal.VolumeGroupAttributes{}
 	}
 
+	cvg.requestName = attrs.RequestName
 	cvg.name = attrs.GroupName
 	cvg.creationTime = attrs.CreationTime
 

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -74,6 +74,12 @@ func GetVolumeGroup(
 
 	attrs, err := vg.getVolumeGroupAttributes(ctx)
 	if err != nil {
+		if errors.Is(err, librbd.ErrNotFound) {
+			log.ErrorLog(ctx, "%v, returning empty volume group %q", vg, err)
+
+			return vg, err
+		}
+
 		return nil, fmt.Errorf("failed to get volume attributes for id %q: %w", vg, err)
 	}
 

--- a/internal/rbd/group_controllerserver.go
+++ b/internal/rbd/group_controllerserver.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2024 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+// CreateVolumeGroupSnapshot receives a list of volume handles and is requested
+// to create a list of snapshots that are created at the same time. This is
+// similar (although not exactly the same) to consistency groups.
+//
+// RBD has a limitation that an image can only belong to a single group. It is
+// therefore required to create a temporary group, add all images, create the
+// group snapshot and remove all images from the group again. This leaves the
+// group and its snapshot around, the group snapshot can be inspected to list
+// the snapshots of the images.
+func (cs *ControllerServer) CreateVolumeGroupSnapshot(
+	ctx context.Context,
+	req *csi.CreateVolumeGroupSnapshotRequest,
+) (*csi.CreateVolumeGroupSnapshotResponse, error) {
+	var (
+		err           error
+		vg            types.VolumeGroup
+		groupSnapshot types.VolumeGroupSnapshot
+
+		// the VG and VGS should not have the same name
+		vgName  = req.GetName() + "-vg" // stable temporary name
+		vgsName = req.GetName()
+	)
+
+	mgr := NewManager(cs.Driver.GetInstanceID(), req.GetParameters(), req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
+	// resolve all volumes, free them later on
+	volumes := make([]types.Volume, len(req.GetSourceVolumeIds()))
+	defer func() {
+		for _, volume := range volumes {
+			if vg != nil {
+				// 'normal' cleanup, remove all images from the group
+				vgErr := vg.RemoveVolume(ctx, volume)
+				if vgErr != nil {
+					log.ErrorLog(
+						ctx,
+						"failed to remove volume %q from volume group %q: %v",
+						volume, vg, vgErr)
+				}
+			}
+
+			// free all allocated volumes
+			if volume != nil {
+				volume.Destroy(ctx)
+			}
+		}
+
+		if vg != nil {
+			// the VG should always be deleted, volumes can only belong to a single VG
+			log.DebugLog(ctx, "removing temporary volume group %q", vg)
+
+			vgErr := vg.Delete(ctx)
+			if vgErr != nil {
+				log.ErrorLog(ctx, "failed to remove temporary volume group %q: %v", vg, vgErr)
+			}
+
+			// free the resources of the VolumeGroup
+			vg.Destroy(ctx)
+		}
+	}()
+	for i, id := range req.GetSourceVolumeIds() {
+		var vol types.Volume
+		vol, err = mgr.GetVolumeByID(ctx, id)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"failed to find required volume %q for volume group snapshot %q: %s",
+				id,
+				vgsName,
+				err.Error())
+		}
+		volumes[i] = vol
+	}
+
+	log.DebugLog(ctx, "all %d Volumes for VolumeGroup %q have been found", len(volumes), vgsName)
+
+	groupSnapshot, err = mgr.GetVolumeGroupSnapshotByName(ctx, vgsName)
+	if groupSnapshot != nil {
+		defer groupSnapshot.Destroy(ctx)
+
+		csiVGS, csiErr := groupSnapshot.ToCSI(ctx)
+		if csiErr != nil {
+			return nil, status.Error(codes.Aborted, csiErr.Error())
+		}
+
+		return &csi.CreateVolumeGroupSnapshotResponse{
+			GroupSnapshot: csiVGS,
+		}, nil
+	}
+	if err != nil {
+		log.DebugLog(ctx, "need to create new volume group snapshot, "+
+			"failed to get existing one with name %q: %v", vgsName, err)
+	}
+
+	// create a temporary VolumeGroup with a different name
+	vg, err = mgr.CreateVolumeGroup(ctx, vgName)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to create volume group %q: %s",
+			vgName,
+			err.Error())
+	}
+	// vg.Destroy(ctx) is called in a defer further up ^
+
+	log.DebugLog(ctx, "VolumeGroup %q has been created: %+v", vgName, vg)
+
+	// add images to the group
+	for _, volume := range volumes {
+		err = vg.AddVolume(ctx, volume)
+		if err != nil {
+			return nil, status.Error(codes.Aborted, err.Error())
+		}
+	}
+
+	groupSnapshot, err = mgr.CreateVolumeGroupSnapshot(ctx, vg, vgsName)
+	if err != nil {
+		return nil, status.Error(codes.Aborted, err.Error())
+	}
+	defer groupSnapshot.Destroy(ctx)
+
+	csiVGS, err := groupSnapshot.ToCSI(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Aborted, err.Error())
+	}
+
+	return &csi.CreateVolumeGroupSnapshotResponse{
+		GroupSnapshot: csiVGS,
+	}, nil
+}
+
+func (cs *ControllerServer) DeleteVolumeGroupSnapshot(
+	ctx context.Context,
+	req *csi.DeleteVolumeGroupSnapshotRequest,
+) (*csi.DeleteVolumeGroupSnapshotResponse, error) {
+	// FIXME: more checking of the request in needed
+	// 1. verify that all snapshots in the request are all snapshots in the group
+	// 2. delete the group
+
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
+	groupSnapshot, err := mgr.GetVolumeGroupSnapshotByID(ctx, req.GetGroupSnapshotId())
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to get volume group snapshot with id %q: %v",
+			req.GetGroupSnapshotId(), err)
+	}
+	defer groupSnapshot.Destroy(ctx)
+
+	err = groupSnapshot.Delete(ctx)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to delete volume group snapshot %q: %v",
+			groupSnapshot, err)
+	}
+
+	return &csi.DeleteVolumeGroupSnapshotResponse{}, nil
+}
+
+// GetVolumeGroupSnapshot is sortof optional, only used for
+// static/pre-provisioned VolumeGroupSnapshots.
+func (cs *ControllerServer) GetVolumeGroupSnapshot(
+	ctx context.Context,
+	req *csi.GetVolumeGroupSnapshotRequest,
+) (*csi.GetVolumeGroupSnapshotResponse, error) {
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
+	groupSnapshot, err := mgr.GetVolumeGroupSnapshotByID(ctx, req.GetGroupSnapshotId())
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to get volume group snapshot with id %q: %v",
+			req.GetGroupSnapshotId(), err)
+	}
+	defer groupSnapshot.Destroy(ctx)
+
+	csiVGS, err := groupSnapshot.ToCSI(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Aborted, err.Error())
+	}
+
+	return &csi.GetVolumeGroupSnapshotResponse{
+		GroupSnapshot: csiVGS,
+	}, nil
+}

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -320,6 +320,23 @@ func (mgr *rbdManager) CreateVolumeGroup(ctx context.Context, name string) (type
 	return vg, nil
 }
 
+func (mgr *rbdManager) GetVolumeGroupSnapshotByID(
+	ctx context.Context,
+	id string,
+) (types.VolumeGroupSnapshot, error) {
+	creds, err := mgr.getCredentials()
+	if err != nil {
+		return nil, err
+	}
+
+	vgs, err := rbd_group.GetVolumeGroupSnapshot(ctx, id, mgr.csiID, creds, mgr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get volume group with id %q: %w", id, err)
+	}
+
+	return vgs, nil
+}
+
 func (mgr *rbdManager) CreateVolumeGroupSnapshot(
 	ctx context.Context,
 	vg types.VolumeGroup,

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -212,6 +212,11 @@ func (mgr *rbdManager) GetSnapshotByID(ctx context.Context, id string) (types.Sn
 		}
 	}
 
+	// FIXME: The snapshot will have RbdImageName set to the image that was
+	// used as source. This is not correct for group snapshots images, and
+	// need to be fixed. See rbdVolume.NewSnapshotByID() for more details.
+	snapshot.RbdImageName = snapshot.RbdSnapName
+
 	return snapshot, nil
 }
 

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -140,22 +140,12 @@ func (mgr *rbdManager) GetVolumeByID(ctx context.Context, id string) (types.Volu
 }
 
 func (mgr *rbdManager) GetVolumeGroupByID(ctx context.Context, id string) (types.VolumeGroup, error) {
-	vi := &util.CSIIdentifier{}
-	if err := vi.DecomposeCSIID(id); err != nil {
-		return nil, fmt.Errorf("failed to parse volume group id %q: %w", id, err)
-	}
-
-	vgJournal, err := mgr.getVolumeGroupJournal(vi.ClusterID)
-	if err != nil {
-		return nil, err
-	}
-
 	creds, err := mgr.getCredentials()
 	if err != nil {
 		return nil, err
 	}
 
-	vg, err := rbd_group.GetVolumeGroup(ctx, id, vgJournal, creds, mgr)
+	vg, err := rbd_group.GetVolumeGroup(ctx, id, mgr.csiID, creds, mgr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get volume group with id %q: %w", id, err)
 	}
@@ -236,7 +226,7 @@ func (mgr *rbdManager) CreateVolumeGroup(ctx context.Context, name string) (type
 		return nil, fmt.Errorf("failed to generate a unique CSI volume group with uuid for %q: %w", uuid, err)
 	}
 
-	vg, err := rbd_group.GetVolumeGroup(ctx, csiID, vgJournal, creds, mgr)
+	vg, err := rbd_group.GetVolumeGroup(ctx, csiID, mgr.csiID, creds, mgr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get volume group %q at cluster %q: %w", name, clusterID, err)
 	}

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -212,11 +212,6 @@ func (mgr *rbdManager) GetSnapshotByID(ctx context.Context, id string) (types.Sn
 		}
 	}
 
-	// FIXME: The snapshot will have RbdImageName set to the image that was
-	// used as source. This is not correct for group snapshots images, and
-	// need to be fixed. See rbdVolume.NewSnapshotByID() for more details.
-	snapshot.RbdImageName = snapshot.RbdSnapName
-
 	return snapshot, nil
 }
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -191,6 +191,9 @@ type rbdSnapshot struct {
 	// RbdSnapName is the name of the RBD snapshot backing this rbdSnapshot
 	SourceVolumeID string
 	RbdSnapName    string
+
+	// groupID is the CSI volume group ID where this snapshot belongs to
+	groupID string
 }
 
 // imageFeature represents required image features and value.
@@ -1052,6 +1055,15 @@ func genSnapFromSnapID(
 			// TODO: If pool is not found we may leak the image (as DeleteSnapshot will return success)
 			return rbdSnap, err
 		}
+	}
+
+	if imageAttributes.GroupID != "" {
+		rbdSnap.groupID = imageAttributes.GroupID
+		// FIXME: The snapshot will have RbdImageName set to the image
+		// that was used as source. This is not correct for group
+		// snapshots images, and need to be fixed. See
+		// rbdVolume.NewSnapshotByID() for more details.
+		rbdSnap.RbdImageName = rbdSnap.RbdSnapName
 	}
 
 	err = rbdSnap.Connect(cr)

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -221,7 +221,12 @@ func (rv *rbdVolume) NewSnapshotByID(
 		}
 	}()
 
-	// a new snapshot image will be created, needs to have a unique name
+	// A new snapshot image will be created, and needs to have a unique
+	// name.
+	// FIXME: the journal contains rv.RbdImageName as SourceName. When
+	// resolving the snapshot image, snap.RbdImageName will be set to the
+	// original RbdImageName/SourceName (incorrect). This is fixed-up in
+	// rbdManager.GetSnapshotByID(), this needs to be done cleaner.
 	snap.RbdImageName = snap.RbdSnapName
 
 	err = rv.Connect(cr)

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -20,9 +20,11 @@ import (
 	"errors"
 	"fmt"
 
+	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/ceph/ceph-csi/internal/rbd/types"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
@@ -175,4 +177,136 @@ func undoSnapshotCloning(
 	err = undoSnapReservation(ctx, rbdSnap, cr)
 
 	return err
+}
+
+// NewSnapshotByID creates a new rbdSnapshot from the rbdVolume.
+//
+// Parameters:
+// - name of the new rbd-image backing the snapshot
+// - id of the rbd-snapshot to clone
+//
+// FIXME: When resolving the Snapshot, the RbdImageName will be set to the name
+// of the parent image. This is can cause issues when not accounting for that
+// and the Snapshot is deleted; instead of deleting the snapshot image, the
+// parent image is removed.
+//
+//nolint:gocyclo,cyclop // TODO: reduce complexity.
+func (rv *rbdVolume) NewSnapshotByID(
+	ctx context.Context,
+	cr *util.Credentials,
+	name string,
+	id uint64,
+) (types.Snapshot, error) {
+	snap := rv.toSnapshot()
+	snap.RequestName = name
+
+	srcVolID, err := rv.GetID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snap.SourceVolumeID = srcVolID
+
+	// reserveSnap sets snap.{RbdSnapName,ReservedID,VolID}
+	err = reserveSnap(ctx, snap, rv, cr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a reservation in the journal for snapshot image %q: %w", snap, err)
+	}
+	defer func() {
+		if err != nil {
+			undoErr := undoSnapReservation(ctx, snap, cr)
+			if undoErr != nil {
+				log.WarningLog(ctx, "failed undoing reservation of snapshot %q: %v", name, undoErr)
+			}
+		}
+	}()
+
+	// a new snapshot image will be created, needs to have a unique name
+	snap.RbdImageName = snap.RbdSnapName
+
+	err = rv.Connect(cr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = rv.openIoctx()
+	if err != nil {
+		return nil, err
+	}
+
+	options, err := rv.constructImageOptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer options.Destroy()
+
+	err = options.SetUint64(librbd.ImageOptionCloneFormat, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	// indicator to remove the snapshot after a failure
+	removeSnap := true
+	var snapImage *librbd.Snapshot
+
+	log.DebugLog(ctx, "going to clone snapshot image %q from image %q with snapshot ID %d", snap, rv, id)
+
+	err = librbd.CloneImageByID(rv.ioctx, rv.RbdImageName, id, rv.ioctx, snap.RbdImageName, options)
+	if err != nil && !errors.Is(librbd.ErrExist, err) {
+		log.ErrorLog(ctx, "failed to clone snapshot %q with id %d: %v", snap, id, err)
+
+		return nil, fmt.Errorf("failed to clone %q with snapshot id %d as new image %q: %w", rv.RbdImageName, id, snap, err)
+	}
+	defer func() {
+		if !removeSnap {
+			// success, no need to remove the snapshot image
+			return
+		}
+
+		if snapImage != nil {
+			err = snapImage.Remove()
+			if err != nil {
+				log.ErrorLog(ctx, "failed to remove snapshot of image %q after failure: %v", snap, err)
+			}
+		}
+
+		err = librbd.RemoveImage(rv.ioctx, snap.RbdImageName)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to remove snapshot image %q after failure: %v", snap, err)
+		}
+	}()
+
+	// update the snapshot image in the journal, after the image info is updated
+	j, err := snapJournal.Connect(snap.Monitors, snap.RadosNamespace, cr)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot image %q failed to connect to journal: %w", snap, err)
+	}
+	defer j.Destroy()
+
+	err = snap.Connect(cr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect snapshot image %q: %w", snap, err)
+	}
+	defer snap.Destroy(ctx)
+
+	image, err := snap.open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open snapshot image %q: %w", snap, err)
+	}
+	defer image.Close()
+
+	snapImage, err = image.CreateSnapshot(snap.RbdSnapName)
+	if err != nil && !errors.Is(librbd.ErrExist, err) {
+		return nil, fmt.Errorf("failed to create snapshot on image %q: %w", snap, err)
+	}
+
+	err = snap.repairImageID(ctx, j, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to repair image id for snapshot image %q: %w", snap, err)
+	}
+
+	// all ok, don't remove the snapshot image in a defer statement
+	removeSnap = false
+
+	return snap, nil
 }

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/ceph/go-ceph/rados"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
+
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 type journalledObject interface {
@@ -66,4 +68,9 @@ type VolumeGroup interface {
 
 	// ListVolumes returns a slice with all Volumes in the VolumeGroup.
 	ListVolumes(ctx context.Context) ([]Volume, error)
+
+	// CreateSnapshots creates Snapshots of all Volume in the VolumeGroup.
+	// The Snapshots are crash consistent, and created as a consistency
+	// group.
+	CreateSnapshots(ctx context.Context, cr *util.Credentials, name string) ([]Snapshot, error)
 }

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -57,6 +57,10 @@ type Manager interface {
 	// CSI id/handle.
 	GetVolumeGroupSnapshotByID(ctx context.Context, id string) (VolumeGroupSnapshot, error)
 
+	// GetVolumeGroupSnapshotByName resolves the VolumeGroupSnapshot by the
+	// name (like the request-id).
+	GetVolumeGroupSnapshotByName(ctx context.Context, name string) (VolumeGroupSnapshot, error)
+
 	// CreateVolumeGroupSnapshot instructs the Manager to create a
 	// VolumeGroupSnapshot from the VolumeGroup. All snapshots in the
 	// returned VolumeGroupSnapshot have been taken while I/O on the

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -26,12 +26,21 @@ type VolumeResolver interface {
 	GetVolumeByID(ctx context.Context, id string) (Volume, error)
 }
 
+// SnapshotResolver can be used to construct a Snapshot from a CSI SnapshotId.
+type SnapshotResolver interface {
+	// GetSnapshotByID uses the CSI SnapshotId to resolve the returned Snapshot.
+	GetSnapshotByID(ctx context.Context, id string) (Snapshot, error)
+}
+
 // Manager provides a way for other packages to get Volumes and VolumeGroups.
 // It handles the operations on the backend, and makes sure the journal
 // reflects the expected state.
 type Manager interface {
 	// VolumeResolver is fully implemented by the Manager.
 	VolumeResolver
+
+	// SnapshotResolver is fully implemented by the Manager.
+	SnapshotResolver
 
 	// Destroy frees all resources that the Manager allocated.
 	Destroy(ctx context.Context)

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -52,4 +52,11 @@ type Manager interface {
 	// CreateVolumeGroup allocates a new VolumeGroup in the backend storage
 	// and records details about it in the journal.
 	CreateVolumeGroup(ctx context.Context, name string) (VolumeGroup, error)
+
+	// CreateVolumeGroupSnapshot instructs the Manager to create a
+	// VolumeGroupSnapshot from the VolumeGroup. All snapshots in the
+	// returned VolumeGroupSnapshot have been taken while I/O on the
+	// VolumeGroup was paused, the snapshots in the group are crash
+	// consistent.
+	CreateVolumeGroupSnapshot(ctx context.Context, vg VolumeGroup, name string) (VolumeGroupSnapshot, error)
 }

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -53,6 +53,10 @@ type Manager interface {
 	// and records details about it in the journal.
 	CreateVolumeGroup(ctx context.Context, name string) (VolumeGroup, error)
 
+	// GetVolumeGroupSnapshotByID resolves the VolumeGroupSnapshot from the
+	// CSI id/handle.
+	GetVolumeGroupSnapshotByID(ctx context.Context, id string) (VolumeGroupSnapshot, error)
+
 	// CreateVolumeGroupSnapshot instructs the Manager to create a
 	// VolumeGroupSnapshot from the VolumeGroup. All snapshots in the
 	// returned VolumeGroupSnapshot have been taken while I/O on the

--- a/internal/rbd/types/snapshot.go
+++ b/internal/rbd/types/snapshot.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 type Snapshot interface {
@@ -35,4 +37,7 @@ type Snapshot interface {
 	ToCSI(ctx context.Context) (*csi.Snapshot, error)
 
 	GetCreationTime(ctx context.Context) (*time.Time, error)
+
+	// SetVolumeGroup sets the CSI volume group ID in the snapshot.
+	SetVolumeGroup(ctx context.Context, creds *util.Credentials, vgID string) error
 }

--- a/internal/rbd/types/volume.go
+++ b/internal/rbd/types/volume.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 //nolint:interfacebloat // more than 10 methods are needed for the interface
@@ -59,4 +61,7 @@ type Volume interface {
 
 	// ToMirror converts the Volume to a Mirror.
 	ToMirror() (Mirror, error)
+
+	// NewSnapshotByID creates a new Snapshot object based on the details of the Volume.
+	NewSnapshotByID(ctx context.Context, cr *util.Credentials, name string, id uint64) (Snapshot, error)
 }

--- a/internal/rbd/types/volume_group_snapshot.go
+++ b/internal/rbd/types/volume_group_snapshot.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2024 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"context"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+// VolumeGroupSnapshot provide functions to inspect and modify a
+// VolumeGroupSnapshot. The rbd.Manager can be used to create or otherwise
+// obtain a VolumeGroupSnapshot struct.
+type VolumeGroupSnapshot interface {
+	journalledObject
+
+	// Destroy frees the resources used by the VolumeGroupSnapshot.
+	Destroy(ctx context.Context)
+
+	// Delete removes the VolumeGroupSnapshot from the storage backend.
+	Delete(ctx context.Context) error
+
+	// ToCSI returns the VolumeGroupSnapshot struct in CSI format.
+	ToCSI(ctx context.Context) (*csi.VolumeGroupSnapshot, error)
+
+	// GetCreationTime retrurns the time when the VolumeGroupSnapshot was
+	// created.
+	GetCreationTime(ctx context.Context) (*time.Time, error)
+
+	// ListSnapshots returns a slice with all Snapshots in the
+	// VolumeGroupSnapshot.
+	ListSnapshots(ctx context.Context) ([]Snapshot, error)
+}


### PR DESCRIPTION
Add support for VolumeGroupSnapshots in RBD. The last two commits enable the feature in the Group Controller Server and expose the capability. All other commits provide the functionality through the `rbd.Manager` interface.

Currently there is no Ceph container-image release that provides the required librbd features. Building from this PR will not provide support for VolumeGroupSnapshot yet, the base container-image needs to be set to Ceph CI main branch (`quay.ceph.io/ceph-ci/ceph:main`) for that. A test-image based on Ceph main can be found at `quay.io/nixpanic/cephcsi:pr_4739`.

Notable changes:

- `internal/rbd_types` package with interfaces so that objects can be passed around cleaner
- `internal/rbd/volume.go` implementing the new `Volume` interface for `rbdImage`
- `internal/rbd_group` package for all RBD-group functionalities
- `internal/rbd/group_controller.go` for all CSI VolumeGroup service procedures

Depends-on: #4794
Depends-on: #4870
Depends-on: #4871
Depends-on: #4884
Depends-on: #4898
Depends-on: #4902
Depends-on: #4904
Depends-on: #4915

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
