### PR TITLE
rbd: check if mirror image has parent image

### DIFF
--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -91,6 +91,10 @@ func (ri *rbdImage) EnableMirroring(_ context.Context, mode librbd.ImageMirrorMo
 
 	err = image.MirrorEnable(mode)
 	if err != nil {
+		if ri.ParentName != "" {
+			return fmt.Errorf("failed to enable mirroring as image %q has a parent %q", ri.ImageID, ri.ParentName)
+		}
+
 		return fmt.Errorf("failed to enable mirroring on %q with error: %w", ri, err)
 	}
 


### PR DESCRIPTION
since enable mirroring fails if it has parent image this commit adds a check for that and returns
suitable error which can be picke by VR status

