### PR TITLE
rbd: add image size in toSnapshot

### DIFF
--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -106,6 +106,7 @@ func (rv *rbdVolume) toSnapshot() *rbdSnapshot {
 		rbdImage: rbdImage{
 			ClusterID:      rv.ClusterID,
 			VolID:          rv.VolID,
+			VolSize:        rv.VolSize,
 			Monitors:       rv.Monitors,
 			Pool:           rv.Pool,
 			JournalPool:    rv.JournalPool,


### PR DESCRIPTION
we need to return the rbd image size as a snapshot size in CreateSnapshot Response.

fixes: #4788

