### PR TITLE
util: exclude empty label values for crushlocation map

### DIFF
--- a/internal/util/crushlocation.go
+++ b/internal/util/crushlocation.go
@@ -48,6 +48,10 @@ func getCrushLocationMap(crushLocationLabels string, nodeLabels map[string]strin
 	// Determine values for requested labels from node labels
 	crushLocationMap := make(map[string]string, len(labelsIn))
 	for key, value := range nodeLabels {
+		// label with empty value is not considered.
+		if value == "" {
+			continue
+		}
 		if _, ok := labelsIn[key]; !ok {
 			continue
 		}

--- a/internal/util/crushlocation_test.go
+++ b/internal/util/crushlocation_test.go
@@ -100,6 +100,17 @@ func Test_getCrushLocationMap(t *testing.T) {
 			},
 			want: map[string]string{"host": "worker-1"},
 		},
+		{
+			name: "matching crushlocation and node labels with empty value",
+			args: input{
+				crushLocationLabels: "topology.io/region,topology.io/zone",
+				nodeLabels: map[string]string{
+					"topology.io/region": "region1",
+					"topology.io/zone":   "",
+				},
+			},
+			want: map[string]string{"region": "region1"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit resolves a bug where node labels with empty values
are processed for the `crush_location` mount option, leading to
invalid mount options and subsequent mount failures.

## Issue:
If Node is labelled with empty value then mount fails - 
(mount option for read affinity is set as `read_from_replica=localize,crush_location=zone:|host:c1]` which is invalid)
```
I0711 10:54:22.595638 3652833 utils.go:198] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 GRPC call: /csi.v1.Node/NodeStageVolume
I0711 10:54:22.595919 3652833 utils.go:199] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 GRPC request: {"secrets":"***stripped***","staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/rook-ceph.rbd.csi.ceph.com/8573304e49ec1ecc6f5f01da6306387ccb7bbf9e866fc4ec959ab7f9190a5a19/globalmount","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":7}},"volume_context":{"clusterID":"rook-ceph","encryptionKMSID":"azure-test","imageFeatures":"layering","imageFormat":"2","imageName":"csi-vol-a1347faa-82f3-4dbe-81e1-e067e3f769c1","journalPool":"replicapool","pool":"replicapool","storage.kubernetes.io/csiProvisionerIdentity":"1720694375759-9475-rook-ceph.rbd.csi.ceph.com"},"volume_id":"0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1"}
I0711 10:54:22.605770 3652833 omap.go:89] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 got omap values: (pool="replicapool", namespace="", name="csi.volume.a1347faa-82f3-4dbe-81e1-e067e3f769c1"): map[csi.imageid:4bfdd951ce312 csi.imagename:csi-vol-a1347faa-82f3-4dbe-81e1-e067e3f769c1 csi.volname:pvc-8a3b5702-d583-429e-8e9d-e4773dc35519 csi.volume.owner:test]
I0711 10:54:22.693064 3652833 rbd_util.go:352] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 checking for ImageFeatures: [layering]
I0711 10:54:22.693370 3652833 crushlocation.go:41] CRUSH location labels passed for processing: [topology.io/zone topology.io/host]
I0711 10:54:22.693399 3652833 crushlocation.go:69] list of CRUSH location processed: map[host:c1 zone:]
I0711 10:54:22.747556 3652833 cephcmds.go:105] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 command succeeded: rbd [device list --format=json --device-type krbd]
I0711 10:54:22.795839 3652833 rbd_attach.go:437] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 rbd: map mon 10.110.151.235:6789
I0711 10:54:22.973494 3652833 cephcmds.go:98] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 an error (exit status 22) occurred while running rbd args: [--id csi-rbd-node -m 10.110.151.235:6789 --keyfile=***stripped*** map replicapool/csi-vol-a1347faa-82f3-4dbe-81e1-e067e3f769c1 --device-type krbd --options noudev --options read_from_replica=localize,crush_location=zone:|host:c1]
W0711 10:54:22.973535 3652833 rbd_attach.go:486] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 rbd: map error an error (exit status 22) occurred while running rbd args: [--id csi-rbd-node -m 10.110.151.235:6789 --keyfile=***stripped*** map replicapool/csi-vol-a1347faa-82f3-4dbe-81e1-e067e3f769c1 --device-type krbd --options noudev --options read_from_replica=localize,crush_location=zone:|host:c1], rbd output: rbd: sysfs write failed
rbd: map failed: (22) Invalid argument
E0711 10:54:22.973810 3652833 utils.go:203] ID: 61 Req-ID: 0001-0009-rook-ceph-0000000000000002-a1347faa-82f3-4dbe-81e1-e067e3f769c1 GRPC error: rpc error: code = Internal desc = rbd: map failed with error an error (exit status 22) occurred while running rbd args: [--id csi-rbd-node -m 10.110.151.235:6789 --keyfile=***stripped*** map replicapool/csi-vol-a1347faa-82f3-4dbe-81e1-e067e3f769c1 --device-type krbd --options noudev --options read_from_replica=localize,crush_location=zone:|host:c1], rbd error output: rbd: sysfs write failed
rbd: map failed: (22) Invalid argument
```

## Solution: 
don't consider node labels with empty value for crush_location.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
