### PR TITLE
ci: run upgrade tests with Kubernetes 1.28

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.27'
+    k8s_version: '1.28'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
The call to `./scripts/get_patch_release.py --version=1.27` returns an
error. Kubernetes 1.27 is really old, so it is good to move to v1.28
now.