### PR TITLE
RBD: Flatten group snapshot

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -2480,7 +2480,7 @@ var _ = Describe(cephfsType, func() {
 
 			By("test volumeGroupSnapshot", func() {
 				scName := "csi-cephfs-sc"
-				snapshotter, err := newCephFSVolumeGroupSnapshot(f, f.UniqueName, scName, false, deployTimeout, 3)
+				snapshotter, err := newCephFSVolumeGroupSnapshot(f, f.UniqueName, scName, false, deployTimeout, 3, 0)
 				if err != nil {
 					framework.Failf("failed to create volumeGroupSnapshot Base: %v", err)
 				}

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -4881,7 +4881,7 @@ var _ = Describe("RBD", func() {
 				}
 
 				scName := "csi-rbd-sc"
-				snapshotter, err := newRBDVolumeGroupSnapshot(f, f.UniqueName, scName, false, deployTimeout, 3)
+				snapshotter, err := newRBDVolumeGroupSnapshot(f, f.UniqueName, scName, false, deployTimeout, 3, 5)
 				if err != nil {
 					framework.Failf("failed to create RBDVolumeGroupSnapshot: %v", err)
 				}

--- a/e2e/volumegroupsnapshot.go
+++ b/e2e/volumegroupsnapshot.go
@@ -35,9 +35,10 @@ var _ VolumeGroupSnapshotter = &cephFSVolumeGroupSnapshot{}
 func newCephFSVolumeGroupSnapshot(f *framework.Framework, namespace,
 	storageClass string,
 	blockPVC bool,
-	timeout, totalPVCCount int,
+	timeout, totalPVCCount, additionalVGSnapshotCount int,
 ) (VolumeGroupSnapshotter, error) {
-	base, err := newVolumeGroupSnapshotBase(f, namespace, storageClass, blockPVC, timeout, totalPVCCount)
+	base, err := newVolumeGroupSnapshotBase(f, namespace, storageClass, blockPVC,
+		timeout, totalPVCCount, additionalVGSnapshotCount)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create volumeGroupSnapshotterBase: %w", err)
 	}
@@ -144,9 +145,10 @@ var _ VolumeGroupSnapshotter = &rbdVolumeGroupSnapshot{}
 func newRBDVolumeGroupSnapshot(f *framework.Framework, namespace,
 	storageClass string,
 	blockPVC bool,
-	timeout, totalPVCCount int,
+	timeout, totalPVCCount, additionalVGSnapshotCount int,
 ) (VolumeGroupSnapshotter, error) {
-	base, err := newVolumeGroupSnapshotBase(f, namespace, storageClass, blockPVC, timeout, totalPVCCount)
+	base, err := newVolumeGroupSnapshotBase(f, namespace, storageClass, blockPVC,
+		timeout, totalPVCCount, additionalVGSnapshotCount)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create volumeGroupSnapshotterBase: %w", err)
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1157,7 +1157,7 @@ func (cs *ControllerServer) CreateSnapshot(
 		return cloneFromSnapshot(ctx, rbdVol, rbdSnap, cr, req.GetParameters())
 	}
 
-	err = flattenTemporaryClonedImages(ctx, rbdVol, cr)
+	err = rbdVol.PrepareVolumeForSnapshot(ctx, cr)
 	if err != nil {
 		return nil, err
 	}
@@ -1373,11 +1373,6 @@ func (cs *ControllerServer) doSnapshotClone(
 	if err != nil {
 		log.ErrorLog(ctx, "failed to reserve volume id: %v", err)
 
-		return cloneRbd, err
-	}
-
-	err = cloneRbd.flattenRbdImage(ctx, false, rbdHardMaxCloneDepth, rbdSoftMaxCloneDepth)
-	if err != nil {
 		return cloneRbd, err
 	}
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -629,8 +629,10 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 		}
 		// If we start flattening all the snapshots at one shot the volume
 		// creation time will be affected,so we will flatten only the extra
-		// snapshots.
-		extraSnapshots := min(len(snaps)-int(minSnapshotsOnImageToStartFlatten), len(children))
+		// snapshots. Use the min of the extra snapshots and the number of children
+		// to avoid scenario where number of children are less than the extra snapshots.
+		// This occurs when the child images are in trash and not yet deleted.
+		extraSnapshots := min((len(snaps) - int(minSnapshotsOnImageToStartFlatten)), len(children))
 		children = children[:extraSnapshots]
 		err = flattenClonedRbdImages(
 			ctx,

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -276,6 +276,10 @@ func (rv *rbdVolume) NewSnapshotByID(
 		return nil, err
 	}
 
+	// set the features for the clone image.
+	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
+	rv.ImageFeatureSet = librbd.FeatureSetFromNames(f)
+
 	options, err := rv.constructImageOptions(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/rbd/types/volume.go
+++ b/internal/rbd/types/volume.go
@@ -58,6 +58,10 @@ type Volume interface {
 	// if the parent image is in trash, it returns an error.
 	// if the parent image exists and is not enabled for mirroring, it returns an error.
 	HandleParentImageExistence(ctx context.Context, flattenMode FlattenMode) error
+	// PrepareVolumeForSnapshot prepares the volume for snapshot by
+	// checking snapshots limit and clone depth limit and flatten it
+	// if required.
+	PrepareVolumeForSnapshot(ctx context.Context, cr *util.Credentials) error
 
 	// ToMirror converts the Volume to a Mirror.
 	ToMirror() (Mirror, error)


### PR DESCRIPTION
# Describe what this PR does #

- Adds e2e loop to create and delete additional 5 groupsnapshots.
- Add PrepareVolumeSnapshot() to check snapLimit and cloneDepth & flatten if necessary.
- Make use of both ListSnapshots & ListChildren to determine Snap count and which child images can be flattened.
- Add features deep-flatten and layering to group snapshot clones.

## Related issues ##

related-to: #5000 

Fixes: #issue_number


**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
