### PR TITLE
journal: fix empty csiCreationTimeKey value

### DIFF
--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -129,7 +129,8 @@ func (vgc *VolumeGroupJournalConfig) Connect(
 ) (VolumeGroupJournal, error) {
 	vgjc := &volumeGroupJournalConnection{}
 	vgjc.config = &VolumeGroupJournalConfig{
-		Config: vgc.Config,
+		Config:             vgc.Config,
+		csiCreationTimeKey: vgc.csiCreationTimeKey,
 	}
 	conn, err := vgc.Config.Connect(monitors, namespace, cr)
 	if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit fixes the issue where the `csiCreationTimeKey` field was missing
during the rebuilding of the `VolumeGroupJournalConfig` struct in the `Connect()` 
method, which led to the `csi.creationtime` key not being stored in the omap.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
