### PR TITLE
ci: pass the correct account token for Snyk jobs

### DIFF
--- a/.github/workflows/snyk-container-image.yaml
+++ b/.github/workflows/snyk-container-image.yaml
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SYNK_TOKEN }}
         with:
           image: quay.io/cephcsi/cephcsi:${{ github.base_ref }}
           args: --file=Dockerfilei

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -27,4 +27,4 @@ jobs:
       - name: run Snyk to check for code vulnerabilities
         uses: snyk/actions/golang@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SYNK_TOKEN }}


### PR DESCRIPTION
The secret in the project settings has a typo and is called `SYNK_TOKEN`
instead of `SNYK_TOKEN`. Changing the name of the secret does not seem
to be trivial; it needs to be deleted and re-created, which requires
obtaining a new token, somehow. Adopting the name with the typo in the
GitHub Workflow is easier.

[The Snyk jobs fail](https://github.com/ceph/ceph-csi/actions/runs/10507509653/job/29109416253#step:5:12) with a message like

> `snyk` requires an authenticated account. Please run `snyk auth` and try again.

Passing the token from the secret that is configured in the project settings should prevent this.

