### PR TITLE
cephfs: return correct error message

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -1067,7 +1067,7 @@ func (cs *ControllerServer) DeleteSnapshot(
 	if acquired := cs.SnapshotLocks.TryAcquire(sid.RequestName); !acquired {
 		log.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, sid.RequestName)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, sid.RequestName)
+		return nil, status.Errorf(codes.Aborted, util.SnapshotOperationAlreadyExistsFmt, sid.RequestName)
 	}
 	defer cs.SnapshotLocks.Release(sid.RequestName)
 


### PR DESCRIPTION
return SnapshotOperationAlreadyExistsFmt instead of VolumeOperationAlreadyExistsFmt incase of delete snapshot operation.

