### PR TITLE
rbd: implement CSI-Addons ControllerGetVolumeGroup operation

### DIFF
--- a/internal/csi-addons/rbd/identity.go
+++ b/internal/csi-addons/rbd/identity.go
@@ -120,6 +120,12 @@ func (is *IdentityServer) GetCapabilities(
 						Type: identity.Capability_VolumeGroup_MODIFY_VOLUME_GROUP,
 					},
 				},
+			}, &identity.Capability{
+				Type: &identity.Capability_VolumeGroup_{
+					VolumeGroup: &identity.Capability_VolumeGroup{
+						Type: identity.Capability_VolumeGroup_GET_VOLUME_GROUP,
+					},
+				},
 			})
 	}
 


### PR DESCRIPTION
With the ControllerGetVolumeGroup operation the caller can verify that a
VolumeGroup exists, and validate the volumes that are part of it.


```
I0725 12:44:52.504216       1 utils.go:235] ID: 37 GRPC call: /volumegroup.Controller/ControllerGetVolumeGroup
I0725 12:44:52.504255       1 utils.go:236] ID: 37 GRPC request: {"secrets":"***stripped***","volume_group_id":"0001-0011-openshift-storage-0000000000000002-2aaad87d-2e93-4647-9ac0-3660a7912de6"}
I0725 12:44:52.505101       1 omap.go:221] ID: 37 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.group.2aaad87d-2e93-4647-9ac0-3660a7912de6"): map[0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a: 0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c: csi.groupname:csi-vol-group-2aaad87d-2e93-4647-9ac0-3660a7912de6 csi.volname:the-group]
I0725 12:44:52.505709       1 omap.go:89] ID: 37 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.0b5e14d8-2237-4262-a1d4-725a2942bf3a"): map[csi.imageid:20e5a173b8bd csi.imagename:csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a csi.volname:pvc-479506a3-b6d7-446c-88a1-d9899789aaff csi.volume.owner:default]
I0725 12:44:52.526239       1 omap.go:89] ID: 37 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a47a50fc-3bb1-40d9-bf58-9a522bfd112c"): map[csi.imageid:20e5705d82c9 csi.imagename:csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c csi.volname:pvc-b3331ae5-d1b8-453d-9d83-a5044f70c56e csi.volume.owner:default]
I0725 12:44:52.543456       1 volume_group.go:149] ID: 37 GetVolumeGroup(0001-0011-openshift-storage-0000000000000002-2aaad87d-2e93-4647-9ac0-3660a7912de6) returns {id:0001-0011-openshift-storage-0000000000000002-2aaad87d-2e93-4647-9ac0-3660a7912de6 name:csi-vol-group-2aaad87d-2e93-4647-9ac0-3660a7912de6 clusterID:openshift-storage credentials:0xc000837380 conn:<nil> ioctx:<nil> monitors:172.30.137.172:3300,172.30.174.236:3300,172.30.128.147:3300 pool:ocs-storagecluster-cephblockpool namespace: journal:0xc000adb510 volumes:[0xc0007dcfc8 0xc0007dd208] volumesToFree:[0xc0007dcfc8 0xc0007dd208]}
I0725 12:44:52.543519       1 volume_group.go:307] ID: 37 destroyed volume group instance with id "0001-0011-openshift-storage-0000000000000002-2aaad87d-2e93-4647-9ac0-3660a7912de6"
I0725 12:44:52.543604       1 utils.go:242] ID: 37 GRPC response: {"volume_group":{"volume_group_id":"0001-0011-openshift-storage-0000000000000002-2aaad87d-2e93-4647-9ac0-3660a7912de6","volumes":[{"capacity_bytes":8589934592,"volume_context":{"imageName":"csi-vol-0b5e14d8-2237-4262-a1d4-725a2942bf3a","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000002-0b5e14d8-2237-4262-a1d4-725a2942bf3a"},{"capacity_bytes":8589934592,"volume_context":{"imageName":"csi-vol-a47a50fc-3bb1-40d9-bf58-9a522bfd112c","journalPool":"ocs-storagecluster-cephblockpool","pool":"ocs-storagecluster-cephblockpool"},"volume_id":"0001-0011-openshift-storage-0000000000000002-a47a50fc-3bb1-40d9-bf58-9a522bfd112c"}]}}
```