### PR TITLE
build: Update go version to 1.22.5 for submodules

### DIFF
--- a/actions/retest/Dockerfile
+++ b/actions/retest/Dockerfile
@@ -1,5 +1,5 @@
 ARG WORK_DIR="/home/src"
-ARG BASE_IMAGE="golang:1.21"
+ARG BASE_IMAGE="golang:1.22"
 
 FROM ${BASE_IMAGE} as builder
 

--- a/actions/retest/go.mod
+++ b/actions/retest/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/actions/retest
 
-go 1.18
+go 1.22.5
 
 require (
 	github.com/google/go-github v17.0.0+incompatible

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/api
 
-go 1.22.0
+go 1.22.5
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,7 +200,7 @@ github.com/cenkalti/backoff/v3
 ## explicit; go 1.18
 github.com/cenkalti/backoff/v4
 # github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.22.0
+## explicit; go 1.22.5
 github.com/ceph/ceph-csi/api/deploy/kubernetes
 github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs


### PR DESCRIPTION
This patch updates the submodules `api` and `retest` to use the go version 1.22.5

