### PR TITLE
rbd: Use assume_storage_prezeroed when formatting

### DIFF
--- a/internal/util/file/file.go
+++ b/internal/util/file/file.go
@@ -52,3 +52,20 @@ func CreateTempFile(prefix, contents string) (*os.File, error) {
 
 	return file, nil
 }
+
+// CreateSpareFile makes `file` a sparse file of size `sizeMB`.
+func CreateSparseFile(file *os.File, sizeMB int64) error {
+	sizeBytes := sizeMB * 1024 * 1024
+
+	// seek to the end of the file.
+	if _, err := file.Seek(sizeBytes-1, 0); err != nil {
+		return fmt.Errorf("failed to seek to the end of the file: %w", err)
+	}
+
+	// write a single byte, effectively making it a sparse file.
+	if _, err := file.Write([]byte{0}); err != nil {
+		return fmt.Errorf("failed to write to the end of the file: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Instead of passing `lazy_itable_init=1` and `lazy_journal_init=1` to
`mkfs.ext4`, pass `assume_storage_prezeroed=1` which is
stronger and allows the filesystem to skip inode table zeroing
completely instead of simply doing it lazily.

The support for this flag is checked by trying to format a fake
temporary image with `mkfs.ext4` and checking its `STDERR`.

Closes: #4948