### PR TITLE
Support storing cephfs omap data store in radosnamespace via cli argument

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -9,5 +9,6 @@
 - deploy: instanceID can be optionally configured for ceph-csi charts in [PR](https://github.com/ceph/ceph-csi/pull/4666)
 - rbd: add support for flattenMode option for replication in [PR](https://github.com/ceph/ceph-csi/pull/4678)
 - cephfs: support omap data store in radosnamespace via cli argument in [PR](https://github.com/ceph/ceph-csi/pull/4652)
+- deploy: radosNamespaceCephFS can be configured for ceph-csi-cephfs chart in [PR](https://github.com/ceph/ceph-csi/pull/4652)
 
 ## NOTE

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -8,5 +8,6 @@
 - deploy: podSecurityContexts can be configured for ceph-csi-rbd chart in [PR](https://github.com/ceph/ceph-csi/pull/4668)
 - deploy: instanceID can be optionally configured for ceph-csi charts in [PR](https://github.com/ceph/ceph-csi/pull/4666)
 - rbd: add support for flattenMode option for replication in [PR](https://github.com/ceph/ceph-csi/pull/4678)
+- cephfs: support omap data store in radosnamespace via cli argument in [PR](https://github.com/ceph/ceph-csi/pull/4652)
 
 ## NOTE

--- a/charts/ceph-csi-cephfs/README.md
+++ b/charts/ceph-csi-cephfs/README.md
@@ -201,6 +201,7 @@ charts and their default values.
 | `CSIDriver.fsGroupPolicy` | Specifies the fsGroupPolicy for the CSI driver object | `File` |
 | `CSIDriver.seLinuxMount` | Specify for efficient SELinux volume relabeling | `true` |
 | `instanceID`                                   | Unique ID distinguishing this instance of Ceph CSI among other instances, when sharing Ceph clusters across CSI instances for provisioning. | ` ` |
+| `radosNamespaceCephFS`                         | CephFS RadosNamespace used to store CSI specific objects and keys. | ` ` |
 
 ### Command Line
 

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -62,6 +62,9 @@ spec:
 {{- if .Values.instanceID }}
             - "--instanceid={{ .Values.instanceID }}"
 {{- end }}
+{{- if .Values.radosNamespaceCephFS }}
+            - "--radosnamespacecephfs={{ .Values.radosNamespaceCephFS }}"
+{{- end }}
 {{- if .Values.nodeplugin.profiling.enabled }}
             - "--enableprofiling={{ .Values.nodeplugin.profiling.enabled }}"
 {{- end }}

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -82,6 +82,9 @@ spec:
 {{- if .Values.instanceID }}
             - "--instanceid={{ .Values.instanceID }}"
 {{- end }}
+{{- if .Values.radosNamespaceCephFS }}
+            - "--radosnamespacecephfs={{ .Values.radosNamespaceCephFS }}"
+{{- end }}
 {{- if .Values.provisioner.profiling.enabled }}
             - "--enableprofiling={{ .Values.provisioner.profiling.enabled }}"
 {{- end }}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -372,6 +372,8 @@ configMapName: ceph-csi-config
 externallyManagedConfigmap: false
 # Name of the configmap used for ceph.conf
 cephConfConfigMapName: ceph-config
+# CephFS RadosNamespace used to store CSI specific objects and keys.
+# radosNamespaceCephFS: csi
 # Unique ID distinguishing this instance of Ceph CSI among other instances,
 # when sharing Ceph clusters across CSI instances for provisioning
 # instanceID: default

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -101,6 +101,11 @@ func init() {
 		"",
 		"Comma separated string of mount options accepted by cephfs kernel mounter")
 	flag.StringVar(
+		&conf.RadosNamespaceCephFS,
+		"radosnamespacecephfs",
+		"",
+		"CephFS RadosNamespace used to store CSI specific objects and keys.")
+	flag.StringVar(
 		&conf.FuseMountOptions,
 		"fusemountoptions",
 		"",

--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -49,6 +49,7 @@ make image-cephcsi
 | `--domainlabels`          | _empty_                     | Kubernetes node labels to use as CSI domain labels for topology aware provisioning, should be a comma separated value (ex:= "failure-domain/region,failure-domain/zone")                                                                                                             |
 | `--enable-read-affinity` | `false`                       | enable read affinity                                                                                                                                                                                                                                                                 |
 | `--crush-location-labels`| _empty_                       | Kubernetes node labels that determine the CRUSH location the node belongs to, separated by ','.<br>`Note: These labels will be replaced if crush location labels are defined in the ceph-csi-config ConfigMap for the specific cluster.`                                                                                                                                                                                       |
+| `--radosnamespacecephfs`| _empty_                       | CephFS RadosNamespace used to store CSI specific objects and keys.                                                                                                                               |
 
 **NOTE:** The parameter `-forcecephkernelclient` enables the Kernel
 CephFS mounter on kernels < 4.17.

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -110,6 +110,11 @@ func (fs *Driver) Run(conf *util.Config) {
 		CSIInstanceID = conf.InstanceID
 	}
 
+	// Use passed in radosNamespace, if provided for storing CSI specific objects and keys.
+	if conf.RadosNamespaceCephFS != "" {
+		fsutil.RadosNamespace = conf.RadosNamespaceCephFS
+	}
+
 	if conf.IsNodeServer && k8s.RunsOnKubernetes() {
 		nodeLabels, err = k8s.GetNodeLabels(conf.NodeID)
 		if err != nil {

--- a/internal/cephfs/util/util.go
+++ b/internal/cephfs/util/util.go
@@ -19,7 +19,5 @@ package util
 // VolumeID string representation.
 type VolumeID string
 
-const (
-	// RadosNamespace to store CSI specific objects and keys.
-	RadosNamespace = "csi"
-)
+// RadosNamespace to store CSI specific objects and keys.
+var RadosNamespace = "csi"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -142,9 +142,9 @@ type Config struct {
 	SkipForceFlatten bool
 
 	// cephfs related flags
-	ForceKernelCephFS bool // force to use the ceph kernel client even if the kernel is < 4.17
-
-	SetMetadata bool // set metadata on the volume
+	ForceKernelCephFS    bool   // force to use the ceph kernel client even if the kernel is < 4.17
+	RadosNamespaceCephFS string // RadosNamespace used to store CSI specific objects and keys
+	SetMetadata          bool   // set metadata on the volume
 
 	// Read affinity related options
 	EnableReadAffinity  bool   // enable OSD read affinity.


### PR DESCRIPTION
# Describe what this PR does #

Fixes #4599

This PR adds a new cli argument to let users override the current hardcoded radosNamespace "csi" used in CephFS.
https://github.com/ceph/ceph-csi/blob/ce3ec6acbf639f9485ba63220329d07407713fa1/internal/cephfs/util/util.go#L24 
Needed is this for multitenant environments where one ceph cluster with one cephfs filesystem is used by multiple kubernetes clusters.
This allows storing the state of every cephfs instance / kubernetes cluster in their own radosNamespaces and allows finer controlled access for cephfs.

This PR also makes those two needed parameters --instanceid (rbd & cephfs Helm Chart) and --radosnamespacecephfs (cephfs Helm Chart) configurable via helm chart.


## Is there anything that requires special attention ##

Is the change backward compatible?

Yes

Are there concerns around backward compatibility?

No, the default values in code have not been changed but are now overrideable via helm and cli arguments.

## Future concerns ##

Depending on future usage of the NFS Controller, currently the NFS controller is using the CephFS variables cephfs.CSIInstanceID and fsutil.RadosNamespace which is now overrideable with the cli argument `--radosnamespacecephfs` and `--instanceid`. 
https://github.com/ceph/ceph-csi/blob/ce3ec6acbf639f9485ba63220329d07407713fa1/internal/nfs/controller/controllerserver.go#L48
https://github.com/ceph/ceph-csi/blob/ce3ec6acbf639f9485ba63220329d07407713fa1/internal/nfs/controller/controllerserver.go#L49
https://github.com/ceph/ceph-csi/blob/ce3ec6acbf639f9485ba63220329d07407713fa1/internal/nfs/controller/volume.go#L291
https://github.com/ceph/ceph-csi/blob/ce3ec6acbf639f9485ba63220329d07407713fa1/internal/nfs/controller/volume.go#L329

# Testing

As i don't have a nice way of testing it and this is my first PR and go code for some time i would appreciate an detailed review.