### PR TITLE
Fixes related to flatten operation in PVC restored from snapshot

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -461,9 +461,9 @@ func flattenParentImage(
 	hardLimit := rbdHardMaxCloneDepth
 	softLimit := rbdSoftMaxCloneDepth
 	if rbdVol != nil {
-		// choosing 2, since cloning image creates a temp clone and a final clone which
-		// will add a total depth of 2.
-		const depthToAvoidFlatten = 2
+		// choosing 3, since cloning image creates a temp clone and a final clone which
+		// will add a total depth of 2 and the parent image itself adds one depth.
+		const depthToAvoidFlatten = 3
 		if rbdHardMaxCloneDepth > depthToAvoidFlatten {
 			hardLimit = rbdHardMaxCloneDepth - depthToAvoidFlatten
 		}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

- rbd: remove checkFlatten() function

CephCSI should not flatten image that can be mounted
for use by the user.
`checkFlatten()` was called in a recovery code flow
of PVC restored from snapshot and was missed while
refractoring in https://github.com/ceph/ceph-csi/pull/2900

refer: https://github.com/ceph/ceph-csi/pull/2900

- rbd: set depthToAvoidFlatten to 3 during PVC-PVC clone

During PVC-PVC clone creation, parent of the datasource
image is flattened after checking for clone depth.
We need to account for data source image as well since
we're calculating depth from the parent image.
depthToAvoidFlatten = 3(datasource image + temp + final clone)

Signed-off-by: Rakshith R <rar@redhat.com>

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
