### PR TITLE
rbd: add VolumeGroup.ModifyVolumeGroupMembership CSI-Addons operation

### DIFF
--- a/internal/csi-addons/rbd/identity.go
+++ b/internal/csi-addons/rbd/identity.go
@@ -114,6 +114,12 @@ func (is *IdentityServer) GetCapabilities(
 						Type: identity.Capability_VolumeGroup_LIMIT_VOLUME_TO_ONE_VOLUME_GROUP,
 					},
 				},
+			}, &identity.Capability{
+				Type: &identity.Capability_VolumeGroup_{
+					VolumeGroup: &identity.Capability_VolumeGroup{
+						Type: identity.Capability_VolumeGroup_MODIFY_VOLUME_GROUP,
+					},
+				},
 			})
 	}
 


### PR DESCRIPTION
The ModifyVolumeGroupMembership operation can be used to change the
volumes that are part of a VolumeGroup. Only empty VolumeGroups can be
removed, this operation is required to make that possible.

These logs contain the following actions:
1. create a VolumeGroup with volumes in the initial request
2. empty the VolumeGroup
3. add volumes to the VolumeGroup
4. emtpy the VolumeGroup again (required for deletion)
5. delete the VolumeGroup

```
I0725 08:59:49.366014       1 utils.go:235] ID: 28 GRPC call: /volumegroup.Controller/CreateVolumeGroup
I0725 08:59:49.366098       1 utils.go:236] ID: 28 GRPC request: {"name":"the-group","parameters":{"clusterID":"openshift-storage","pool":"ocs-storagecluster-cephblockpool"},"secrets":"***stripped***","volume_ids":["0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a","0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c"]}
I0725 08:59:49.368070       1 omap.go:89] ID: 28 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.0b5e14d8-2237-4262-a1d4-725a2942bf3a"): map[csi.imageid:20e5a173b8bd csi.imagename:csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a csi.volname:pvc-479506a3-b6d7-446c-88a1-d9899789aaff csi.volume.owner:default]
I0725 08:59:49.398679       1 omap.go:89] ID: 28 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a47a50fc-3bb1-40d9-bf58-9a522bfd112c"): map[csi.imageid:20e5705d82c9 csi.imagename:csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c csi.volname:pvc-b3331ae5-d1b8-453d-9d83-a5044f70c56e csi.volume.owner:default]
I0725 08:59:49.424641       1 volumegroup.go:106] ID: 28 all 2 Volumes for VolumeGroup "the-group" have been found
I0725 08:59:49.426299       1 omap.go:89] ID: 28 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.groups."): map[csi.volume.group.the-group:48efc0bc-6ffa-49a2-b173-7cefdad35d7b]
E0725 08:59:49.426897       1 omap.go:212] ID: 28 omap not found (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.48efc0bc-6ffa-49a2-b173-7cefdad35d7b"): rados: ret=-2, No such file or directory
I0725 08:59:49.435993       1 omap.go:126] ID: 28 removed omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.groups."): [csi.volume.group.the-group]
I0725 08:59:49.436009       1 manager.go:198] ID: 28 the journal does not contain a reservation for a volume group with name "the-group" yet
I0725 08:59:49.445174       1 omap.go:159] ID: 28 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.groups."): map[csi.volume.group.the-group:8857a21c-fc4f-4577-98f4-a7b5f055388e])
I0725 08:59:49.448697       1 omap.go:159] ID: 28 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[csi.groupname:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e csi.volname:the-group])
I0725 08:59:49.450082       1 omap.go:221] ID: 28 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[csi.groupname:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e csi.volname:the-group]
I0725 08:59:49.450103       1 volume_group.go:149] ID: 28 GetVolumeGroup(0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e) returns {id:0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e name:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e clusterID:openshift-storage credentials:0xc000905320 conn:<nil> ioctx:<nil> monitors:172.30.137.172:3300,172.30.174.236:3300,172.30.128.147:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc000b225c0 volumes:[] volumesToFree:[]}
I0725 08:59:49.450127       1 volume_group.go:249] ID: 28 connection established for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.450137       1 volume_group.go:277] ID: 28 iocontext created for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" in pool "ocs-storagecluster-cephblockpool"
I0725 08:59:49.462040       1 volume_group.go:330] ID: 28 volume group "csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e" has been created
I0725 08:59:49.462070       1 volumegroup.go:118] ID: 28 VolumeGroup "the-group" has been created: csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e
I0725 08:59:49.502483       1 omap.go:159] ID: 28 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a:])
I0725 08:59:49.543343       1 omap.go:159] ID: 28 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c:])
I0725 08:59:49.543364       1 volumegroup.go:133] ID: 28 all 2 Volumes have been added to for VolumeGroup "the-group"
I0725 08:59:49.543456       1 utils.go:242] ID: 28 GRPC response: {"volume_group":{"volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e","volumes":[{"capacity_bytes":8589934592,"volume_context":{"imageName":"csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a"},{"capacity_bytes":8589934592,"volume_context":{"imageName":"csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c"}]}}
I0725 08:59:49.544607       1 utils.go:235] ID: 29 GRPC call: /volumegroup.Controller/ModifyVolumeGroupMembership
I0725 08:59:49.544662       1 utils.go:236] ID: 29 GRPC request: {"secrets":"***stripped***","volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"}
I0725 08:59:49.546477       1 omap.go:221] ID: 29 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a: 0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c: csi.groupname:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e csi.volname:the-group]
I0725 08:59:49.549084       1 omap.go:89] ID: 29 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a47a50fc-3bb1-40d9-bf58-9a522bfd112c"): map[csi.imageid:20e5705d82c9 csi.imagename:csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c csi.volname:pvc-b3331ae5-d1b8-453d-9d83-a5044f70c56e csi.volume.owner:default]
I0725 08:59:49.575885       1 omap.go:89] ID: 29 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.0b5e14d8-2237-4262-a1d4-725a2942bf3a"): map[csi.imageid:20e5a173b8bd csi.imagename:csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a csi.volname:pvc-479506a3-b6d7-446c-88a1-d9899789aaff csi.volume.owner:default]
I0725 08:59:49.603296       1 volume_group.go:149] ID: 29 GetVolumeGroup(0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e) returns {id:0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e name:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e clusterID:openshift-storage credentials:0xc000905b00 conn:<nil> ioctx:<nil> monitors:172.30.137.172:3300,172.30.174.236:3300,172.30.128.147:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc000b238c0 volumes:[0xc00075db08 0xc00075dd48] volumesToFree:[0xc00075db08 0xc00075dd48]}
I0725 08:59:49.603342       1 volume_group.go:249] ID: 29 connection established for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.603358       1 volume_group.go:277] ID: 29 iocontext created for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" in pool "ocs-storagecluster-cephblockpool"
I0725 08:59:49.627724       1 omap.go:126] ID: 29 removed omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): [0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a]
I0725 08:59:49.652372       1 omap.go:126] ID: 29 removed omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): [0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c]
I0725 08:59:49.652409       1 volume_group.go:307] ID: 29 destroyed volume group instance with id "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.652449       1 utils.go:242] ID: 29 GRPC response: {"volume_group":{"volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"}}
I0725 08:59:49.652843       1 utils.go:235] ID: 30 GRPC call: /volumegroup.Controller/ModifyVolumeGroupMembership
I0725 08:59:49.652909       1 utils.go:236] ID: 30 GRPC request: {"secrets":"***stripped***","volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e","volume_ids":["0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a","0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c"]}
I0725 08:59:49.654508       1 omap.go:221] ID: 30 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[csi.groupname:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e csi.volname:the-group]
I0725 08:59:49.654529       1 volume_group.go:149] ID: 30 GetVolumeGroup(0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e) returns {id:0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e name:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e clusterID:openshift-storage credentials:0xc0005ca080 conn:<nil> ioctx:<nil> monitors:172.30.137.172:3300,172.30.174.236:3300,172.30.128.147:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc000b4e160 volumes:[] volumesToFree:[]}
I0725 08:59:49.655819       1 omap.go:89] ID: 30 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.0b5e14d8-2237-4262-a1d4-725a2942bf3a"): map[csi.imageid:20e5a173b8bd csi.imagename:csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a csi.volname:pvc-479506a3-b6d7-446c-88a1-d9899789aaff csi.volume.owner:default]
I0725 08:59:49.677462       1 volume_group.go:249] ID: 30 connection established for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.677483       1 volume_group.go:277] ID: 30 iocontext created for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" in pool "ocs-storagecluster-cephblockpool"
I0725 08:59:49.715159       1 omap.go:159] ID: 30 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a:])
I0725 08:59:49.717248       1 omap.go:89] ID: 30 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a47a50fc-3bb1-40d9-bf58-9a522bfd112c"): map[csi.imageid:20e5705d82c9 csi.imagename:csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c csi.volname:pvc-b3331ae5-d1b8-453d-9d83-a5044f70c56e csi.volume.owner:default]
I0725 08:59:49.778482       1 omap.go:159] ID: 30 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c:])
I0725 08:59:49.778537       1 volume_group.go:307] ID: 30 destroyed volume group instance with id "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.778632       1 utils.go:242] ID: 30 GRPC response: {"volume_group":{"volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e","volumes":[{"capacity_bytes":8589934592,"volume_context":{"imageName":"csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a"},{"capacity_bytes":8589934592,"volume_context":{"imageName":"csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c"}]}}
I0725 08:59:49.779089       1 utils.go:235] ID: 31 GRPC call: /volumegroup.Controller/ModifyVolumeGroupMembership
I0725 08:59:49.779131       1 utils.go:236] ID: 31 GRPC request: {"secrets":"***stripped***","volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"}
I0725 08:59:49.780732       1 omap.go:221] ID: 31 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a: 0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c: csi.groupname:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e csi.volname:the-group]
I0725 08:59:49.783568       1 omap.go:89] ID: 31 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.0b5e14d8-2237-4262-a1d4-725a2942bf3a"): map[csi.imageid:20e5a173b8bd csi.imagename:csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a csi.volname:pvc-479506a3-b6d7-446c-88a1-d9899789aaff csi.volume.owner:default]
I0725 08:59:49.807983       1 omap.go:89] ID: 31 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a47a50fc-3bb1-40d9-bf58-9a522bfd112c"): map[csi.imageid:20e5705d82c9 csi.imagename:csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c csi.volname:pvc-b3331ae5-d1b8-453d-9d83-a5044f70c56e csi.volume.owner:default]
I0725 08:59:49.828351       1 volume_group.go:149] ID: 31 GetVolumeGroup(0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e) returns {id:0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e name:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e clusterID:openshift-storage credentials:0xc000b88660 conn:<nil> ioctx:<nil> monitors:172.30.137.172:3300,172.30.174.236:3300,172.30.128.147:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc000a29770 volumes:[0xc0007f2b48 0xc0007f2d88] volumesToFree:[0xc0007f2b48 0xc0007f2d88]}
I0725 08:59:49.828392       1 volume_group.go:249] ID: 31 connection established for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.828444       1 volume_group.go:277] ID: 31 iocontext created for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" in pool "ocs-storagecluster-cephblockpool"
I0725 08:59:49.859081       1 omap.go:126] ID: 31 removed omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): [0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c]
I0725 08:59:49.880057       1 omap.go:126] ID: 31 removed omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): [0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a]
I0725 08:59:49.880093       1 volume_group.go:307] ID: 31 destroyed volume group instance with id "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.880129       1 utils.go:242] ID: 31 GRPC response: {"volume_group":{"volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"}}
I0725 08:59:49.880528       1 utils.go:235] ID: 32 GRPC call: /volumegroup.Controller/DeleteVolumeGroup
I0725 08:59:49.880569       1 utils.go:236] ID: 32 GRPC request: {"secrets":"***stripped***","volume_group_id":"0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"}
I0725 08:59:49.883407       1 omap.go:221] ID: 32 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.8857a21c-fc4f-4577-98f4-a7b5f055388e"): map[csi.groupname:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e csi.volname:the-group]
I0725 08:59:49.883429       1 volume_group.go:149] ID: 32 GetVolumeGroup(0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e) returns {id:0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e name:csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e clusterID:openshift-storage credentials:0xc000756bc0 conn:<nil> ioctx:<nil> monitors:172.30.137.172:3300,172.30.174.236:3300,172.30.128.147:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc00072f970 volumes:[] volumesToFree:[]}
I0725 08:59:49.883440       1 volumegroup.go:185] ID: 32 VolumeGroup "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" has been found
I0725 08:59:49.883448       1 volumegroup.go:197] ID: 32 VolumeGroup "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" contains 0 volumes
I0725 08:59:49.883477       1 volume_group.go:249] ID: 32 connection established for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.883490       1 volume_group.go:277] ID: 32 iocontext created for volume group "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" in pool "ocs-storagecluster-cephblockpool"
I0725 08:59:49.898821       1 volume_group.go:351] ID: 32 volume group "csi-vol-group-8857a21c-fc4f-4577-98f4-a7b5f055388e" has been removed
I0725 08:59:49.909091       1 omap.go:126] ID: 32 removed omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.groups."): [csi.volume.group.0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e]
I0725 08:59:49.909108       1 volumegroup.go:215] ID: 32 VolumeGroup "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e" has been deleted
I0725 08:59:49.909130       1 volume_group.go:307] ID: 32 destroyed volume group instance with id "0001-0011-openshift-storage-0000000000000002-8857a21c-fc4f-4577-98f4-a7b5f055388e"
I0725 08:59:49.909153       1 utils.go:242] ID: 32 GRPC response: {}

```