### PR TITLE
ci: update centos to 9 stream

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -1,6 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
+def duffy_pool = 'virt-ec2-t2-centos-9s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit updates the CentOS 8 Stream to 9 Stream.

Due to observed CI failures - 
```
+ duffy client request-session pool=virt-ec2-t2-centos-8s-x86_64,quantity=1
Cannot get property 'nodes' on null object
```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
