### PR TITLE
ci: update CSI_UPGRADE_VERSION to v3.13.1

### DIFF
--- a/build.env
+++ b/build.env
@@ -12,7 +12,7 @@
 CSI_IMAGE_VERSION=canary
 
 # cephcsi upgrade version
-CSI_UPGRADE_VERSION=v3.12.1
+CSI_UPGRADE_VERSION=v3.13.1
 
 # Ceph version to use
 BASE_IMAGE=quay.io/ceph/ceph:v19


### PR DESCRIPTION
ci: update CSI_UPGRADE_VERSION to v3.13.1

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
