### PR TITLE
e2e: retry when a pod does not have a host assigned (yet)

### DIFF
--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -58,6 +58,13 @@ func isRetryableAPIError(err error) bool {
 		return true
 	}
 
+	// "pod nfs-820 does not have a host assigned" seems to get reported
+	// when a Pod is not completely started yet, or was restarted while
+	// trying to access it
+	if strings.Contains(err.Error(), "does not have a host assigned") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Errors like "pod nfs-820 does not have a host assigned" seem to get
reported when a Pod is not completely started yet, or was restarted
while trying to access it.

Reported: https://github.com/ceph/ceph-csi/pull/4656#issuecomment-2151794926