### PR TITLE
Proper support for caching helm chart from Artifactory.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -84,7 +84,7 @@ push_helm_charts() {
 	popd >/dev/null
 
 	pushd "${CHARTDIR}/csi-charts/docs" >/dev/null
-	helm repo index .
+	helm repo index . --url "https://ceph.github.io/csi-charts/"
 	git config user.name "${GITHUB_USER}"
 	git config user.email "${GITHUB_EMAIL}"
 	git add --all :/ && git commit -m "Update for helm charts ${PACKAGE}-${VERSION}"


### PR DESCRIPTION
Currently helm index of ceph helm repository configures URLs to charts with relative path (see https://ceph.github.io/csi-charts/index.yaml).

Artifactory contains support for virtual repositories. Virtual repositories are able to cache remote repositories and provide offline access to those repositories.

In order for this to work correctly, charts must specify absolute base URL to artifacts.

This commit adds this base URL using argument for helm index command.

URL with previous approach:
```yaml
    urls:
    - cephfs/ceph-csi-cephfs-3.13.0.tgz
```

URL with current approach (my personal "lirt" repo was used to test this, the MR specifies correct "ceph" path)
```yaml
    urls:
    - https://lirt.github.io/csi-charts/cephfs/ceph-csi-cephfs-3.13.0.tgz
```

## Is there anything that requires special attention ##

This change is backwards compatible.

You can try following commands that suggest the path is the same as previously and work with original repo and updated repo as well. Of course the MR specifies `ceph.` prefix.
```bash
helm pull https://lirt.github.io/csi-charts/cephfs/ceph-csi-cephfs-3.13.0.tgz
helm pull https://ceph.github.io/csi-charts/cephfs/ceph-csi-cephfs-3.13.0.tgz
```
**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.