### PR TITLE
ci: do not add the `ok-to-test` label if there is a conflict

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -95,6 +95,7 @@ pull_request_rules:
   - name: start CI jobs for PRs in the merge queue
     conditions:
       - base~=^(devel)|(release-.+)$
+      - label!=conflicts
       - not:
           check-pending~=^ci/centos
       - not:


### PR DESCRIPTION
When there is a conflict in merging a PR, the `ok-to-test` label should
not be added automatically. This prevents a loop in triggering CI jobs
for PRs that might not even build.

See-also: #4555