### PR TITLE
rbd: fail DisableVolumeReplication() if image is not mirror disabled

### DIFF
--- a/internal/rbd/replication.go
+++ b/internal/rbd/replication.go
@@ -90,8 +90,10 @@ func DisableVolumeReplication(mirror types.Mirror,
 		return fmt.Errorf("failed to get mirroring info of image: %w", err)
 	}
 
-	if info.GetState() == librbd.MirrorImageDisabling.String() {
-		return fmt.Errorf("%w: image is in disabling state", ErrAborted)
+	// error out if the image is not in disabled state.
+	if info.GetState() != librbd.MirrorImageDisabled.String() {
+		return fmt.Errorf("%w: image is in %q state, expected state %q", ErrAborted,
+			info.GetState(), librbd.MirrorImageDisabled.String())
 	}
 
 	return nil


### PR DESCRIPTION
This commit modifies DisableVolumeReplication() to fail if the image is not in mirror disabled state

> I ran creation/deletion of VR a couple of times but didn't hit the error.
It probably very hard to hit it.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
