### PR TITLE
rbd: conditionally advertise topology-aware provisioning capability

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -57,7 +57,7 @@ spec:
             - "--csi-addons-endpoint=$(CSI_ADDONS_ENDPOINT)"
             - "--v={{ .Values.logLevel }}"
             - "--drivername=$(DRIVER_NAME)"
-{{- if .Values.topology.domainLabels }}
+{{- if and .Values.topology.enabled .Values.topology.domainLabels }}
             - "--domainlabels={{ .Values.topology.domainLabels | join "," }}"
 {{- end }}
 {{- if .Values.instanceID }}

--- a/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
@@ -81,7 +81,7 @@ rules:
     resources: ["persistentvolumeclaims/status"]
     verbs: ["update", "patch"]
 {{- end }}
-{{- if .Values.topology.domainLabels }}
+{{- if .Values.topology.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list","watch"]

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -97,6 +97,7 @@ spec:
             - "--clustername={{ .Values.provisioner.clustername }}"
             {{- end }}
             - "--setmetadata={{ .Values.provisioner.setmetadata }}"
+            - "--enable-topology={{ .Values.topology.enabled | default false }}"
           env:
             - name: POD_IP
               valueFrom:

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -300,6 +300,9 @@ provisioner:
   podSecurityContext: {}
 
 topology:
+  # Specifies whether topology based provisioning support should
+  # be exposed by CSI
+  enabled: false
   # domainLabels define which node labels to use as domains
   # for CSI nodeplugins to advertise their domains
   # NOTE: the value here serves as an example and needs to be

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -75,6 +75,7 @@ func init() {
 	flag.IntVar(&conf.PidLimit, "pidlimit", 0, "the PID limit to configure through cgroups")
 	flag.BoolVar(&conf.IsControllerServer, "controllerserver", false, "start cephcsi controller server")
 	flag.BoolVar(&conf.IsNodeServer, "nodeserver", false, "start cephcsi node server")
+	flag.BoolVar(&conf.EnableTopology, "enable-topology", false, "enable for topology aware provisioning")
 	flag.StringVar(
 		&conf.DomainLabels,
 		"domainlabels",

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -62,6 +62,8 @@ spec:
             - "--rbdsoftmaxclonedepth=4"
             - "--enableprofiling=false"
             - "--setmetadata=true"
+            # for topology aware provisioning enable the below flag
+            # - "--enable-topology=true"
           env:
             - name: POD_IP
               valueFrom:

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -49,9 +49,10 @@ func NewDriver() *Driver {
 }
 
 // NewIdentityServer initialize a identity server for rbd CSI driver.
-func NewIdentityServer(d *csicommon.CSIDriver) *rbd.IdentityServer {
+func NewIdentityServer(d *csicommon.CSIDriver, config *util.Config) *rbd.IdentityServer {
 	return &rbd.IdentityServer{
 		DefaultIdentityServer: csicommon.NewDefaultIdentityServer(d),
+		Config:                config,
 	}
 }
 
@@ -137,7 +138,7 @@ func (r *Driver) Run(conf *util.Config) {
 	}
 
 	// Create GRPC servers
-	r.ids = NewIdentityServer(r.cd)
+	r.ids = NewIdentityServer(r.cd, conf)
 
 	if conf.IsNodeServer {
 		topology, err = util.GetTopologyFromDomainLabels(conf.DomainLabels, conf.NodeID, conf.DriverName)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -132,6 +132,7 @@ type Config struct {
 	PollTime    time.Duration // time interval in seconds between each poll
 	PoolTimeout time.Duration // probe timeout in seconds
 
+	EnableTopology     bool // flag to enable topology aware provisioning
 	EnableProfiling    bool // flag to enable profiling
 	IsControllerServer bool // if set to true start provisioner server
 	IsNodeServer       bool // if set to true start node server


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Since external-provisioner (>v5) enabled Topology FeatureGate by default.
It expects CSI to advertise `VOLUME_ACCESSIBILITY_CONSTRAINTS` capability
and provide the `AccessibleTopology` in NodeGetInfoResponse which is required
by external-provisioner during provisioning to generate accessibility
requirement. `AccessibleTopology` is generated by domainlabels passed.

Issue: If `AccessibleTopology` is empty, provisioning fails as always
`VOLUME_ACCESSIBILITY_CONSTRAINTS` is advertised from Ceph-CSI.

Fix: 
- Introduce a `EnableTopology` flag on controller server (default: false) to enable/disable topology based provisioning
- advertise `VOLUME_ACCESSIBILITY_CONSTRAINTS` only if `EnableTopology` flag is passed.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
