### PR TITLE
ci: prevent breakage when including certain commands in the PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -464,3 +464,17 @@ pull_request_rules:
           - Repo activity
           - ci/skip/e2e
           - ci/skip/multi-arch-build
+
+  # A [skip ci] in the PR description prevents Jenkins jobs from running, mark
+  # the PR as Draft so that CI jobs do not automatically run anymore.
+  - name: detect [skip ci] in the PR description
+    conditions:
+      - "body-raw~=[skip ci]"
+    actions:
+      edit:
+        draft: true
+      comment:
+        # yamllint disable-line rule:truthy
+        message: "The PR description contains the unsupported `[skip ci]`
+        command, please update the description and mark the PR ready for review
+        again."

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -278,8 +278,11 @@ need to be met before it will be merged:
   on the PR. The bot will merge the PR if it's having one approval and the
   label `ready-to-merge`.
 
-When the criteria are met, a project maintainer can merge your changes into
-the project's devel branch.
+When the criteria are met, a project maintainer can instruct the Mergify bot to
+queue the PR for merging. This usually is done by leaving two comments:
+
+* `@mergifyio rebase` to rebase on the latest HEAD of the branch
+* `@mergifyio queue` once the rebasing is done, to add the PR to the merge queue
 
 ### Backport a Fix to a Release Branch
 


### PR DESCRIPTION
[paragraph removed due to CI blockage, see the commit description]

This causes Mergify to add the `ok-to-test` label again, instructing a
GitHub Action to add comments to start jobs in Jenkins. Once all
comments have been posted, the `ok-to-test` label is removed. Mergify
then notices that the jobs were not run, and adds the `ok-to-test` label
again.... Endlessly looping of adding the label, commenting and removing
the label as a result.

By reporting the brokenness of the PR description and marking the PR as
Draft, the looping is prevented.

See-also: #4749
skip-checks: false