### PR TITLE
rbd: correct default encryption type

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -599,7 +599,7 @@ func RegenerateJournal(
 
 	rbdVol.Owner = owner
 
-	kmsID, encryptionType, err = ParseEncryptionOpts(volumeAttributes, util.EncryptionTypeNone)
+	kmsID, encryptionType, err = ParseEncryptionOpts(volumeAttributes, rbdDefaultEncryptionType)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

**Problem**: When the encryptionType is not specified in the StorageClass,
the default type (block) is used and stored in OMAP. However, during
OMAP regeneration in a secondary cluster, the default type is incorrectly
set to none. This discrepancy leads to errors during PVC cloning,
with the message: `cannot create encrypted volume from unencrypted volume.`

**Solution**: Update the default encryption type to consistently use block
instead of none.

<hr/>

👇  Problem logs 

In Secondary cluster - 
- encrypted StorageClass with no `encryptionType` parameter - 
```
$ k get pv pvc-d5c846ab-7869-42e8-b066-7f80c7b00046 -ojsonpath='{.spec.csi.volumeAttributes}' | jq
{
  "clusterID": "rook-ceph",
  "encrypted": "true",
  "encryptionKMSID": "metadata",
  "imageFeatures": "layering,fast-diff,deep-flatten,exclusive-lock,object-map",
  "imageFormat": "2",
  "imageName": "csi-vol-5dc739ef-ed47-4d42-8527-0511d7824e90",
  "journalPool": "replicapool",
  "pool": "replicapool",
  "storage.kubernetes.io/csiProvisionerIdentity": "1737009185949-7744-rook-ceph.rbd.csi.ceph.com"
}
```

- OMAP value for `csi.volume.encryptionType` is empty
```
$ rados listomapvals csi.volume.5dc739ef-ed47-4d42-8527-0511d7824e90 -p replicapool
csi.imageid
value (13 bytes) :
00000000  31 63 62 64 63 65 61 30  33 39 30 39 61           |1cbdcea03909a|
0000000d

csi.imagename
value (44 bytes) :
00000000  63 73 69 2d 76 6f 6c 2d  35 64 63 37 33 39 65 66  |csi-vol-5dc739ef|
00000010  2d 65 64 34 37 2d 34 64  34 32 2d 38 35 32 37 2d  |-ed47-4d42-8527-|
00000020  30 35 31 31 64 37 38 32  34 65 39 30              |0511d7824e90|
0000002c

csi.volname
value (40 bytes) :
00000000  70 76 63 2d 64 35 63 38  34 36 61 62 2d 37 38 36  |pvc-d5c846ab-786|
00000010  39 2d 34 32 65 38 2d 62  30 36 36 2d 37 66 38 30  |9-42e8-b066-7f80|
00000020  63 37 62 30 30 30 34 36                           |c7b00046|
00000028

csi.volume.encryptKMS
value (8 bytes) :
00000000  6d 65 74 61 64 61 74 61                           |metadata|
00000008

csi.volume.encryptionType
value (0 bytes) :

csi.volume.owner
value (9 bytes) :
00000000  72 6f 6f 6b 2d 63 65 70  68                       |rook-ceph|
00000009
```

- PVC clone fails with - 
```
failed to provision volume with StorageClass "rook-ceph-block-e": rpc error: code = InvalidArgument desc = cannot clone from volume replicapool/csi-vol-5dc739ef-ed47-4d42-8527-0511d7824e90: cannot create encrypted volume from unencrypted volume "replicapool/csi-vol-5dc739ef-ed47-4d42-8527-0511d7824e90"
```


## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
