### PR TITLE
ci: fix Dockerfile path for snyk container action

### DIFF
--- a/.github/workflows/snyk-container-image.yaml
+++ b/.github/workflows/snyk-container-image.yaml
@@ -38,7 +38,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SYNK_TOKEN }}
         with:
           image: quay.io/cephcsi/cephcsi:${{ github.base_ref }}
-          args: --file=Dockerfilei
+          args: --file=./deploy/cephcsi/image/Dockerfile
       - name: Upload result to GitHub Code Scanning
         # yamllint disable-line rule:line-length
         uses: github/codeql-action/upload-sarif@c36620d31ac7c881962c3d9dd939c40ec9434f2b  # v3.26.12


### PR DESCRIPTION
Update the Dockerfile path for the snyk github action

Fixes: #4824 

**Checklist:**

* [X] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [X] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [X] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [X] Documentation has been updated, if necessary.
* [X] Unit tests have been added, if necessary.
* [X] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
