### PR TITLE
build: include MirrorDaemonCount in the ConfigMap API

### DIFF
--- a/api/deploy/kubernetes/csi-config-map.go
+++ b/api/deploy/kubernetes/csi-config-map.go
@@ -46,6 +46,8 @@ type RBD struct {
 	NetNamespaceFilePath string `json:"netNamespaceFilePath"`
 	// RadosNamespace is a rados namespace in the pool
 	RadosNamespace string `json:"radosNamespace"`
+	// RBD mirror daemons running in the ceph cluster.
+	MirrorDaemonCount int `json:"mirrorDaemonCount"`
 }
 
 type NFS struct {


### PR DESCRIPTION
It seems that original commit 4c2d2caf9f modified the API under the
vendor/ directory. Weirdly this did not cause any issues?! The change
should have been done in the api/deploy/kubernetes/ file instead, that
gets sync'd after running "go mod vendor".