### PR TITLE
doc: add VolumeGroupSnapshot examples for RBD

### DIFF
--- a/examples/rbd/groupsnapshot.yaml
+++ b/examples/rbd/groupsnapshot.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+kind: VolumeGroupSnapshot
+metadata:
+  name: rbd-groupsnapshot
+spec:
+  source:
+    selector:
+      matchLabels:
+        # The PVCs will need to have this label for it to be
+        # included in the VolumeGroupSnapshot
+        group: test
+  volumeGroupSnapshotClassName: csi-rbdplugin-groupsnapclass

--- a/examples/rbd/groupsnapshotclass.yaml
+++ b/examples/rbd/groupsnapshotclass.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: csi-rbdplugin-groupsnapclass
+driver: rbd.csi.ceph.com
+parameters:
+  # String representing a Ceph cluster to provision storage from.
+  # Should be unique across all Ceph clusters in use for provisioning,
+  # cannot be greater than 36 bytes in length, and should remain immutable for
+  # the lifetime of the StorageClass in use
+  clusterID: <cluster-id>
+
+  # eg: pool: rbdpool
+  pool: <rbd-pool-name>
+
+  csi.storage.k8s.io/group-snapshotter-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/group-snapshotter-secret-namespace: default
+deletionPolicy: Delete

--- a/examples/rbd/pvc.yaml
+++ b/examples/rbd/pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: rbd-pvc
+  labels:
+    group: test
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
By labelling the PersistentVolumeClaim with `group: test`, the label
selector in the VolumeGroupSnapshot will create a snapshot of an RBD
group containing the single volume (or more if there are other volumes
in the same namespace with that label).

Once the VolumeGroupSnapshot is created, each volume in the group will
have a VolumeSnapshot that can be restored.

These files are also used by #4899 and eventually #4502, but the test is skipped until Ceph has a
new release with the required feature.