### PR TITLE
ci: install ruby-devel in test container

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -37,6 +37,7 @@ RUN source /build.env \
         libcephfs-devel \
 	librbd-devel \
 	openssl \
+	ruby-devel \
 	rubygems \
 	ShellCheck \
 	codespell \


### PR DESCRIPTION
The tests are failing due to the missing ruby-devel package in the base image

