### PR TITLE
cephfs: correct the id for cephfs locks

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -151,7 +151,7 @@ func maybeUnlockFileEncryption(
 	}
 	defer ioctx.Destroy()
 
-	res, err := ioctx.LockExclusive(volOptions.VolID, lockName, lockCookie, lockDesc, lockDuration, &flags)
+	res, err := ioctx.LockExclusive(string(volID), lockName, lockCookie, lockDesc, lockDuration, &flags)
 	if res != 0 {
 		switch res {
 		case -int(syscall.EBUSY):


### PR DESCRIPTION
There was a discrepancy between the objectId when creating the lock and when releasing the lock this causes every lock to hang.

Fixes: #4727 

This removes the performance concerns discussed in this [review thread](https://github.com/ceph/ceph-csi/pull/4697#discussion_r1690157131), after this change the pods with this encrypted filesystems comes up in seconds as expected.