### PR TITLE
rbd: add backend support for VolumeGroup operations

### DIFF
--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -18,7 +18,6 @@ package rbd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
@@ -103,7 +102,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 		volumes[i] = vol
 	}
 
-	log.DebugLog(ctx, fmt.Sprintf("all %d Volumes for VolumeGroup %q have been found", len(volumes), req.GetName()))
+	log.DebugLog(ctx, "all %d Volumes for VolumeGroup %q have been found", len(volumes), req.GetName())
 
 	// create a RBDVolumeGroup
 	vg, err := mgr.CreateVolumeGroup(ctx, req.GetName())
@@ -115,7 +114,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 			err.Error())
 	}
 
-	log.DebugLog(ctx, fmt.Sprintf("VolumeGroup %q had been created", req.GetName()))
+	log.DebugLog(ctx, "VolumeGroup %q has been created: %+v", req.GetName(), vg)
 
 	// add each rbd-image to the RBDVolumeGroup
 	for _, vol := range volumes {
@@ -130,7 +129,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 		}
 	}
 
-	log.DebugLog(ctx, fmt.Sprintf("all %d Volumes have been added to for VolumeGroup %q", len(volumes), req.GetName()))
+	log.DebugLog(ctx, "all %d Volumes have been added to for VolumeGroup %q", len(volumes), req.GetName())
 
 	csiVG, err := vg.ToCSI(ctx)
 	if err != nil {
@@ -182,7 +181,7 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 	}
 	defer vg.Destroy(ctx)
 
-	log.DebugLog(ctx, fmt.Sprintf("VolumeGroup %q has been found", req.GetVolumeGroupId()))
+	log.DebugLog(ctx, "VolumeGroup %q has been found", req.GetVolumeGroupId())
 
 	// verify that the volume group is empty
 	volumes, err := vg.ListVolumes(ctx)
@@ -194,7 +193,7 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 			err.Error())
 	}
 
-	log.DebugLog(ctx, fmt.Sprintf("VolumeGroup %q contains %d volumes", req.GetVolumeGroupId(), len(volumes)))
+	log.DebugLog(ctx, "VolumeGroup %q contains %d volumes", req.GetVolumeGroupId(), len(volumes))
 
 	if len(volumes) != 0 {
 		return nil, status.Errorf(
@@ -212,7 +211,7 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 			err.Error())
 	}
 
-	log.DebugLog(ctx, fmt.Sprintf("VolumeGroup %q has been deleted", req.GetVolumeGroupId()))
+	log.DebugLog(ctx, "VolumeGroup %q has been deleted", req.GetVolumeGroupId())
 
 	return &volumegroup.DeleteVolumeGroupResponse{}, nil
 }

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -37,12 +37,17 @@ type VolumeGroupServer struct {
 	// if volumegroup spec add more RPC services in the proto file, then we
 	// don't need to add all RPC methods leading to forward compatibility.
 	*volumegroup.UnimplementedControllerServer
+
+	// csiID is the unique ID for this CSI-driver deployment.
+	csiID string
 }
 
 // NewVolumeGroupServer creates a new VolumeGroupServer which handles the
 // VolumeGroup Service requests from the CSI-Addons specification.
-func NewVolumeGroupServer() *VolumeGroupServer {
-	return &VolumeGroupServer{}
+func NewVolumeGroupServer(instanceID string) *VolumeGroupServer {
+	return &VolumeGroupServer{
+		csiID: instanceID,
+	}
 }
 
 func (vs *VolumeGroupServer) RegisterService(server grpc.ServiceRegistrar) {

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -77,10 +77,14 @@ type VolumeGroupJournalConfig struct {
 	Config
 }
 
-type VolumeGroupJournalConnection struct {
+type volumeGroupJournalConnection struct {
 	config     *VolumeGroupJournalConfig
 	connection *Connection
 }
+
+// assert that volumeGroupJournalConnection implements the VolumeGroupJournal
+// interface.
+var _ VolumeGroupJournal = &volumeGroupJournalConnection{}
 
 // NewCSIVolumeGroupJournal returns an instance of VolumeGroupJournal for groups.
 func NewCSIVolumeGroupJournal(suffix string) VolumeGroupJournalConfig {
@@ -116,7 +120,7 @@ func (vgc *VolumeGroupJournalConfig) Connect(
 	namespace string,
 	cr *util.Credentials,
 ) (VolumeGroupJournal, error) {
-	vgjc := &VolumeGroupJournalConnection{}
+	vgjc := &volumeGroupJournalConnection{}
 	vgjc.config = &VolumeGroupJournalConfig{
 		Config: vgc.Config,
 	}
@@ -130,7 +134,7 @@ func (vgc *VolumeGroupJournalConfig) Connect(
 }
 
 // Destroy frees any resources and invalidates the journal connection.
-func (vgjc *VolumeGroupJournalConnection) Destroy() {
+func (vgjc *volumeGroupJournalConnection) Destroy() {
 	vgjc.connection.Destroy()
 }
 
@@ -167,7 +171,7 @@ Return values:
     reservation found.
   - error: non-nil in case of any errors.
 */
-func (vgjc *VolumeGroupJournalConnection) CheckReservation(ctx context.Context,
+func (vgjc *volumeGroupJournalConnection) CheckReservation(ctx context.Context,
 	journalPool, reqName, namePrefix string,
 ) (*VolumeGroupData, error) {
 	var (
@@ -244,7 +248,7 @@ Input arguments:
   - groupID: ID of the volume group, generated from the UUID
   - reqName: Request name for the volume group
 */
-func (vgjc *VolumeGroupJournalConnection) UndoReservation(ctx context.Context,
+func (vgjc *volumeGroupJournalConnection) UndoReservation(ctx context.Context,
 	csiJournalPool, groupID, reqName string,
 ) error {
 	// delete volume UUID omap (first, inverse of create order)
@@ -303,7 +307,7 @@ Return values:
   - string: Contains the VolumeGroup name that was reserved for the passed in reqName
   - error: non-nil in case of any errors
 */
-func (vgjc *VolumeGroupJournalConnection) ReserveName(ctx context.Context,
+func (vgjc *volumeGroupJournalConnection) ReserveName(ctx context.Context,
 	journalPool, reqName, namePrefix string,
 ) (string, string, error) {
 	cj := vgjc.config
@@ -366,7 +370,7 @@ type VolumeGroupAttributes struct {
 	VolumeMap   map[string]string // Contains the volumeID and the corresponding value mapping
 }
 
-func (vgjc *VolumeGroupJournalConnection) GetVolumeGroupAttributes(
+func (vgjc *volumeGroupJournalConnection) GetVolumeGroupAttributes(
 	ctx context.Context,
 	pool, objectUUID string,
 ) (*VolumeGroupAttributes, error) {
@@ -401,7 +405,7 @@ func (vgjc *VolumeGroupJournalConnection) GetVolumeGroupAttributes(
 	return groupAttributes, nil
 }
 
-func (vgjc *VolumeGroupJournalConnection) AddVolumesMapping(
+func (vgjc *volumeGroupJournalConnection) AddVolumesMapping(
 	ctx context.Context,
 	pool,
 	reservedUUID string,
@@ -418,7 +422,7 @@ func (vgjc *VolumeGroupJournalConnection) AddVolumesMapping(
 	return nil
 }
 
-func (vgjc *VolumeGroupJournalConnection) RemoveVolumesMapping(
+func (vgjc *volumeGroupJournalConnection) RemoveVolumesMapping(
 	ctx context.Context,
 	pool,
 	reservedUUID string,

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -222,7 +222,7 @@ func (r *Driver) setupCSIAddonsServer(conf *util.Config) error {
 		rcs := casrbd.NewReplicationServer(NewControllerServer(r.cd))
 		r.cas.RegisterService(rcs)
 
-		vgcs := casrbd.NewVolumeGroupServer()
+		vgcs := casrbd.NewVolumeGroupServer(conf.InstanceID)
 		r.cas.RegisterService(vgcs)
 	}
 

--- a/internal/rbd/group.go
+++ b/internal/rbd/group.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"fmt"
+
+	librbd "github.com/ceph/go-ceph/rbd"
+
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+)
+
+// AddToGroup adds the image to the group. This is called from the rbd_group
+// package.
+func (rv *rbdVolume) AddToGroup(ctx context.Context, vg types.VolumeGroup) error {
+	ioctx, err := vg.GetIOContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not get iocontext for volume group %q: %w", vg, err)
+	}
+
+	name, err := vg.GetName(ctx)
+	if err != nil {
+		return fmt.Errorf("could not get name for volume group %q: %w", vg, err)
+	}
+
+	return librbd.GroupImageAdd(ioctx, name, rv.ioctx, rv.RbdImageName)
+}
+
+// RemoveFromGroup removes the image from the group. This is called from the
+// rbd_group package.
+func (rv *rbdVolume) RemoveFromGroup(ctx context.Context, vg types.VolumeGroup) error {
+	ioctx, err := vg.GetIOContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not get iocontext for volume group %q: %w", vg, err)
+	}
+
+	name, err := vg.GetName(ctx)
+	if err != nil {
+		return fmt.Errorf("could not get name for volume group %q: %w", vg, err)
+	}
+
+	return librbd.GroupImageRemove(ioctx, name, rv.ioctx, rv.RbdImageName)
+}

--- a/internal/rbd/group.go
+++ b/internal/rbd/group.go
@@ -38,7 +38,28 @@ func (rv *rbdVolume) AddToGroup(ctx context.Context, vg types.VolumeGroup) error
 		return fmt.Errorf("could not get name for volume group %q: %w", vg, err)
 	}
 
-	return librbd.GroupImageAdd(ioctx, name, rv.ioctx, rv.RbdImageName)
+	// check if the image is already part of a group
+	// "rbd: ret=-17, File exists" is returned if the image is part of ANY group
+	image, err := rv.open()
+	if err != nil {
+		return fmt.Errorf("failed to open image %q: %w", rv, err)
+	}
+
+	info, err := image.GetGroup()
+	if err != nil {
+		return fmt.Errorf("could not get group information for image %q: %w", rv, err)
+	}
+
+	if info.Name != "" && info.Name != name {
+		return fmt.Errorf("image %q is already part of volume group %q", rv, info.Name)
+	}
+
+	err = librbd.GroupImageAdd(ioctx, name, rv.ioctx, rv.RbdImageName)
+	if err != nil {
+		return fmt.Errorf("failed to add image %q to volume group %q: %w", rv, vg, err)
+	}
+
+	return nil
 }
 
 // RemoveFromGroup removes the image from the group. This is called from the

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2024 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ceph/go-ceph/rados"
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/csi-addons/spec/lib/go/volumegroup"
+
+	"github.com/ceph/ceph-csi/internal/journal"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+var ErrRBDGroupNotConnected = errors.New("RBD group is not connected")
+
+// volumeGroup handles all requests for 'rbd group' operations.
+type volumeGroup struct {
+	// id is a unique value for this volume group in the Ceph cluster, it
+	// is used to find the group in the journal.
+	id string
+
+	// name is used in RBD API calls as the name of this object
+	name string
+
+	clusterID string
+
+	credentials *util.Credentials
+
+	// temporary connection attributes
+	conn  *util.ClusterConnection
+	ioctx *rados.IOContext
+
+	// required details to perform operations on the group
+	monitors  string
+	pool      string
+	namespace string
+
+	// volumes is a list of rbd-images that are part of the group. The ID
+	// of each volume is stored in the journal.
+	volumes []types.Volume
+
+	journal journal.VolumeGroupJournal
+}
+
+// verify that volumeGroup implements the VolumeGroup and Stringer interfaces.
+var (
+	_ types.VolumeGroup = &volumeGroup{}
+	_ fmt.Stringer      = &volumeGroup{}
+)
+
+// GetVolumeGroup initializes a new VolumeGroup object that can be used
+// to manage an `rbd group`.
+func GetVolumeGroup(
+	ctx context.Context,
+	id string,
+	j journal.VolumeGroupJournal,
+	creds *util.Credentials,
+) (types.VolumeGroup, error) {
+	csiID := util.CSIIdentifier{}
+	err := csiID.DecomposeCSIID(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompose volume group id %q: %w", id, err)
+	}
+
+	mons, err := util.Mons(util.CsiConfigFile, csiID.ClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get MONs for cluster id %q: %w", csiID.ClusterID, err)
+	}
+
+	namespace, err := util.GetRadosNamespace(util.CsiConfigFile, csiID.ClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RADOS namespace for cluster id %q: %w", csiID.ClusterID, err)
+	}
+
+	pool, err := util.GetPoolName(mons, creds, csiID.LocationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pool for volume group id %q: %w", id, err)
+	}
+
+	attrs, err := j.GetVolumeGroupAttributes(ctx, pool, csiID.ObjectUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get attributes for volume group id %q: %w", id, err)
+	}
+
+	// TODO: get the volumes that are part of this volume group
+
+	return &volumeGroup{
+		journal:     j,
+		credentials: creds,
+		id:          id,
+		name:        attrs.GroupName,
+		clusterID:   csiID.ClusterID,
+		monitors:    mons,
+		pool:        pool,
+		namespace:   namespace,
+	}, nil
+}
+
+// String makes it easy to include the volumeGroup object in log and error
+// messages.
+func (vg *volumeGroup) String() string {
+	if vg.name != "" {
+		return vg.name
+	}
+
+	if vg.id != "" {
+		return vg.id
+	}
+
+	return fmt.Sprintf("<unidentified volume %v>", *vg)
+}
+
+// GetID returns the CSI-Addons VolumeGroupId of the VolumeGroup.
+func (vg *volumeGroup) GetID(ctx context.Context) (string, error) {
+	if vg.id == "" {
+		return "", errors.New("BUG: ID is not set")
+	}
+
+	return vg.id, nil
+}
+
+// GetName returns the name in the backend storage for the VolumeGroup.
+func (vg *volumeGroup) GetName(ctx context.Context) (string, error) {
+	if vg.name == "" {
+		return "", errors.New("BUG: name is not set")
+	}
+
+	return vg.name, nil
+}
+
+// ToCSI creates a CSI-Addons type for the VolumeGroup.
+func (vg *volumeGroup) ToCSI(ctx context.Context) (*volumegroup.VolumeGroup, error) {
+	volumes, err := vg.ListVolumes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list volumes for volume group %q: %w", vg, err)
+	}
+
+	csiVolumes := make([]*csi.Volume, len(volumes))
+	for i, vol := range volumes {
+		csiVolumes[i], err = vol.ToCSI(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert volume %q to CSI type: %w", vol, err)
+		}
+	}
+
+	id, err := vg.GetID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get id for volume group %q: %w", vg, err)
+	}
+
+	// TODO: maybe store the VolumeContext in the journal?
+	vgContext := map[string]string{}
+
+	return &volumegroup.VolumeGroup{
+		VolumeGroupId:      id,
+		VolumeGroupContext: vgContext,
+		Volumes:            csiVolumes,
+	}, nil
+}
+
+// getConnection returns the ClusterConnection for the volume group if it
+// exists, otherwise it will open a new one.
+// Destroy should be used to close the ClusterConnection.
+func (vg *volumeGroup) getConnection(ctx context.Context) (*util.ClusterConnection, error) {
+	if vg.conn != nil {
+		return vg.conn, nil
+	}
+
+	conn := &util.ClusterConnection{}
+	err := conn.Connect(vg.monitors, vg.credentials)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to MONs %q: %w", vg.monitors, err)
+	}
+
+	vg.conn = conn
+	log.DebugLog(ctx, "connection established for volume group %q", vg.id)
+
+	return conn, nil
+}
+
+// GetIOContext returns the IOContext for the volume group if it exists,
+// otherwise it will allocate a new one.
+// Destroy should be used to free the IOContext.
+func (vg *volumeGroup) GetIOContext(ctx context.Context) (*rados.IOContext, error) {
+	if vg.ioctx != nil {
+		return vg.ioctx, nil
+	}
+
+	conn, err := vg.getConnection(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to connect: %w", ErrRBDGroupNotConnected, err)
+	}
+
+	ioctx, err := conn.GetIoctx(vg.pool)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to get IOContext: %w", ErrRBDGroupNotConnected, err)
+	}
+
+	if vg.namespace != "" {
+		ioctx.SetNamespace(vg.namespace)
+	}
+
+	vg.ioctx = ioctx
+	log.DebugLog(ctx, "iocontext created for volume group %q in pool %q", vg.id, vg.pool)
+
+	return ioctx, nil
+}
+
+// Destroy frees the resources used by the volumeGroup.
+func (vg *volumeGroup) Destroy(ctx context.Context) {
+	if vg.ioctx != nil {
+		vg.ioctx.Destroy()
+		vg.ioctx = nil
+	}
+
+	if vg.conn != nil {
+		vg.conn.Destroy()
+		vg.conn = nil
+	}
+
+	if vg.credentials != nil {
+		vg.credentials.DeleteCredentials()
+		vg.credentials = nil
+	}
+
+	// FIXME: maybe need to .Destroy() all vg.volumes?
+	log.DebugLog(ctx, "destroyed volume group instance with id %q", vg.id)
+}
+
+func (vg *volumeGroup) Create(ctx context.Context, name string) error {
+	// TODO: if the group already exists, resolve details and use that
+	ioctx, err := vg.GetIOContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = librbd.GroupCreate(ioctx, name)
+	if err != nil {
+		if !errors.Is(rados.ErrObjectExists, err) {
+			return fmt.Errorf("failed to create volume group %q: %w", name, err)
+		}
+
+		log.DebugLog(ctx, "ignoring error while creating volume group %q: %v", vg, err)
+	}
+
+	log.DebugLog(ctx, "volume group %q has been created", name)
+
+	return nil
+}
+
+func (vg *volumeGroup) Delete(ctx context.Context) error {
+	ioctx, err := vg.GetIOContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = librbd.GroupRemove(ioctx, vg.name)
+	if err != nil {
+		return fmt.Errorf("failed to remove volume group %q: %w", vg, err)
+	}
+
+	log.DebugLog(ctx, "volume group %q has been removed", vg)
+
+	return nil
+}
+
+func (vg *volumeGroup) AddVolume(ctx context.Context, vol types.Volume) error {
+	err := vol.AddToGroup(ctx, vg)
+	if err != nil {
+		// rados.ErrObjectExists does not match the rbd error (there is no EEXISTS error)
+		if errors.Is(rados.ErrObjectExists, err) || strings.Contains(err.Error(), "ret=-17") {
+			log.DebugLog(ctx, "volume %q is already part of volume group %q: %v", vol, vg, err)
+			return nil
+		}
+
+		return fmt.Errorf("failed to add volume %q to volume group %q: %w", vol, vg, err)
+	}
+
+	vg.volumes = append(vg.volumes, vol)
+
+	volID, err := vol.GetID(ctx)
+	if err != nil {
+		return err
+	}
+
+	pool, err := vg.GetPool(ctx)
+	if err != nil {
+		return err
+	}
+
+	id, err := vg.GetID(ctx)
+	if err != nil {
+		return err
+	}
+
+	csiID := util.CSIIdentifier{}
+	err = csiID.DecomposeCSIID(id)
+	if err != nil {
+		return fmt.Errorf("failed to decompose volume group id %q: %w", id, err)
+	}
+
+	toAdd := map[string]string{
+		volID: "",
+	}
+
+	err = vg.journal.AddVolumesMapping(ctx, pool, csiID.ObjectUUID, toAdd)
+	if err != nil {
+		return fmt.Errorf("failed to add mapping for volume %q to volume group id %q: %w", volID, id, err)
+	}
+
+	return nil
+}
+
+func (vg *volumeGroup) RemoveVolume(ctx context.Context, vol types.Volume) error {
+	// volume was already removed from the group
+	if len(vg.volumes) == 0 {
+		return nil
+	}
+
+	err := vol.RemoveFromGroup(ctx, vg)
+	if err != nil {
+		return fmt.Errorf("failed to remove volume %q from volume group %q: %w", vol, vg, err)
+	}
+
+	// toRemove contain the ID of the volume that is removed from the group
+	toRemove, err := vol.GetID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get volume id for %q: %w", vol, err)
+	}
+
+	// volumes is the updated list, without the volume that was removed
+	volumes := make([]types.Volume, 0)
+	var id string
+	for _, v := range vg.volumes {
+		id, err = v.GetID(ctx)
+		if err != nil {
+			return err
+		}
+
+		if id == toRemove {
+			// do not add the volume to the list
+			continue
+		}
+
+		volumes = append(volumes, v)
+	}
+
+	// update the list of volumes
+	vg.volumes = volumes
+
+	pool, err := vg.GetPool(ctx)
+	if err != nil {
+		return err
+	}
+
+	id, err = vg.GetID(ctx)
+	if err != nil {
+		return err
+	}
+
+	csiID := util.CSIIdentifier{}
+	err = csiID.DecomposeCSIID(id)
+	if err != nil {
+		return fmt.Errorf("failed to decompose volume group id %q: %w", id, err)
+	}
+
+	mapping := []string{
+		toRemove,
+	}
+
+	err = vg.journal.RemoveVolumesMapping(ctx, pool, csiID.ObjectUUID, mapping)
+	if err != nil {
+		return fmt.Errorf("failed to remove mapping for volume %q to volume group id %q: %w", toRemove, id, err)
+	}
+
+	return nil
+}
+
+func (vg *volumeGroup) ListVolumes(ctx context.Context) ([]types.Volume, error) {
+	return vg.volumes, nil
+}

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -356,12 +356,6 @@ func (vg *volumeGroup) Delete(ctx context.Context) error {
 func (vg *volumeGroup) AddVolume(ctx context.Context, vol types.Volume) error {
 	err := vol.AddToGroup(ctx, vg)
 	if err != nil {
-		// rados.ErrObjectExists does not match the rbd error (there is no EEXISTS error)
-		if errors.Is(rados.ErrObjectExists, err) || strings.Contains(err.Error(), "ret=-17") {
-			log.DebugLog(ctx, "volume %q is already part of volume group %q: %v", vol, vg, err)
-			return nil
-		}
-
 		return fmt.Errorf("failed to add volume %q to volume group %q: %w", vol, vg, err)
 	}
 

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -179,6 +179,24 @@ func (vg *volumeGroup) GetName(ctx context.Context) (string, error) {
 	return vg.name, nil
 }
 
+// GetPool returns the name of the pool that holds the VolumeGroup.
+func (vg *volumeGroup) GetPool(ctx context.Context) (string, error) {
+	if vg.pool == "" {
+		return "", errors.New("BUG: pool is not set")
+	}
+
+	return vg.pool, nil
+}
+
+// GetClusterID returns the name of the pool that holds the VolumeGroup.
+func (vg *volumeGroup) GetClusterID(ctx context.Context) (string, error) {
+	if vg.clusterID == "" {
+		return "", errors.New("BUG: clusterID is not set")
+	}
+
+	return vg.clusterID, nil
+}
+
 // ToCSI creates a CSI-Addons type for the VolumeGroup.
 func (vg *volumeGroup) ToCSI(ctx context.Context) (*volumegroup.VolumeGroup, error) {
 	volumes, err := vg.ListVolumes(ctx)

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -237,16 +237,9 @@ func (mgr *rbdManager) CreateVolumeGroup(ctx context.Context, name string) (type
 		}
 	}()
 
-	// check if the volume group exists in the backend
-	existingName, err := vg.GetName(ctx)
+	err = vg.Create(ctx)
 	if err != nil {
-		// the volume group does not exist yet
-		err = vg.Create(ctx, vgName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create volume group %q: %w", name, err)
-		}
-	} else if existingName != vgName {
-		return nil, fmt.Errorf("volume group id %q has a name mismatch, expected %q, not %q", name, vgName, existingName)
+		return nil, fmt.Errorf("failed to create volume group %q: %w", name, err)
 	}
 
 	return vg, nil

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -19,6 +19,7 @@ package types
 import (
 	"context"
 
+	"github.com/ceph/go-ceph/rados"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
 )
 
@@ -28,11 +29,22 @@ type VolumeGroup interface {
 	// Destroy frees the resources used by the VolumeGroup.
 	Destroy(ctx context.Context)
 
+	// GetIOContext returns the IOContext for performing librbd operations
+	// on the VolumeGroup. This is used by the rbdVolume struct when it
+	// needs to add/remove itself from the VolumeGroup.
+	GetIOContext(ctx context.Context) (*rados.IOContext, error)
+
 	// GetID returns the CSI-Addons VolumeGroupId of the VolumeGroup.
 	GetID(ctx context.Context) (string, error)
 
+	// GetName returns the name in the backend storage for the VolumeGroup.
+	GetName(ctx context.Context) (string, error)
+
 	// ToCSI creates a CSI-Addons type for the VolumeGroup.
-	ToCSI(ctx context.Context) *volumegroup.VolumeGroup
+	ToCSI(ctx context.Context) (*volumegroup.VolumeGroup, error)
+
+	// Create makes a new group in the backend storage.
+	Create(ctx context.Context, name string) error
 
 	// Delete removes the VolumeGroup from the backend storage.
 	Delete(ctx context.Context) error

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -53,7 +53,7 @@ type VolumeGroup interface {
 	ToCSI(ctx context.Context) (*volumegroup.VolumeGroup, error)
 
 	// Create makes a new group in the backend storage.
-	Create(ctx context.Context, name string) error
+	Create(ctx context.Context) error
 
 	// Delete removes the VolumeGroup from the backend storage.
 	Delete(ctx context.Context) error

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -23,9 +23,24 @@ import (
 	"github.com/csi-addons/spec/lib/go/volumegroup"
 )
 
-// VolumeGroup contains a number of volumes, and can be used to create a
-// VolumeGroupSnapshot.
+type journalledObject interface {
+	// GetID returns the CSI-Addons VolumeGroupId of the VolumeGroup.
+	GetID(ctx context.Context) (string, error)
+
+	// GetName returns the name in the backend storage for the VolumeGroup.
+	GetName(ctx context.Context) (string, error)
+
+	// GetPool returns the name of the pool that holds the VolumeGroup.
+	GetPool(ctx context.Context) (string, error)
+
+	// GetClusterID returns the ID of the cluster of the VolumeGroup.
+	GetClusterID(ctx context.Context) (string, error)
+}
+
+// VolumeGroup contains a number of volumes.
 type VolumeGroup interface {
+	journalledObject
+
 	// Destroy frees the resources used by the VolumeGroup.
 	Destroy(ctx context.Context)
 
@@ -33,12 +48,6 @@ type VolumeGroup interface {
 	// on the VolumeGroup. This is used by the rbdVolume struct when it
 	// needs to add/remove itself from the VolumeGroup.
 	GetIOContext(ctx context.Context) (*rados.IOContext, error)
-
-	// GetID returns the CSI-Addons VolumeGroupId of the VolumeGroup.
-	GetID(ctx context.Context) (string, error)
-
-	// GetName returns the name in the backend storage for the VolumeGroup.
-	GetName(ctx context.Context) (string, error)
 
 	// ToCSI creates a CSI-Addons type for the VolumeGroup.
 	ToCSI(ctx context.Context) (*volumegroup.VolumeGroup, error)

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -20,15 +20,21 @@ import (
 	"context"
 )
 
+// VolumeResolver can be used to construct a Volume from a CSI VolumeId.
+type VolumeResolver interface {
+	// GetVolumeByID uses the CSI VolumeId to resolve the returned Volume.
+	GetVolumeByID(ctx context.Context, id string) (Volume, error)
+}
+
 // Manager provides a way for other packages to get Volumes and VolumeGroups.
 // It handles the operations on the backend, and makes sure the journal
 // reflects the expected state.
 type Manager interface {
+	// VolumeResolver is fully implemented by the Manager.
+	VolumeResolver
+
 	// Destroy frees all resources that the Manager allocated.
 	Destroy(ctx context.Context)
-
-	// GetVolumeByID uses the CSI VolumeId to resolve the returned Volume.
-	GetVolumeByID(ctx context.Context, id string) (Volume, error)
 
 	// GetVolumeGroupByID uses the CSI-Addons VolumeGroupId to resolve the
 	// returned VolumeGroup.

--- a/internal/rbd/types/volume.go
+++ b/internal/rbd/types/volume.go
@@ -33,5 +33,11 @@ type Volume interface {
 	GetID(ctx context.Context) (string, error)
 
 	// ToCSI creates a CSI protocol formatted struct of the volume.
-	ToCSI(ctx context.Context) *csi.Volume
+	ToCSI(ctx context.Context) (*csi.Volume, error)
+
+	// AddToGroup adds the Volume to the VolumeGroup.
+	AddToGroup(ctx context.Context, vg VolumeGroup) error
+
+	// RemoveFromGroup removes the Volume from the VolumeGroup.
+	RemoveFromGroup(ctx context.Context, vg VolumeGroup) error
 }


### PR DESCRIPTION
# Describe what this PR does #

Implementation of the VolumeGroup backend. It contains a clear separation of the VolumeGroup type and functions and CSI-Addons responsibilities.

## Is there anything that requires special attention ##

Tested with a [small application that calls the CSI-Addons procedures directly](https://gist.github.com/nixpanic/3aab1eb6ad1937a52fb289e91ace3272). The application was modified several times to test different scenarios. At the moment I am confident that the basic functionality works as expected.

```
I0722 14:28:27.040708       1 utils.go:235] ID: 22 GRPC call: /volumegroup.Controller/CreateVolumeGroup
I0722 14:28:27.040980       1 utils.go:236] ID: 22 GRPC request: {"name":"my-group","parameters":{"clusterID":"openshift-storage","pool":"ocs-storagecluster-cephblockpool"},"secrets":"***stripped***","volume_ids":["0001-0011-openshift-storage-0000000000000001-eafd9e22-70de-459b-97fc-2d46e03d5f88","0001-0011-openshift-storage-0000000000000001-2f1acca8-95ca-4594-be0c-e5e70b6cbc43"]}
I0722 14:28:27.065729       1 omap.go:89] ID: 22 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.eafd9e22-70de-459b-97fc-2d46e03d5f88"): map[csi.imageid:67c16fdb4f5d csi.imagename:csi-vol-eafd9e22-70de-459b-97fc-2d46e03d5f88 csi.volname:pvc-37249c71-61f2-4c2f-8cdd-08cb2f99d668 csi.volume.owner:default]
I0722 14:28:27.112579       1 omap.go:89] ID: 22 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.2f1acca8-95ca-4594-be0c-e5e70b6cbc43"): map[csi.imageid:67c1ec38b881 csi.imagename:csi-vol-2f1acca8-95ca-4594-be0c-e5e70b6cbc43 csi.volname:pvc-5aae7b38-7ec3-4c45-b3c9-1a21c1d37b78 csi.volume.owner:default]
I0722 14:28:27.143738       1 volumegroup.go:106] ID: 22 all 2 Volumes for VolumeGroup "my-group" have been found
I0722 14:28:27.156146       1 omap.go:159] ID: 22 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.groups."): map[csi.volume.group.my-group:46ae4226-e71b-4955-8440-4801f178979a])
I0722 14:28:27.160879       1 omap.go:159] ID: 22 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.46ae4226-e71b-4955-8440-4801f178979a"): map[csi.groupname:csi-vol-group-46ae4226-e71b-4955-8440-4801f178979a csi.volname:my-group])
I0722 14:28:27.161611       1 omap.go:221] ID: 22 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.46ae4226-e71b-4955-8440-4801f178979a"): map[csi.groupname:csi-vol-group-46ae4226-e71b-4955-8440-4801f178979a csi.volname:my-group]
I0722 14:28:27.161663       1 volume_group.go:149] ID: 22 GetVolumeGroup(0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a) returns {id:0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a name:csi-vol-group-46ae4226-e71b-4955-8440-4801f178979a clusterID:openshift-storage credentials:0xc0008111a0 conn:<nil> ioctx:<nil> monitors:172.30.253.8:3300,172.30.149.93:3300,172.30.68.64:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc000b2e840 volumes:[] volumesToFree:[]}
I0722 14:28:27.161697       1 volume_group.go:249] ID: 22 connection established for volume group "0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a"
I0722 14:28:27.161710       1 volume_group.go:277] ID: 22 iocontext created for volume group "0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a" in pool "ocs-storagecluster-cephblockpool"
I0722 14:28:27.170848       1 volume_group.go:326] ID: 22 volume group "csi-vol-group-46ae4226-e71b-4955-8440-4801f178979a" has been created
I0722 14:28:27.170869       1 volumegroup.go:118] ID: 22 VolumeGroup "my-group" had been created: csi-vol-group-46ae4226-e71b-4955-8440-4801f178979a
I0722 14:28:27.194642       1 omap.go:159] ID: 22 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.46ae4226-e71b-4955-8440-4801f178979a"): map[0001-0011-openshift-storage-0000000000000001-eafd9e22-70de-459b-97fc-2d46e03d5f88:])
I0722 14:28:27.216181       1 omap.go:159] ID: 22 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.46ae4226-e71b-4955-8440-4801f178979a"): map[0001-0011-openshift-storage-0000000000000001-2f1acca8-95ca-4594-be0c-e5e70b6cbc43:])
I0722 14:28:27.216203       1 volumegroup.go:133] ID: 22 all 2 Volumes have been added to for VolumeGroup "my-group"
I0722 14:28:27.216519       1 utils.go:242] ID: 22 GRPC response: {"volume_group":{"volume_group_id":"0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a","volumes":[{"capacity_bytes":17179869184,"volume_context":{"imageName":"csi-vol-eafd9e22-70de-459b-97fc-2d46e03d5f88","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000001-eafd9e22-70de-459b-97fc-2d46e03d5f88"},{"capacity_bytes":8589934592,"volume_context":{"imageName":"csi-vol-2f1acca8-95ca-4594-be0c-e5e70b6cbc43","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000001-2f1acca8-95ca-4594-be0c-e5e70b6cbc43"}]}}
I0722 14:28:27.217582       1 utils.go:235] ID: 23 GRPC call: /volumegroup.Controller/DeleteVolumeGroup
I0722 14:28:27.217667       1 utils.go:236] ID: 23 GRPC request: {"secrets":"***stripped***","volume_group_id":"0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a"}
I0722 14:28:27.218503       1 omap.go:221] ID: 23 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.46ae4226-e71b-4955-8440-4801f178979a"): map[0001-0011-openshift-storage-0000000000000001-2f1acca8-95ca-4594-be0c-e5e70b6cbc43: 0001-0011-openshift-storage-0000000000000001-eafd9e22-70de-459b-97fc-2d46e03d5f88: csi.groupname:csi-vol-group-46ae4226-e71b-4955-8440-4801f178979a csi.volname:my-group]
I0722 14:28:27.219984       1 omap.go:89] ID: 23 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.2f1acca8-95ca-4594-be0c-e5e70b6cbc43"): map[csi.imageid:67c1ec38b881 csi.imagename:csi-vol-2f1acca8-95ca-4594-be0c-e5e70b6cbc43 csi.volname:pvc-5aae7b38-7ec3-4c45-b3c9-1a21c1d37b78 csi.volume.owner:default]
I0722 14:28:27.258472       1 omap.go:89] ID: 23 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.eafd9e22-70de-459b-97fc-2d46e03d5f88"): map[csi.imageid:67c16fdb4f5d csi.imagename:csi-vol-eafd9e22-70de-459b-97fc-2d46e03d5f88 csi.volname:pvc-37249c71-61f2-4c2f-8cdd-08cb2f99d668 csi.volume.owner:default]
I0722 14:28:27.289357       1 volume_group.go:149] ID: 23 GetVolumeGroup(0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a) returns {id:0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a name:csi-vol-group-46ae4226-e71b-4955-8440-4801f178979a clusterID:openshift-storage credentials:0xc000c832c0 conn:<nil> ioctx:<nil> monitors:172.30.253.8:3300,172.30.149.93:3300,172.30.68.64:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc00016f640 volumes:[0xc000658b48 0xc000658d88] volumesToFree:[0xc000658b48 0xc000658d88]}
I0722 14:28:27.289378       1 volumegroup.go:185] ID: 23 VolumeGroup "0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a" has been found
I0722 14:28:27.289387       1 volumegroup.go:197] ID: 23 VolumeGroup "0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a" contains 2 volumes
I0722 14:28:27.289420       1 volume_group.go:307] ID: 23 destroyed volume group instance with id "0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a"
E0722 14:28:27.289438       1 utils.go:240] ID: 23 GRPC error: rpc error: code = FailedPrecondition desc = rejecting to delete non-empty volume group "0001-0011-openshift-storage-0000000000000001-46ae4226-e71b-4955-8440-4801f178979a"
```

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
