### PR TITLE
rbd: use correct radosNamespace

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -608,6 +608,10 @@ func RegenerateJournal(
 	if err != nil {
 		return "", err
 	}
+	rbdVol.RadosNamespace, err = util.GetRBDRadosNamespace(util.CsiConfigFile, rbdVol.ClusterID)
+	if err != nil {
+		return "", err
+	}
 
 	if rbdVol.Pool, ok = volumeAttributes["pool"]; !ok {
 		return "", errors.New("required 'pool' parameter missing in volume attributes")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Issue: When an RBD image is created in a non-default namespace, the OMAP data for the PersistentVolume fails to regenerate because it still attempts to locate the RBD image in the default namespace.

This commit ensures the correct radosNamespace is retrieved from the ceph-csi-config.


- RBD image created in namespace `namespace-a`

```
I0121 09:52:54.042570       1 cluster_mapping.go:157] found new clusterID mapping "rook-ceph" for existing clusterID "rook-ceph"
I0121 09:52:54.045417       1 omap.go:89] got omap values: (pool="replicapool", namespace="", name="csi.volumes.default"): map[]
I0121 09:52:54.058290       1 omap.go:159] set omap keys (pool="replicapool", namespace="", name="csi.volumes.default"): map[csi.volume.pvc-3399dd51-26a1-42f6-8d04-f4d811f2fcf8:c19c8329-00ff-491f-bed3-463ba55b0878])
I0121 09:52:54.065726       1 omap.go:159] set omap keys (pool="replicapool", namespace="", name="csi.volume.c19c8329-00ff-491f-bed3-463ba55b0878"): map[csi.imagename:csi-vol-c19c8329-00ff-491f-bed3-463ba55b0878 csi.volname:pvc-3399dd51-26a1-42f6-8d04-f4d811f2fcf8 csi.volume.encryptKMS:metadata csi.volume.encryptionType: csi.volume.owner:rook-ceph])
I0121 09:52:54.065890       1 rbd_journal.go:699] re-generated Volume ID (0001-0009-rook-ceph-0000000000000006-c19c8329-00ff-491f-bed3-463ba55b0878) and image name (csi-vol-c19c8329-00ff-491f-bed3-463ba55b0878) for request name (pvc-3399dd51-26a1-42f6-8d04-f4d811f2fcf8)
E0121 09:52:54.071402       1 rbd_journal.go:715] failed to get image id replicapool/csi-vol-c19c8329-00ff-491f-bed3-463ba55b0878: Failed as image not found (internal RBD image not found: rbd: ret=-2, No such file or directory)
I0121 09:52:54.083157       1 omap.go:126] removed omap keys (pool="replicapool", namespace="", name="csi.volumes.default"): [csi.volume.pvc-3399dd51-26a1-42f6-8d04-f4d811f2fcf8]
E0121 09:52:54.083328       1 persistentvolume.go:196] failed to regenerate journal Failed as image not found (internal RBD image not found: rbd: ret=-2, No such file or directory)
```

- After the change 
```
I0121 09:56:21.493457       1 cluster_mapping.go:157] found new clusterID mapping "rook-ceph" for existing clusterID "rook-ceph"
I0121 09:56:21.550271       1 omap.go:89] got omap values: (pool="replicapool", namespace="namespace-a", name="csi.volumes.default"): map[]
I0121 09:56:21.566790       1 omap.go:159] set omap keys (pool="replicapool", namespace="namespace-a", name="csi.volumes.default"): map[csi.volume.pvc-3399dd51-26a1-42f6-8d04-f4d811f2fcf8:c19c8329-00ff-491f-bed3-463ba55b0878])
I0121 09:56:21.572828       1 omap.go:159] set omap keys (pool="replicapool", namespace="namespace-a", name="csi.volume.c19c8329-00ff-491f-bed3-463ba55b0878"): map[csi.imagename:csi-vol-c19c8329-00ff-491f-bed3-463ba55b0878 csi.volname:pvc-3399dd51-26a1-42f6-8d04-f4d811f2fcf8 csi.volume.encryptKMS:metadata csi.volume.encryptionType: csi.volume.owner:rook-ceph])
I0121 09:56:21.572987       1 rbd_journal.go:703] re-generated Volume ID (0001-0009-rook-ceph-0000000000000006-c19c8329-00ff-491f-bed3-463ba55b0878) and image name (csi-vol-c19c8329-00ff-491f-bed3-463ba55b0878) for request name (pvc-3399dd51-26a1-42f6-8d04-f4d811f2fcf8)
I0121 09:56:21.620512       1 omap.go:159] set omap keys (pool="replicapool", namespace="namespace-a", name="csi.volume.c19c8329-00ff-491f-bed3-463ba55b0878"): map[csi.imageid:3fc4d40012e0d])
I0121 09:56:21.620569       1 persistentvolume.go:201] volumeHandler changed from 0001-0009-rook-ceph-0000000000000002-c19c8329-00ff-491f-bed3-463ba55b0878 to 0001-0009-rook-ceph-0000000000000006-c19c8329-00ff-491f-bed3-463ba55b0878
```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
