### PR TITLE
build: prevent "Operation not supported" failures while extracting Golang in CI jobs

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -8,7 +8,7 @@
 # little different.
 #
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:39
 
 ARG GOPATH=/go
 ARG GOROOT=/usr/local/go


### PR DESCRIPTION
It seems GitHub has an issue with the Fedora 40 container image, extracting the Golang tarball fails. The Fedora 39 image does not have this problem, so use that for the time being.