### PR TITLE
wip: implement a global lock for cephfs encryption

### DIFF
--- a/internal/util/radosmutex/errors/errors.go
+++ b/internal/util/radosmutex/errors/errors.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	goerrors "errors"
+	"fmt"
+
+	"github.com/ceph/go-ceph/rados"
+	"golang.org/x/sys/unix"
+)
+
+// ErrObjectOutOfDate is an error returned by RADOS read/write ops whose
+// rados_*_op_assert_version failed.
+var ErrObjectOutOfDate = goerrors.New("object is out of date since the last time it was read, try again later")
+
+// UnexpectedReadSize formats an error message for a failure due to bad read
+// size.
+func UnexpectedReadSize(expectedBytes, actualBytes int) error {
+	return fmt.Errorf("unexpected size read: expected %d bytes, got %d",
+		expectedBytes, actualBytes)
+}
+
+// UnknownObjectVersion formats an error message for a failure due to unknown
+// reftracker object version.
+func UnknownObjectVersion(unknownVersion uint32) error {
+	return fmt.Errorf("unknown reftracker version %d", unknownVersion)
+}
+
+// FailedObjectRead formats an error message for a failed RADOS read op.
+func FailedObjectRead(cause error) error {
+	if cause != nil {
+		return fmt.Errorf("failed to read object: %w", TryRADOSAborted(cause))
+	}
+
+	return nil
+}
+
+// FailedObjectRead formats an error message for a failed RADOS read op.
+func FailedObjectWrite(cause error) error {
+	if cause != nil {
+		return fmt.Errorf("failed to write object: %w", TryRADOSAborted(cause))
+	}
+
+	return nil
+}
+
+// TryRADOSAborted tries to extract rados_*_op_assert_version from opErr.
+func TryRADOSAborted(opErr error) error {
+	if opErr == nil {
+		return nil
+	}
+
+	var radosOpErr rados.OperationError
+	if !goerrors.As(opErr, &radosOpErr) {
+		return opErr
+	}
+
+	errnoErr, ok := radosOpErr.OpError.(interface{ ErrorCode() int })
+	if !ok {
+		return opErr
+	}
+
+	errno := errnoErr.ErrorCode()
+	if errno == -int(unix.EOVERFLOW) || errno == -int(unix.ERANGE) {
+		return ErrObjectOutOfDate
+	}
+
+	return nil
+}

--- a/internal/util/radosmutex/lock/lock.go
+++ b/internal/util/radosmutex/lock/lock.go
@@ -1,0 +1,97 @@
+package lock
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/lockstate"
+)
+
+// Lock represents a lock with an owner, state, and expiry time.
+type Lock struct {
+	LockOwner  string
+	LockState  lockstate.LockState
+	LockExpiry time.Time
+}
+
+const (
+	// LockOwnerMaxSize defines the maximum size of the lock owner string in bytes.
+	LockOwnerMaxSize = 256
+	// TimeStampSize defines the size of the timestamp in bytes.
+	TimeStampSize = 8
+)
+
+// ToBytes serializes the Lock structure into a byte slice.
+func (l *Lock) ToBytes() ([]byte, error) {
+	ownerBytes := []byte(l.LockOwner)
+	if len(ownerBytes) > LockOwnerMaxSize {
+		return nil, fmt.Errorf("lock owner exceeds max size of %d bytes", LockOwnerMaxSize)
+	}
+
+	buffer := new(bytes.Buffer)
+
+	// Write the length of the lock owner string
+	if err := binary.Write(buffer, binary.LittleEndian, int16(len(ownerBytes))); err != nil {
+		return nil, err
+	}
+
+	// Write the lock owner string
+	if _, err := buffer.Write(ownerBytes); err != nil {
+		return nil, err
+	}
+
+	// Write the lock state
+	if _, err := buffer.Write(lockstate.ToBytes(l.LockState)); err != nil {
+		return nil, err
+	}
+
+	// Write the lock expiry timestamp
+	expiryBytes := make([]byte, TimeStampSize)
+	binary.LittleEndian.PutUint64(expiryBytes, uint64(l.LockExpiry.Unix()))
+	if _, err := buffer.Write(expiryBytes); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+// FromBytes deserializes the byte slice into a Lock structure.
+func (l *Lock) FromBytes(data []byte) error {
+	buffer := bytes.NewReader(data)
+
+	// Read the length of the lock owner string
+	var ownerLength int16
+	if err := binary.Read(buffer, binary.LittleEndian, &ownerLength); err != nil {
+		return err
+	}
+
+	// Read the lock owner string
+	ownerBytes := make([]byte, ownerLength)
+	if _, err := buffer.Read(ownerBytes); err != nil {
+		return err
+	}
+	l.LockOwner = string(ownerBytes)
+
+	// Read the lock state
+	stateBytes := make([]byte, lockstate.LockStateSize)
+	if _, err := buffer.Read(stateBytes); err != nil {
+		return err
+	}
+	lockState, err := lockstate.FromBytes(stateBytes)
+	if err != nil {
+		return err
+	}
+	l.LockState = lockState
+
+	// Read the lock expiry timestamp
+	expiryBytes := make([]byte, TimeStampSize)
+	if _, err := buffer.Read(expiryBytes); err != nil {
+		return err
+	}
+	expiryUnix := int64(binary.LittleEndian.Uint64(expiryBytes))
+	l.LockExpiry = time.Unix(expiryUnix, 0)
+
+	return nil
+}

--- a/internal/util/radosmutex/lock/lock_test.go
+++ b/internal/util/radosmutex/lock/lock_test.go
@@ -1,0 +1,96 @@
+package lock
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/lockstate"
+)
+
+func TestLockSerializationDeserialization(t *testing.T) {
+	// Setup
+	lockInstance := Lock{
+		LockOwner:  "testUser",
+		LockState:  lockstate.Unlocked,
+		LockExpiry: time.Now().Add(10 * time.Minute),
+	}
+
+	// Test Successful Serialization and Deserialization
+	serialized, err := lockInstance.ToBytes()
+	if err != nil {
+		t.Fatalf("Failed to serialize lock: %v", err)
+	}
+
+	deserializedLock := Lock{}
+	err = deserializedLock.FromBytes(serialized)
+	if err != nil {
+		t.Fatalf("Failed to deserialize lock: %v", err)
+	}
+
+	t.Logf("Original LockOwner: %s", lockInstance.LockOwner)
+	t.Logf("Deserialized LockOwner: %s", deserializedLock.LockOwner)
+	t.Logf("Original LockState: %v", lockInstance.LockState)
+	t.Logf("Deserialized LockState: %v", deserializedLock.LockState)
+	t.Logf("Original LockExpiry: %v", lockInstance.LockExpiry)
+	t.Logf("Deserialized LockExpiry: %v", deserializedLock.LockExpiry)
+
+	// Check if the original and deserialized locks match
+
+	if lockInstance.LockOwner != deserializedLock.LockOwner {
+		t.Errorf("Serialized and deserialized lock instances do not match. LockOwner: Expected '%s', Got '%s'", lockInstance.LockOwner, deserializedLock.LockOwner)
+	}
+
+	if lockInstance.LockState != deserializedLock.LockState {
+		t.Errorf("Serialized and deserialized lock instances do not match. LockState: Expected '%v', Got '%v'", lockInstance.LockState, deserializedLock.LockState)
+	}
+
+	if lockInstance.LockExpiry.Unix() != deserializedLock.LockExpiry.Unix() {
+		t.Errorf("Serialized and deserialized lock instances do not match. LockExpiry: Expected '%v', Got '%v'", lockInstance.LockExpiry, deserializedLock.LockExpiry)
+	}
+}
+
+func TestLockSerializationWithLongOwnerFails(t *testing.T) {
+	lockInstance := Lock{
+		LockOwner:  strings.Repeat("x", 300), // Creates a string longer than LockOwnerMaxSize
+		LockState:  lockstate.Unlocked,
+		LockExpiry: time.Now().Add(10 * time.Minute),
+	}
+
+	_, err := lockInstance.ToBytes()
+	if err == nil || err.Error() != "lock owner exceeds max size of 256 bytes" {
+		t.Errorf("Expected error due to long owner name, got %v", err)
+	}
+}
+
+func TestLockSerializationWithEmptyFields(t *testing.T) {
+	// Setup
+	lockInstance := Lock{
+		LockOwner:  "",
+		LockState:  lockstate.Unlocked,
+		LockExpiry: time.Time{},
+	}
+
+	serialized, err := lockInstance.ToBytes()
+	if err != nil {
+		t.Fatalf("Failed to serialize lock: %v", err)
+	}
+
+	deserializedLock := Lock{}
+	err = deserializedLock.FromBytes(serialized)
+	if err != nil {
+		t.Fatalf("Failed to deserialize lock: %v", err)
+	}
+
+	if lockInstance.LockOwner != deserializedLock.LockOwner {
+		t.Errorf("Serialized and deserialized lock instances do not match. LockOwner: Expected '%s', Got '%s'", lockInstance.LockOwner, deserializedLock.LockOwner)
+	}
+
+	if lockInstance.LockState != deserializedLock.LockState {
+		t.Errorf("Serialized and deserialized lock instances do not match. LockState: Expected '%v', Got '%v'", lockInstance.LockState, deserializedLock.LockState)
+	}
+
+	if lockInstance.LockExpiry.Unix() != deserializedLock.LockExpiry.Unix() {
+		t.Errorf("Serialized and deserialized lock instances do not match. LockExpiry: Expected '%v', Got '%v'", lockInstance.LockExpiry, deserializedLock.LockExpiry)
+	}
+}

--- a/internal/util/radosmutex/lockstate/lockstate.go
+++ b/internal/util/radosmutex/lockstate/lockstate.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lockstate
+
+import (
+	"fmt"
+
+	"github.com/ceph/ceph-csi/internal/util/reftracker/errors"
+)
+
+// LockState describes type of the reftracker reference.
+type LockState int8
+
+const (
+	LockStateSize = 1
+
+	Unlocked LockState = 0
+
+	Locked LockState = 1
+
+	Unknown LockState = 2
+)
+
+func ToBytes(t LockState) []byte {
+	return []byte{byte(t)}
+}
+
+func FromBytes(bs []byte) (LockState, error) {
+	if len(bs) != LockStateSize {
+		return Unlocked, errors.UnexpectedReadSize(LockStateSize, len(bs))
+	}
+
+	num := LockState(bs[0])
+	switch num { //nolint:exhaustive // LockState.Unknown is handled in default case.
+	case Unlocked, Locked:
+		return num, nil
+	default:
+		return Unknown, fmt.Errorf("unknown LockState %d", num)
+	}
+}

--- a/internal/util/radosmutex/lockstate/lockstate_test.go
+++ b/internal/util/radosmutex/lockstate/lockstate_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lockstate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockStateBytes(t *testing.T) {
+	t.Parallel()
+
+	var (
+		LockStateUnlockedBytes = []byte{0}
+		LockStateLockedBytes   = []byte{1}
+
+		expectedBytes = [][]byte{LockStateUnlockedBytes, LockStateLockedBytes}
+		LockStates    = []LockState{Unlocked, Locked}
+
+		LockStateInvalidBytes   = []byte{0xFF}
+		LockStateWrongSizeBytes = []byte{0, 0, 0, 0, 1}
+	)
+
+	t.Run("ToBytes", func(ts *testing.T) {
+		ts.Parallel()
+
+		for i := range expectedBytes {
+			bs := ToBytes(LockStates[i])
+			require.Equal(ts, expectedBytes[i], bs)
+		}
+	})
+
+	t.Run("FromBytes", func(ts *testing.T) {
+		ts.Parallel()
+
+		for i := range LockStates {
+			LockState, err := FromBytes(expectedBytes[i])
+			require.NoError(ts, err)
+			require.Equal(ts, LockStates[i], LockState)
+		}
+
+		_, err := FromBytes(LockStateInvalidBytes)
+		require.Error(ts, err)
+
+		_, err = FromBytes(LockStateWrongSizeBytes)
+		require.Error(ts, err)
+	})
+}

--- a/internal/util/radosmutex/radosmutex.go
+++ b/internal/util/radosmutex/radosmutex.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package radosmutex
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/errors"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/retryoptions"
+	v1 "github.com/ceph/ceph-csi/internal/util/radosmutex/v1"
+	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
+	"github.com/ceph/ceph-csi/internal/util/reftracker/reftype"
+	"github.com/ceph/ceph-csi/internal/util/reftracker/version"
+
+	"github.com/ceph/go-ceph/rados"
+)
+
+func CreateOrAquireLock(
+	ctx context.Context,
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	lockRequestor string,
+	retryOptions retryoptions.RetryOptions,
+) (bool, error) {
+	if err := validateLockInput(lockName, lockRequestor); err != nil {
+		log.DebugLog(ctx, "Failed Input validation in in creating lock")
+		return false, err
+	}
+
+	lockVer, err := version.Read(ioctx, lockName)
+
+	if err != nil {
+		if goerrors.Is(err, rados.ErrNotFound) {
+			if err = v1.Init(ctx, ioctx, lockName, lockRequestor); err != nil {
+				log.DebugLog(ctx, "failed to initialize lock: %w", err)
+				return false, fmt.Errorf("failed to initialize lock: %w", err)
+			}
+
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to read lock version: %w", err)
+	}
+
+	switch lockVer {
+	case v1.Version:
+		_, err = v1.TryToAquireLock(ctx, ioctx, lockName, lockRequestor, retryOptions)
+		if err != nil {
+			err = fmt.Errorf("failed to add lock: %w", err)
+		}
+	default:
+		err = errors.UnknownObjectVersion(lockVer)
+	}
+
+	return true, err
+}
+
+func ReleaseLock(
+	ctx context.Context,
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	lockRequestor string,
+) (bool, error) {
+	if err := validateLockInput(lockName, lockRequestor); err != nil {
+		return false, err
+	}
+
+	// Read lock version.
+
+	rtVer, err := version.Read(ioctx, lockName)
+	if err != nil {
+		if goerrors.Is(err, rados.ErrNotFound) {
+			// This lock doesn't exist. Assume it was already deleted.
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to read reftracker version: %w", err)
+	}
+
+	gen, err := ioctx.GetLastVersion()
+	if err != nil {
+		return false, fmt.Errorf("failed to get RADOS object version: %w", err)
+	}
+
+	switch rtVer {
+	case v1.Version:
+		err = v1.ReleaseLock(ctx, ioctx, lockName, lockRequestor, gen)
+		if err != nil {
+			err = fmt.Errorf("failed to remove refs: %w", err)
+		}
+	default:
+		err = errors.UnknownObjectVersion(rtVer)
+	}
+
+	return true, err
+}
+
+func Remove(
+	ctx context.Context,
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	refs map[string]reftype.RefType,
+) (bool, error) {
+	if err := validateRemoveInput(lockName); err != nil {
+		return false, err
+	}
+
+	// Read lock version.
+
+	rtVer, err := version.Read(ioctx, lockName)
+	if err != nil {
+		if goerrors.Is(err, rados.ErrNotFound) {
+			// This lock doesn't exist. Assume it was already deleted.
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to read reftracker version: %w", err)
+	}
+
+	gen, err := ioctx.GetLastVersion()
+	if err != nil {
+		return false, fmt.Errorf("failed to get RADOS object version: %w", err)
+	}
+
+	switch rtVer {
+	case v1.Version:
+		err = v1.DeleteLock(ctx, ioctx, lockName, gen)
+		if err != nil {
+			err = fmt.Errorf("failed to remove refs: %w", err)
+		}
+	default:
+		err = errors.UnknownObjectVersion(rtVer)
+	}
+
+	return true, err
+}
+
+var (
+	errLockName = goerrors.New("missing lock name")
+	errNoOwner  = goerrors.New("missing lock requestor")
+)
+
+func validateLockInput(lockName string, lockRequestor string) error {
+	if lockName == "" {
+		return errLockName
+	}
+
+	if lockRequestor == "" {
+		return errNoOwner
+	}
+
+	return nil
+}
+
+func validateRemoveInput(rtName string) error {
+	if rtName == "" {
+		return errLockName
+	}
+
+	return nil
+}

--- a/internal/util/radosmutex/radosmutex_test.go
+++ b/internal/util/radosmutex/radosmutex_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package radosmutex
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/retryoptions"
+	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
+
+	"github.com/stretchr/testify/require"
+)
+
+const lockName = "hello-lock"
+const lockOwner = "helloWorld"
+
+func TestTryToAquireLockWithMultipleClients(ts *testing.T) {
+	ts.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ioctx := radoswrapper.NewFakeIOContext(radoswrapper.NewFakeRados())
+	const lockName = "volume-1-lock"
+
+	retryOptions := retryoptions.RetryOptions{
+		MaxAttempts:   10,
+		SleepDuration: 500 * time.Millisecond,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		lockResult, err := CreateOrAquireLock(ctx, ioctx, lockName, "pod-1", retryOptions)
+		time.Sleep(250 * time.Millisecond)
+		require.NoError(ts, err)
+		require.Equal(ts, true, lockResult)
+		time.Sleep(250 * time.Millisecond)
+		releaseResult, err1 := ReleaseLock(ctx, ioctx, lockName, "pod-1")
+		require.NoError(ts, err1)
+		require.Equal(ts, true, releaseResult)
+	}()
+
+	go func() {
+		defer wg.Done()
+		lockResult, err := CreateOrAquireLock(ctx, ioctx, lockName, "pod-2", retryOptions)
+		time.Sleep(250 * time.Millisecond)
+		require.NoError(ts, err)
+		require.Equal(ts, true, lockResult)
+		time.Sleep(250 * time.Millisecond)
+		releaseResult, err1 := ReleaseLock(ctx, ioctx, lockName, "pod-2")
+		require.NoError(ts, err1)
+		require.Equal(ts, true, releaseResult)
+	}()
+
+	go func() {
+		defer wg.Done()
+		lockResult, err := CreateOrAquireLock(ctx, ioctx, lockName, "pod-3", retryOptions)
+		time.Sleep(250 * time.Millisecond)
+		require.NoError(ts, err)
+		require.Equal(ts, true, lockResult)
+		time.Sleep(250 * time.Millisecond)
+		releaseResult, err1 := ReleaseLock(ctx, ioctx, lockName, "pod-3")
+		require.NoError(ts, err1)
+		require.Equal(ts, true, releaseResult)
+	}()
+
+	wg.Wait()
+}

--- a/internal/util/radosmutex/retryoptions/retryoptions.go
+++ b/internal/util/radosmutex/retryoptions/retryoptions.go
@@ -1,0 +1,8 @@
+package retryoptions
+
+import "time"
+
+type RetryOptions struct {
+	MaxAttempts   int
+	SleepDuration time.Duration
+}

--- a/internal/util/radosmutex/v1/v1.go
+++ b/internal/util/radosmutex/v1/v1.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/errors"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/lock"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/lockstate"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/retryoptions"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/version"
+	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
+
+	"github.com/ceph/go-ceph/rados"
+)
+
+const (
+	Version = 1
+)
+
+// Init atomically initializes a new lock object.
+func Init(
+	ctx context.Context,
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	lockOwner string,
+) error {
+	// Create lock instance.
+	lockData := lock.Lock{
+		LockOwner:  lockOwner,
+		LockState:  lockstate.Locked,
+		LockExpiry: time.Now().Add(30 * time.Second),
+	}
+
+	// Serialize the lock.
+	lockBytes, err := lockData.ToBytes()
+	if err != nil {
+		return err
+	}
+
+	// Perform the write.
+	w := ioctx.CreateWriteOp()
+	defer w.Release()
+
+	w.Create(rados.CreateExclusive)
+	w.SetXattr(version.XattrName, version.ToBytes(Version))
+	w.SetOmap(map[string][]byte{lockName: lockBytes})
+
+	return errors.FailedObjectWrite(w.Operate(lockName))
+}
+
+func TryToAquireLock(
+	ctx context.Context,
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	lockOwner string,
+	retryOptions retryoptions.RetryOptions,
+) (lock.Lock, error) {
+
+	var lastLock lock.Lock
+	var lastErr error
+
+	for i := 0; i < retryOptions.MaxAttempts; i++ {
+		lock, err := aquireLock(ctx, ioctx, lockName, lockOwner)
+		if err == nil {
+			return lock, nil
+		}
+		lastLock = lock
+		lastErr = err
+		time.Sleep(retryOptions.SleepDuration)
+	}
+
+	return lastLock, fmt.Errorf("Lock could not be acquired after %d attempts: %w", retryOptions.MaxAttempts, lastErr)
+}
+
+// Atomically trying to acquire an existing lock object.
+func aquireLock(
+	ctx context.Context,
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	lockOwner string,
+) (lock.Lock, error) {
+
+	fmt.Println("Trying to get lock for my owner: ")
+	fmt.Println(lockOwner)
+	var currentLock lock.Lock
+	gen, err := ioctx.GetLastVersion()
+	if err != nil {
+		return currentLock, fmt.Errorf("failed to get RADOS object version: %w", err)
+	}
+
+	w := ioctx.CreateWriteOp()
+	defer w.Release()
+
+	w.AssertVersion(gen)
+
+	currentLock, err = ReadLock(ioctx, lockName, gen)
+	if err != nil {
+		return currentLock, errors.FailedObjectRead(err)
+	}
+
+	if currentLock.LockState == lockstate.Locked && !currentLock.LockExpiry.Before(time.Now()) {
+		log.DebugLog(ctx, "Could not acquire lock as it is owned by %s and expires in %s",
+			currentLock.LockOwner,
+			currentLock.LockExpiry,
+		)
+		return currentLock, fmt.Errorf("Cannot acquire lock")
+	}
+
+	if currentLock.LockExpiry.Before((time.Now())) {
+		log.DebugLog(ctx, "Lock owned by %s has expired at %s, try to aquire",
+			currentLock.LockOwner,
+			currentLock.LockExpiry,
+		)
+	}
+
+	newLockStatus := lockstate.Locked
+	newExpiryTime := time.Now().Add(30 * time.Second)
+
+	newLock := lock.Lock{
+		LockOwner:  lockOwner,
+		LockState:  newLockStatus,
+		LockExpiry: newExpiryTime,
+	}
+
+	newLockBytes, err := newLock.ToBytes()
+	if err != nil {
+		return lock.Lock{}, err
+	}
+
+	writeOp := ioctx.CreateWriteOp()
+	defer writeOp.Release()
+	writeOp.AssertVersion(gen)
+
+	writeOp.SetOmap(map[string][]byte{lockName: newLockBytes})
+	err = writeOp.Operate(lockName)
+
+	if err != nil {
+		return currentLock, err
+	}
+	log.DebugLog(ctx, "Succesfully aquired the lock and moved as new owner")
+	return newLock, nil
+}
+
+func ReadLock(
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	gen uint64,
+) (lock.Lock, error) {
+
+	w := ioctx.CreateReadOp()
+	defer w.Release()
+	w.AssertVersion(gen)
+
+	var lockBytes []byte
+	s := w.GetOmapValuesByKeys([]string{lockName})
+
+	err := w.Operate(lockName)
+	if err != nil {
+		return lock.Lock{}, errors.FailedObjectRead(err)
+	}
+
+	kvPair, err := s.Next()
+	lockBytes = kvPair.Value
+
+	if len(lockBytes) == 0 {
+		return lock.Lock{}, nil
+	}
+
+	var lockData lock.Lock
+	err = lockData.FromBytes(lockBytes)
+	if err != nil {
+		return lock.Lock{}, err
+	}
+
+	return lockData, nil
+}
+
+// ReleaseLock frees a lock from the RADOS pool to be aquired.
+func ReleaseLock(
+	ctx context.Context,
+	ioctx radoswrapper.IOContextW,
+	lockName string,
+	lockOwner string,
+	gen uint64,
+) error {
+	var currentLock lock.Lock
+	gen, err := ioctx.GetLastVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get RADOS object version: %w", err)
+	}
+
+	w := ioctx.CreateWriteOp()
+	defer w.Release()
+
+	w.AssertVersion(gen)
+
+	currentLock, err = ReadLock(ioctx, lockName, gen)
+	if err != nil {
+		return errors.FailedObjectRead(err)
+	}
+
+	if currentLock.LockOwner != lockOwner {
+		fmt.Println("Cannot release a lock that is owned by another party")
+		return fmt.Errorf("Cannot release a lock that is owned by another party")
+	}
+
+	releasedLock := lock.Lock{
+		LockState:  lockstate.Unlocked,
+		LockOwner:  "",
+		LockExpiry: time.Time{},
+	}
+
+	newLockBytes, err := releasedLock.ToBytes()
+	if err != nil {
+		return err
+	}
+
+	writeOp := ioctx.CreateWriteOp()
+	defer writeOp.Release()
+	writeOp.AssertVersion(gen)
+
+	writeOp.SetOmap(map[string][]byte{lockName: newLockBytes})
+	err = writeOp.Operate(lockName)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteLock deletes a lock object from the RADOS pool.
+func DeleteLock(ctx context.Context, ioctx radoswrapper.IOContextW, lockName string, gen uint64) error {
+	deleteOp := ioctx.CreateWriteOp()
+	defer deleteOp.Release()
+	deleteOp.AssertVersion(gen)
+
+	deleteOp.Remove()
+	if err := deleteOp.Operate(lockName); err != nil {
+		return fmt.Errorf("failed to operate on lock object: %w", err)
+	}
+
+	fmt.Printf("Lock object %s deleted successfully\n", lockName)
+	return nil
+}

--- a/internal/util/radosmutex/v1/v1_test.go
+++ b/internal/util/radosmutex/v1/v1_test.go
@@ -1,0 +1,200 @@
+package v1
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/lock"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/lockstate"
+	"github.com/ceph/ceph-csi/internal/util/radosmutex/retryoptions"
+	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryToAquireLock(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const lockUnlockedName = "hello"
+	const lockLockedName = "bye-lock"
+	const lockOwner = "HelloWorld"
+
+	var (
+		unlockedLock = lock.Lock{
+			LockOwner:  "",
+			LockState:  lockstate.Unlocked,
+			LockExpiry: time.Time{},
+		}
+
+		lockedLock = lock.Lock{
+			LockOwner:  "AnotherWorld",
+			LockState:  lockstate.Locked,
+			LockExpiry: time.Now().Add(24 * time.Hour),
+		}
+
+		serializedUnlockedLock, _ = unlockedLock.ToBytes()
+		serializedLockedLock, _   = lockedLock.ToBytes()
+
+		unlockedObj = radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+			Objs: map[string]*radoswrapper.FakeObj{
+				lockUnlockedName: {
+					Oid: lockUnlockedName,
+					Omap: map[string][]byte{
+						"hello": serializedUnlockedLock,
+					},
+				},
+			},
+		})
+
+		lockedObj = radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+			Objs: map[string]*radoswrapper.FakeObj{
+				lockLockedName: {
+					Oid:  lockLockedName,
+					Omap: map[string][]byte{lockLockedName: serializedLockedLock},
+				},
+			},
+		})
+	)
+
+	retryOptions := retryoptions.RetryOptions{
+		MaxAttempts:   3,
+		SleepDuration: 1 * time.Millisecond,
+	}
+
+	returnedLock, err := TryToAquireLock(ctx, unlockedObj, lockUnlockedName, lockOwner, retryOptions)
+	require.NoError(t, err)
+	require.Equal(t, lockOwner, returnedLock.LockOwner)
+	require.Equal(t, lockstate.Locked, returnedLock.LockState)
+	require.NotEmpty(t, returnedLock.LockExpiry)
+	require.True(t, time.Now().Before(returnedLock.LockExpiry), "Lock expiry must be in the future")
+
+	returnedLock, err = TryToAquireLock(ctx, lockedObj, lockLockedName, lockOwner, retryOptions)
+	require.Error(t, err)
+	require.Equal(t, "AnotherWorld", returnedLock.LockOwner)
+	require.Equal(t, lockstate.Locked, returnedLock.LockState)
+
+}
+
+func TestTryToAquireExpiredLock(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const lockUnlockedName = "hello"
+	const lockLockedName = "bye-lock"
+	const lockOwner = "HelloWorld"
+
+	var (
+		unlockedLock = lock.Lock{
+			LockOwner:  "AnotherWorld",
+			LockState:  lockstate.Locked,
+			LockExpiry: time.Now().Add(-24 * time.Hour), // Past time
+		}
+
+		serializedUnlockedLock, _ = unlockedLock.ToBytes()
+
+		unlockedObj = radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+			Objs: map[string]*radoswrapper.FakeObj{
+				lockUnlockedName: {
+					Oid: lockUnlockedName,
+					Omap: map[string][]byte{
+						lockUnlockedName: serializedUnlockedLock,
+					},
+				},
+			},
+		})
+	)
+
+	retryOptions := retryoptions.RetryOptions{
+		MaxAttempts:   3,
+		SleepDuration: 1 * time.Millisecond,
+	}
+
+	returnedLock, err := TryToAquireLock(ctx, unlockedObj, lockUnlockedName, lockOwner, retryOptions)
+	require.NoError(t, err)
+	require.Equal(t, lockOwner, returnedLock.LockOwner)
+	require.Equal(t, lockstate.Locked, returnedLock.LockState)
+	require.NotEmpty(t, returnedLock.LockExpiry)
+	require.True(t, time.Now().Before(returnedLock.LockExpiry), "Lock expiry must be in the future")
+}
+
+func TestTryToAquireLockWithMultipleClients(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const lockName = "volume-1-lock"
+
+	var (
+		unlockedLock = lock.Lock{
+			LockOwner:  "",
+			LockState:  lockstate.Unlocked,
+			LockExpiry: time.Time{},
+		}
+
+		serializedUnlockedLock, _ = unlockedLock.ToBytes()
+
+		unlockedObj = radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+			Objs: map[string]*radoswrapper.FakeObj{
+				lockName: {
+					Oid: lockName,
+					Omap: map[string][]byte{
+						lockName: serializedUnlockedLock,
+					},
+				},
+			},
+		})
+	)
+
+	retryOptions := retryoptions.RetryOptions{
+		MaxAttempts:   10,
+		SleepDuration: 500 * time.Millisecond,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		returnedLockPod1, err1 := TryToAquireLock(ctx, unlockedObj, lockName, "pod-1", retryOptions)
+		time.Sleep(250 * time.Millisecond)
+		require.NoError(t, err1)
+		require.Equal(t, "pod-1", returnedLockPod1.LockOwner)
+		time.Sleep(250 * time.Millisecond)
+		gen, _ := unlockedObj.GetLastVersion()
+		err1 = ReleaseLock(ctx, unlockedObj, lockName, "pod-1", gen)
+		require.NoError(t, err1)
+	}()
+
+	go func() {
+		defer wg.Done()
+		returnedLockPod2, err2 := TryToAquireLock(ctx, unlockedObj, lockName, "pod-2", retryOptions)
+		time.Sleep(250 * time.Millisecond)
+		require.NoError(t, err2)
+		require.Equal(t, "pod-2", returnedLockPod2.LockOwner)
+		time.Sleep(250 * time.Millisecond)
+		gen, _ := unlockedObj.GetLastVersion()
+		err2 = ReleaseLock(ctx, unlockedObj, lockName, "pod-2", gen)
+		require.NoError(t, err2)
+	}()
+
+	go func() {
+		defer wg.Done()
+		returnedLockPod3, err3 := TryToAquireLock(ctx, unlockedObj, lockName, "pod-3", retryOptions)
+		time.Sleep(250 * time.Millisecond)
+		require.NoError(t, err3)
+		require.Equal(t, "pod-3", returnedLockPod3.LockOwner)
+		time.Sleep(250 * time.Millisecond)
+		gen, _ := unlockedObj.GetLastVersion()
+		err3 = ReleaseLock(ctx, unlockedObj, lockName, "pod-3", gen)
+		require.NoError(t, err3)
+	}()
+
+	wg.Wait()
+}

--- a/internal/util/radosmutex/version/version.go
+++ b/internal/util/radosmutex/version/version.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"encoding/binary"
+
+	"github.com/ceph/ceph-csi/internal/util/reftracker/errors"
+	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
+)
+
+// reftracker objects are versioned, should the object layout need to change.
+// Version is stored in its underlying RADOS object xattr as uint32.
+
+const (
+	// Name of the xattr entry in the RADOS object.
+	XattrName = "csi.ceph.com/rt-version"
+
+	// SizeBytes is the size of version in bytes.
+	SizeBytes = 4
+)
+
+func ToBytes(v uint32) []byte {
+	bs := make([]byte, SizeBytes)
+	binary.BigEndian.PutUint32(bs, v)
+
+	return bs
+}
+
+func FromBytes(bs []byte) (uint32, error) {
+	if len(bs) != SizeBytes {
+		return 0, errors.UnexpectedReadSize(SizeBytes, len(bs))
+	}
+
+	return binary.BigEndian.Uint32(bs), nil
+}
+
+func Read(ioctx radoswrapper.IOContextW, rtName string) (uint32, error) {
+	verBytes := make([]byte, SizeBytes)
+	readSize, err := ioctx.GetXattr(rtName, XattrName, verBytes)
+	if err != nil {
+		return 0, err
+	}
+
+	if readSize != SizeBytes {
+		return 0, errors.UnexpectedReadSize(SizeBytes, readSize)
+	}
+
+	return FromBytes(verBytes)
+}

--- a/internal/util/radosmutex/version/version_test.go
+++ b/internal/util/radosmutex/version/version_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	v1Bytes = []byte{0, 0, 0, 1}
+	v1Value = uint32(1)
+
+	wrongSizeVersionBytes = []byte{0, 0, 1}
+)
+
+func TestVersionBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ToBytes", func(ts *testing.T) {
+		ts.Parallel()
+
+		bs := ToBytes(v1Value)
+		require.Equal(ts, v1Bytes, bs)
+	})
+
+	t.Run("FromBytes", func(ts *testing.T) {
+		ts.Parallel()
+
+		ver, err := FromBytes(v1Bytes)
+		require.NoError(ts, err)
+		require.Equal(ts, v1Value, ver)
+
+		_, err = FromBytes(wrongSizeVersionBytes)
+		require.Error(ts, err)
+	})
+}
+
+func TestVersionRead(t *testing.T) {
+	t.Parallel()
+
+	const rtName = "hello-rt"
+
+	var (
+		validObj = radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+			Objs: map[string]*radoswrapper.FakeObj{
+				rtName: {
+					Oid: rtName,
+					Xattrs: map[string][]byte{
+						XattrName: v1Bytes,
+					},
+				},
+			},
+		})
+
+		invalidObjs = []*radoswrapper.FakeIOContext{
+			// Missing object.
+			radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+				Objs: map[string]*radoswrapper.FakeObj{},
+			}),
+			// Missing xattr.
+			radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+				Objs: map[string]*radoswrapper.FakeObj{
+					rtName: {
+						Oid: rtName,
+						Xattrs: map[string][]byte{
+							"some-other-xattr": v1Bytes,
+						},
+					},
+				},
+			}),
+			// Wrongly sized version value.
+			radoswrapper.NewFakeIOContext(&radoswrapper.FakeRados{
+				Objs: map[string]*radoswrapper.FakeObj{
+					rtName: {
+						Oid: rtName,
+						Xattrs: map[string][]byte{
+							XattrName: wrongSizeVersionBytes,
+						},
+					},
+				},
+			}),
+		}
+	)
+
+	ver, err := Read(validObj, rtName)
+	require.NoError(t, err)
+	require.Equal(t, v1Value, ver)
+
+	for i := range invalidObjs {
+		_, err = Read(invalidObjs[i], rtName)
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #

The pr implements a global mutex with the help of rados omap, this is needed because there is a concurrency in cephfs when encryption is used. This fixes the issue: #4654.    

## Is there anything that requires special attention ##

Due to this kernel requirement the testing is limited to the functionality of the mutex rather than the full feature

Sorry, I had to open this in a work in progress state, since I will be away on vacation the next four weeks and thought in case there is interest in continuing the work this would not go to waste. However I have tested this on a test setup with fscrypt compatible kernel and the concurrency issue is fixed. I will however add some things below that might need some attention still

**Checklist:**

* [ ] Move the rados client from reftracker to more common location so that both reftracker and radosmutex can utilize it nicely
* [ ] The LockOwner is not set properly currently
* [ ] There is both release and remove lock think if these both are necessary and in that case when can the lock be released
* [ ] Give the unit tests a bit more love
* [ ] Make sure the logging is sensible
* [ ] Overall tidiness of the code


