### PR TITLE
doc: Add hint that the userID must not include the `client.` prefix

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -383,6 +383,7 @@ secret:
   # Key values correspond to a user name and its key, as defined in the
   # ceph cluster. User ID should have required access to the 'pool'
   # specified in the storage class
+  # The userID must not include the "client." prefix!
   userID: <plaintext ID>
   userKey: <Ceph auth key corresponding to the userID above>
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -538,6 +538,7 @@ secret:
   # Key values correspond to a user name and its key, as defined in the
   # ceph cluster. User ID should have required access to the 'pool'
   # specified in the storage class
+  # The userID must not include the "client." prefix!
   userID: <plaintext ID>
   userKey: <Ceph auth key corresponding to userID above>
   # Encryption passphrase

--- a/examples/cephfs/secret.yaml
+++ b/examples/cephfs/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
 stringData:
   # Required for statically and dynamically provisioned volumes
+  # The userID must not include the "client." prefix!
   userID: <plaintext ID>
   userKey: <Ceph auth key corresponding to ID above>
 

--- a/examples/rbd/secret.yaml
+++ b/examples/rbd/secret.yaml
@@ -8,6 +8,7 @@ stringData:
   # Key values correspond to a user name and its key, as defined in the
   # ceph cluster. User ID should have required access to the 'pool'
   # specified in the storage class
+  # The userID must not include the "client." prefix!
   userID: <plaintext ID>
   userKey: <Ceph auth key corresponding to ID above>
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This PR only adds a small hint in the rbd helm values chart. It took me quite some time to find my config error and this hint hopefully safes someone some debug time :) 

Problem was that i included the `client.` prefix in the `userID` secret. 

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Problem mentioned in: #4304

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
