### PR TITLE
doc: Removes Helm 2 related documentation

### DIFF
--- a/charts/ceph-csi-cephfs/README.md
+++ b/charts/ceph-csi-cephfs/README.md
@@ -22,27 +22,19 @@ cd charts
 
 ### Install Chart
 
-To install the Chart into your Kubernetes cluster
+To install the Chart into your Kubernetes cluster(For helm 3.x):
 
-- For helm 2.x
+Create the namespace where Helm should install the components with
 
-    ```bash
-    helm install --namespace "ceph-csi-cephfs" --name "ceph-csi-cephfs" ceph-csi/ceph-csi-cephfs
-    ```
+```bash
+kubectl create namespace ceph-csi-cephfs
+```
 
-- For helm 3.x
+Run the installation
 
-    Create the namespace where Helm should install the components with
-
-    ```bash
-    kubectl create namespace ceph-csi-cephfs
-    ```
-
-    Run the installation
-
-    ```bash
-    helm install --namespace "ceph-csi-cephfs" "ceph-csi-cephfs" ceph-csi/ceph-csi-cephfs
-    ```
+```bash
+helm install --namespace "ceph-csi-cephfs" "ceph-csi-cephfs" ceph-csi/ceph-csi-cephfs
+```
 
 After installation succeeds, you can get a status of Chart
 
@@ -111,17 +103,9 @@ permissions will be granted globally via a *ClusterRole*.
 
 If you want to delete your Chart, use this command
 
-- For helm 2.x
-
-    ```bash
-    helm delete --purge "ceph-csi-cephfs"
-    ```
-
-- For helm 3.x
-
-    ```bash
-    helm uninstall "ceph-csi-cephfs" --namespace "ceph-csi-cephfs"
-    ```
+```bash
+helm uninstall "ceph-csi-cephfs" --namespace "ceph-csi-cephfs"
+```
 
 If you want to delete the namespace, use this command
 

--- a/charts/ceph-csi-rbd/README.md
+++ b/charts/ceph-csi-rbd/README.md
@@ -22,27 +22,19 @@ cd charts
 
 ### Install chart
 
-To install the Chart into your Kubernetes cluster
+To install the Chart into your Kubernetes cluster(For helm 3.x):
 
-- For helm 2.x
+Create the namespace where Helm should install the components with
 
-    ```bash
-    helm install --namespace "ceph-csi-rbd" --name "ceph-csi-rbd" ceph-csi/ceph-csi-rbd
-    ```
+```bash
+kubectl create namespace "ceph-csi-rbd"
+```
 
-- For helm 3.x
+Run the installation
 
-    Create the namespace where Helm should install the components with
-
-    ```bash
-    kubectl create namespace "ceph-csi-rbd"
-    ```
-
-    Run the installation
-
-    ```bash
-    helm install --namespace "ceph-csi-rbd" "ceph-csi-rbd" ceph-csi/ceph-csi-rbd
-    ```
+```bash
+helm install --namespace "ceph-csi-rbd" "ceph-csi-rbd" ceph-csi/ceph-csi-rbd
+```
 
 After installation succeeds, you can get a status of Chart
 
@@ -84,17 +76,9 @@ compare your currently used values with the new default values.
 
 If you want to delete your Chart, use this command
 
-- For helm 2.x
-
-    ```bash
-    helm delete --purge "ceph-csi-rbd"
-    ```
-
-- For helm 3.x
-
-    ```bash
-    helm uninstall "ceph-csi-rbd" --namespace "ceph-csi-rbd"
-    ```
+```bash
+helm uninstall "ceph-csi-rbd" --namespace "ceph-csi-rbd"
+```
 
 If you want to delete the namespace, use this command
 


### PR DESCRIPTION
The documentation has been updated to reflect the deprecation of Helm v2.
https://helm.sh/blog/helm-v2-deprecation-timeline/ 

Fixes: #5003 
