### PR TITLE
ci: run tests with more logs

### DIFF
--- a/run-k8s-external-storage-e2e.sh
+++ b/run-k8s-external-storage-e2e.sh
@@ -22,6 +22,7 @@ export KUBECONFIG="${KUBECONFIG_TMP}"
 for driver in /opt/build/go/src/github.com/ceph/ceph-csi/scripts/k8s-storage/driver-*.yaml
 do
 	kubernetes/test/bin/ginkgo \
+		--vv \
 		-focus="External.Storage.*.csi.ceph.com" \
 		-skip='\[Feature:|\[Disruptive\]|Generic Ephemeral-volume' \
 		kubernetes/test/bin/e2e.test \


### PR DESCRIPTION
```
  -v
    If set, emits more output including GinkgoWriter
    contents.
  --vv
    If set, emits with maximal verbosity -
    includes skipped and pending tests.
```

The above is output from the ginkgo CLI output

