### PR TITLE
ci: increase e2e run timeout with 30 minutes

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -197,7 +197,7 @@ node('cico-workspace') {
 			}
 		}
 		stage('run e2e') {
-			timeout(time: 120, unit: 'MINUTES') {
+			timeout(time: 150, unit: 'MINUTES') {
 				def t_type = ""
 				if ("${test_type}" == "cephfs"){
 					t_type = '--test-cephfs=true --test-rbd=false --test-nfs=false'

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -184,7 +184,7 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
 		}
 		stage('run e2e') {
-			timeout(time: 120, unit: 'MINUTES') {
+			timeout(time: 150, unit: 'MINUTES') {
 				def t_type = ""
 				if ("${test_type}" == "cephfs"){
 					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"


### PR DESCRIPTION
When VolumeGroupSnapshot tests are included, 120 minutes is not
sufficient anymore. Add another 30 minutes to the timeout, so that the
e2e run can finish.

The timeouts are hit in #4974.