### PR TITLE
rbd: move repairImageID() from rbdVolume struct to rbdImage

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -352,29 +352,30 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 	return true, nil
 }
 
-// repairImageID checks if rv.ImageID is already available (if so, it was
+// repairImageID checks if ri.ImageID is already available (if so, it was
 // fetched from the journal), in case it is missing, the imageID is obtained
 // and stored in the journal.
 // if the force is set to true, the latest imageID will get added/updated in OMAP.
-func (rv *rbdVolume) repairImageID(ctx context.Context, j *journal.Connection, force bool) error {
+func (ri *rbdImage) repairImageID(ctx context.Context, j *journal.Connection, force bool) error {
 	if force {
 		// reset the imageID so that we can fetch latest imageID from ceph cluster.
-		rv.ImageID = ""
+		ri.ImageID = ""
 	}
 
-	if rv.ImageID != "" {
+	if ri.ImageID != "" {
 		return nil
 	}
 
-	err := rv.getImageID()
+	err := ri.getImageID()
 	if err != nil {
-		log.ErrorLog(ctx, "failed to get image id %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to get image id %s: %v", ri, err)
 
 		return err
 	}
-	err = j.StoreImageID(ctx, rv.JournalPool, rv.ReservedID, rv.ImageID)
+
+	err = j.StoreImageID(ctx, ri.JournalPool, ri.ReservedID, ri.ImageID)
 	if err != nil {
-		log.ErrorLog(ctx, "failed to store volume id %s: %v", rv, err)
+		log.ErrorLog(ctx, "failed to store volume id %s: %v", ri, err)
 
 		return err
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -110,6 +110,7 @@ type rbdImage struct {
 	// This does not have a JSON tag as it is not stashed in JSON encoded
 	// config maps in v1.0.0
 	RequestName string
+	ReservedID  string
 	NamePrefix  string
 	// ParentName represents the parent image name of the image.
 	ParentName string
@@ -167,7 +168,6 @@ type rbdVolume struct {
 	AdminID            string
 	UserID             string
 	Mounter            string
-	ReservedID         string
 	MapOptions         string
 	UnmapOptions       string
 	LogDir             string
@@ -190,7 +190,6 @@ type rbdSnapshot struct {
 	// SourceVolumeID is the volume ID of RbdImageName, that is exchanged with CSI drivers
 	// RbdSnapName is the name of the RBD snapshot backing this rbdSnapshot
 	SourceVolumeID string
-	ReservedID     string
 	RbdSnapName    string
 }
 


### PR DESCRIPTION
The `repairImageID()` function is useful for the `rbdSnapshot` objects
as well. Move it to the `rbdImage` struct that is the base for both
`rbdVolume` and `rbdSnapshot`.