### PR TITLE
helm: don't specify default topology domainlabels in rbd chart

### DIFF
--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -304,9 +304,9 @@ topology:
   # for CSI nodeplugins to advertise their domains
   # NOTE: the value here serves as an example and needs to be
   # updated with node labels that define domains of interest
-  domainLabels:
-    - failure-domain/region
-    - failure-domain/zone
+  domainLabels: []
+  # - topology.kubernetes.io/region
+  # - topology.kubernetes.io/zone
 
 # readAffinity:
 # Enable read affinity for RBD volumes. Recommended to


### PR DESCRIPTION
Remove the bad default, add commented-out standard labels as a suggestion.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This fixes a problem I noticed while digging into #4775.

It brings the default `topology.domainLabels` value in line with what the README.md claims (default={}), and in line with what the installer manifest does (leaves the command-line parameter commented out).

## Is there anything that requires special attention ##

I believe this change is beneficial enough to stand on its own.  That said, these label definitions are 4 years old, and I don't know what's different between the 3.11.0 and 3.12.0 releases to cause #4775 to occur now.

I had to work around the problem with `helm --set topology.domainLabels=[]`, which worked for me.  This PR updates the default to reflect that, and updates the comments to suggest the standard topology labels.

There are two places in the helm chart which reference this value, both are guarded with:
```
{{- if .Values.topology.domainLabels }}
```

So I think it doesn't need to be an explicitly empty array (`[]`), leaving the whole thing commented out is fine.

## Related issues ##

Fixes: #4775

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
