### PR TITLE
ci: use quay.io for ceph image

### DIFF
--- a/containerized-tests.groovy
+++ b/containerized-tests.groovy
@@ -155,7 +155,7 @@ node('cico-workspace') {
 					).trim()
 					def q_io_regex = ~"^quay.io/"
 
-					// base_image is like ceph/ceph:v15 or quay.io/ceph/ceph:v15, strip "quay.io/"
+					// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
 					podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 				}
 			}

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -139,7 +139,7 @@ node('cico-workspace') {
 				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
-			// base_image is like ceph/ceph:v15 or quay.io/ceph/ceph:v15, strip "quay.io/"
+			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
@@ -163,11 +163,11 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_CEPH_CLUSTER_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			if (rook_ceph_cluster_image != '') {
 				// single-node-k8s.sh pushes the image into minikube
-				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
+				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - q_io_regex)
 			}
 
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -141,7 +141,7 @@ node('cico-workspace') {
 				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
-			// base_image is like ceph/ceph:v15 or quay.io/ceph/ceph:v15, strip "quay.io/"
+			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
@@ -167,11 +167,11 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_CEPH_CLUSTER_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			if (rook_ceph_cluster_image != '') {
 				// single-node-k8s.sh pushes the image into minikube
-				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
+				podman_pull(ci_registry, "quay.io", rook_ceph_cluster_image - q_io_regex)
 			}
 
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -138,7 +138,7 @@ node('cico-workspace') {
 				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
-			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
+			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
@@ -164,11 +164,11 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_CEPH_CLUSTER_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			if (rook_ceph_cluster_image != '') {
 				// single-node-k8s.sh pushes the image into minikube
-				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
+				podman_pull(ci_registry, "quay.io", rook_ceph_cluster_image - q_io_regex)
 			}
 
 			timeout(time: 30, unit: 'MINUTES') {

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -132,14 +132,14 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${BASE_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			withCredentials([usernamePassword(credentialsId: 'container-registry-auth', usernameVariable: 'CREDS_USER', passwordVariable: 'CREDS_PASSWD')]) {
 				podman_login(ci_registry, '$CREDS_USER', '$CREDS_PASSWD')
 			}
 
-			// base_image is like ceph/ceph:v15 or docker.io/ceph/ceph:v15, strip "docker.io/"
-			podman_pull(ci_registry, "docker.io", "${base_image}" - d_io_regex)
+			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
+			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 		}
@@ -164,11 +164,11 @@ node('cico-workspace') {
 				script: 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CICO_NODE} \'source /opt/build/go/src/github.com/ceph/ceph-csi/build.env && echo ${ROOK_CEPH_CLUSTER_IMAGE}\'',
 				returnStdout: true
 			).trim()
-			def d_io_regex = ~"^docker.io/"
+			def q_io_regex = ~"^quay.io/"
 
 			if (rook_ceph_cluster_image != '') {
 				// single-node-k8s.sh pushes the image into minikube
-				podman_pull(ci_registry, "docker.io", rook_ceph_cluster_image - d_io_regex)
+				podman_pull(ci_registry, "quay.io", rook_ceph_cluster_image - q_io_regex)
 			}
 
 			timeout(time: 30, unit: 'MINUTES') {


### PR DESCRIPTION
ceph image is using quay.io not the docker.io, This commit updates the same in CI. Currently CI is failing here https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/organizations/jenkins/mini-e2e-helm_k8s-1.27/detail/mini-e2e-helm_k8s-1.27/1086/pipeline for PR https://github.com/ceph/ceph-csi/pull/4736

