### PR TITLE
cephfs: upgrading mount syntax

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -482,14 +482,6 @@ var _ = Describe(cephfsType, func() {
 				}
 			})
 
-			By("check static PVC with without FsName", func() {
-				scPath := cephFSExamplePath + "secret.yaml"
-				err := validateCephFsStaticPV(f, appPath, scPath, "")
-				if err != nil {
-					framework.Failf("failed to validate CephFS static pv without filesystem name: %v", err)
-				}
-			})
-
 			By("create a storageclass with pool and a PVC then bind it to an app", func() {
 				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
 				if err != nil {

--- a/internal/cephfs/mounter/kernel.go
+++ b/internal/cephfs/mounter/kernel.go
@@ -72,25 +72,24 @@ func (m *kernelMounter) mountKernel(
 		m.needsModprobe = false
 	}
 
+	fsID, err := volOptions.GetFSID()
+	if err != nil {
+		return fmt.Errorf("failed to get fsID, stop mounting: %w", err)
+	}
+
 	args := []string{
 		"-t", "ceph",
-		fmt.Sprintf("%s:%s", volOptions.Monitors, volOptions.RootPath),
+		fmt.Sprintf("%s@%s.%s=%s", cr.ID, fsID, volOptions.FsName, volOptions.RootPath),
 		mountPoint,
 	}
 
-	optionsStr := fmt.Sprintf("name=%s,secretfile=%s", cr.ID, cr.KeyFile)
-	mdsNamespace := ""
-	if volOptions.FsName != "" {
-		mdsNamespace = "mds_namespace=" + volOptions.FsName
-	}
-	optionsStr = util.MountOptionsAdd(optionsStr, mdsNamespace, volOptions.KernelMountOptions, netDev)
+	optionsStr := fmt.Sprintf("mon_addr=%s,secretfile=%s", strings.ReplaceAll(volOptions.Monitors, ",", "/"), cr.KeyFile)
+
+	optionsStr = util.MountOptionsAdd(optionsStr, volOptions.KernelMountOptions, netDev)
 
 	args = append(args, "-o", optionsStr)
 
-	var (
-		stderr string
-		err    error
-	)
+	var stderr string
 
 	if volOptions.NetNamespaceFilePath != "" {
 		_, stderr, err = util.ExecuteCommandWithNSEnter(ctx, volOptions.NetNamespaceFilePath, "mount", args[:]...)

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -103,6 +103,19 @@ func (vo *VolumeOptions) Destroy() {
 	}
 }
 
+func (vo *VolumeOptions) GetFSID() (string, error) {
+	if vo.conn == nil {
+		return "", errors.New("cluster not connected yet")
+	}
+
+	fsID, err := vo.conn.GetFSID()
+	if err != nil {
+		return "", err
+	}
+
+	return fsID, nil
+}
+
 func validateNonEmptyField(field, fieldName string) error {
 	if field == "" {
 		return fmt.Errorf("parameter '%s' cannot be empty", fieldName)
@@ -682,6 +695,17 @@ func NewVolumeOptionsFromMonitorList(
 		opts.BackingSnapshot = true
 	}
 
+	cr, err := util.NewAdminCredentials(secrets)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cr.DeleteCredentials()
+
+	err = opts.Connect(cr)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return &opts, &vid, nil
 }
 
@@ -730,7 +754,7 @@ func NewVolumeOptionsFromStaticVolume(
 		return nil, nil, err
 	}
 
-	if err = extractOptionalOption(&opts.FsName, "fsName", options); err != nil {
+	if err = extractOption(&opts.FsName, "fsName", options); err != nil {
 		return nil, nil, err
 	}
 
@@ -759,6 +783,17 @@ func NewVolumeOptionsFromStaticVolume(
 
 	if opts.BackingSnapshotID != "" {
 		opts.BackingSnapshot = true
+	}
+
+	cr, err := util.NewAdminCredentials(secrets)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cr.DeleteCredentials()
+
+	err = opts.Connect(cr)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return &opts, &vid, nil


### PR DESCRIPTION
[The old syntax](https://docs.ceph.com/en/pacific/man/8/mount.ceph/) is almost deprecated, and there are reasons to upgrade it to [the new one](https://docs.ceph.com/en/reef/man/8/mount.ceph/)
 - old syntax is lack of fsid param, which is critical for debugging and observability
 - mds_namespace is deprecated, so it might be inappropriate to continue using it
 - kernel will try new syntax first and then the old one(check with mount -v), it is a waste to use the old one
 
From the ubuntu manpage，[20.04 LTS](https://manpages.ubuntu.com/manpages/focal/man8/mount.ceph.8.html) supports the old syntax while [22.04 LTS](https://manpages.ubuntu.com/manpages/jammy/man8/mount.ceph.8.html) supports the new one.