### PR TITLE
ci: update centos stream 8 baseurl

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -4,6 +4,11 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE} as updated_base
 
+# Since CentOS Stream 8 is EOL, update the config to use vault.centos.org for CentOS Stream 8
+# TODO: remove once https://github.com/ceph/ceph-csi/issues/4659 is fixed.
+RUN sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/*.repo && \
+    sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*.repo
+
 # TODO: remove the following cmd, when issues
 # https://github.com/ceph/ceph-container/issues/2034
 # https://github.com/ceph/ceph-container/issues/2141 are fixed.

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -1,6 +1,11 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+# Since CentOS Stream 8 is EOL, update the config to use vault.centos.org for CentOS Stream 8
+# TODO: remove once https://github.com/ceph/ceph-csi/issues/4659 is fixed.
+RUN sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/*.repo && \
+    sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*.repo
+
 ARG GOROOT=/usr/local/go
 ARG GOARCH
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Since CentOS Stream 8 is EOL, this commit updates the config to use vault.centos.org for CentOS Stream 8. 
This should be removed once the base image (ceph) is updated to a version with a newer CentOS.

update baseurl with: http://vault.centos.org

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
