### PR TITLE
ci: use latest Fedora container-image

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -8,7 +8,7 @@
 # little different.
 #
 
-FROM registry.fedoraproject.org/fedora:39
+FROM registry.fedoraproject.org/fedora:latest
 
 ARG GOPATH=/go
 ARG GOROOT=/usr/local/go


### PR DESCRIPTION
GitHub had issues with Fedora 40 when it was released. Hopefully this is
not the case anymore.

Closes: #4585