### PR TITLE
cleanup: use standard Golang "slices" instead of k8s package

### DIFF
--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -36,7 +37,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"k8s.io/utils/strings/slices"
 )
 
 // validateCreateVolumeGroupSnapshotRequest validates the request for creating


### PR DESCRIPTION
The "slices" package has been introduced in Go 1.21 and can be used
instead of the Kubernetes package that will be replaced by the standard
package at one point too.