### PR TITLE
rbd: use internal as default error code in getGRPCError()

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -776,14 +776,10 @@ func getGRPCError(err error) error {
 	}
 
 	errorStatusMap := map[error]codes.Code{
-		corerbd.ErrFetchingLocalState:          codes.Internal,
-		corerbd.ErrResyncImageFailed:           codes.Internal,
-		corerbd.ErrDisableImageMirroringFailed: codes.Internal,
-		corerbd.ErrFetchingMirroringInfo:       codes.Internal,
-		corerbd.ErrInvalidArgument:             codes.InvalidArgument,
-		corerbd.ErrAborted:                     codes.Aborted,
-		corerbd.ErrFailedPrecondition:          codes.FailedPrecondition,
-		corerbd.ErrUnavailable:                 codes.Unavailable,
+		corerbd.ErrInvalidArgument:    codes.InvalidArgument,
+		corerbd.ErrAborted:            codes.Aborted,
+		corerbd.ErrFailedPrecondition: codes.FailedPrecondition,
+		corerbd.ErrUnavailable:        codes.Unavailable,
 	}
 
 	for e, code := range errorStatusMap {
@@ -792,8 +788,8 @@ func getGRPCError(err error) error {
 		}
 	}
 
-	// Handle any other non nil error not listed in the map
-	return status.Error(codes.Unknown, err.Error())
+	// Handle any other non nil error not listed in the map as internal error
+	return status.Error(codes.Internal, err.Error())
 }
 
 // GetVolumeReplicationInfo extracts the RBD volume information from the volumeID, If the

--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -542,26 +542,6 @@ func TestGetGRPCError(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:        "FetchingLocalStateFailed",
-			err:         corerbd.ErrFetchingLocalState,
-			expectedErr: status.Error(codes.Internal, corerbd.ErrFetchingLocalState.Error()),
-		},
-		{
-			name:        "ResyncImageFailed",
-			err:         corerbd.ErrResyncImageFailed,
-			expectedErr: status.Error(codes.Internal, corerbd.ErrResyncImageFailed.Error()),
-		},
-		{
-			name:        "DisableImageMirroringFailed",
-			err:         corerbd.ErrDisableImageMirroringFailed,
-			expectedErr: status.Error(codes.Internal, corerbd.ErrDisableImageMirroringFailed.Error()),
-		},
-		{
-			name:        "FetchingMirroringInfoFailed",
-			err:         corerbd.ErrFetchingMirroringInfo,
-			expectedErr: status.Error(codes.Internal, corerbd.ErrFetchingMirroringInfo.Error()),
-		},
-		{
 			name:        "InvalidArgument",
 			err:         corerbd.ErrInvalidArgument,
 			expectedErr: status.Error(codes.InvalidArgument, corerbd.ErrInvalidArgument.Error()),
@@ -584,7 +564,7 @@ func TestGetGRPCError(t *testing.T) {
 		{
 			name:        "InvalidError",
 			err:         errors.New("some error"),
-			expectedErr: status.Error(codes.Unknown, "some error"),
+			expectedErr: status.Error(codes.Internal, "some error"),
 		},
 		{
 			name:        "NilError",

--- a/internal/rbd/errors.go
+++ b/internal/rbd/errors.go
@@ -55,14 +55,6 @@ var (
 	ErrAborted = errors.New("operation got aborted")
 	// ErrInvalidArgument is returned when the client specified an invalid argument.
 	ErrInvalidArgument = errors.New("invalid arguments provided")
-	// ErrFetchingLocalState is returned when the operation to fetch local state fails.
-	ErrFetchingLocalState = errors.New("failed to get local state")
-	// ErrDisableImageMirroringFailed is returned when the operation to disable image mirroring fails.
-	ErrDisableImageMirroringFailed = errors.New("failed to disable image mirroring")
-	// ErrFetchingMirroringInfo is returned when the operation to fetch mirroring info of image fails.
-	ErrFetchingMirroringInfo = errors.New("failed to get mirroring info of image")
-	// ErrResyncImageFailed is returned when the operation to resync the image fails.
-	ErrResyncImageFailed = errors.New("failed to resync image")
 	// ErrImageInUse is returned when the image is in use.
 	ErrImageInUse = errors.New("image is in use")
 )

--- a/internal/rbd/replication.go
+++ b/internal/rbd/replication.go
@@ -25,7 +25,7 @@ import (
 
 func (rv *rbdVolume) ResyncVol(localStatus librbd.SiteMirrorImageStatus) error {
 	if err := rv.resyncImage(); err != nil {
-		return fmt.Errorf("%w: failed to resync image: %w", ErrResyncImageFailed, err)
+		return fmt.Errorf("failed to resync image: %w", err)
 	}
 
 	// If we issued a resync, return a non-final error as image needs to be recreated
@@ -73,7 +73,7 @@ func (rv *rbdVolume) DisableVolumeReplication(
 		// replication Kubernetes artifacts after failback operation.
 		localStatus, rErr := rv.GetLocalState()
 		if rErr != nil {
-			return fmt.Errorf("%w: %w", ErrFetchingLocalState, rErr)
+			return fmt.Errorf("failed to get local state: %w", rErr)
 		}
 		if localStatus.Up && localStatus.State == librbd.MirrorImageStatusStateReplaying {
 			return nil
@@ -84,13 +84,13 @@ func (rv *rbdVolume) DisableVolumeReplication(
 	}
 	err := rv.DisableImageMirroring(force)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrDisableImageMirroringFailed, err)
+		return fmt.Errorf("failed to disable image mirroring: %w", err)
 	}
 	// the image state can be still disabling once we disable the mirroring
 	// check the mirroring is disabled or not
 	mirroringInfo, err = rv.GetImageMirroringInfo()
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrFetchingMirroringInfo, err)
+		return fmt.Errorf("failed to get mirroring info of image: %w", err)
 	}
 	if mirroringInfo.State == librbd.MirrorImageDisabling {
 		return fmt.Errorf("%w: %q is in disabling state", ErrAborted, rv.VolID)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit replaces `codes.Unknown` with `codes.Internal` as the default error code in getGRPCError()
since it much better suited.


**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
