### PR TITLE
rbd: Add timeout for cryptsetup commands

### DIFF
--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/internal/util/stripsecrets"
 
 	"github.com/ceph/go-ceph/rados"
 )
@@ -49,7 +50,7 @@ func ExecuteCommandWithNSEnter(ctx context.Context, netPath, program string, arg
 	}
 	//  nsenter --net=%s -- <program> <args>
 	args = append([]string{"--net=" + netPath, "--", program}, args...)
-	sanitizedArgs := StripSecretInArgs(args)
+	sanitizedArgs := stripsecrets.InArgs(args)
 	cmd := exec.Command(nsenter, args...) // #nosec:G204, commands executing not vulnerable.
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -80,7 +81,7 @@ func ExecuteCommandWithNSEnter(ctx context.Context, netPath, program string, arg
 func ExecCommand(ctx context.Context, program string, args ...string) (string, string, error) {
 	var (
 		cmd           = exec.Command(program, args...) // #nosec:G204, commands executing not vulnerable.
-		sanitizedArgs = StripSecretInArgs(args)
+		sanitizedArgs = stripsecrets.InArgs(args)
 		stdoutBuf     bytes.Buffer
 		stderrBuf     bytes.Buffer
 	)
@@ -122,7 +123,7 @@ func ExecCommandWithTimeout(
 	error,
 ) {
 	var (
-		sanitizedArgs = StripSecretInArgs(args)
+		sanitizedArgs = stripsecrets.InArgs(args)
 		stdoutBuf     bytes.Buffer
 		stderrBuf     bytes.Buffer
 	)

--- a/internal/util/stripsecrets/stripsecrets.go
+++ b/internal/util/stripsecrets/stripsecrets.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package stripsecrets
 
 import (
 	"strings"
@@ -30,10 +30,10 @@ const (
 	strippedSecret      = "secret=***stripped***"
 )
 
-// StripSecretInArgs strips values of either "--key"/"--keyfile" or "secret=".
+// InArgs strips values of either "--key"/"--keyfile" or "secret=".
 // `args` is left unchanged.
 // Expects only one occurrence of either "--key"/"--keyfile" or "secret=".
-func StripSecretInArgs(args []string) []string {
+func InArgs(args []string) []string {
 	out := make([]string, len(args))
 	copy(out, args)
 


### PR DESCRIPTION
# Describe what this PR does #

This PR introduces a new wrapper around LUKS utility functions that allow us to have context aware subsequent operations, `util.NewLuksWrapperWithContext`. This context is shared across the functions exposed by this wrapper.

A sample use case is to have a context that times out after certain period of time.

# How to Test #

We can simulate a timeout by replacing the cryptsetup binary with a wrapper script that introduces some delay.

- Exec into the pod where the cryptsetup binary is located (rbd-plugin in case of key rotation)
- `mv /usr/sbin/cryptsetup /usr/sbin/cryptsetup_orig`
- Create a new `/usr/sbin/cryptsetup` and paste the following:
```sh
#!/usr/bin/env bash

set -m

sleep 140

exec /usr/sbin/cryptsetup_orig "$@"
```
- `chmod +x /usr/sbin/cryptsetup`
- When the process is killed due to timeout you will see a log like:
```log
timeout occurred while running cryptsetup args: [...]
```