### PR TITLE
RBD: retain temp snap

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -185,6 +185,20 @@ func createORDeleteRbdResources(action kubectlAction) {
 	}
 }
 
+func validateRBDSnapshotCount(f *framework.Framework, count int, pool, image string) error {
+	snapshotList, err := listRBDSnapshots(f, pool, image)
+	if err != nil {
+		return fmt.Errorf("failed to list RBD snapshots: %w", err)
+	}
+	if len(snapshotList) != count {
+		return fmt.Errorf("RBD snapshots count not matching, snapshot count for image %s/%s %d, expected %d"+
+			"snapshots in cluster: %v",
+			pool, image, len(snapshotList), count, snapshotList)
+	}
+
+	return nil
+}
+
 func validateRBDImageCount(f *framework.Framework, count int, pool string) {
 	imageList, err := listRBDImages(f, pool)
 	if err != nil {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -248,6 +248,17 @@ type imageInfoFromPVC struct {
 	pvName          string
 }
 
+type snapInfo struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Size      int64  `json:"size"`
+	Protected string `json:"protected"`
+}
+
+func (s snapInfo) String() string {
+	return fmt.Sprintf("{id: %d, name: %s, protected: %s}", s.ID, s.Name, s.Protected)
+}
+
 // getImageInfoFromPVC reads volume handle of the bound PV to the passed in PVC,
 // and returns imageInfoFromPVC or error.
 func getImageInfoFromPVC(pvcNamespace, pvcName string, f *framework.Framework) (imageInfoFromPVC, error) {
@@ -713,6 +724,25 @@ func librbdSupportsVolumeGroupSnapshot(f *framework.Framework) (bool, error) {
 	}
 
 	return strings.TrimSpace(stdout) == "0", nil
+}
+
+func listRBDSnapshots(f *framework.Framework, pool, image string) ([]snapInfo, error) {
+	var snapInfos []snapInfo
+	command := fmt.Sprintf("rbd snap ls --format=json %s %s", rbdOptions(pool), image)
+	stdout, stdErr, err := execCommandInToolBoxPod(f, command, rookNamespace)
+	if err != nil {
+		return snapInfos, err
+	}
+	if stdErr != "" {
+		return snapInfos, fmt.Errorf("failed to list RBD snapshots %v", stdErr)
+	}
+
+	err = json.Unmarshal([]byte(stdout), &snapInfos)
+	if err != nil {
+		return snapInfos, err
+	}
+
+	return snapInfos, nil
 }
 
 func listRBDImages(f *framework.Framework, pool string) ([]string, error) {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1003,6 +1003,16 @@ func validatePVCClone(
 			if wgErrs[n] == nil && validatePVC != nil && kms != noKMS {
 				wgErrs[n] = validatePVC(f, &p, &a)
 			}
+			if wgErrs[n] == nil {
+				// validate RBD snapshot under temporary clone is not deleted.
+				imageData, imageInfoerr := getImageInfoFromPVC(p.Namespace, name, f)
+				if imageInfoerr != nil {
+					wgErrs[n] = imageInfoerr
+				} else {
+					tempRBDImageName := imageData.imageName + "-temp"
+					wgErrs[n] = validateRBDSnapshotCount(f, 1, defaultRBDPool, tempRBDImageName)
+				}
+			}
 			wg.Done()
 		}(i, *pvcClone, *appClone)
 	}

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -34,13 +34,11 @@ import (
 // checkCloneImage check the cloned image exists, if the cloned image is not
 // found it will check the temporary cloned snapshot exists, and again it will
 // check the snapshot exists on the temporary cloned image, if yes it will
-// create a new cloned and delete the temporary snapshot and adds a task to
-// flatten the temp cloned image and return success.
+// create a new cloned and adds a task to flatten the temp cloned image and return success.
 //
 // if the temporary snapshot does not exists it creates a temporary snapshot on
 // temporary cloned image and creates  a new cloned with user-provided image
-// features and delete the temporary snapshot and adds a task to flatten the
-// temp cloned image and return success
+// features and adds a task to flatten the temp cloned image and return success
 //
 // if the temporary clone does not exist and if there is a temporary snapshot
 // present on the parent image it will delete the temporary snapshot and
@@ -59,9 +57,9 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrSnapNotFound):
-			// as the snapshot is not present, create new snapshot,clone and
-			// delete the temporary snapshot
-			err = createRBDClone(ctx, tempClone, rv, snap)
+			// as the snapshot is not present, create new snapshot, clone and
+			// don't delete the temporary snapshot
+			err = createRBDClone(ctx, tempClone, rv, snap, false)
 			if err != nil {
 				return false, err
 			}
@@ -97,12 +95,6 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 	if err != nil {
 		log.ErrorLog(ctx, "failed to clone rbd image %s from snapshot %s: %v", rv.RbdImageName, snap.RbdSnapName, err)
 		err = fmt.Errorf("failed to clone rbd image %s from snapshot %s: %w", rv.RbdImageName, snap.RbdSnapName, err)
-
-		return false, err
-	}
-	err = tempClone.deleteSnapshot(ctx, snap)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to delete snapshot: %v", err)
 
 		return false, err
 	}
@@ -207,7 +199,7 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 	cloneSnap.Pool = rv.Pool
 
 	// create snapshot and temporary clone and delete snapshot
-	err := createRBDClone(ctx, parentVol, tempClone, tempSnap)
+	err := createRBDClone(ctx, parentVol, tempClone, tempSnap, true)
 	if err != nil {
 		return err
 	}
@@ -238,8 +230,8 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 
 	// create snap of temp clone from temporary cloned image
 	// create final clone
-	// delete snap of temp clone
-	errClone = createRBDClone(ctx, tempClone, rv, cloneSnap)
+	// don't delete snap of temp clone (needed for mirroring of PVC-PVC clone).
+	errClone = createRBDClone(ctx, tempClone, rv, cloneSnap, false)
 	if errClone != nil {
 		return errClone
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1388,7 +1388,8 @@ func (cs *ControllerServer) doSnapshotClone(
 		return cloneRbd, err
 	}
 
-	err = createRBDClone(ctx, parentVol, cloneRbd, rbdSnap)
+	// create snapshot, clone and delete snapshot
+	err = createRBDClone(ctx, parentVol, cloneRbd, rbdSnap, true)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to create snapshot: %v", err)
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -750,7 +750,21 @@ func (ri *rbdImage) trashRemoveImage(ctx context.Context) error {
 // DeleteTempImage deletes the temporary image created for volume datasource.
 func (rv *rbdVolume) DeleteTempImage(ctx context.Context) error {
 	tempClone := rv.generateTempClone()
-	err := tempClone.Delete(ctx)
+	snap := &rbdSnapshot{}
+	defer snap.Destroy(ctx)
+
+	snap.RbdImageName = tempClone.RbdImageName
+	snap.RbdSnapName = rv.RbdImageName
+	snap.Pool = rv.Pool
+	snap.RadosNamespace = rv.RadosNamespace
+	err := tempClone.deleteSnapshot(ctx, snap)
+	if err != nil {
+		if !errors.Is(err, util.ErrImageNotFound) && !errors.Is(err, ErrSnapNotFound) {
+			return fmt.Errorf("failed to delete snapshot %q: %w", snap, err)
+		}
+	}
+
+	err = tempClone.Delete(ctx)
 	if err != nil {
 		if errors.Is(err, util.ErrImageNotFound) {
 			return tempClone.ensureImageCleanup(ctx)

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -29,10 +29,14 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
+// createRBDClone creates a clone of the parentVol by creating a
+// snapshot of the parentVol and cloning the snapshot to the cloneRbdVol.
+// If deleteSnap is true, the snapshot is deleted after the clone is created.
 func createRBDClone(
 	ctx context.Context,
 	parentVol, cloneRbdVol *rbdVolume,
 	snap *rbdSnapshot,
+	deleteSnap bool,
 ) error {
 	// create snapshot
 	err := parentVol.createSnapshot(ctx, snap)
@@ -58,6 +62,10 @@ func createRBDClone(
 			snap.RbdSnapName,
 			err)
 	}
+	if !deleteSnap {
+		return nil
+	}
+
 	errSnap := parentVol.deleteSnapshot(ctx, snap)
 	if errSnap != nil {
 		log.ErrorLog(ctx, "failed to delete snapshot: %v", errSnap)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Currently, Ceph-CSI deletes RBD snapshot on temporary
cloned image (`csi-vol-xxxx-temp@csi-vol-xxxx`) which is
the parent of the final clone image.

The parent-child mirroring requires both the parent and child
images to be present (i.e, not in trash).

This commit makes enhancement to `createRBDClone` function by
introducing `deleteSnap` parameter. If `deleteSnap` is true,
the snapshot is deleted after the clone is created.

This is required to support mirroring of child image with its
parent image.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
