### PR TITLE
Fix the Slack invite link on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,6 @@ Please use the following to reach members of the community:
   [#ceph-csi](https://ceph-storage.slack.com/archives/C05522L7P60) channel
   on the [ceph Slack](https://ceph-storage.slack.com) to discuss anything
   related to this project. You can join the Slack by this
-  [invite link](bit.ly/ceph-slack-invite)
+  [invite link](https://bit.ly/ceph-slack-invite)
 - Forums: [ceph-csi](https://groups.google.com/forum/#!forum/ceph-csi)
 - Twitter: [@CephCsi](https://twitter.com/CephCsi)


### PR DESCRIPTION
The link on the README file to get an invite to the Ceph Slack was missing a URL scheme, so it was interpreted as a relative link and resulted in a 404.

# Describe what this PR does #

Adds the URL scheme of `https://` to the link to the Slack invite.

## Is there anything that requires special attention ##

No

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release. **n/a**
* [ ] Documentation has been updated, if necessary. **n/a**
* [ ] Unit tests have been added, if necessary. **n/a**
* [ ] Integration tests have been added, if necessary. **n/a**

