### PR TITLE
revert: revert to 3.11-canary

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.11.0
+CSI_IMAGE_VERSION=v3.11-canary
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.10.2

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -117,7 +117,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.11.0
+      tag: v3.11-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -145,7 +145,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.11.0
+      tag: v3.11-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -143,7 +143,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -124,7 +124,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -120,7 +120,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -47,7 +47,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -173,7 +173,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -194,7 +194,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -28,7 +28,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -134,7 +134,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.11.0
+          image: quay.io/cephcsi/cephcsi:v3.11-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
# Describe what this PR does #

This commit makes template changes for
3.11 release branch to use 3.11-canary tag.


**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
