### PR TITLE
journal: store CreationTime for VolumeGroups

### DIFF
--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -617,7 +617,7 @@ func TestGetGRPCError(t *testing.T) {
 }
 
 func Test_timestampFromString(t *testing.T) {
-	tm := timestamppb.Now()
+	tm := time.Now()
 	t.Parallel()
 	tests := []struct {
 		name      string
@@ -627,8 +627,8 @@ func Test_timestampFromString(t *testing.T) {
 	}{
 		{
 			name:      "valid timestamp",
-			timestamp: timestampToString(tm),
-			want:      tm.AsTime().Local(),
+			timestamp: timestampToString(&tm),
+			want:      tm,
 			wantErr:   false,
 		},
 		{
@@ -669,8 +669,8 @@ func Test_timestampFromString(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("timestampFromString() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("timestampFromString() = %v, want %v", got, tt.want)
+			if !tt.want.Equal(got) {
+				t.Errorf("timestampFromString() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -1240,7 +1241,7 @@ func (cs *ControllerServer) CreateSnapshot(
 			SizeBytes:      vol.VolSize,
 			SnapshotId:     vol.VolID,
 			SourceVolumeId: req.GetSourceVolumeId(),
-			CreationTime:   vol.CreatedAt,
+			CreationTime:   timestamppb.New(*vol.CreatedAt),
 			ReadyToUse:     true,
 		},
 	}, nil
@@ -1300,7 +1301,7 @@ func cloneFromSnapshot(
 			SizeBytes:      rbdSnap.VolSize,
 			SnapshotId:     rbdSnap.VolID,
 			SourceVolumeId: rbdSnap.SourceVolumeID,
-			CreationTime:   rbdSnap.CreatedAt,
+			CreationTime:   timestamppb.New(*rbdSnap.CreatedAt),
 			ReadyToUse:     true,
 		},
 	}, nil

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -32,7 +32,6 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -1236,14 +1235,13 @@ func (cs *ControllerServer) CreateSnapshot(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	csiSnap, err := vol.toSnapshot().ToCSI(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &csi.CreateSnapshotResponse{
-		Snapshot: &csi.Snapshot{
-			SizeBytes:      vol.VolSize,
-			SnapshotId:     vol.VolID,
-			SourceVolumeId: req.GetSourceVolumeId(),
-			CreationTime:   timestamppb.New(*vol.CreatedAt),
-			ReadyToUse:     true,
-		},
+		Snapshot: csiSnap,
 	}, nil
 }
 
@@ -1296,14 +1294,13 @@ func cloneFromSnapshot(
 		}
 	}
 
+	csiSnap, err := rbdSnap.ToCSI(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &csi.CreateSnapshotResponse{
-		Snapshot: &csi.Snapshot{
-			SizeBytes:      rbdSnap.VolSize,
-			SnapshotId:     rbdSnap.VolID,
-			SourceVolumeId: rbdSnap.SourceVolumeID,
-			CreationTime:   timestamppb.New(*rbdSnap.CreatedAt),
-			ReadyToUse:     true,
-		},
+		Snapshot: csiSnap,
 	}, nil
 }
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -36,8 +36,6 @@ import (
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cloud-provider/volume/helpers"
 	mount "k8s.io/mount-utils"
@@ -138,7 +136,7 @@ type rbdImage struct {
 	// fileEncryption provides access to optional VolumeEncryption functions (e.g fscrypt)
 	fileEncryption *util.VolumeEncryption
 
-	CreatedAt *timestamp.Timestamp
+	CreatedAt *time.Time
 
 	// conn is a connection to the Ceph cluster obtained from a ConnPool
 	conn *util.ClusterConnection
@@ -1595,7 +1593,7 @@ func (rv *rbdVolume) setImageOptions(ctx context.Context, options *librbd.ImageO
 
 // GetCreationTime returns the creation time of the image. if the image
 // creation time is not set, it queries the image info and returns the creation time.
-func (ri *rbdImage) GetCreationTime() (*timestamppb.Timestamp, error) {
+func (ri *rbdImage) GetCreationTime(ctx context.Context) (*time.Time, error) {
 	if ri.CreatedAt != nil {
 		return ri.CreatedAt, nil
 	}
@@ -1648,8 +1646,9 @@ func (ri *rbdImage) getImageInfo() error {
 	if err != nil {
 		return err
 	}
+
 	t := time.Unix(tm.Sec, tm.Nsec)
-	ri.CreatedAt = timestamppb.New(t)
+	ri.CreatedAt = &t
 
 	return nil
 }

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -101,6 +101,27 @@ func cleanUpSnapshot(
 	return nil
 }
 
+func (rv *rbdVolume) toSnapshot() *rbdSnapshot {
+	return &rbdSnapshot{
+		rbdImage: rbdImage{
+			ClusterID:      rv.ClusterID,
+			VolID:          rv.VolID,
+			Monitors:       rv.Monitors,
+			Pool:           rv.Pool,
+			JournalPool:    rv.JournalPool,
+			RadosNamespace: rv.RadosNamespace,
+			RbdImageName:   rv.RbdImageName,
+			ImageID:        rv.ImageID,
+			CreatedAt:      rv.CreatedAt,
+			// copyEncryptionConfig cannot be used here because the volume and the
+			// snapshot will have the same volumeID which cases the panic in
+			// copyEncryptionConfig function.
+			blockEncryption: rv.blockEncryption,
+			fileEncryption:  rv.fileEncryption,
+		},
+	}
+}
+
 func (rbdSnap *rbdSnapshot) toVolume() *rbdVolume {
 	return &rbdVolume{
 		rbdImage: rbdImage{
@@ -112,6 +133,7 @@ func (rbdSnap *rbdSnapshot) toVolume() *rbdVolume {
 			RadosNamespace: rbdSnap.RadosNamespace,
 			RbdImageName:   rbdSnap.RbdSnapName,
 			ImageID:        rbdSnap.ImageID,
+			CreatedAt:      rbdSnap.CreatedAt,
 			// copyEncryptionConfig cannot be used here because the volume and the
 			// snapshot will have the same volumeID which cases the panic in
 			// copyEncryptionConfig function.

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -20,6 +20,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
@@ -116,6 +119,16 @@ func (rbdSnap *rbdSnapshot) toVolume() *rbdVolume {
 			fileEncryption:  rbdSnap.fileEncryption,
 		},
 	}
+}
+
+func (rbdSnap *rbdSnapshot) ToCSI(ctx context.Context) (*csi.Snapshot, error) {
+	return &csi.Snapshot{
+		SizeBytes:      rbdSnap.VolSize,
+		SnapshotId:     rbdSnap.VolID,
+		SourceVolumeId: rbdSnap.SourceVolumeID,
+		CreationTime:   timestamppb.New(*rbdSnap.CreatedAt),
+		ReadyToUse:     true,
+	}, nil
 }
 
 func undoSnapshotCloning(

--- a/internal/rbd/types/volume.go
+++ b/internal/rbd/types/volume.go
@@ -18,9 +18,9 @@ package types
 
 import (
 	"context"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 //nolint:interfacebloat // more than 10 methods are needed for the interface
@@ -42,7 +42,8 @@ type Volume interface {
 	RemoveFromGroup(ctx context.Context, vg VolumeGroup) error
 
 	// GetCreationTime returns the creation time of the volume.
-	GetCreationTime() (*timestamppb.Timestamp, error)
+	GetCreationTime(ctx context.Context) (*time.Time, error)
+
 	// GetMetadata returns the value of the metadata key from the volume.
 	GetMetadata(key string) (string, error)
 	// SetMetadata sets the value of the metadata key on the volume.


### PR DESCRIPTION
VolumeGroupSnapshots expect to have a CreationTime attribute. This can not be obtained by any (go-ceph) API calls, so it need to be stored in the journal.