### PR TITLE
cleanup: client cert decoding is not required

### DIFF
--- a/internal/kms/azure_vault.go
+++ b/internal/kms/azure_vault.go
@@ -18,7 +18,6 @@ package kms
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -106,18 +105,10 @@ func initAzureKeyVaultKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 		return nil, fmt.Errorf("failed to get secrets for %T, %w", kms, err)
 	}
 
-	var encodedClientCertificate string
-	err = setConfigString(&encodedClientCertificate, secrets, azureClientCertificate)
+	err = setConfigString(&kms.clientCertificate, secrets, azureClientCertificate)
 	if err != nil {
 		return nil, err
 	}
-
-	clientCertificate, err := base64.StdEncoding.DecodeString(encodedClientCertificate)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode client certificate: %w", err)
-	}
-
-	kms.clientCertificate = string(clientCertificate)
 
 	return kms, nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Earlier I had a discussion that Client certificate will be base64 encoded twice and placed into secret.
But that was misunderstood, and its only encoded once. So the extra decoding is not required.
This commit removes the base64 decoding work

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
