### PR TITLE
rbd: prevent re-use of destroyed resources

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -390,15 +390,19 @@ func (ri *rbdImage) Connect(cr *util.Credentials) error {
 func (ri *rbdImage) Destroy(ctx context.Context) {
 	if ri.ioctx != nil {
 		ri.ioctx.Destroy()
+		ri.ioctx = nil
 	}
 	if ri.conn != nil {
 		ri.conn.Destroy()
+		ri.conn = nil
 	}
 	if ri.isBlockEncrypted() {
 		ri.blockEncryption.Destroy()
+		ri.blockEncryption = nil
 	}
 	if ri.isFileEncrypted() {
 		ri.fileEncryption.Destroy()
+		ri.fileEncryption = nil
 	}
 }
 


### PR DESCRIPTION
When an `.Destroy()` is called on an rbdImage (or rbdVolume or
rbdSnapshot), the IOContext, Connection and other attributes are
invalid. When using a destroyed resource that points to an object that
was allocated through librbd, the process most likely ends with a panic.