### PR TITLE
helm: fix seLinuxMount option for csi driver object

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -12,6 +12,6 @@ spec:
   attachRequired: false
   podInfoOnMount: false
   fsGroupPolicy: {{ .Values.CSIDriver.fsGroupPolicy }}
-{{- if and (semverCompare ">= 1.25.x" .Capabilities.KubeVersion.Version) .Values.seLinuxMount }}
+{{- if and (semverCompare ">= 1.25.x" .Capabilities.KubeVersion.Version) .Values.CSIDriver.seLinuxMount }}
   seLinuxMount: true
 {{- end }}

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -12,6 +12,6 @@ spec:
   attachRequired: true
   podInfoOnMount: false
   fsGroupPolicy: {{ .Values.CSIDriver.fsGroupPolicy }}
-{{- if and (semverCompare ">= 1.25.x" .Capabilities.KubeVersion.Version) .Values.seLinuxMount }}
+{{- if and (semverCompare ">= 1.25.x" .Capabilities.KubeVersion.Version) .Values.CSIDriver.seLinuxMount }}
   seLinuxMount: true
 {{- end }}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit fixes the typo from `.Values.seLinuxMount` to `.Values.CSIDriver.seLinuxMount`.

- `Values.selinuxMount` is for adding mountPath `/etc/selinux`. Ref #2883
- `Values.CSIDriver.seLinuxMount` is for k8s efficient SELinux volume relabelling . Ref #3902

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
