### PR TITLE
ci: run upgrade tests with Kubernetes 1.32

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.28'
+    k8s_version: '1.32'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
# Describe what this PR does #

The call to `./scripts/get_patch_release.py --version=1.28` returns an error. Kubernetes 1.28 is really old, so it is good to move to v1.32 now.

similar to https://github.com/ceph/ceph-csi/pull/5085

failure example:
- https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/organizations/jenkins/upgrade-tests-rbd/detail/upgrade-tests-rbd/8502/pipeline/
- https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/organizations/jenkins/upgrade-tests-cephfs/detail/upgrade-tests-cephfs/8522/pipeline/

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
