### PR TITLE
build: the Fedora container image is now maintained at quay.io

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -8,7 +8,7 @@
 # little different.
 #
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM quay.io/fedora/fedora:latest
 
 ARG GOPATH=/go
 ARG GOROOT=/usr/local/go


### PR DESCRIPTION
The registry.fedoraproject.org site now redirect to
https://quay.io/organization/fedora, so fetch the image from Quay
directly.