### PR TITLE
rebase: update minikube to 1.33

### DIFF
--- a/build.env
+++ b/build.env
@@ -44,7 +44,7 @@ HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 HELM_VERSION=v3.14.3
 
 # minikube settings
-MINIKUBE_VERSION=v1.32.0
+MINIKUBE_VERSION=v1.33.0
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 


### PR DESCRIPTION
Updating Minikube to the latest [1.33 release](https://github.com/kubernetes/minikube/releases/tag/v1.33.0)
