### PR TITLE
rbd: log formatting and go-ceph deprecation in `constructImageOptions`

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1586,7 +1586,7 @@ func (rv *rbdVolume) constructImageOptions(ctx context.Context) (*librbd.ImageOp
 
 	logMsg := fmt.Sprintf("setting image options on %s", rv)
 	if rv.DataPool != "" {
-		logMsg += ", data pool %s" + rv.DataPool
+		logMsg += ", data pool " + rv.DataPool
 		err = options.SetString(librbd.RbdImageOptionDataPool, rv.DataPool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set data pool: %w", err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1587,14 +1587,14 @@ func (rv *rbdVolume) constructImageOptions(ctx context.Context) (*librbd.ImageOp
 	logMsg := fmt.Sprintf("setting image options on %s", rv)
 	if rv.DataPool != "" {
 		logMsg += ", data pool " + rv.DataPool
-		err = options.SetString(librbd.RbdImageOptionDataPool, rv.DataPool)
+		err = options.SetString(librbd.ImageOptionDataPool, rv.DataPool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set data pool: %w", err)
 		}
 	}
 
 	if rv.ImageFeatureSet != 0 {
-		err = options.SetUint64(librbd.RbdImageOptionFeatures, uint64(rv.ImageFeatureSet))
+		err = options.SetUint64(librbd.ImageOptionFeatures, uint64(rv.ImageFeatureSet))
 		if err != nil {
 			return nil, fmt.Errorf("failed to set image features: %w", err)
 		}
@@ -1602,11 +1602,11 @@ func (rv *rbdVolume) constructImageOptions(ctx context.Context) (*librbd.ImageOp
 
 	if rv.StripeCount != 0 {
 		logMsg += fmt.Sprintf(", stripe count %d, stripe unit %d", rv.StripeCount, rv.StripeUnit)
-		err = options.SetUint64(librbd.RbdImageOptionStripeCount, rv.StripeCount)
+		err = options.SetUint64(librbd.ImageOptionStripeCount, rv.StripeCount)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set stripe count: %w", err)
 		}
-		err = options.SetUint64(librbd.RbdImageOptionStripeUnit, rv.StripeUnit)
+		err = options.SetUint64(librbd.ImageOptionStripeUnit, rv.StripeUnit)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set stripe unit: %w", err)
 		}
@@ -1615,7 +1615,7 @@ func (rv *rbdVolume) constructImageOptions(ctx context.Context) (*librbd.ImageOp
 	if rv.ObjectSize != 0 {
 		order := uint64(math.Log2(float64(rv.ObjectSize)))
 		logMsg += fmt.Sprintf(", object size %d, order %d", rv.ObjectSize, order)
-		err = options.SetUint64(librbd.RbdImageOptionOrder, order)
+		err = options.SetUint64(librbd.ImageOptionOrder, order)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set object size: %w", err)
 		}


### PR DESCRIPTION
When a `dataPool` is passed while creating a volume, there is a
`%!s(MISSING)` piece added to a debug log message. By using
`fmt.Sprintf()` instead of concatinating the string, this should be gone
now.

go-ceph also deprecated `Rbd` prefix from go-ceph `rbd.ImageOption*`
long ago, so we should not use those anymore.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
