### PR TITLE
cleanup: rename EncryptionTypeString() to EncryptionType.String()

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -2006,7 +2006,7 @@ var _ = Describe("RBD", func() {
 						"mapOptions":      nbdMapOptions,
 						"cephLogStrategy": e2eDefaultCephLogStrategy,
 						"encrypted":       "true",
-						"encryptionType":  util.EncryptionTypeString(encType),
+						"encryptionType":  encType.String(),
 					},
 					deletePolicy)
 				if err != nil {
@@ -2041,7 +2041,7 @@ var _ = Describe("RBD", func() {
 					f,
 					defaultSCName,
 					nil,
-					map[string]string{"encrypted": "true", "encryptionType": util.EncryptionTypeString(encType)},
+					map[string]string{"encrypted": "true", "encryptionType": encType.String()},
 					deletePolicy)
 				if err != nil {
 					framework.Failf("failed to create storageclass: %v", err)
@@ -2075,7 +2075,7 @@ var _ = Describe("RBD", func() {
 					f,
 					defaultSCName,
 					nil,
-					map[string]string{"encrypted": "true", "encryptionType": util.EncryptionTypeString(encType)},
+					map[string]string{"encrypted": "true", "encryptionType": encType.String()},
 					deletePolicy)
 				if err != nil {
 					framework.Failf("failed to create storageclass: %v", err)
@@ -2120,7 +2120,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2153,7 +2153,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-tokens-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2207,7 +2207,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-tenant-sa-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2246,7 +2246,7 @@ var _ = Describe("RBD", func() {
 					scOpts := map[string]string{
 						"encrypted":       "true",
 						"encryptionKMSID": "secrets-metadata-test",
-						"encryptionType":  util.EncryptionTypeString(encType),
+						"encryptionType":  encType.String(),
 					}
 					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 					if err != nil {
@@ -2279,7 +2279,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "user-ns-secrets-metadata-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2333,7 +2333,7 @@ var _ = Describe("RBD", func() {
 					scOpts := map[string]string{
 						"encrypted":       "true",
 						"encryptionKMSID": "user-secrets-metadata-test",
-						"encryptionType":  util.EncryptionTypeString(encType),
+						"encryptionType":  encType.String(),
 					}
 					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 					if err != nil {
@@ -2460,7 +2460,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2494,7 +2494,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2504,7 +2504,7 @@ var _ = Describe("RBD", func() {
 				scOpts = map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-tenant-sa-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, restoreSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2554,7 +2554,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2564,7 +2564,7 @@ var _ = Describe("RBD", func() {
 				scOpts = map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-tenant-sa-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, restoreSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2617,7 +2617,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "secrets-metadata-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -2655,7 +2655,7 @@ var _ = Describe("RBD", func() {
 				scOpts := map[string]string{
 					"encrypted":       "true",
 					"encryptionKMSID": "vault-test",
-					"encryptionType":  util.EncryptionTypeString(encType),
+					"encryptionType":  encType.String(),
 				}
 				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 				if err != nil {
@@ -4202,7 +4202,7 @@ var _ = Describe("RBD", func() {
 					scOpts := map[string]string{
 						"encrypted":       "true",
 						"encryptionKMSID": "vault-test",
-						"encryptionType":  util.EncryptionTypeString(encType),
+						"encryptionType":  encType.String(),
 					}
 					err := createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)
 					if err != nil {
@@ -4264,7 +4264,7 @@ var _ = Describe("RBD", func() {
 				) {
 					scOpts := map[string]string{
 						"encrypted":       "true",
-						"encryptionType":  util.EncryptionTypeString(encType),
+						"encryptionType":  encType.String(),
 						"encryptionKMSID": "vault-test",
 					}
 					err := createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, scOpts, deletePolicy)

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -387,8 +387,8 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 		if savedImageAttributes.EncryptionType != encryptionType {
 			return nil, fmt.Errorf("internal state inconsistent, omap encryption type"+
 				" mismatch, request type %q(%d) volume UUID (%s) volume omap encryption type %q (%d)",
-				util.EncryptionTypeString(encryptionType), encryptionType,
-				objUUID, util.EncryptionTypeString(savedImageAttributes.EncryptionType),
+				encryptionType, encryptionType,
+				objUUID, savedImageAttributes.EncryptionType,
 				savedImageAttributes.EncryptionType)
 		}
 	}
@@ -561,7 +561,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	imagePool string, imagePoolID int64,
 	reqName, namePrefix, parentName, kmsConf, volUUID, owner,
 	backingSnapshotID string,
-	encryptionType util.EncryptionType,
+	encryptionType util.EncryptionType, //nolint:interfacer // prefer util.EncryptionType over fmt.Stringer
 ) (string, string, error) {
 	// TODO: Take in-arg as ImageAttributes?
 	var (
@@ -642,7 +642,7 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	// Update UUID directory to store encryption values
 	if kmsConf != "" {
 		omapValues[cj.encryptKMSKey] = kmsConf
-		omapValues[cj.encryptionType] = util.EncryptionTypeString(encryptionType)
+		omapValues[cj.encryptionType] = encryptionType.String()
 	}
 
 	// if owner is passed, set it in the UUID directory too

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -111,7 +111,7 @@ func ParseEncryptionType(typeStr string) EncryptionType {
 	}
 }
 
-func EncryptionTypeString(encType EncryptionType) string {
+func (encType EncryptionType) String() string {
 	switch encType {
 	case EncryptionTypeBlock:
 		return encryptionTypeBlockString

--- a/internal/util/crypto_test.go
+++ b/internal/util/crypto_test.go
@@ -77,7 +77,7 @@ func TestEncryptionType(t *testing.T) {
 	assert.EqualValues(t, EncryptionTypeNone, ParseEncryptionType(""))
 
 	for _, s := range []string{"file", "block", ""} {
-		assert.EqualValues(t, s, EncryptionTypeString(ParseEncryptionType(s)))
+		assert.EqualValues(t, s, ParseEncryptionType(s).String())
 	}
 }
 


### PR DESCRIPTION
This makes it easier to log the EncryptionType as string, or int,
whatever is preferred. Standard fmt formatting notations like %s or %d
can be used now.