### PR TITLE
rbd: remove unneeded updateSnapshotDetails() function

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1042,31 +1042,12 @@ func genSnapFromSnapID(
 		}
 	}
 
-	err = updateSnapshotDetails(rbdSnap)
+	err = rbdSnap.getImageInfo()
 	if err != nil {
 		return rbdSnap, fmt.Errorf("failed to update snapshot details for %q: %w", rbdSnap, err)
 	}
 
 	return rbdSnap, err
-}
-
-// updateSnapshotDetails will copy the details from the rbdVolume to the
-// rbdSnapshot. example copying size from rbdVolume to rbdSnapshot.
-func updateSnapshotDetails(rbdSnap *rbdSnapshot) error {
-	vol := rbdSnap.toVolume()
-	err := vol.Connect(rbdSnap.conn.Creds)
-	if err != nil {
-		return err
-	}
-	defer vol.Destroy()
-
-	err = vol.getImageInfo()
-	if err != nil {
-		return err
-	}
-	rbdSnap.VolSize = vol.VolSize
-
-	return nil
 }
 
 // generateVolumeFromVolumeID generates a rbdVolume structure from the provided identifier.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -508,7 +508,7 @@ func (ri *rbdImage) open() (*librbd.Image, error) {
 	image, err := librbd.OpenImage(ri.ioctx, ri.RbdImageName, librbd.NoSnapshot)
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {
-			err = util.JoinErrors(ErrImageNotFound, err)
+			err = fmt.Errorf("failed to open image (%w): %w", ErrImageNotFound, err)
 		}
 
 		return nil, err


### PR DESCRIPTION
updateSnapshotDetails() calls getImageInfo() on the rbdVolume that is
related to the rbdSnapshot. This is not needed at all, as both types
have the same getImageInfo() function, so it can be called directly on
the rbdSnapshot.