### PR TITLE
doc: inform users that the OS in the container-image is updated

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -11,5 +11,6 @@
 - cephfs: support omap data store in radosnamespace via cli argument in [PR](https://github.com/ceph/ceph-csi/pull/4652)
 - deploy: radosNamespaceCephFS can be configured for ceph-csi-cephfs chart in [PR](https://github.com/ceph/ceph-csi/pull/4652)
 - build: update ceph release to squid in [PR](https://github.com/ceph/ceph-csi/pull/4735)
+- build: CentOS Stream 9 is used as OS in the container-images [PR](https://github.com/ceph/ceph-csi/pull/4735)
 
 ## NOTE


### PR DESCRIPTION
The Squid container-image that is used as base for the Ceph-CSI
container-image uses CentOS Stream 9.

Closes: #4659