### PR TITLE
cleanup: remove unneeded `updateSnapshotDetails()` function

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -790,7 +790,7 @@ func (cs *ControllerServer) createBackingImage(
 			}
 		}
 	}()
-	err = rbdVol.storeImageID(ctx, j)
+	err = rbdVol.repairImageID(ctx, j, true)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -541,7 +541,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 // The volume handler won't remain same as its contains poolID,clusterID etc
 // which are not same across clusters.
 //
-//nolint:gocyclo,cyclop,nestif // TODO: reduce complexity
+//nolint:gocyclo,cyclop // TODO: reduce complexity
 func RegenerateJournal(
 	volumeAttributes map[string]string,
 	claimName,
@@ -623,12 +623,12 @@ func RegenerateJournal(
 		rbdVol.ImageID = imageData.ImageAttributes.ImageID
 		rbdVol.Owner = imageData.ImageAttributes.Owner
 		rbdVol.RbdImageName = imageData.ImageAttributes.ImageName
-		if rbdVol.ImageID == "" {
-			err = rbdVol.storeImageID(ctx, j)
-			if err != nil {
-				return "", err
-			}
+
+		err = rbdVol.repairImageID(ctx, j, false)
+		if err != nil {
+			return "", err
 		}
+
 		if rbdVol.Owner != owner {
 			err = j.ResetVolumeOwner(ctx, rbdVol.JournalPool, rbdVol.ReservedID, owner)
 			if err != nil {
@@ -675,30 +675,11 @@ func RegenerateJournal(
 
 	log.DebugLog(ctx, "re-generated Volume ID (%s) and image name (%s) for request name (%s)",
 		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.RequestName)
-	if rbdVol.ImageID == "" {
-		err = rbdVol.storeImageID(ctx, j)
-		if err != nil {
-			return "", err
-		}
+
+	err = rbdVol.repairImageID(ctx, j, false)
+	if err != nil {
+		return "", err
 	}
 
 	return rbdVol.VolID, nil
-}
-
-// storeImageID retrieves the image ID and stores it in OMAP.
-func (rv *rbdVolume) storeImageID(ctx context.Context, j *journal.Connection) error {
-	err := rv.getImageID()
-	if err != nil {
-		log.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
-
-		return err
-	}
-	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
-
-		return err
-	}
-
-	return nil
 }

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1080,31 +1080,12 @@ func genSnapFromSnapID(
 		}
 	}
 
-	err = updateSnapshotDetails(ctx, rbdSnap)
+	err = rbdSnap.getImageInfo()
 	if err != nil {
 		return rbdSnap, fmt.Errorf("failed to update snapshot details for %q: %w", rbdSnap, err)
 	}
 
 	return rbdSnap, err
-}
-
-// updateSnapshotDetails will copy the details from the rbdVolume to the
-// rbdSnapshot. example copying size from rbdVolume to rbdSnapshot.
-func updateSnapshotDetails(ctx context.Context, rbdSnap *rbdSnapshot) error {
-	vol := rbdSnap.toVolume()
-	err := vol.Connect(rbdSnap.conn.Creds)
-	if err != nil {
-		return err
-	}
-	defer vol.Destroy(ctx)
-
-	err = vol.getImageInfo()
-	if err != nil {
-		return err
-	}
-	rbdSnap.VolSize = vol.VolSize
-
-	return nil
 }
 
 // generateVolumeFromVolumeID generates a rbdVolume structure from the provided identifier.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1169,12 +1169,11 @@ func generateVolumeFromVolumeID(
 		}
 	}
 
-	if rbdVol.ImageID == "" {
-		err = rbdVol.storeImageID(ctx, j)
-		if err != nil {
-			return rbdVol, err
-		}
+	err = rbdVol.repairImageID(ctx, j, false)
+	if err != nil {
+		return rbdVol, err
 	}
+
 	err = rbdVol.getImageInfo()
 
 	return rbdVol, err


### PR DESCRIPTION
`updateSnapshotDetails()` just calls `getImageInfo()` on an `rbdVolume`
created from the `rbdSnapshot`. `getImageInfo()` is a function of the
base `rbdImage` struct, so there really is no need for this indirection.
