### PR TITLE
util: add support to configure mirror daemon count

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -27,6 +27,7 @@ serviceAccounts:
 #       - "<MONValue2>"
 #     rbd:
 #       netNamespaceFilePath: "{{ .kubeletDir }}/plugins/{{ .driverName }}/net"
+#       mirrorDaemonCount: 1
 #     readAffinity:
 #       enabled: true
 #       crushLocationLabels:

--- a/deploy/csi-config-map-sample.yaml
+++ b/deploy/csi-config-map-sample.yaml
@@ -19,6 +19,8 @@ kind: ConfigMap
 # NOTE: The given radosNamespace must already exists in the pool.
 # NOTE: Make sure you don't add radosNamespace option to a currently in use
 # configuration as it will cause issues.
+# The "rbd.mirrorDaemonCount" is optional and represents the total number of
+# RBD mirror daemons running on the ceph cluster.
 # The field "cephFS.subvolumeGroup" is optional and defaults to "csi".
 # NOTE: The given subvolumeGroup must already exist in the filesystem.
 # The "cephFS.netNamespaceFilePath" fields are the various network namespace
@@ -64,6 +66,7 @@ data:
         "rbd": {
            "netNamespaceFilePath": "<kubeletRootPath>/plugins/rbd.csi.ceph.com/net",
            "radosNamespace": "<rados-namespace>",
+           "mirrorDaemonCount": 1,
         },
         "monitors": [
           "<MONValue1>",

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -553,9 +553,13 @@ func (ri *rbdImage) isInUse() (bool, error) {
 	// because we opened the image, there is at least one watcher
 	defaultWatchers := 1
 	if mirrorInfo.Primary {
+		count, err := util.GetRBDMirrorDaemonCount(util.CsiConfigFile, ri.ClusterID)
+		if err != nil {
+			return false, err
+		}
 		// if rbd mirror daemon is running, a watcher will be added by the rbd
 		// mirror daemon for mirrored images.
-		defaultWatchers++
+		defaultWatchers += count
 	}
 
 	return len(watchers) > defaultWatchers, nil

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -45,6 +45,7 @@ const (
 	"clusterID": "<cluster-id>",
 	"rbd": {
 		"radosNamespace": "<rados-namespace>"
+		"mirrorDaemonCount": 1
 	},
 	"monitors": [
 		"<monitor-value>",
@@ -103,6 +104,22 @@ func GetRadosNamespace(pathToConfig, clusterID string) (string, error) {
 	}
 
 	return cluster.RBD.RadosNamespace, nil
+}
+
+// GetRBDMirrorDaemonCount returns the number of mirror daemon count for the
+// given clusterID.
+func GetRBDMirrorDaemonCount(pathToConfig, clusterID string) (int, error) {
+	cluster, err := readClusterInfo(pathToConfig, clusterID)
+	if err != nil {
+		return 0, err
+	}
+
+	// if it is empty, set the default to 1 which is most common in a cluster.
+	if cluster.RBD.MirrorDaemonCount == 0 {
+		return 1, nil
+	}
+
+	return cluster.RBD.MirrorDaemonCount, nil
 }
 
 // CephFSSubvolumeGroup returns the subvolumeGroup for CephFS volumes. If not set, it returns the default value "csi".

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/csi-config-map.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/csi-config-map.go
@@ -46,6 +46,8 @@ type RBD struct {
 	NetNamespaceFilePath string `json:"netNamespaceFilePath"`
 	// RadosNamespace is a rados namespace in the pool
 	RadosNamespace string `json:"radosNamespace"`
+	// RBD mirror daemons running in the ceph cluster.
+	MirrorDaemonCount int `json:"mirrorDaemonCount"`
 }
 
 type NFS struct {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Currently, we are assuming that only one rbd mirror daemon running on the ceph cluster but that is not true for many cases and it can be more than one, this PR makes this a configurable parameter.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

yes 

Are there concerns around backward compatibility?

No

Fixes: #4312
