### PR TITLE
cleanup: destroy connections after .Copy() an other one

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -183,6 +183,8 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 
 	// generate temp cloned volume
 	tempClone := rv.generateTempClone()
+	defer tempClone.Destroy()
+
 	// snapshot name is same as temporary cloned image, This helps to
 	// flatten the temporary cloned images as we cannot have more than 510
 	// snapshots on an rbd image

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -669,6 +669,7 @@ func (cs *ControllerServer) createVolumeFromSnapshot(
 	parentVol := rbdSnap.toVolume()
 	// as we are operating on single cluster reuse the connection
 	parentVol.conn = rbdVol.conn.Copy()
+	defer parentVol.Destroy()
 
 	// create clone image and delete snapshot
 	err = rbdVol.cloneRbdImageFromSnapshot(ctx, rbdSnap, parentVol)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1662,6 +1662,7 @@ func (ri *rbdImage) flattenParent(ctx context.Context, hardLimit, softLimit uint
 	if parentImage == nil {
 		return nil
 	}
+	defer parentImage.Destroy()
 
 	return parentImage.flattenRbdImage(ctx, false, hardLimit, softLimit)
 }


### PR DESCRIPTION
Everytime a connection is copied with the .Copy() function, it needs to
be destroyed once the object is not needed anymore. This was not done
consistently, a few more locations require the freeing of the connection
resources.