### PR TITLE
e2e: add tests for RBD VolumeGroupSnapshots

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -4857,6 +4857,14 @@ var _ = Describe("RBD", func() {
 			})
 
 			By("test volumeGroupSnapshot", func() {
+				supported, err := librbdSupportsVolumeGroupSnapshot(f)
+				if err != nil {
+					framework.Failf("failed to check for VolumeGroupSnapshot support: %v", err)
+				}
+				if !supported {
+					Skip("librbd does not support required VolumeGroupSnapshot function(s)")
+				}
+
 				scName := "csi-rbd-sc"
 				snapshotter, err := newRBDVolumeGroupSnapshot(f, f.UniqueName, scName, false, deployTimeout, 3)
 				if err != nil {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -4856,6 +4856,19 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("test volumeGroupSnapshot", func() {
+				scName := "csi-rbd-sc"
+				snapshotter, err := newRBDVolumeGroupSnapshot(f, f.UniqueName, scName, false, deployTimeout, 3)
+				if err != nil {
+					framework.Failf("failed to create RBDVolumeGroupSnapshot: %v", err)
+				}
+
+				err = snapshotter.TestVolumeGroupSnapshot()
+				if err != nil {
+					framework.Failf("failed to test volumeGroupSnapshot: %v", err)
+				}
+			})
+
 			// delete RBD provisioner secret
 			err := deleteCephUser(f, keyringRBDProvisionerUsername)
 			if err != nil {


### PR DESCRIPTION
Support for RBD VolumeGroupSnapshots is coming soon. However the implementation depends on changes in librbd, which are currently only available in the Ceph master branch.

Only when librbd in the Ceph-CSI container has support for the new function, the tests should te attempred

## Related issues ##

This is no a 100% strict dependency, as current Ceph releases do not have the required functions yet. It is expected that #4502 gets merged before Ceph has a stable release (non master branch builds).

Sortof-depends-on: #4502

Example YAML files that are used by the test are posted as #4901.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
