### PR TITLE
rbd: add one depth for softlimit of snapshot for restore PVC

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2255,8 +2255,9 @@ func (rv *rbdVolume) PrepareVolumeForSnapshot(ctx context.Context, cr *util.Cred
 		return err
 	}
 
-	// choosing 2, since snapshot adds one depth and we'll be flattening the parent.
-	const depthToAvoidFlatten = 2
+	// choosing 3, since snapshot adds one depth, restore pvc will add one in future
+	// and we'll be flattening the parent.
+	const depthToAvoidFlatten = 3
 	if rbdHardMaxCloneDepth > depthToAvoidFlatten {
 		hardLimit = rbdHardMaxCloneDepth - depthToAvoidFlatten
 	}


### PR DESCRIPTION
# Describe what this PR does #

Currently, while preparing a volume for snapshot,
the depthToAvoidFlatten is set to 2. This accounts one for snapshot and another since parent of the volume is being flattened.
This commit modifies the depth to 3 to also account for future PVC restore since
- snapshot alone is useless and it is very likely to be restored at one point in time.
- this ensures snapshot is not flattened when restore does occur.
- flattening of snapshot in the above case will make the snapshot no longer eligible for changed block tracking(snap diff) operation.
- maintain similarity with PVC-PVC clone operation which currently depthToAvoidFlatten set to 3. 

https://github.com/ceph/ceph-csi/blob/a81dc2cbad01fc67d02748cf004a61748103ae8d/internal/rbd/controllerserver.go#L480-L493

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
