### PR TITLE
ci: Use temporary directory for unit tests

### DIFF
--- a/internal/rbd/nodeserver_test.go
+++ b/internal/rbd/nodeserver_test.go
@@ -243,11 +243,8 @@ func TestReadAffinity_GetReadAffinityMapOptions(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to marshal csi config info %v", err)
 	}
-	tmpConfPath := util.CsiConfigFile
-	err = os.Mkdir("/etc/ceph-csi-config", 0o600)
-	if err != nil {
-		t.Errorf("failed to create directory %s: %v", "/etc/ceph-csi-config", err)
-	}
+	tmpConfPath := t.TempDir() + "/ceph-csi.json"
+
 	err = os.WriteFile(tmpConfPath, csiConfigFileContent, 0o600)
 	if err != nil {
 		t.Errorf("failed to write %s file content: %v", util.CsiConfigFile, err)


### PR DESCRIPTION
ci: Use temporary directory for unit tests

This commit implements the use of a temporary directory for unit tests in order to ensure a clean and isolated environment for testing purposes.

Signed-off-by: Mayank Pal <mayankpal9654@gmail.com>

 Fixes #4617