### PR TITLE
rbd: validate IOContext before getting the list of trashed images

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -881,9 +881,9 @@ func (cs *ControllerServer) checkErrAndUndoReserve(
 	}
 
 	if errors.Is(err, ErrImageNotFound) {
-		err = rbdVol.ensureImageCleanup(ctx)
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+		notFoundErr := rbdVol.ensureImageCleanup(ctx)
+		if notFoundErr != nil {
+			return nil, status.Errorf(codes.Internal, "failed to cleanup image %q: %v", rbdVol, notFoundErr)
 		}
 	} else {
 		// All errors other than ErrImageNotFound should return an error back to the caller
@@ -1537,11 +1537,6 @@ func cleanUpImageAndSnapReservation(ctx context.Context, rbdSnap *rbdSnapshot, c
 		return status.Error(codes.Internal, err.Error())
 	}
 	defer rbdVol.Destroy(ctx)
-
-	err = rbdVol.openIoctx()
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
 
 	// cleanup the image from trash if the error is image not found.
 	err = rbdVol.ensureImageCleanup(ctx)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -621,6 +621,11 @@ func isCephMgrSupported(ctx context.Context, clusterID string, err error) bool {
 // ensureImageCleanup finds image in trash and if found removes it
 // from trash.
 func (ri *rbdImage) ensureImageCleanup(ctx context.Context) error {
+	err := ri.openIoctx()
+	if err != nil {
+		return err
+	}
+
 	trashInfoList, err := librbd.GetTrashList(ri.ioctx)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to list images in trash: %v", err)


### PR DESCRIPTION
`ensureImageCleanup()` can cause a panic when an image was deleted, but the journal still contained a reference. By opening the IOContext before using, an error may be returned instead of a panic when using a `nil` or freed IOContext.

```
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x5e
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:16 +0x13
github.com/ceph/ceph-csi/internal/csi-common.panicHandler.func1()
        /go/src/github.com/ceph/ceph-csi/internal/csi-common/utils.go:336 +0xca
panic({0x21c43c0?, 0x4066500?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/ceph/go-ceph/rados.(*IOContext).Pointer(...)
        /go/src/github.com/ceph/ceph-csi/vendor/github.com/ceph/go-ceph/rados/ioctx.go:121
github.com/ceph/go-ceph/rbd.cephIoctx(...)
        /go/src/github.com/ceph/ceph-csi/vendor/github.com/ceph/go-ceph/rbd/rbd.go:102
github.com/ceph/go-ceph/rbd.GetTrashList.func1.1(0x7f23d8275418?, 0x10?, 0x7f242218bf18?)
        /go/src/github.com/ceph/ceph-csi/vendor/github.com/ceph/go-ceph/rbd/rbd.go:1025 +0x12
github.com/ceph/go-ceph/rbd.GetTrashList.func1(0x41bba5?)
        /go/src/github.com/ceph/ceph-csi/vendor/github.com/ceph/go-ceph/rbd/rbd.go:1025 +0x85
github.com/ceph/go-ceph/internal/retry.WithSizes(0xc000788f28?, 0x2800, 0xc000789048)
        /go/src/github.com/ceph/ceph-csi/vendor/github.com/ceph/go-ceph/internal/retry/sizer.go:51 +0x4a
github.com/ceph/go-ceph/rbd.GetTrashList(0x0)
        /go/src/github.com/ceph/ceph-csi/vendor/github.com/ceph/go-ceph/rbd/rbd.go:1022 +0xf4
github.com/ceph/ceph-csi/internal/rbd.(*rbdImage).ensureImageCleanup(0xc0008ae908, {0x2cdc138, 0xc000d13410})
        /go/src/github.com/ceph/ceph-csi/internal/rbd/rbd_util.go:624 +0x45
```

## Related issues ##

Found while working on #4502.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
