### PR TITLE
rbd: add ParentInTrash parameter in rbdImage struct

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -3553,7 +3553,7 @@ var _ = Describe("RBD", func() {
 					validateRBDImageCount(f, 1, defaultRBDPool)
 					validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
 					for i := 0; i < snapChainDepth; i++ {
-						var pvcClone *v1.PersistentVolumeClaim
+						var pvcClone, smartClonePVC *v1.PersistentVolumeClaim
 						snap := getSnapshot(snapshotPath)
 						snap.Name = fmt.Sprintf("%s-%d", snap.Name, i)
 						snap.Namespace = f.UniqueName
@@ -3602,6 +3602,41 @@ var _ = Describe("RBD", func() {
 						err = deleteSnapshot(&snap, deployTimeout)
 						if err != nil {
 							framework.Failf("failed to delete snapshot: %v", err)
+						}
+
+						// validate created backend rbd images = clone
+						totalImages = 1
+						validateRBDImageCount(f, totalImages, defaultRBDPool)
+						validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+						validateOmapCount(f, 0, rbdType, defaultRBDPool, snapsType)
+
+						// create pvc-pvc clone to validate pvc-pvc clone creation
+						// of child PVC created from a snapshot which no longer exits.
+						// Snapshot-> restore PVC -> delete Snapshot -> PVC-PVC clone.
+						smartClonePVC, err = loadPVC(pvcSmartClonePath)
+						if err != nil {
+							framework.Failf("failed to load smart clone PVC: %v", err)
+						}
+
+						smartClonePVC.Name = fmt.Sprintf("%s-%d", smartClonePVC.Name, i)
+						smartClonePVC.Namespace = f.UniqueName
+						smartClonePVC.Spec.DataSource.Name = pvcClone.Name
+						err = createPVCAndvalidatePV(f.ClientSet, smartClonePVC, deployTimeout)
+						if err != nil {
+							framework.Failf("failed to create smart clone PVC %q: %v",
+								smartClonePVC.Name, err)
+						}
+
+						// validate created backend rbd images = clone + smart clone + temp image
+						totalImages = 3
+						validateRBDImageCount(f, totalImages, defaultRBDPool)
+						validateOmapCount(f, 2, rbdType, defaultRBDPool, volumesType)
+						validateOmapCount(f, 0, rbdType, defaultRBDPool, snapsType)
+
+						err = deletePVCAndValidatePV(f.ClientSet, smartClonePVC, deployTimeout)
+						if err != nil {
+							framework.Failf("failed to delete smart clone PVC %q: %v",
+								smartClonePVC.Name, err)
 						}
 
 						// validate created backend rbd images = clone

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -116,8 +116,6 @@ type rbdImage struct {
 	ParentName string
 	// Parent Pool is the pool that contains the parent image.
 	ParentPool string
-	// ParentInTrash indicates the parent image is in trash.
-	ParentInTrash bool
 	// Cluster name
 	ClusterName string
 
@@ -148,6 +146,8 @@ type rbdImage struct {
 
 	// Set metadata on volume
 	EnableMetadata bool
+	// ParentInTrash indicates the parent image is in trash.
+	ParentInTrash bool
 }
 
 // rbdVolume represents a CSI volume and its RBD image specifics.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -116,6 +116,8 @@ type rbdImage struct {
 	ParentName string
 	// Parent Pool is the pool that contains the parent image.
 	ParentPool string
+	// ParentInTrash indicates the parent image is in trash.
+	ParentInTrash bool
 	// Cluster name
 	ClusterName string
 
@@ -1615,6 +1617,7 @@ func (ri *rbdImage) getImageInfo() error {
 	} else {
 		ri.ParentName = parentInfo.Image.ImageName
 		ri.ParentPool = parentInfo.Image.PoolName
+		ri.ParentInTrash = parentInfo.Image.Trash
 	}
 	// Get image creation time
 	tm, err := image.GetCreateTimestamp()
@@ -1633,7 +1636,9 @@ func (ri *rbdImage) getParent() (*rbdImage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ri.ParentName == "" {
+	// The image may not have a parent or the parent maybe in trash.
+	// Return nil in both the cases.
+	if ri.ParentName == "" || ri.ParentInTrash {
 		return nil, nil
 	}
 


### PR DESCRIPTION
rbd: add ParentInTrash parameter in rbdImage struct
- This commit adds ParentInTrash parameter in rbdImage struct
and makes use of it in getParent() function in order to avoid
error in case the parent is present but in trash.

- This commit modifies a test case to check creation of PVC-PVC clone of a restored PVC when parent snapshot is deleted.

Signed-off-by: Rakshith R <rar@redhat.com>

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
