### PR TITLE
rbd: rename groupNamePrefix to volumeGroupNamePrefix

### DIFF
--- a/examples/rbd/groupsnapshotclass.yaml
+++ b/examples/rbd/groupsnapshotclass.yaml
@@ -14,6 +14,10 @@ parameters:
   # eg: pool: rbdpool
   pool: <rbd-pool-name>
 
+  # (optional) Prefix to use for naming RBD groups.
+  # If omitted, defaults to "csi-vol-group-".
+  # volumeGroupNamePrefix: "foo-bar-"
+
   csi.storage.k8s.io/group-snapshotter-secret-name: csi-rbd-secret
   csi.storage.k8s.io/group-snapshotter-secret-namespace: default
 deletionPolicy: Delete

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -346,8 +346,8 @@ func (mgr *rbdManager) GetVolumeGroupSnapshotByName(
 		return nil, errors.New("required 'pool' option missing in volume group parameters")
 	}
 
-	// groupNamePrefix is an optional parameter, can be an empty string
-	prefix := mgr.parameters["groupNamePrefix"]
+	// volumeGroupNamePrefix is an optional parameter, can be an empty string
+	prefix := mgr.parameters["volumeGroupNamePrefix"]
 
 	clusterID, err := util.GetClusterID(mgr.parameters)
 	if err != nil {
@@ -409,8 +409,8 @@ func (mgr *rbdManager) CreateVolumeGroupSnapshot(
 		return nil, err
 	}
 
-	// groupNamePrefix is an optional parameter, can be an empty string
-	prefix := mgr.parameters["groupNamePrefix"]
+	// volumeGroupNamePrefix is an optional parameter, can be an empty string
+	prefix := mgr.parameters["volumeGroupNamePrefix"]
 
 	clusterID, err := vg.GetClusterID(ctx)
 	if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

CephFS uses the parameter `volumeGroupNamePrefix` for creating VolumeGroups.
This commit renames `groupNamePrefix` to `volumeGroupNamePrefix` for RBD
VolumeGroup creation to ensure consistent naming.


See - https://github.com/ceph/ceph-csi/pull/4750#discussion_r1856184047

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
