### PR TITLE
rbd: make CreateVolumeGroup more idempotent

### DIFF
--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -192,7 +192,7 @@ func (mgr *rbdManager) CreateVolumeGroup(ctx context.Context, name string) (type
 	}
 
 	var uuid string
-	if vgData != nil && vgData.GroupName != "" {
+	if vgData != nil && vgData.GroupUUID != "" {
 		uuid = vgData.GroupUUID
 	} else {
 		log.DebugLog(ctx, "the journal does not contain a reservation for a volume group with name %q yet", name)


### PR DESCRIPTION
It seems to be possible that the UUID was found, but the name is not
set. Checking on UUID makes the CreateVolumeGroup operation more
idempotent.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
