### PR TITLE
rbd: do not return an error when deleting a non-existing image

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -671,7 +671,7 @@ func (ri *rbdImage) Delete(ctx context.Context) error {
 
 	rbdImage := librbd.GetImage(ri.ioctx, image)
 	err = rbdImage.Trash(0)
-	if err != nil {
+	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		log.ErrorLog(ctx, "failed to delete rbd image: %s, error: %v", ri, err)
 
 		return err
@@ -694,7 +694,7 @@ func (ri *rbdImage) trashRemoveImage(ctx context.Context) error {
 	_, err = ta.AddTrashRemove(admin.NewImageSpec(ri.Pool, ri.RadosNamespace, ri.ImageID))
 
 	rbdCephMgrSupported := isCephMgrSupported(ctx, ri.ClusterID, err)
-	if rbdCephMgrSupported && err != nil {
+	if rbdCephMgrSupported && err != nil && !errors.Is(err, librbd.ErrNotFound) {
 		log.ErrorLog(ctx, "failed to add task to delete rbd image: %s, %v", ri, err)
 
 		return err


### PR DESCRIPTION
Deleting an image that has been already remove, should not be reported
as a failure. This improves the idempotency of the `rbdImage.Delete()`
function, making it easier for callers to detect real errors.


## Related issues ##

Found while working on #4502.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
