### PR TITLE
RBD: Advertise health conditions cap

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1202,6 +1202,13 @@ func (ns *NodeServer) NodeGetCapabilities(
 			{
 				Type: &csi.NodeServiceCapability_Rpc{
 					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+					},
+				},
+			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
 						Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 					},
 				},

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1365,6 +1365,10 @@ func blockNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.NodeG
 				Unit:  csi.VolumeUsage_BYTES,
 			},
 		},
+		VolumeCondition: &csi.VolumeCondition{
+			Abnormal: false,
+			Message:  "volume is in a healthy condition",
+		},
 	}, nil
 }
 


### PR DESCRIPTION
Advertise the volume condition cap for RBD and set the volume condition for the missing block mode.