### PR TITLE
cephfs: add examples for volumegroupsnapshot

### DIFF
--- a/examples/cephfs/groupsnapshot.yaml
+++ b/examples/cephfs/groupsnapshot.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+kind: VolumeGroupSnapshot
+metadata:
+  name: new-groupsnapshot-demo-1
+spec:
+  source:
+    selector:
+      matchLabels:
+        # The PVCs will need to have this label for it to be
+        # included in the VolumeGroupSnapshot
+        group: test
+  volumeGroupSnapshotClassName: csi-cephfsplugin-groupsnapclass

--- a/examples/cephfs/groupsnapshotclass.yaml
+++ b/examples/cephfs/groupsnapshotclass.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: csi-cephfsplugin-groupsnapclass
+driver: cephfs.csi.ceph.com
+parameters:
+  # String representing a Ceph cluster to provision storage from.
+  # Should be unique across all Ceph clusters in use for provisioning,
+  # cannot be greater than 36 bytes in length, and should remain immutable for
+  # the lifetime of the StorageClass in use
+  clusterID: <cluster-id>
+  # eg: fsName: myfs
+  fsName: <cephfs-name>
+  csi.storage.k8s.io/group-snapshotter-secret-name: csi-cephfs-secret
+  csi.storage.k8s.io/group-snapshotter-secret-namespace: default
+deletionPolicy: Delete


### PR DESCRIPTION
this commit add yaml exampl files for creation of
volumegroupsnapshotclass and volumegroupsnapshot for cephfs driver

