### PR TITLE
ci: only update jobs, do not check views

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -5,4 +5,4 @@ test:
 	cd $(WORKDIR) && jenkins-jobs --allow-empty-variables test -o $(OUTPUT) jobs
 
 deploy:
-	cd $(WORKDIR) && jenkins-jobs --allow-empty-variables update --delete-old jobs
+	cd $(WORKDIR) && jenkins-jobs --allow-empty-variables update --jobs-only --delete-old jobs


### PR DESCRIPTION
Updating jobs works, but there is also an error returned:

    Jenkins returned an unexpected view name All (expected: all)

There is no need to update the Views, as there are none configured. Only
the default "All" view is available, and that seems to cause the
failure.

Logs of the failure:
```
make: Entering directory '/opt/build/deploy'
cd /opt/build/deploy/../ && jenkins-jobs --allow-empty-variables update --delete-old jobs
INFO:jenkins_jobs.cli.subcommand.base:Updating jobs in [PosixPath('jobs')] ([])
INFO:root:Caching type properties of properties = jenkins_jobs.modules.properties:Properties
INFO:root:Caching type scm of scm = jenkins_jobs.modules.scm:SCM
INFO:root:Caching type triggers of triggers = jenkins_jobs.modules.triggers:Triggers
INFO:root:Caching type parameters of parameters = jenkins_jobs.modules.parameters:Parameters
INFO:jenkins_jobs.builder:Number of jobs generated:  26
INFO:jenkins_jobs.builder:Reconfiguring jenkins job build-images
INFO:jenkins_jobs.builder:Reconfiguring jenkins job ci-job-validation
INFO:jenkins_jobs.builder:Reconfiguring jenkins job commitlint
INFO:jenkins_jobs.builder:Reconfiguring jenkins job containerized-tests
INFO:jenkins_jobs.builder:Reconfiguring jenkins job jjb-deploy
INFO:jenkins_jobs.builder:Reconfiguring jenkins job jjb-validate
INFO:jenkins_jobs.builder:Reconfiguring jenkins job k8s-e2e-external-storage-1.25
INFO:jenkins_jobs.builder:Reconfiguring jenkins job k8s-e2e-external-storage-1.26
INFO:jenkins_jobs.builder:Reconfiguring jenkins job k8s-e2e-external-storage-1.27
INFO:jenkins_jobs.builder:Reconfiguring jenkins job k8s-e2e-external-storage-1.28
INFO:jenkins_jobs.builder:Reconfiguring jenkins job k8s-e2e-external-storage-1.29
INFO:jenkins_jobs.builder:Reconfiguring jenkins job k8s-e2e-external-storage-1.30
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e-helm_k8s-1.25
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e-helm_k8s-1.26
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e-helm_k8s-1.27
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e-helm_k8s-1.28
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e-helm_k8s-1.29
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e-helm_k8s-1.30
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e_k8s-1.25
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e_k8s-1.26
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e_k8s-1.27
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e_k8s-1.28
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e_k8s-1.29
INFO:jenkins_jobs.builder:Reconfiguring jenkins job mini-e2e_k8s-1.30
INFO:jenkins_jobs.builder:Reconfiguring jenkins job upgrade-tests-cephfs
INFO:jenkins_jobs.builder:Reconfiguring jenkins job upgrade-tests-rbd
INFO:jenkins_jobs.cli.subcommand.update:Number of jobs updated: 26
INFO:jenkins_jobs.builder:Number of views generated:  0
INFO:jenkins_jobs.cli.subcommand.update:Number of views updated: 0
INFO:jenkins_jobs.cli.subcommand.update:Number of jobs deleted: 0
Traceback (most recent call last):
  File "/usr/local/bin/jenkins-jobs", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/jenkins_jobs/cli/entry.py", line 179, in main
    jjb.execute()
  File "/usr/local/lib/python3.9/site-packages/jenkins_jobs/cli/entry.py", line 158, in execute
    ext.obj.execute(self.options, self.jjb_config)
  File "/usr/local/lib/python3.9/site-packages/jenkins_jobs/cli/subcommand/update.py", line 154, in execute
    n = builder.delete_old_managed_views(keep=keep_views)
  File "/usr/local/lib/python3.9/site-packages/jenkins_jobs/builder.py", line 402, in delete_old_managed_views
    if view["name"] not in keep and self.is_view(view["name"], use_cache=False):
  File "/usr/local/lib/python3.9/site-packages/jenkins_jobs/builder.py", line 384, in is_view
    return self.jenkins.view_exists(view_name)
  File "/usr/local/lib/python3.9/site-packages/jenkins/__init__.py", line 1856, in view_exists
    if self.get_view_name(name) == name:
  File "/usr/local/lib/python3.9/site-packages/jenkins/__init__.py", line 1833, in get_view_name
    raise JenkinsException(
jenkins.JenkinsException: Jenkins returned an unexpected view name All (expected: all)
```