### PR TITLE
rbd: add types.Snapshot interface

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1641,6 +1641,10 @@ func (ri *rbdImage) GetCreationTime(ctx context.Context) (*time.Time, error) {
 		return nil, err
 	}
 
+	if ri.CreatedAt == nil {
+		return nil, fmt.Errorf("failed to get creation time for image %q", ri)
+	}
+
 	return ri.CreatedAt, nil
 }
 

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -145,11 +145,16 @@ func (rbdSnap *rbdSnapshot) toVolume() *rbdVolume {
 }
 
 func (rbdSnap *rbdSnapshot) ToCSI(ctx context.Context) (*csi.Snapshot, error) {
+	created, err := rbdSnap.GetCreationTime(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &csi.Snapshot{
 		SizeBytes:      rbdSnap.VolSize,
 		SnapshotId:     rbdSnap.VolID,
 		SourceVolumeId: rbdSnap.SourceVolumeID,
-		CreationTime:   timestamppb.New(*rbdSnap.CreatedAt),
+		CreationTime:   timestamppb.New(*created),
 		ReadyToUse:     true,
 	}, nil
 }

--- a/internal/rbd/types/snapshot.go
+++ b/internal/rbd/types/snapshot.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"context"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+type Snapshot interface {
+	journalledObject
+
+	// Destroy frees the resources used by the Snapshot.
+	Destroy(ctx context.Context)
+
+	// Delete removes the snapshot from the storage backend.
+	Delete(ctx context.Context) error
+
+	ToCSI(ctx context.Context) (*csi.Snapshot, error)
+
+	GetCreationTime(ctx context.Context) (*time.Time, error)
+}


### PR DESCRIPTION
The rbdSnapshot/rbdImage object implements all functions for a useful
Snapshot interface. The rbd.Manager will be able to use this for
providing VolumeGroupSnapshot support.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
