### PR TITLE
build: include `--nobest` while upgrading the devel container packages

### DIFF
--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -35,7 +35,7 @@ RUN dnf -y install \
 	librados-devel \
         libcephfs-devel \
 	librbd-devel \
-    && dnf -y update \
+    && dnf -y --nobest update \
     && dnf clean all \
     && rm -rf /var/cache/yum \
     && true


### PR DESCRIPTION
On occasion there are inconsistencies in the CentOS or Ceph RPM
repositories. This can cause `dnf update` to fail when there are
conflicting versions of a package. By adding the `--nobest` option,
packages can get upgraded to an older version, but not the latest.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
