### PR TITLE
rbd: return group not found error for Get,Delete RPC calls

### DIFF
--- a/internal/rbd/group/util.go
+++ b/internal/rbd/group/util.go
@@ -145,6 +145,12 @@ func (cvg *commonVolumeGroup) getVolumeGroupAttributes(ctx context.Context) (*jo
 		attrs = &journal.VolumeGroupAttributes{}
 	}
 
+	if attrs.GroupName == "" || attrs.CreationTime == nil {
+		log.ErrorLog(ctx, "volume group with id %v not found", cvg.id)
+
+		return nil, ErrRBDGroupNotFound
+	}
+
 	cvg.requestName = attrs.RequestName
 	cvg.name = attrs.GroupName
 	cvg.creationTime = attrs.CreationTime

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/ceph/go-ceph/rados"
+	librados "github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
@@ -31,7 +32,10 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
-var ErrRBDGroupNotConnected = errors.New("RBD group is not connected")
+var (
+	ErrRBDGroupNotConnected = fmt.Errorf("%w: RBD group is not connected", librados.ErrNotConnected)
+	ErrRBDGroupNotFound     = fmt.Errorf("%w: RBD group not found", librbd.ErrNotFound)
+)
 
 // volumeGroup handles all requests for 'rbd group' operations.
 type volumeGroup struct {


### PR DESCRIPTION
We should return `NotFound` GRPC status if the group doesn't exists for ControllerGetVolumeGroup RPC call.
And, an empty/OK response for DeleteVolumeGroup if the group doesn't exists

Fixes: #4999 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
