### PR TITLE
ci: downgrade Rook to v1.14.9

### DIFF
--- a/build.env
+++ b/build.env
@@ -49,7 +49,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.16.4
+ROOK_VERSION=v1.14.9
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v19
 


### PR DESCRIPTION
Many CI jobs fail with weird errors, including:

- `failed to validate CephFS pvc and application binding: failed to get app: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline`
- `runtime: failed to create new OS thread (have 10 already; errno=11)`
- `timeout waiting for deployment csi-cephfs-demo-depl: error waiting for deployment "csi-cephfs-demo-depl" status to match desired state: deployment status: `
- `failed to verify readAffinity: failed to create application: failed to get app: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline`

This PR has been created to check if updates to certain components contribute to the increased occurrence of problems.