### PR TITLE
doc: update coding guideline to suggest to place local imports last

### DIFF
--- a/docs/coding.md
+++ b/docs/coding.md
@@ -18,14 +18,14 @@ the code and will be pointed out in the review process:
 
 ### Imports
 
-We use the following convention for specifying imports:
+We prefer the following convention for specifying imports:
 
 ```
 <import standard library packages>
 
-<import ceph-csi packages>
-
 <import third-party packages>
+
+<import ceph-csi packages>
 ```
 
 Example:
@@ -37,9 +37,9 @@ import (
  "strings"
  "time"
 
- "github.com/ceph/ceph-csi/internal/util"
-
  "github.com/pborman/uuid"
+
+ "github.com/ceph/ceph-csi/internal/util"
 )
 ```
 


### PR DESCRIPTION
It seems very common in other Go based projects to place the local
packages in the import statement last. Currently Ceph-CSI expects the
imports to group the local packages immediately after standard packages.
This exception compared to other projects often requires new
contributors to 'correct' their PR.

Following a more common convention for grouping imports should make it a
little easier to contribute to the project.