### PR TITLE
doc: reset PendingReleaseNotes.md to v3.12.0

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,9 +1,7 @@
-# v3.11 Pending Release Notes
+# v3.12 Pending Release Notes
 
 ## Breaking Changes
 
 ## Features
-
-- kms: added Azure Key Vault as a supported KMS in [PR](https://github.com/ceph/ceph-csi/pull/4455)
 
 ## NOTE


### PR DESCRIPTION
This commit resets PendingReleaseNotes.md and
points it to release v3.12.0.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
