### PR TITLE
rbd: use the new go-ceph rbd.ErrExist for checking rbd.GroupCreate()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.31.3
 	github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000
-	github.com/ceph/go-ceph v0.29.0
+	github.com/ceph/go-ceph v0.29.1-0.20240925141413-065319c78733
 	github.com/container-storage-interface/spec v1.10.0
 	github.com/csi-addons/spec v0.2.1-0.20240730084235-3958a5b17d24
 	github.com/gemalto/kmip-go v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -1440,8 +1440,8 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
-github.com/ceph/go-ceph v0.29.0 h1:pJQY+++PyY2FMP0ffVaE7FbIdivemBPCu4MWr4S8CtI=
-github.com/ceph/go-ceph v0.29.0/go.mod h1:U/l216/AzIWrFe7ny+9cJ5Yjzyb5otrEGfdrU5VtCME=
+github.com/ceph/go-ceph v0.29.1-0.20240925141413-065319c78733 h1:vX8mfbKwE24CbO5t1Xc02u53pjWAsyvjgAMJk7o7nsQ=
+github.com/ceph/go-ceph v0.29.1-0.20240925141413-065319c78733/go.mod h1:OJFju/Xmtb7ihHo/aXOayw6RhVOUGNke5EwTipwaf6A=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -1647,8 +1647,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
 github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid/v5 v5.3.0 h1:m0mUMr+oVYUdxpMLgSYCZiXe7PuVPnI94+OMeVBNedk=
+github.com/gofrs/uuid/v5 v5.3.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
@@ -164,7 +163,7 @@ func (vg *volumeGroup) Create(ctx context.Context) error {
 
 	err = librbd.GroupCreate(ioctx, name)
 	if err != nil {
-		if !errors.Is(rados.ErrObjectExists, err) && !strings.Contains(err.Error(), "rbd: ret=-17, File exists") {
+		if !errors.Is(err, librbd.ErrExist) {
 			return fmt.Errorf("failed to create volume group %q: %w", name, err)
 		}
 

--- a/vendor/github.com/ceph/go-ceph/internal/dlsym/dlsym.go
+++ b/vendor/github.com/ceph/go-ceph/internal/dlsym/dlsym.go
@@ -2,12 +2,10 @@ package dlsym
 
 // #cgo LDFLAGS: -ldl
 //
+// #define _GNU_SOURCE
+//
 // #include <stdlib.h>
 // #include <dlfcn.h>
-//
-// #ifndef RTLD_DEFAULT /* from dlfcn.h */
-// #define RTLD_DEFAULT ((void *) 0)
-// #endif
 import "C"
 
 import (

--- a/vendor/github.com/ceph/go-ceph/rados/snapshot.go
+++ b/vendor/github.com/ceph/go-ceph/rados/snapshot.go
@@ -85,8 +85,8 @@ func (ioctx *IOContext) GetSnapName(snapID SnapID) (string, error) {
 		err error
 	)
 	// range from 1k to 64KiB
-	retry.WithSizes(1024, 1<<16, func(len int) retry.Hint {
-		cLen := C.int(len)
+	retry.WithSizes(1024, 1<<16, func(length int) retry.Hint {
+		cLen := C.int(length)
 		buf = make([]byte, cLen)
 		ret := C.rados_ioctx_snap_get_name(
 			ioctx.ioctx,

--- a/vendor/github.com/ceph/go-ceph/rados/watcher.go
+++ b/vendor/github.com/ceph/go-ceph/rados/watcher.go
@@ -298,11 +298,11 @@ func (c *Conn) WatcherFlush() error {
 //
 // NOTE: starting with pacific this is implemented as a C function and this can
 // be replaced later
-func decodeNotifyResponse(response *C.char, len C.size_t) ([]NotifyAck, []NotifyTimeout) {
-	if len == 0 || response == nil {
+func decodeNotifyResponse(response *C.char, length C.size_t) ([]NotifyAck, []NotifyTimeout) {
+	if length == 0 || response == nil {
 		return nil, nil
 	}
-	b := (*[math.MaxInt32]byte)(unsafe.Pointer(response))[:len:len]
+	b := (*[math.MaxInt32]byte)(unsafe.Pointer(response))[:length:length]
 	pos := 0
 
 	num := binary.LittleEndian.Uint32(b[pos:])

--- a/vendor/github.com/ceph/go-ceph/rbd/errors.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/errors.go
@@ -73,6 +73,8 @@ var (
 
 // Public general error
 const (
+	// ErrExist indicates a non-specific already existing resource.
+	ErrExist = rbdError(-C.EEXIST)
 	// ErrNotExist indicates a non-specific missing resource.
 	ErrNotExist = rbdError(-C.ENOENT)
 	// ErrNotImplemented indicates a function is not implemented in by librbd.

--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
@@ -50,8 +50,8 @@ func (image *Image) GetSnapByID(snapID uint64) (string, error) {
 		err error
 	)
 	// range from 1k to 64KiB
-	retry.WithSizes(1024, 1<<16, func(len int) retry.Hint {
-		cLen := C.size_t(len)
+	retry.WithSizes(1024, 1<<16, func(length int) retry.Hint {
+		cLen := C.size_t(length)
 		buf = make([]byte, cLen)
 		ret := C.rbd_snap_get_name(
 			image.image,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.29.0
+# github.com/ceph/go-ceph v0.29.1-0.20240925141413-065319c78733
 ## explicit; go 1.19
 github.com/ceph/go-ceph/cephfs
 github.com/ceph/go-ceph/cephfs/admin


### PR DESCRIPTION
The go-ceph rbd.GroupCreate() now returns ErrExist in case the group
that is created, already exists. The previous check only ever matched
the string comparison, which is prone to errors in case the contents is
modified by go-ceph.

## Related issues ##

Found while working on #4502.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
