### PR TITLE
ci: use CentOS 9 Stream machines for all Jenkins jobs

### DIFF
--- a/ci-job-validation.groovy
+++ b/ci-job-validation.groovy
@@ -1,6 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
+def duffy_pool = 'virt-ec2-t2-centos-9s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'

--- a/commitlint.groovy
+++ b/commitlint.groovy
@@ -1,6 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
+def duffy_pool = 'virt-ec2-t2-centos-9s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def ref = "devel"

--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -1,6 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
+def duffy_pool = 'virt-ec2-t2-centos-9s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'

--- a/jobs/ci-job-validation.yaml
+++ b/jobs/ci-job-validation.yaml
@@ -20,7 +20,7 @@
       lightweight-checkout: true
     triggers:
       - github-pull-request:
-          status-url: ${RUN_DISPLAY_URL}
+          status-url: $RUN_DISPLAY_URL
           status-context: ci/centos/job-validation
           trigger-phrase: '/(re)?test ((all)|(ci/centos/job-validation))'
           permit-all: true

--- a/jobs/jjb-validate.yaml
+++ b/jobs/jjb-validate.yaml
@@ -28,7 +28,7 @@
       lightweight-checkout: false
     triggers:
       - github-pull-request:
-          status-url: ${RUN_DISPLAY_URL}
+          status-url: $RUN_DISPLAY_URL
           status-context: ci/centos/jjb-validate
           trigger-phrase: "/(re)?test ((all)|(ci/centos/jjb-validate))"
           permit-all: true

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -1,6 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
+def duffy_pool = 'virt-ec2-t2-centos-9s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -1,6 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
+def duffy_pool = 'virt-ec2-t2-centos-9s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'

--- a/mirror/Containerfile
+++ b/mirror/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 RUN true \
  && dnf -y install skopeo \

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -1,6 +1,6 @@
 def cico_retries = 16
 def cico_retry_interval = 60
-def duffy_pool = 'virt-ec2-t2-centos-8s-x86_64'
+def duffy_pool = 'virt-ec2-t2-centos-9s-x86_64'
 def ci_git_repo = 'https://github.com/ceph/ceph-csi'
 def ci_git_branch = 'ci/centos'
 def git_repo = 'https://github.com/ceph/ceph-csi'


### PR DESCRIPTION
CentOS 8 Stream will be EOL at the end of this month, use CentOS 9 Stream instead.