### PR TITLE
build: Use Go v1.22.5

### DIFF
--- a/build.env
+++ b/build.env
@@ -19,7 +19,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v19
 CEPH_VERSION=squid
 
 # standard Golang options
-GOLANG_VERSION=1.22.2
+GOLANG_VERSION=1.22.5
 GO111MODULE=on
 
 # commitlint version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi
 
-go 1.22.0
+go 1.22.5
 
 require (
 	github.com/IBM/keyprotect-go-client v0.15.1


### PR DESCRIPTION
Go versions 1.22.0 through 1.22.4 are affected
by CVE-2024-24791