### PR TITLE
journal: Update group journal to accomudate rbd group

### DIFF
--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -644,7 +644,7 @@ func (cs *ControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Contex
 			ctx,
 			vgo.MetadataPool,
 			vgsi.ReservedID,
-			volID)
+			[]string{volID})
 		j.Destroy()
 		if err != nil {
 			log.ErrorLog(ctx, "failed to remove volume snapshot mapping: %v", err)

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -461,11 +461,13 @@ func (cs *ControllerServer) createSnapshotAndAddMapping(
 	}
 	defer j.Destroy()
 	// Add the snapshot to the volume group journal
-	err = j.AddVolumeMapping(ctx,
+	err = j.AddVolumesMapping(ctx,
 		vgo.MetadataPool,
 		vgs.ReservedID,
-		req.GetSourceVolumeId(),
-		resp.GetSnapshot().GetSnapshotId())
+		map[string]string{
+			req.GetSourceVolumeId(): resp.GetSnapshot().GetSnapshotId(),
+		},
+	)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to add volume snapshot mapping: %v", err)
 		// Delete the last created snapshot as its still not added to the
@@ -640,7 +642,7 @@ func (cs *ControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Contex
 			return err
 		}
 		// remove the entry from the omap
-		err = j.RemoveVolumeMapping(
+		err = j.RemoveVolumesMapping(
 			ctx,
 			vgo.MetadataPool,
 			vgsi.ReservedID,

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -461,7 +461,7 @@ func (cs *ControllerServer) createSnapshotAndAddMapping(
 	}
 	defer j.Destroy()
 	// Add the snapshot to the volume group journal
-	err = j.AddVolumeSnapshotMapping(ctx,
+	err = j.AddVolumeMapping(ctx,
 		vgo.MetadataPool,
 		vgs.ReservedID,
 		req.GetSourceVolumeId(),
@@ -640,7 +640,7 @@ func (cs *ControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Contex
 			return err
 		}
 		// remove the entry from the omap
-		err = j.RemoveVolumeSnapshotMapping(
+		err = j.RemoveVolumeMapping(
 			ctx,
 			vgo.MetadataPool,
 			vgsi.ReservedID,

--- a/internal/cephfs/store/volumegroup.go
+++ b/internal/cephfs/store/volumegroup.go
@@ -169,7 +169,7 @@ func NewVolumeGroupOptionsFromID(
 	vgs.RequestName = groupAttributes.RequestName
 	vgs.FsVolumeGroupSnapshotName = groupAttributes.GroupName
 	vgs.VolumeGroupSnapshotID = volumeGroupSnapshotID
-	vgs.VolumeSnapshotMap = groupAttributes.VolumeSnapshotMap
+	vgs.VolumeSnapshotMap = groupAttributes.VolumeMap
 
 	return volOptions, &vgs, nil
 }
@@ -208,7 +208,7 @@ func CheckVolumeGroupSnapExists(
 	vgs.RequestName = volOptions.RequestName
 	vgs.ReservedID = volGroupData.GroupUUID
 	vgs.FsVolumeGroupSnapshotName = volGroupData.GroupName
-	vgs.VolumeSnapshotMap = volGroupData.VolumeGroupAttributes.VolumeSnapshotMap
+	vgs.VolumeSnapshotMap = volGroupData.VolumeGroupAttributes.VolumeMap
 
 	// found a snapshot already available, process and return it!
 	vgs.VolumeGroupSnapshotID, err = util.GenerateVolID(ctx, volOptions.Monitors, cr, volOptions.FscID,

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -64,12 +64,12 @@ type VolumeGroupJournal interface {
 		reservedUUID,
 		volumeID,
 		value string) error
-	// RemoveVolumeMapping removes a volumeID mapping from the UUID directory.
+	// RemoveVolumeMapping removes volumeIDs mapping from the UUID directory.
 	RemoveVolumeMapping(
 		ctx context.Context,
 		pool,
-		reservedUUID,
-		volumeID string) error
+		reservedUUID string,
+		volumeIDs []string) error
 }
 
 // VolumeGroupJournalConfig contains the configuration.
@@ -424,14 +424,14 @@ func (vgjc *VolumeGroupJournalConnection) AddVolumeMapping(
 func (vgjc *VolumeGroupJournalConnection) RemoveVolumeMapping(
 	ctx context.Context,
 	pool,
-	reservedUUID,
-	volumeID string,
+	reservedUUID string,
+	volumeIDs []string,
 ) error {
 	err := removeMapKeys(ctx, vgjc.connection, pool, vgjc.config.namespace,
 		vgjc.config.cephUUIDDirectoryPrefix+reservedUUID,
-		[]string{volumeID})
+		volumeIDs)
 	if err != nil {
-		log.ErrorLog(ctx, "failed removing volume mapping from group: key %q: %v", volumeID, err)
+		log.ErrorLog(ctx, "failed removing volume mapping from group: key: %q %v", volumeIDs, err)
 
 		return err
 	}

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -55,17 +55,18 @@ type VolumeGroupJournal interface {
 		journalPoolID int64,
 		reqName,
 		namePrefix string) (string, string, error)
-	// AddVolumeMapping adds a volumeID and value mapping to the UUID
+	// AddVolumesMapping adds a volumeMap map which contains volumeID's and its
+	// corresponding values mapping which need to be added to the UUID
 	// directory. value can be anything which needs mapping, in case of
-	// volumegroupsnapshot its a snapshotID and its empty in case of volumegroup.
-	AddVolumeMapping(
+	// volumegroupsnapshot its a snapshotID and its empty in case of
+	// volumegroup.
+	AddVolumesMapping(
 		ctx context.Context,
 		pool,
-		reservedUUID,
-		volumeID,
-		value string) error
-	// RemoveVolumeMapping removes volumeIDs mapping from the UUID directory.
-	RemoveVolumeMapping(
+		reservedUUID string,
+		volumeMap map[string]string) error
+	// RemoveVolumesMapping removes volumeIDs mapping from the UUID directory.
+	RemoveVolumesMapping(
 		ctx context.Context,
 		pool,
 		reservedUUID string,
@@ -403,17 +404,16 @@ func (vgjc *VolumeGroupJournalConnection) GetVolumeGroupAttributes(
 	return groupAttributes, nil
 }
 
-func (vgjc *VolumeGroupJournalConnection) AddVolumeMapping(
+func (vgjc *VolumeGroupJournalConnection) AddVolumesMapping(
 	ctx context.Context,
 	pool,
-	reservedUUID,
-	volumeID,
-	value string,
+	reservedUUID string,
+	volumeMap map[string]string,
 ) error {
 	err := setOMapKeys(ctx, vgjc.connection, pool, vgjc.config.namespace, vgjc.config.cephUUIDDirectoryPrefix+reservedUUID,
-		map[string]string{volumeID: value})
+		volumeMap)
 	if err != nil {
-		log.ErrorLog(ctx, "failed adding volume mapping: %v", err)
+		log.ErrorLog(ctx, "failed to add volumeMap %v: %w ", volumeMap, err)
 
 		return err
 	}
@@ -421,7 +421,7 @@ func (vgjc *VolumeGroupJournalConnection) AddVolumeMapping(
 	return nil
 }
 
-func (vgjc *VolumeGroupJournalConnection) RemoveVolumeMapping(
+func (vgjc *VolumeGroupJournalConnection) RemoveVolumesMapping(
 	ctx context.Context,
 	pool,
 	reservedUUID string,


### PR DESCRIPTION
Updated the group journal to remove snapshot-specific things from it and make it generic as it can be reused for rbd as well and also added a new key to the volume journal to store the groupID which is required to track the groupID of the volume from which we can identify the rbd image belongs to which group.