### PR TITLE
deploy: setting RequiredDropCapabilities to ALL for ceph-csi scc

### DIFF
--- a/api/deploy/ocp/scc.yaml
+++ b/api/deploy/ocp/scc.yaml
@@ -20,6 +20,8 @@ allowHostPID: true
 allowHostIPC: true
 # Set to false as we write to RootFilesystem inside csi containers
 readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/deploy/scc.yaml
+++ b/deploy/scc.yaml
@@ -27,6 +27,8 @@ allowHostPID: true
 allowHostIPC: true
 # Set to false as we write to RootFilesystem inside csi containers
 readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
@@ -20,6 +20,8 @@ allowHostPID: true
 allowHostIPC: true
 # Set to false as we write to RootFilesystem inside csi containers
 readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
This commit sets the RequiredDropCapabilities of ceph-csi to "ALL".

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

In line with the principle of least privilege, permissions should be granted with only the minimal access necessary to perform the required tasks. Previously, the security context constraints for ceph-csi did not have RequiredDropCapabilities set. This commit ensures that it is now set to "ALL".
`$oc describe scc rook-ceph-csi | grep " Required Drop Capabilities"`
`Required Drop Capabilities:			ALL`


