### PR TITLE
cephfs: remove extraneous creation of credentials

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -717,12 +717,6 @@ func (cs *ControllerServer) ControllerExpandVolume(
 	}
 	defer cs.OperationLocks.ReleaseExpandLock(volID)
 
-	cr, err := util.NewAdminCredentials(secret)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-	defer cr.DeleteCredentials()
-
 	volOptions, volIdentifier, err := store.NewVolumeOptionsFromVolID(ctx, volID, nil, secret,
 		cs.ClusterName, cs.SetMetadata)
 	if err != nil {


### PR DESCRIPTION
`ControllerExpandVolume` creates the credentials from secrets but never actually uses it for anything.

The secrets map is passed on to `NewVolumeOptionsFromVolID` which does the same check again. 

This patch removes the extraneous step inside `ControllerExpandVolume`