### PR TITLE
cleanup: use `rbd.Manager` for fetching volumes in CSI-Addons operations

### DIFF
--- a/internal/csi-addons/rbd/encryptionkeyrotation.go
+++ b/internal/csi-addons/rbd/encryptionkeyrotation.go
@@ -32,14 +32,14 @@ import (
 
 type EncryptionKeyRotationServer struct {
 	*ekr.UnimplementedEncryptionKeyRotationControllerServer
-	driver  string
-	volLock *util.VolumeLocks
+	driverInstance string
+	volLock        *util.VolumeLocks
 }
 
-func NewEncryptionKeyRotationServer(driver string, volLock *util.VolumeLocks) *EncryptionKeyRotationServer {
+func NewEncryptionKeyRotationServer(driverInstance string, volLock *util.VolumeLocks) *EncryptionKeyRotationServer {
 	return &EncryptionKeyRotationServer{
-		driver:  driver,
-		volLock: volLock,
+		driverInstance: driverInstance,
+		volLock:        volLock,
 	}
 }
 
@@ -62,7 +62,7 @@ func (ekrs *EncryptionKeyRotationServer) EncryptionKeyRotate(
 	}
 	defer ekrs.volLock.Release(volID)
 
-	mgr := rbd.NewManager(ekrs.driver, nil, req.GetSecrets())
+	mgr := rbd.NewManager(ekrs.driverInstance, nil, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volID)

--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -38,16 +38,19 @@ import (
 type ReclaimSpaceControllerServer struct {
 	*rs.UnimplementedReclaimSpaceControllerServer
 
-	driver      string
-	volumeLocks *util.VolumeLocks
+	driverInstance string
+	volumeLocks    *util.VolumeLocks
 }
 
 // NewReclaimSpaceControllerServer creates a new ReclaimSpaceControllerServer which handles
 // the ReclaimSpace Service requests from the CSI-Addons specification.
-func NewReclaimSpaceControllerServer(driver string, volumeLocks *util.VolumeLocks) *ReclaimSpaceControllerServer {
+func NewReclaimSpaceControllerServer(
+	driverInstance string,
+	volumeLocks *util.VolumeLocks,
+) *ReclaimSpaceControllerServer {
 	return &ReclaimSpaceControllerServer{
-		driver:      driver,
-		volumeLocks: volumeLocks,
+		driverInstance: driverInstance,
+		volumeLocks:    volumeLocks,
 	}
 }
 
@@ -71,7 +74,7 @@ func (rscs *ReclaimSpaceControllerServer) ControllerReclaimSpace(
 	}
 	defer rscs.volumeLocks.Release(volumeID)
 
-	mgr := rbdutil.NewManager(rscs.driver, nil, req.GetSecrets())
+	mgr := rbdutil.NewManager(rscs.driverInstance, nil, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)

--- a/internal/csi-addons/rbd/reclaimspace_test.go
+++ b/internal/csi-addons/rbd/reclaimspace_test.go
@@ -32,7 +32,7 @@ import (
 func TestControllerReclaimSpace(t *testing.T) {
 	t.Parallel()
 
-	controller := NewReclaimSpaceControllerServer(util.NewVolumeLocks())
+	controller := NewReclaimSpaceControllerServer("test.driver", util.NewVolumeLocks())
 
 	req := &rs.ControllerReclaimSpaceRequest{
 		VolumeId: "",

--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -95,8 +95,8 @@ type ReplicationServer struct {
 	*replication.UnimplementedControllerServer
 	// Embed ControllerServer as it implements helper functions
 	*corerbd.ControllerServer
-	// csiID is the unique ID for this CSI-driver deployment.
-	csiID string
+	// driverInstance is the unique ID for this CSI-driver deployment.
+	driverInstance string
 }
 
 // NewReplicationServer creates a new ReplicationServer which handles
@@ -104,7 +104,7 @@ type ReplicationServer struct {
 func NewReplicationServer(instanceID string, c *corerbd.ControllerServer) *ReplicationServer {
 	return &ReplicationServer{
 		ControllerServer: c,
-		csiID:            instanceID,
+		driverInstance:   instanceID,
 	}
 }
 
@@ -277,7 +277,7 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	mgr := rbd.NewManager(rs.csiID, req.GetParameters(), req.GetSecrets())
+	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -347,7 +347,7 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	mgr := rbd.NewManager(rs.csiID, req.GetParameters(), req.GetSecrets())
+	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -415,7 +415,7 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	mgr := rbd.NewManager(rs.csiID, req.GetParameters(), req.GetSecrets())
+	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -508,7 +508,7 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	mgr := rbd.NewManager(rs.csiID, req.GetParameters(), req.GetSecrets())
+	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -618,7 +618,7 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer rs.VolumeLocks.Release(volumeID)
-	mgr := rbd.NewManager(rs.csiID, req.GetParameters(), req.GetSecrets())
+	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -827,7 +827,7 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer rs.VolumeLocks.Release(volumeID)
-	mgr := rbd.NewManager(rs.csiID, nil, req.GetSecrets())
+	mgr := rbd.NewManager(rs.driverInstance, nil, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -41,15 +41,15 @@ type VolumeGroupServer struct {
 	// don't need to add all RPC methods leading to forward compatibility.
 	*volumegroup.UnimplementedControllerServer
 
-	// csiID is the unique ID for this CSI-driver deployment.
-	csiID string
+	// driverInstance is the unique ID for this CSI-driver deployment.
+	driverInstance string
 }
 
 // NewVolumeGroupServer creates a new VolumeGroupServer which handles the
 // VolumeGroup Service requests from the CSI-Addons specification.
 func NewVolumeGroupServer(instanceID string) *VolumeGroupServer {
 	return &VolumeGroupServer{
-		csiID: instanceID,
+		driverInstance: instanceID,
 	}
 }
 
@@ -85,7 +85,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 	ctx context.Context,
 	req *volumegroup.CreateVolumeGroupRequest,
 ) (*volumegroup.CreateVolumeGroupResponse, error) {
-	mgr := rbd.NewManager(vs.csiID, req.GetParameters(), req.GetSecrets())
+	mgr := rbd.NewManager(vs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	// resolve all volumes
@@ -188,7 +188,7 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 	ctx context.Context,
 	req *volumegroup.DeleteVolumeGroupRequest,
 ) (*volumegroup.DeleteVolumeGroupResponse, error) {
-	mgr := rbd.NewManager(vs.csiID, nil, req.GetSecrets())
+	mgr := rbd.NewManager(vs.driverInstance, nil, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	// resolve the volume group
@@ -285,7 +285,7 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	ctx context.Context,
 	req *volumegroup.ModifyVolumeGroupMembershipRequest,
 ) (*volumegroup.ModifyVolumeGroupMembershipResponse, error) {
-	mgr := rbd.NewManager(vs.csiID, nil, req.GetSecrets())
+	mgr := rbd.NewManager(vs.driverInstance, nil, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	// resolve the volume group
@@ -427,7 +427,7 @@ func (vs *VolumeGroupServer) ControllerGetVolumeGroup(
 	ctx context.Context,
 	req *volumegroup.ControllerGetVolumeGroupRequest,
 ) (*volumegroup.ControllerGetVolumeGroupResponse, error) {
-	mgr := rbd.NewManager(vs.csiID, nil, req.GetSecrets())
+	mgr := rbd.NewManager(vs.driverInstance, nil, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	// resolve the volume group

--- a/internal/rbd/diskusage.go
+++ b/internal/rbd/diskusage.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rbd
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -25,7 +26,7 @@ import (
 // of the image.
 // This function will return ErrImageInUse if the image is in use, since
 // sparsifying an image on which i/o is in progress is not optimal.
-func (ri *rbdImage) Sparsify() error {
+func (ri *rbdImage) Sparsify(_ context.Context) error {
 	inUse, err := ri.isInUse()
 	if err != nil {
 		return fmt.Errorf("failed to check if image is in use: %w", err)

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -229,7 +229,7 @@ func (r *Driver) setupCSIAddonsServer(conf *util.Config) error {
 	r.cas.RegisterService(is)
 
 	if conf.IsControllerServer {
-		rs := casrbd.NewReclaimSpaceControllerServer(r.cs.VolumeLocks)
+		rs := casrbd.NewReclaimSpaceControllerServer(conf.InstanceID, r.cs.VolumeLocks)
 		r.cas.RegisterService(rs)
 
 		fcs := casrbd.NewFenceControllerServer()

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -249,7 +249,7 @@ func (r *Driver) setupCSIAddonsServer(conf *util.Config) error {
 		rs := casrbd.NewReclaimSpaceNodeServer(r.ns.VolumeLocks)
 		r.cas.RegisterService(rs)
 
-		ekr := casrbd.NewEncryptionKeyRotationServer(r.ns.VolumeLocks)
+		ekr := casrbd.NewEncryptionKeyRotationServer(conf.InstanceID, r.ns.VolumeLocks)
 		r.cas.RegisterService(ekr)
 	}
 

--- a/internal/rbd/types/volume.go
+++ b/internal/rbd/types/volume.go
@@ -45,6 +45,9 @@ type csiAddonsVolume interface {
 	// RotateEncryptionKey processes the key rotation for the RBD Volume.
 	RotateEncryptionKey(ctx context.Context) error
 
+	// Sparsify tries to free unused blocks of the volume from the CSI-Addons Controller.
+	Sparsify(ctx context.Context) error
+
 	// HandleParentImageExistence checks the image's parent.
 	// if the parent image does not exist and is not in trash, it returns nil.
 	// if the flattenMode is FlattenModeForce, it flattens the image itself.


### PR DESCRIPTION
ReclaimSpace and EncryptionKeyRotation now use the `Volume` type instead of the (supposed to be) internal `rbdVolume`.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
