### PR TITLE
journal: only destroy the connection if it is set

### DIFF
--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -143,7 +143,10 @@ func (vgc *VolumeGroupJournalConfig) Connect(
 
 // Destroy frees any resources and invalidates the journal connection.
 func (vgjc *volumeGroupJournalConnection) Destroy() {
-	vgjc.connection.Destroy()
+	if vgjc.connection != nil {
+		vgjc.connection.Destroy()
+		vgjc.connection = nil
+	}
 }
 
 // VolumeGroupData contains the GroupUUID and VolumeGroupAttributes for a


### PR DESCRIPTION
Prevent re-use of a destroyed connection by setting it to `nil`. This
way it is also safe to call `Destroy()` multiple times without causing a
panic.

Found while working on #4502.