### PR TITLE
build: no need to use the CentOS 8 archived repositories on CentOS 9

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -4,11 +4,6 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE} as updated_base
 
-# Since CentOS Stream 8 is EOL, update the config to use vault.centos.org for CentOS Stream 8
-# TODO: remove once https://github.com/ceph/ceph-csi/issues/4659 is fixed.
-RUN sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/*.repo && \
-    sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*.repo
-
 # TODO: remove the following cmd, when issues
 # https://github.com/ceph/ceph-container/issues/2034
 # https://github.com/ceph/ceph-container/issues/2141 are fixed.

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -1,11 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-# Since CentOS Stream 8 is EOL, update the config to use vault.centos.org for CentOS Stream 8
-# TODO: remove once https://github.com/ceph/ceph-csi/issues/4659 is fixed.
-RUN sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/*.repo && \
-    sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*.repo
-
 ARG GOROOT=/usr/local/go
 ARG GOARCH
 


### PR DESCRIPTION
The Ceph base container-image moved to CentOS Stream 9, so there is no
need to adapt the repositories anymore.

Closes: #4659