### PR TITLE
util: use protobuf encoding for core k8s apis

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/ceph/ceph-csi/internal/util/log"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	clientConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -69,7 +71,11 @@ func Start(config Config) error {
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaderElectionID:           electionID,
 	}
-	mgr, err := manager.New(clientConfig.GetConfigOrDie(), opts)
+
+	kubeConfig := clientConfig.GetConfigOrDie()
+	coreKubeConfig := rest.CopyConfig(kubeConfig)
+	coreKubeConfig.ContentType = runtime.ContentTypeProtobuf
+	mgr, err := manager.New(coreKubeConfig, opts)
 	if err != nil {
 		log.ErrorLogMsg("failed to create manager %s", err)
 

--- a/internal/util/k8s/client.go
+++ b/internal/util/k8s/client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -47,6 +48,7 @@ func NewK8sClient() (*kubernetes.Clientset, error) {
 			return nil, fmt.Errorf("failed to get cluster config: %w", err)
 		}
 	}
+	cfg.ContentType = runtime.ContentTypeProtobuf
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)


### PR DESCRIPTION
For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which reduces CPU consumption related to (de)serialization, reduces overall latency of the API call, reduces memory footprint, reduces the amount of work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.