### PR TITLE
build: use Go 1.21.9 to include latest security fixes

### DIFF
--- a/build.env
+++ b/build.env
@@ -19,7 +19,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v18
 CEPH_VERSION=reef
 
 # standard Golang options
-GOLANG_VERSION=1.21.5
+GOLANG_VERSION=1.21.9
 GO111MODULE=on
 
 # commitlint version

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ceph/ceph-csi
 
 go 1.21
 
-toolchain go1.21.5
+toolchain go1.21.9
 
 require (
 	github.com/IBM/keyprotect-go-client v0.12.2


### PR DESCRIPTION
Update from v1.21.5 to latest v1.21.9, to include the following fixes:

go1.21.6 (released 2024-01-09) includes fixes to the compiler, the
runtime, and the crypto/tls, maps, and runtime/pprof packages.

go1.21.7 (released 2024-02-06) includes fixes to the compiler, the go
command, the runtime, and the crypto/x509 package.

go1.21.8 (released 2024-03-05) includes security fixes to the
crypto/x509, html/template, net/http, net/http/cookiejar, and net/mail
packages, as well as bug fixes to the go command and the runtime.

go1.21.9 (released 2024-04-03) includes a security fix to the net/http
package, as well as bug fixes to the linker, and the go/types and
net/http packages.

See-also: https://go.dev/doc/devel/release#go1.21.0
Signed-off-by: Niels de Vos <ndevos@ibm.com>
