### PR TITLE
rbd: replace Manager.DeleteVolumeGroup() by VolumeGroup.Delete()

### DIFF
--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -222,7 +222,7 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 	}
 
 	// delete the volume group
-	err = mgr.DeleteVolumeGroup(ctx, vg)
+	err = vg.Delete(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"failed to delete volume group %q: %s",

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -194,7 +194,7 @@ func (vg *volumeGroup) Delete(ctx context.Context) error {
 
 	log.DebugLog(ctx, "volume group %q has been removed", vg)
 
-	return nil
+	return vg.commonVolumeGroup.Delete(ctx)
 }
 
 func (vg *volumeGroup) AddVolume(ctx context.Context, vol types.Volume) error {

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ceph/go-ceph/rados"
-
 	"github.com/ceph/ceph-csi/internal/journal"
 	rbd_group "github.com/ceph/ceph-csi/internal/rbd/group"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
@@ -254,43 +252,4 @@ func (mgr *rbdManager) CreateVolumeGroup(ctx context.Context, name string) (type
 	}
 
 	return vg, nil
-}
-
-func (mgr *rbdManager) DeleteVolumeGroup(ctx context.Context, vg types.VolumeGroup) error {
-	err := vg.Delete(ctx)
-	if err != nil && !errors.Is(rados.ErrNotFound, err) {
-		return fmt.Errorf("failed to delete volume group %q: %w", vg, err)
-	}
-
-	clusterID, err := vg.GetClusterID(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get cluster id for volume group %q: %w", vg, err)
-	}
-
-	vgJournal, err := mgr.getVolumeGroupJournal(clusterID)
-	if err != nil {
-		return err
-	}
-
-	name, err := vg.GetName(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get name for volume group %q: %w", vg, err)
-	}
-
-	csiID, err := vg.GetID(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get id for volume group %q: %w", vg, err)
-	}
-
-	pool, err := vg.GetPool(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get pool for volume group %q: %w", vg, err)
-	}
-
-	err = vgJournal.UndoReservation(ctx, pool, name, csiID)
-	if err != nil /* TODO? !errors.Is(..., err) */ {
-		return fmt.Errorf("failed to undo the reservation for volume group %q: %w", vg, err)
-	}
-
-	return nil
 }

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -43,8 +43,4 @@ type Manager interface {
 	// CreateVolumeGroup allocates a new VolumeGroup in the backend storage
 	// and records details about it in the journal.
 	CreateVolumeGroup(ctx context.Context, name string) (VolumeGroup, error)
-
-	// DeleteVolumeGroup removes VolumeGroup from the backend storage and
-	// any details from the journal.
-	DeleteVolumeGroup(ctx context.Context, vg VolumeGroup) error
 }


### PR DESCRIPTION
There is no need for the `Manager.DeleteVolumeGroup()` function as
`VolumeGroup.Delete()` should cover everything too.

By moving the `.Delete()` functionality of removing the group from the
journal to the shared `commonVolumeGroup` type, a volume group snaphot
can use it as well.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
