### PR TITLE
cleanup: incorrect fuserecovery logging

### DIFF
--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -151,6 +151,10 @@ func validateMounter(m string) error {
 	return nil
 }
 
+func (v *VolumeOptions) DetectMounter(options map[string]string) error {
+	return extractMounter(&v.Mounter, options)
+}
+
 func extractMounter(dest *string, options map[string]string) error {
 	if err := extractOptionalOption(dest, "mounter", options); err != nil {
 		return err

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -340,12 +340,6 @@ func IsCorruptedMountError(err error) bool {
 	return mount.IsCorruptedMnt(err)
 }
 
-// ReadMountInfoForProc reads /proc/<PID>/mountpoint and marshals it into
-// MountInfo structs.
-func ReadMountInfoForProc(proc string) ([]mount.MountInfo, error) {
-	return mount.ParseMountInfo(fmt.Sprintf("/proc/%s/mountinfo", proc))
-}
-
 // Mount mounts the source to target path.
 func Mount(mounter mount.Interface, source, target, fstype string, options []string) error {
 	return mounter.MountSensitiveWithoutSystemd(source, target, fstype, options, nil)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

cleanup: incorrect fuserecovery logging
This commit make sure that logs `fuserecovery.go` is only logged
when the chosen mount is FUSE.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
