### PR TITLE
rbd: fix encrypted PVC with metadata KMS cannot be deleted

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -11,5 +11,6 @@
   value [PR](https://github.com/ceph/ceph-csi/pull/4887)
 - cephfs: support omap data store in radosnamespace [PR](https://github.com/ceph/ceph-csi/pull/4661)
 - helm: Support setting nodepluigin and provisioner annotations
+- rbd: fix encrypted PVC with metadata KMS cannot be deleted
 
 ## NOTE

--- a/internal/kms/dummy.go
+++ b/internal/kms/dummy.go
@@ -54,8 +54,11 @@ func newDefaultTestDummy() EncryptionKMS {
 
 func newSecretsMetadataTestDummy() EncryptionKMS {
 	smKMS := secretsMetadataKMS{}
-	smKMS.secretsKMS = secretsKMS{passphrase: base64.URLEncoding.EncodeToString(
-		[]byte("test dummy passphrase"))}
+	smKMS.Secrets = map[string]string{
+		encryptionPassphraseKey: "test dummy passphrase",
+	}
+	smKMS.Tenant = "tenant"
+	smKMS.Config = nil
 
 	return smKMS
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Creating an encrypted Persistent Volume Claim with reclaim policy Retain, the Persistent Volume cannot be deleted after the Namespace with the corresponding secret of the encrypted volume was deleted.

```
CSI DeleteVolume Request -> calls GenVolFromVolID -> calls generateVolumeFromVolumeID -> calls rbdVol.configureBlockEncryption which initiates the metadata kms provider
```

This fix moves the logic from the kms class initialization to the method where the encryption key is needed.
As the Delete Volume CSI request does not need or call the `FetchDEK` method, the volume get's deleted successfully.


## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?


## Related issues ##

Fixes: #5148 



**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
