### PR TITLE
ci: Harden GitHub Actions

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: take the issue
-        uses: bdougie/take-action@main
+        # yamllint disable-line rule:line-length
+        uses: bdougie/take-action@1439165ac45a7461c2d89a59952cd7d941964b87  # main
         with:
           message: >
             Thanks for taking this issue!

--- a/.github/workflows/build-multi-stage.yaml
+++ b/.github/workflows/build-multi-stage.yaml
@@ -13,7 +13,8 @@ jobs:
     name: multi-arch-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: multi-arch-build
         # yamllint disable-line rule:line-length
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip/multi-arch-build') }}

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -15,6 +15,7 @@ jobs:
     name: codespell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: codespell
         run: make containerized-test TARGET=codespell

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -14,7 +14,8 @@ jobs:
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: commitlint

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c  # v4.3.4
         with:
           allow-ghsas: GHSA-f4w6-3rh6-6q4q

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332   # v4.1.7
 
       - name: Check generated deploy code
         run: make generate-deploy
@@ -29,20 +30,23 @@ jobs:
     name: e2e-build-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: e2e-build-test
         run: make containerized-build TARGET=e2e.test
   go-test:
     name: go-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: go-test
         run: make containerized-test TARGET=go-test
   go-test-api:
     name: go-test-api
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: go-test-api
         run: make containerized-test TARGET=go-test-api

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,6 +13,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: golangci-lint
         run: make containerized-test TARGET=go-lint

--- a/.github/workflows/lint-extras.yaml
+++ b/.github/workflows/lint-extras.yaml
@@ -13,6 +13,7 @@ jobs:
     name: lint-extras
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: lint-extras
         run: make containerized-test TARGET=lint-extras

--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Copying labels
-        uses: Mergifyio/gha-mergify-merge-queue-labels-copier@main
+        uses: Mergifyio/gha-mergify-merge-queue-labels-copier@1d2b277f94d52987008ec05b571fb68f2357e63f  # main
         with:
           additional-labels: 'ok-to-test'
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}

--- a/.github/workflows/mod-check.yaml
+++ b/.github/workflows/mod-check.yaml
@@ -13,6 +13,7 @@ jobs:
     name: mod-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: mod-check
         run: make containerized-test TARGET=mod-check

--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -18,10 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'ceph/ceph-csi'
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
 
       - name: Login to Quay
-        uses: docker/login-action@v3
+        # yamllint disable-line rule:line-length
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_IO_USERNAME }}

--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -51,7 +51,8 @@ jobs:
           Add comment to trigger external storage tests for Kubernetes
           ${{ matrix.k8s }}
         if: ${{ github.base_ref == matrix.branch }}
-        uses: peter-evans/create-or-update-comment@v4
+        # yamllint disable-line rule:line-length
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -62,7 +63,8 @@ jobs:
           Add comment to trigger helm E2E tests for Kubernetes
           ${{ matrix.k8s }}
         if: ${{ github.base_ref == matrix.branch }}
-        uses: peter-evans/create-or-update-comment@v4
+        # yamllint disable-line rule:line-length
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -70,7 +72,8 @@ jobs:
             /test ci/centos/mini-e2e-helm/k8s-${{ matrix.k8s }}
 
       - name: Add comment to trigger E2E tests for Kubernetes ${{ matrix.k8s }}
-        uses: peter-evans/create-or-update-comment@v4
+        # yamllint disable-line rule:line-length
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         if: ${{ github.base_ref == matrix.branch }}
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
@@ -87,7 +90,8 @@ jobs:
 
     steps:
       - name: Add comment to trigger cephfs upgrade tests
-        uses: peter-evans/create-or-update-comment@v4
+        # yamllint disable-line rule:line-length
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -95,7 +99,8 @@ jobs:
             /test ci/centos/upgrade-tests-cephfs
 
       - name: Add comment to trigger rbd upgrade tests
-        uses: peter-evans/create-or-update-comment@v4
+        # yamllint disable-line rule:line-length
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -116,7 +121,8 @@ jobs:
 
     steps:
       - name: remove ok-to-test-label after commenting
-        uses: actions/github-script@v7
+        # yamllint disable-line rule:line-length
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           github-token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           script: |

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # path to the retest action
-      - uses: ceph/ceph-csi/actions/retest@devel
+      # yamllint disable-line rule:line-length
+      - uses: ceph/ceph-csi/actions/retest@28dc64dcae3cec8d11d84bdf525bda0ef757c688  # devel
         with:
           GITHUB_TOKEN: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
           required-label: "ci/retry/e2e"

--- a/.github/workflows/snyk-container-image.yaml
+++ b/.github/workflows/snyk-container-image.yaml
@@ -26,18 +26,21 @@ jobs:
     if: github.repository == 'ceph/ceph-csi'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: Build a Docker image
         run: make image-cephcsi
       - name: Run Snyk to check Docker image for vulnerabilities
         continue-on-error: true
-        uses: snyk/actions/docker@master
+        # yamllint disable-line rule:line-length
+        uses: snyk/actions/docker@cdb760004ba9ea4d525f2e043745dfe85bb9077e  # master
         env:
           SNYK_TOKEN: ${{ secrets.SYNK_TOKEN }}
         with:
           image: quay.io/cephcsi/cephcsi:${{ github.base_ref }}
           args: --file=Dockerfilei
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/upload-sarif@8214744c546c1e5c8f03dde8fab3a7353211988d  # v3.26.7
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -20,11 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           fetch-depth: 0
 
       - name: run Snyk to check for code vulnerabilities
-        uses: snyk/actions/golang@master
+        # yamllint disable-line rule:line-length
+        uses: snyk/actions/golang@cdb760004ba9ea4d525f2e043745dfe85bb9077e  # master
         env:
           SNYK_TOKEN: ${{ secrets.SYNK_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'ceph/ceph-csi'
     steps:
-      - uses: actions/stale@v9
+      # yamllint disable-line rule:line-length
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e  # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/test-retest-action.yaml
+++ b/.github/workflows/test-retest-action.yaml
@@ -15,7 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
 
       - name: Docker build
         # Run cd to avoid loading complete cephcsi directory in docker context

--- a/.github/workflows/tickgit.yaml
+++ b/.github/workflows/tickgit.yaml
@@ -14,5 +14,6 @@ jobs:
     name: tickgit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - run: make containerized-test TARGET=tickgit


### PR DESCRIPTION
Update GitHub actions to use full length commit ids for third-party actions to reduce security risk in case of vulnerabilities.