### PR TITLE
doc: remove contacts from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,5 +208,3 @@ Please use the following to reach members of the community:
   on the [ceph Slack](https://ceph-storage.slack.com) to discuss anything
   related to this project. You can join the Slack by this
   [invite link](https://bit.ly/ceph-slack-invite)
-- Forums: [ceph-csi](https://groups.google.com/forum/#!forum/ceph-csi)
-- Twitter: [@CephCsi](https://twitter.com/CephCsi)


### PR DESCRIPTION
The Twitter and google forums are not maintained and do not have any updates, This is a good chance to remove the same from the cephcsi readme as well.

