### PR TITLE
rbd: prevent panic when using rbdImage that is not connected

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -468,6 +468,10 @@ func (ri *rbdImage) openIoctx() error {
 		return nil
 	}
 
+	if ri.conn == nil {
+		return fmt.Errorf("can not get IOContext of unconnected image %q", ri)
+	}
+
 	ioctx, err := ri.conn.GetIoctx(ri.Pool)
 	if err != nil {
 		// GetIoctx() can return util.ErrPoolNotFound


### PR DESCRIPTION
When an `rbdVolume` or `rbdSnapshot` is not connected with credentials
to the Ceph cluster, operations may try to get the IOContext which then
causes a panic.