### PR TITLE
rbd: cleanup some parts in the ControllerServer

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -208,7 +208,7 @@ func (cs *ControllerServer) parseVolCreateRequest(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	rbdVol.RequestName = req.GetName()
+	rbdVol.requestName = req.GetName()
 
 	// Volume Size - Default is 1 GiB
 	volSizeBytes := int64(oneGB)
@@ -772,7 +772,11 @@ func (cs *ControllerServer) createBackingImage(
 		}
 	}
 
-	log.DebugLog(ctx, "created image %s backed for request name %s", rbdVol, rbdVol.RequestName)
+	requestName, err := rbdVol.GetRequestName(ctx)
+	if err != nil {
+		requestName = "<unset request name>"
+	}
+	log.DebugLog(ctx, "created image %s backed for request name %s", rbdVol, requestName)
 
 	defer func() {
 		if err != nil {
@@ -884,12 +888,12 @@ func (cs *ControllerServer) checkErrAndUndoReserve(
 	// If error is ErrImageNotFound then we failed to find the image, but found the imageOMap
 	// to lead us to the image, hence the imageOMap needs to be garbage collected, by calling
 	// unreserve for the same
-	if acquired := cs.VolumeLocks.TryAcquire(rbdVol.RequestName); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, rbdVol.RequestName)
+	if acquired := cs.VolumeLocks.TryAcquire(rbdVol.requestName); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, rbdVol.requestName)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, rbdVol.RequestName)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, rbdVol.requestName)
 	}
-	defer cs.VolumeLocks.Release(rbdVol.RequestName)
+	defer cs.VolumeLocks.Release(rbdVol.requestName)
 
 	if err = undoVolReservation(ctx, rbdVol, cr); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -965,12 +969,17 @@ func (cs *ControllerServer) DeleteVolume(
 
 	// lock out parallel create requests against the same volume name as we
 	// clean up the image and associated omaps for the same
-	if acquired := cs.VolumeLocks.TryAcquire(rbdVol.RequestName); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, rbdVol.RequestName)
-
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, rbdVol.RequestName)
+	requestName, err := rbdVol.GetRequestName(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
-	defer cs.VolumeLocks.Release(rbdVol.RequestName)
+
+	if acquired := cs.VolumeLocks.TryAcquire(requestName); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, requestName)
+
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, requestName)
+	}
+	defer cs.VolumeLocks.Release(requestName)
 
 	return cleanupRBDImage(ctx, rbdVol, cr)
 }
@@ -1012,7 +1021,7 @@ func cleanupRBDImage(ctx context.Context,
 		if localStatus.IsUP() && localStatus.GetState() == librbd.MirrorImageStatusStateReplaying.String() {
 			if err = undoVolReservation(ctx, rbdVol, cr); err != nil {
 				log.ErrorLog(ctx, "failed to remove reservation for volume (%s) with backing image (%s) (%s)",
-					rbdVol.RequestName, rbdVol.RbdImageName, err)
+					rbdVol.requestName, rbdVol.RbdImageName, err)
 
 				return nil, status.Error(codes.Internal, err.Error())
 			}
@@ -1057,7 +1066,7 @@ func cleanupRBDImage(ctx context.Context,
 
 	if err = undoVolReservation(ctx, rbdVol, cr); err != nil {
 		log.ErrorLog(ctx, "failed to remove reservation for volume (%s) with backing image (%s) (%s)",
-			rbdVol.RequestName, rbdVol.RbdImageName, err)
+			rbdVol.requestName, rbdVol.RbdImageName, err)
 
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -1146,7 +1155,7 @@ func (cs *ControllerServer) CreateSnapshot(
 	rbdSnap.RbdImageName = rbdVol.RbdImageName
 	rbdSnap.VolSize = rbdVol.VolSize
 	rbdSnap.SourceVolumeID = req.GetSourceVolumeId()
-	rbdSnap.RequestName = req.GetName()
+	rbdSnap.requestName = req.GetName()
 
 	if acquired := cs.SnapshotLocks.TryAcquire(req.GetName()); !acquired {
 		log.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, req.GetName())
@@ -1250,7 +1259,7 @@ func cloneFromSnapshot(
 	if err != nil {
 		uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 		if uErr != nil {
-			log.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.RequestName, uErr)
+			log.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.requestName, uErr)
 		}
 
 		return nil, status.Error(codes.Internal, err.Error())
@@ -1269,7 +1278,7 @@ func cloneFromSnapshot(
 	} else if err != nil {
 		uErr := undoSnapshotCloning(ctx, rbdVol, rbdSnap, vol, cr)
 		if uErr != nil {
-			log.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.RequestName, uErr)
+			log.WarningLog(ctx, "failed undoing reservation of snapshot: %s %v", rbdSnap.requestName, uErr)
 		}
 
 		return nil, status.Error(codes.Internal, err.Error())
@@ -1476,12 +1485,17 @@ func (cs *ControllerServer) DeleteSnapshot(
 
 	// safeguard against parallel create or delete requests against the same
 	// name
-	if acquired := cs.SnapshotLocks.TryAcquire(rbdSnap.RequestName); !acquired {
-		log.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, rbdSnap.RequestName)
-
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, rbdSnap.RequestName)
+	requestName, err := rbdSnap.GetRequestName(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
-	defer cs.SnapshotLocks.Release(rbdSnap.RequestName)
+
+	if acquired := cs.SnapshotLocks.TryAcquire(requestName); !acquired {
+		log.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, requestName)
+
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, requestName)
+	}
+	defer cs.SnapshotLocks.Release(requestName)
 
 	// Deleting snapshot and cloned volume
 	log.DebugLog(ctx, "deleting cloned rbd volume %s", rbdSnap.RbdSnapName)
@@ -1516,7 +1530,7 @@ func cleanUpImageAndSnapReservation(ctx context.Context, rbdSnap *rbdSnapshot, c
 	err = undoSnapReservation(ctx, rbdSnap, cr)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap %q",
-			rbdSnap.RequestName, rbdSnap, err)
+			rbdSnap.requestName, rbdSnap, err)
 
 		return status.Error(codes.Internal, err.Error())
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -276,7 +277,7 @@ func (rbdVol *rbdVolume) ToCSI(ctx context.Context) (*csi.Volume, error) {
 func buildCreateVolumeResponse(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
-	rbdVol *rbdVolume,
+	rbdVol types.Volume,
 ) (*csi.CreateVolumeResponse, error) {
 	volume, err := rbdVol.ToCSI(ctx)
 	if err != nil {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1613,36 +1613,3 @@ func (cs *ControllerServer) ControllerExpandVolume(
 		NodeExpansionRequired: nodeExpansion,
 	}, nil
 }
-
-// ControllerPublishVolume is a dummy publish implementation to mimic a successful attach operation being a NOOP.
-func (cs *ControllerServer) ControllerPublishVolume(
-	ctx context.Context,
-	req *csi.ControllerPublishVolumeRequest,
-) (*csi.ControllerPublishVolumeResponse, error) {
-	if req.GetVolumeId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
-	}
-	if req.GetNodeId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "Node ID cannot be empty")
-	}
-	if req.GetVolumeCapability() == nil {
-		return nil, status.Error(codes.InvalidArgument, "Volume Capabilities cannot be empty")
-	}
-
-	return &csi.ControllerPublishVolumeResponse{
-		// the dummy response carry an empty map in its response.
-		PublishContext: map[string]string{},
-	}, nil
-}
-
-// ControllerUnPublishVolume is a dummy unpublish implementation to mimic a successful attach operation being a NOOP.
-func (cs *ControllerServer) ControllerUnpublishVolume(
-	ctx context.Context,
-	req *csi.ControllerUnpublishVolumeRequest,
-) (*csi.ControllerUnpublishVolumeResponse, error) {
-	if req.GetVolumeId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
-	}
-
-	return &csi.ControllerUnpublishVolumeResponse{}, nil
-}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -957,12 +957,30 @@ func (cs *ControllerServer) DeleteVolume(
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 
-	rbdVol, err := GenVolFromVolID(ctx, volumeID, cr, req.GetSecrets())
-	defer func() {
-		if rbdVol != nil {
-			rbdVol.Destroy(ctx)
+	// secrets can be different for volumes created with in-tree drivers
+	secrets := req.GetSecrets()
+	if util.IsMigrationSecret(secrets) {
+		secrets, err = util.ParseAndSetSecretMapFromMigSecret(secrets)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
 		}
-	}()
+	}
+
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, secrets)
+	defer mgr.Destroy(ctx)
+
+	var rbdVol *rbdVolume
+	vol, err := mgr.GetVolumeByID(ctx, volumeID)
+	if vol != nil {
+		defer vol.Destroy(ctx)
+
+		var ok bool
+		rbdVol, ok = vol.(*rbdVolume) // FIXME: temporary cast until rbdVolume is cleaned up
+		if !ok {
+			// this can never happen, mgr.GetVolumeByID() returns a *rbdVolume on success
+			log.ErrorLog(ctx, "failed to cast %q of type %T to %T", vol, vol, rbdVol)
+		}
+	}
 	if err != nil {
 		return cs.checkErrAndUndoReserve(ctx, err, volumeID, rbdVol, cr)
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1471,7 +1471,7 @@ func (cs *ControllerServer) DeleteSnapshot(
 		if errors.Is(err, ErrImageNotFound) {
 			log.UsefulLog(ctx, "cleaning up leftovers of snapshot %s: %v", snapshotID, err)
 
-			err = cleanUpImageAndSnapReservation(ctx, rbdSnap, cr)
+			err = rbdSnap.Delete(ctx)
 			if err != nil {
 				return nil, status.Error(codes.Internal, err.Error())
 			}
@@ -1508,34 +1508,6 @@ func (cs *ControllerServer) DeleteSnapshot(
 	}
 
 	return &csi.DeleteSnapshotResponse{}, nil
-}
-
-// cleanUpImageAndSnapReservation cleans up the image from the trash and
-// snapshot reservation in rados OMAP.
-func cleanUpImageAndSnapReservation(ctx context.Context, rbdSnap *rbdSnapshot, cr *util.Credentials) error {
-	rbdVol := rbdSnap.toVolume()
-	err := rbdVol.Connect(cr)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	defer rbdVol.Destroy(ctx)
-
-	// cleanup the image from trash if the error is image not found.
-	err = rbdVol.ensureImageCleanup(ctx)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to delete rbd image: %q with error: %v", rbdVol.Pool, rbdVol.VolName, err)
-
-		return status.Error(codes.Internal, err.Error())
-	}
-	err = undoSnapReservation(ctx, rbdSnap, cr)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap %q",
-			rbdSnap.requestName, rbdSnap, err)
-
-		return status.Error(codes.Internal, err.Error())
-	}
-
-	return nil
 }
 
 // ControllerExpandVolume expand RBD Volumes on demand based on resizer request.

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -981,12 +981,12 @@ func (cs *ControllerServer) DeleteVolume(
 	}
 	defer cs.VolumeLocks.Release(requestName)
 
-	return cleanupRBDImage(ctx, rbdVol, cr)
+	return rbdVol.cleanupRBDImage(ctx, cr)
 }
 
 // cleanupRBDImage removes the rbd image and OMAP metadata associated with it.
-func cleanupRBDImage(ctx context.Context,
-	rbdVol *rbdVolume, cr *util.Credentials,
+func (rbdVol *rbdVolume) cleanupRBDImage(ctx context.Context,
+	cr *util.Credentials,
 ) (*csi.DeleteVolumeResponse, error) {
 	info, err := rbdVol.GetMirroringInfo(ctx)
 	if err != nil {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1421,12 +1421,6 @@ func (cs *ControllerServer) DeleteSnapshot(
 		return nil, err
 	}
 
-	cr, err := util.NewUserCredentials(req.GetSecrets())
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	defer cr.DeleteCredentials()
-
 	snapshotID := req.GetSnapshotId()
 	if snapshotID == "" {
 		return nil, status.Error(codes.InvalidArgument, "snapshot ID cannot be empty")
@@ -1440,14 +1434,17 @@ func (cs *ControllerServer) DeleteSnapshot(
 	defer cs.SnapshotLocks.Release(snapshotID)
 
 	// lock out snapshotID for restore operation
-	if err = cs.OperationLocks.GetDeleteLock(snapshotID); err != nil {
+	if err := cs.OperationLocks.GetDeleteLock(snapshotID); err != nil {
 		log.ErrorLog(ctx, err.Error())
 
 		return nil, status.Error(codes.Aborted, err.Error())
 	}
 	defer cs.OperationLocks.ReleaseDeleteLock(snapshotID)
 
-	rbdSnap, err := genSnapFromSnapID(ctx, snapshotID, cr, req.GetSecrets())
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
+	rbdSnap, err := mgr.GetSnapshotByID(ctx, snapshotID)
 	if err != nil {
 		// if error is ErrPoolNotFound, the pool is already deleted we don't
 		// need to worry about deleting snapshot or omap data, return success
@@ -1498,7 +1495,7 @@ func (cs *ControllerServer) DeleteSnapshot(
 	defer cs.SnapshotLocks.Release(requestName)
 
 	// Deleting snapshot and cloned volume
-	log.DebugLog(ctx, "deleting cloned rbd volume %s", rbdSnap.RbdSnapName)
+	log.DebugLog(ctx, "deleting cloned rbd volume %s", rbdSnap)
 
 	err = rbdSnap.Delete(ctx)
 	if err != nil {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -38,7 +38,7 @@ func validateNonEmptyField(field, fieldName, structName string) error {
 func validateRbdSnap(rbdSnap *rbdSnapshot) error {
 	var err error
 
-	if err = validateNonEmptyField(rbdSnap.RequestName, "RequestName", "rbdSnapshot"); err != nil {
+	if err = validateNonEmptyField(rbdSnap.requestName, "RequestName", "rbdSnapshot"); err != nil {
 		return err
 	}
 
@@ -64,7 +64,7 @@ func validateRbdSnap(rbdSnap *rbdSnapshot) error {
 func validateRbdVol(rbdVol *rbdVolume) error {
 	var err error
 
-	if err = validateNonEmptyField(rbdVol.RequestName, "RequestName", "rbdVolume"); err != nil {
+	if err = validateNonEmptyField(rbdVol.requestName, "RequestName", "rbdVolume"); err != nil {
 		return err
 	}
 
@@ -145,7 +145,7 @@ func checkSnapCloneExists(
 	defer j.Destroy()
 
 	snapData, err := j.CheckReservation(ctx, rbdSnap.JournalPool,
-		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdSnap.RbdImageName, "", util.EncryptionTypeNone)
+		rbdSnap.requestName, rbdSnap.NamePrefix, rbdSnap.RbdImageName, "", util.EncryptionTypeNone)
 	if err != nil {
 		return false, err
 	}
@@ -235,7 +235,7 @@ func checkSnapCloneExists(
 	}
 
 	log.DebugLog(ctx, "found existing image (%s) with name (%s) for request (%s)",
-		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
+		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.requestName)
 
 	return true, nil
 }
@@ -269,7 +269,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 	defer j.Destroy()
 
 	imageData, err := j.CheckReservation(
-		ctx, rv.JournalPool, rv.RequestName, rv.NamePrefix, "", kmsID, encryptionType)
+		ctx, rv.JournalPool, rv.requestName, rv.NamePrefix, "", kmsID, encryptionType)
 	if err != nil {
 		return false, err
 	}
@@ -310,7 +310,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 				}
 			}
 			err = j.UndoReservation(ctx, rv.JournalPool, rv.Pool,
-				rv.RbdImageName, rv.RequestName)
+				rv.RbdImageName, rv.requestName)
 
 			return false, err
 		}
@@ -347,7 +347,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 	}
 
 	log.DebugLog(ctx, "found existing volume (%s) with image name (%s) for request (%s)",
-		rv.VolID, rv.RbdImageName, rv.RequestName)
+		rv.VolID, rv.RbdImageName, rv.requestName)
 
 	return true, nil
 }
@@ -415,7 +415,7 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 
 	rbdSnap.ReservedID, rbdSnap.RbdSnapName, err = j.ReserveName(
 		ctx, rbdSnap.JournalPool, journalPoolID, rbdSnap.Pool, imagePoolID,
-		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, kmsID, rbdSnap.ReservedID, rbdVol.Owner,
+		rbdSnap.requestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, kmsID, rbdSnap.ReservedID, rbdVol.Owner,
 		"", encryptionType)
 	defer func() {
 		// only undo the reservation when an error occurred
@@ -439,7 +439,7 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 	}
 
 	log.DebugLog(ctx, "generated Volume ID (%s) and image name (%s) for request name (%s)",
-		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.RequestName)
+		rbdSnap.VolID, rbdSnap.RbdSnapName, rbdSnap.requestName)
 
 	return nil
 }
@@ -501,7 +501,7 @@ func reserveVol(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials) er
 
 	rbdVol.ReservedID, rbdVol.RbdImageName, err = j.ReserveName(
 		ctx, rbdVol.JournalPool, journalPoolID, rbdVol.Pool, imagePoolID,
-		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, rbdVol.ReservedID, rbdVol.Owner, "", encryptionType)
+		rbdVol.requestName, rbdVol.NamePrefix, "", kmsID, rbdVol.ReservedID, rbdVol.Owner, "", encryptionType)
 	if err != nil {
 		return err
 	}
@@ -513,7 +513,7 @@ func reserveVol(ctx context.Context, rbdVol *rbdVolume, cr *util.Credentials) er
 	}
 
 	log.DebugLog(ctx, "generated Volume ID (%s) and image name (%s) for request name (%s)",
-		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.RequestName)
+		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.requestName)
 
 	return nil
 }
@@ -528,7 +528,7 @@ func undoSnapReservation(ctx context.Context, rbdSnap *rbdSnapshot, cr *util.Cre
 
 	err = j.UndoReservation(
 		ctx, rbdSnap.JournalPool, rbdSnap.Pool, rbdSnap.RbdSnapName,
-		rbdSnap.RequestName)
+		rbdSnap.requestName)
 
 	return err
 }
@@ -542,7 +542,7 @@ func undoVolReservation(ctx context.Context, rbdVol *rbdVolume, cr *util.Credent
 	defer j.Destroy()
 
 	err = j.UndoReservation(ctx, rbdVol.JournalPool, rbdVol.Pool,
-		rbdVol.RbdImageName, rbdVol.RequestName)
+		rbdVol.RbdImageName, rbdVol.requestName)
 
 	return err
 }
@@ -636,11 +636,11 @@ func RegenerateJournal(
 		return "", err
 	}
 
-	rbdVol.RequestName = requestName
+	rbdVol.requestName = requestName
 	rbdVol.NamePrefix = volumeAttributes["volumeNamePrefix"]
 
 	imageData, err := j.CheckReservation(
-		ctx, rbdVol.JournalPool, rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, encryptionType)
+		ctx, rbdVol.JournalPool, rbdVol.requestName, rbdVol.NamePrefix, "", kmsID, encryptionType)
 	if err != nil {
 		return "", err
 	}
@@ -680,7 +680,7 @@ func RegenerateJournal(
 
 	rbdVol.ReservedID, rbdVol.RbdImageName, err = j.ReserveName(
 		ctx, rbdVol.JournalPool, journalPoolID, rbdVol.Pool, imagePoolID,
-		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, vi.ObjectUUID, rbdVol.Owner, "", encryptionType)
+		rbdVol.requestName, rbdVol.NamePrefix, "", kmsID, vi.ObjectUUID, rbdVol.Owner, "", encryptionType)
 	if err != nil {
 		return "", err
 	}
@@ -688,7 +688,7 @@ func RegenerateJournal(
 	defer func() {
 		if err != nil {
 			undoErr := j.UndoReservation(ctx, rbdVol.JournalPool, rbdVol.Pool,
-				rbdVol.RbdImageName, rbdVol.RequestName)
+				rbdVol.RbdImageName, rbdVol.requestName)
 			if undoErr != nil {
 				log.ErrorLog(ctx, "failed to undo reservation %s: %v", rbdVol, undoErr)
 			}
@@ -701,7 +701,7 @@ func RegenerateJournal(
 	}
 
 	log.DebugLog(ctx, "re-generated Volume ID (%s) and image name (%s) for request name (%s)",
-		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.RequestName)
+		rbdVol.VolID, rbdVol.RbdImageName, rbdVol.requestName)
 	if rbdVol.ImageID == "" {
 		err = rbdVol.storeImageID(ctx, j)
 		if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -106,10 +106,10 @@ type rbdImage struct {
 	Pool           string
 	RadosNamespace string
 	ClusterID      string `json:"clusterId"`
-	// RequestName is the CSI generated volume name for the rbdVolume.
+	// requestName is the CSI generated volume name for the rbdVolume.
 	// This does not have a JSON tag as it is not stashed in JSON encoded
 	// config maps in v1.0.0
-	RequestName string
+	requestName string
 	ReservedID  string
 	NamePrefix  string
 	// ParentName represents the parent image name of the image.
@@ -415,6 +415,16 @@ func (ri *rbdImage) String() string {
 	}
 
 	return fmt.Sprintf("%s/%s", ri.Pool, ri.RbdImageName)
+}
+
+func (ri *rbdImage) GetRequestName(_ context.Context) (string, error) {
+	var err error
+
+	if ri.requestName == "" {
+		err = fmt.Errorf("rbd image %q does not have a request name", ri)
+	}
+
+	return ri.requestName, err
 }
 
 func (ri *rbdImage) GetPoolName() string {
@@ -1026,7 +1036,7 @@ func genSnapFromSnapID(
 		return rbdSnap, err
 	}
 	rbdSnap.ImageID = imageAttributes.ImageID
-	rbdSnap.RequestName = imageAttributes.RequestName
+	rbdSnap.requestName = imageAttributes.RequestName
 	rbdSnap.RbdImageName = imageAttributes.SourceName
 	rbdSnap.RbdSnapName = imageAttributes.ImageName
 	rbdSnap.ReservedID = vi.ObjectUUID
@@ -1156,7 +1166,7 @@ func generateVolumeFromVolumeID(
 	if err != nil {
 		return rbdVol, err
 	}
-	rbdVol.RequestName = imageAttributes.RequestName
+	rbdVol.requestName = imageAttributes.RequestName
 	rbdVol.RbdImageName = imageAttributes.ImageName
 	rbdVol.ReservedID = vi.ObjectUUID
 	rbdVol.ImageID = imageAttributes.ImageID

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -190,7 +190,7 @@ func (rbdSnap *rbdSnapshot) Delete(ctx context.Context) error {
 	err = undoSnapReservation(ctx, rbdSnap, rbdSnap.conn.Creds)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) on image (%s) (%s)",
-			rbdSnap.RequestName, rbdSnap.RbdSnapName, rbdSnap.RbdImageName, err)
+			rbdSnap.requestName, rbdSnap.RbdSnapName, rbdSnap.RbdImageName, err)
 
 		return err
 	}
@@ -235,7 +235,7 @@ func (rv *rbdVolume) NewSnapshotByID(
 	id uint64,
 ) (types.Snapshot, error) {
 	snap := rv.toSnapshot()
-	snap.RequestName = name
+	snap.requestName = name
 
 	srcVolID, err := rv.GetID(ctx)
 	if err != nil {

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -177,6 +177,14 @@ func (rbdSnap *rbdSnapshot) Delete(ctx context.Context) error {
 	}
 	defer rbdVol.Destroy(ctx)
 
+	// cleanup the image from trash if the error is image not found.
+	err = rbdVol.ensureImageCleanup(ctx)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to delete rbd image %q: %v", rbdVol, err)
+
+		return err
+	}
+
 	rbdVol.ImageID = rbdSnap.ImageID
 	// update parent name to delete the snapshot
 	rbdSnap.RbdImageName = rbdVol.RbdImageName

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -29,6 +29,9 @@ type journalledObject interface {
 	// GetID returns the ID in the backend storage for the object.
 	GetID(ctx context.Context) (string, error)
 
+	// GetRequestName returns the requestName of the VolumeGroup.
+	GetRequestName(ctx context.Context) (string, error)
+
 	// GetName returns the name of the object in the backend storage.
 	GetName(ctx context.Context) (string, error)
 

--- a/internal/util/credentials.go
+++ b/internal/util/credentials.go
@@ -135,7 +135,7 @@ func GetMonValFromSecret(secrets map[string]string) (string, error) {
 func ParseAndSetSecretMapFromMigSecret(secretmap map[string]string) (map[string]string, error) {
 	newSecretMap := make(map[string]string)
 	// parse and set userKey
-	if !isMigrationSecret(secretmap) {
+	if !IsMigrationSecret(secretmap) {
 		return nil, errors.New("passed secret map does not contain user key or it is nil")
 	}
 	newSecretMap[credUserKey] = secretmap[migUserKey]
@@ -148,11 +148,11 @@ func ParseAndSetSecretMapFromMigSecret(secretmap map[string]string) (map[string]
 	return newSecretMap, nil
 }
 
-// isMigrationSecret validates if the passed in secretmap is a secret
+// IsMigrationSecret validates if the passed in secretmap is a secret
 // of a migration volume request. The migration secret carry a field
 // called `key` which is the equivalent of `userKey` which is what we
 // check here for identifying the secret.
-func isMigrationSecret(secrets map[string]string) bool {
+func IsMigrationSecret(secrets map[string]string) bool {
 	// the below 'nil' check is an extra measure as the request validators like
 	// ValidateNodeStageVolumeRequest() already does the nil check, however considering
 	// this function can be called independently with a map of secret values
@@ -166,7 +166,7 @@ func isMigrationSecret(secrets map[string]string) bool {
 // secret. If it is not a migration it will continue the attempt to create credentials from it
 // without parsing the secret. This function returns credentials and error.
 func NewUserCredentialsWithMigration(secrets map[string]string) (*Credentials, error) {
-	if isMigrationSecret(secrets) {
+	if IsMigrationSecret(secrets) {
 		migSecret, err := ParseAndSetSecretMapFromMigSecret(secrets)
 		if err != nil {
 			return nil, err

--- a/internal/util/credentials_test.go
+++ b/internal/util/credentials_test.go
@@ -41,8 +41,8 @@ func TestIsMigrationSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := isMigrationSecret(tt.vc); got != tt.want {
-				t.Errorf("isMigrationSecret() = %v, want %v", got, tt.want)
+			if got := IsMigrationSecret(tt.vc); got != tt.want {
+				t.Errorf("IsMigrationSecret() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Miscellaneous cleanups. This should help in restructuring the rbd package with cleaner APIs. Eventually the `rbdImage`, `rbdVolume` and `rbdSnapshot` types should be used as a interface/type similar to `VolumeGroup` provided by the `internal/rbd/group` package.

1. remove unused ControllerPublishVolume and ControllerUnpublishVolume

> The RBD ControllerService does not expose the `PUBLISH_UNPUBLISH_VOLUME`
> capability, so ControllerPublishVolume and ControllerUnpublishVolume
> will never get called.

2. move `cleanUpImageAndSnapReservation()` into `rbdSnapshot.Delete()`

3. make `RequestName` internal to `rbdVolume`

4. use `rbd.Manager` within `ControllerServer.DeleteVolume()` and `ControllerServer.DeleteSnapshot()`

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
