### PR TITLE
rbd: use pre-existing volume group if content matches

### DIFF
--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -89,7 +89,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 	defer mgr.Destroy(ctx)
 
 	// resolve all volumes
-	volumes := make([]types.Volume, len(req.GetVolumeIds()))
+	volumes := make([]types.Volume, 0)
 	defer func() {
 		for _, vol := range volumes {
 			vol.Destroy(ctx)
@@ -105,7 +105,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 				req.GetName(),
 				err.Error())
 		}
-		volumes[i] = vol
+		volumes = append(volumes, vol)
 	}
 
 	log.DebugLog(ctx, "all %d Volumes for VolumeGroup %q have been found", len(volumes), req.GetName())

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -76,15 +76,26 @@ func (vs *VolumeGroupServer) RegisterService(server grpc.ServiceRegistrar) {
 //
 // Implementation steps:
 // 1. resolve all volumes given in the volume_ids list (can be empty)
-// 2. create the Volume Group
-// 3. add all volumes to the Volume Group
+// 2. check if the volumes belong to a (and all the same) group
+// 3. create the Volume Group
+// 4. verify that the Volume Group contains all the images (if it pre-exists)
+// 5. add all volumes to the Volume Group
 //
 // Idempotency should be handled by the rbd.Manager, keeping this function and
 // the potential error handling as simple as possible.
+//
+//nolint:gocyclo,cyclop // FIXME: make this function simpler
 func (vs *VolumeGroupServer) CreateVolumeGroup(
 	ctx context.Context,
 	req *volumegroup.CreateVolumeGroupRequest,
 ) (*volumegroup.CreateVolumeGroupResponse, error) {
+	var (
+		err       error
+		vgHandle  string
+		vg        types.VolumeGroup
+		groupName = req.GetName()
+	)
+
 	mgr := rbd.NewManager(vs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
@@ -102,62 +113,137 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 				codes.InvalidArgument,
 				"failed to find required volume %q for volume group %q: %s",
 				id,
-				req.GetName(),
+				groupName,
 				err.Error())
 		}
 		volumes = append(volumes, vol)
-	}
 
-	log.DebugLog(ctx, "all %d Volumes for VolumeGroup %q have been found", len(volumes), req.GetName())
+		// only resolve vgHandle the 1st time
+		if i != 0 {
+			continue
+		}
 
-	// create a RBDVolumeGroup
-	vg, err := mgr.CreateVolumeGroup(ctx, req.GetName())
-	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to create volume group %q: %s",
-			req.GetName(),
-			err.Error())
-	}
-
-	log.DebugLog(ctx, "VolumeGroup %q has been created: %+v", req.GetName(), vg)
-
-	// extract the flatten mode
-	flattenMode, err := getFlattenMode(ctx, req.GetParameters())
-	if err != nil {
-		return nil, err
-	}
-	// Flatten the image if the flatten mode is set to FlattenModeForce
-	// before adding it to the volume group.
-	for _, v := range volumes {
-		err = v.HandleParentImageExistence(ctx, flattenMode)
-		if err != nil {
-			err = fmt.Errorf("failed to handle parent image for volume group %q: %w", vg, err)
-
-			return nil, getGRPCError(err)
+		// reuse the existing group, it contains the volumes already
+		// check for pre-existing volume group name
+		vgHandle, err = vol.GetVolumeGroupID(ctx, mgr)
+		if err != nil && !errors.Is(err, rbderrors.ErrGroupNotFound) {
+			return nil, status.Errorf(
+				codes.Internal,
+				"could not get name of group for volume %q: %v",
+				volumes[0],
+				err)
 		}
 	}
-	// add each rbd-image to the RBDVolumeGroup
-	for _, vol := range volumes {
-		err = vg.AddVolume(ctx, vol)
+
+	log.DebugLog(ctx, "all %d Volumes for VolumeGroup %q have been found", len(volumes), groupName)
+
+	// verify that the volumes are not in a group yet
+	// if one volume is in a group, all other volumes need to be in the same group
+	if groupMatches, err := mgr.VolumesInSameGroup(ctx, volumes); !groupMatches || err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"not all volumes belong to the same group: %v",
+			err)
+	}
+
+	if vgHandle == "" {
+		// create a RBDVolumeGroup
+		vg, err = mgr.CreateVolumeGroup(ctx, groupName)
 		if err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
-				"failed to add volume %q to volume group %q: %s",
-				vol,
-				req.GetName(),
+				"failed to create volume group %q: %s",
+				groupName,
 				err.Error())
 		}
+
+		log.DebugLog(ctx, "volume group %q has been created: %+v", groupName, vg)
+	} else {
+		vg, err = mgr.GetVolumeGroupByID(ctx, vgHandle)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"failed to get volume group with id %q: %s",
+				vgHandle,
+				err.Error())
+		}
+
+		groupName, err = vg.GetName(ctx)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"failed to get name of volume group %q: %s",
+				vg,
+				err.Error())
+		}
+
+		log.DebugLog(ctx, "existing volume group %q has been resolved: %+v", groupName, vg)
 	}
 
-	log.DebugLog(ctx, "all %d Volumes have been added to for VolumeGroup %q", len(volumes), req.GetName())
+	// TODO: check the number of volumes in the vg, it needs to be empty, or match len(volumes)
+	matches, err := mgr.CompareVolumesInGroup(ctx, volumes, vg)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to compare %d volumes with volume group %q: %s",
+			len(volumes),
+			groupName,
+			err.Error())
+	} else if !matches {
+		return nil, status.Errorf(
+			codes.Internal,
+			"volume group %q does not match with requested volumes",
+			groupName)
+	}
+
+	vols, err := vg.ListVolumes(ctx)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to list volumes of volume group %q: %s",
+			vg,
+			err.Error())
+	} else if len(vols) == 0 {
+		// need to add the volumes to the group
+
+		// extract the flatten mode
+		var flattenMode types.FlattenMode
+		flattenMode, err = getFlattenMode(ctx, req.GetParameters())
+		if err != nil {
+			return nil, err
+		}
+		// Flatten the image if the flatten mode is set to FlattenModeForce
+		// before adding it to the volume group.
+		for _, v := range volumes {
+			err = v.HandleParentImageExistence(ctx, flattenMode)
+			if err != nil {
+				err = fmt.Errorf("failed to handle parent image for volume group %q: %w", vg, err)
+
+				return nil, getGRPCError(err)
+			}
+		}
+		// add each rbd-image to the RBDVolumeGroup
+		for _, vol := range volumes {
+			err = vg.AddVolume(ctx, vol)
+			if err != nil {
+				return nil, status.Errorf(
+					codes.Internal,
+					"failed to add volume %q to volume group %q: %s",
+					vol,
+					groupName,
+					err.Error())
+			}
+		}
+
+		log.DebugLog(ctx, "all %d Volumes have been added to for volume group %q", len(volumes), vg)
+	}
 
 	csiVG, err := vg.ToCSI(ctx)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to convert volume group %q to CSI type: %s",
-			req.GetName(),
+			groupName,
 			err.Error())
 	}
 

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ceph/ceph-csi/internal/util"
@@ -164,6 +165,28 @@ func generateVolumeGroupName(namePrefix, groupUUID string) string {
 	}
 
 	return namePrefix + groupUUID
+}
+
+// MakeVolumeGroupID is a utility function that takes details of a VolumeGroup
+// and creates the CSI VolumeGroupId out of those.
+func MakeVolumeGroupID(clusterID string, poolID int64, name, prefix string) (string, error) {
+	namePrefix := prefix
+	if prefix == "" {
+		namePrefix = defaultVolumeGroupNamingPrefix
+	}
+
+	id, found := strings.CutPrefix(name, namePrefix)
+	if !found {
+		return "", fmt.Errorf("volume group name %q does not start with %q", name, namePrefix)
+	}
+
+	handle := util.CSIIdentifier{
+		ClusterID:  clusterID,
+		LocationID: poolID,
+		ObjectUUID: id,
+	}
+
+	return handle.ComposeCSIID()
 }
 
 /*

--- a/internal/rbd/group.go
+++ b/internal/rbd/group.go
@@ -22,6 +22,7 @@ import (
 
 	librbd "github.com/ceph/go-ceph/rbd"
 
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
 )
 
@@ -77,6 +78,28 @@ func (rv *rbdVolume) RemoveFromGroup(ctx context.Context, vg types.VolumeGroup) 
 	}
 
 	return librbd.GroupImageRemove(ioctx, name, rv.ioctx, rv.RbdImageName)
+}
+
+// GetVolumeGroupID returns the ID of the VolumeGroup where this rbdVolume
+// belongs to. If the rbdVolume does not belong to a VolumeGroup, a
+// rbderrors.ErrGroupNotFound is returned.
+func (rv *rbdVolume) GetVolumeGroupID(ctx context.Context, resolver types.VolumeGroupResolver) (string, error) {
+	image, err := rv.open()
+	if err != nil {
+		return "", fmt.Errorf("failed to open image %q: %w", rv, err)
+	}
+	defer image.Close()
+
+	info, err := image.GetGroup()
+	if err != nil {
+		return "", fmt.Errorf("could not get group information for image %q: %w", rv, err)
+	}
+
+	if info.Name == "" {
+		return "", fmt.Errorf("%w: image %q is not part of a volume group", rbderrors.ErrGroupNotFound, rv)
+	}
+
+	return resolver.MakeVolumeGroupID(ctx, info.PoolID, info.Name)
 }
 
 func (rv *rbdVolume) ToMirror() (types.Mirror, error) {

--- a/internal/rbd/group_controllerserver.go
+++ b/internal/rbd/group_controllerserver.go
@@ -40,7 +40,7 @@ import (
 // group and its snapshot around, the group snapshot can be inspected to list
 // the snapshots of the images.
 //
-//nolint:gocyclo,cyclop // TODO: reduce complexity.
+//nolint:gocyclo,cyclop,gocognit // TODO: reduce complexity.
 func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 	ctx context.Context,
 	req *csi.CreateVolumeGroupSnapshotRequest,
@@ -53,6 +53,8 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 		// the VG and VGS should not have the same name
 		vgName  = req.GetName() + "-vg" // stable temporary name
 		vgsName = req.GetName()
+
+		vgNeedsDeletion = true
 	)
 
 	// Existence and conflict checks
@@ -70,7 +72,7 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 	volumes := make([]types.Volume, len(req.GetSourceVolumeIds()))
 	defer func() {
 		for _, volume := range volumes {
-			if vg != nil {
+			if vg != nil && vgNeedsDeletion {
 				// 'normal' cleanup, remove all images from the group
 				vgErr := vg.RemoveVolume(ctx, volume)
 				if vgErr != nil {
@@ -87,7 +89,7 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 			}
 		}
 
-		if vg != nil {
+		if vg != nil && vgNeedsDeletion {
 			// the VG should always be deleted, volumes can only belong to a single VG
 			log.DebugLog(ctx, "removing temporary volume group %q", vg)
 
@@ -115,6 +117,51 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 	}
 
 	log.DebugLog(ctx, "all %d Volumes for VolumeGroup %q have been found", len(volumes), vgsName)
+
+	// all volumes should belong to the same group, or to no group at all
+	groupMatches, err := mgr.VolumesInSameGroup(ctx, volumes)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to compare %d volumes: %s",
+			len(volumes),
+			err.Error())
+	} else if !groupMatches {
+		return nil, status.Error(
+			codes.Internal,
+			"not all volumes belong to the same group")
+	}
+
+	// check for pre-existing volume group name
+	vgHandle, err := volumes[0].GetVolumeGroupID(ctx, mgr)
+	if err != nil && !errors.Is(err, rbderrors.ErrGroupNotFound) {
+		return nil, status.Errorf(
+			codes.Internal,
+			"could not get volume group for volume %q: %v",
+			volumes[0],
+			err)
+	} else if vgHandle != "" {
+		vg, err = mgr.GetVolumeGroupByID(ctx, vgHandle)
+		// vg.Destroy(ctx) is called in a defer further up ^
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"failed to resolve volume group with id %q: %s",
+				vgHandle,
+				err.Error())
+		}
+
+		vgName, err = vg.GetName(ctx)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"failed to get name of volume group %q: %s",
+				vg,
+				err.Error())
+		}
+
+		vgNeedsDeletion = false
+	}
 
 	groupSnapshot, err = mgr.GetVolumeGroupSnapshotByName(ctx, vgsName)
 	if groupSnapshot != nil {
@@ -155,24 +202,35 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 			errList)
 	}
 
-	// create a temporary VolumeGroup with a different name
-	vg, err = mgr.CreateVolumeGroup(ctx, vgName)
+	if vg == nil {
+		// create a temporary VolumeGroup with a different name
+		vg, err = mgr.CreateVolumeGroup(ctx, vgName)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"failed to create volume group %q: %s",
+				vgName,
+				err.Error())
+		}
+		// vg.Destroy(ctx) is called in a defer further up ^
+
+		log.DebugLog(ctx, "VolumeGroup %q has been created: %+v", vgName, vg)
+	}
+
+	vols, err := vg.ListVolumes(ctx)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
-			"failed to create volume group %q: %s",
-			vgName,
+			"failed to list volumes of volume group %q: %s",
+			vg,
 			err.Error())
-	}
-	// vg.Destroy(ctx) is called in a defer further up ^
-
-	log.DebugLog(ctx, "VolumeGroup %q has been created: %+v", vgName, vg)
-
-	// add images to the group
-	for _, volume := range volumes {
-		err = vg.AddVolume(ctx, volume)
-		if err != nil {
-			return nil, status.Error(codes.Aborted, err.Error())
+	} else if len(vols) == 0 {
+		// add images to the group
+		for _, volume := range volumes {
+			err = vg.AddVolume(ctx, volume)
+			if err != nil {
+				return nil, status.Error(codes.Aborted, err.Error())
+			}
 		}
 	}
 

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -652,3 +652,76 @@ func (mgr *rbdManager) RegenerateVolumeGroupJournal(
 
 	return groupHandle, nil
 }
+
+// CompareVolumesInGroup returns 'true' when the list of volumes matches the
+// volumes in the group. In case a volume belongs to no group, or an other
+// group than the VolumeGroup, 'false' is returned.
+func (mgr *rbdManager) CompareVolumesInGroup(
+	ctx context.Context,
+	volumes []types.Volume,
+	vg types.VolumeGroup,
+) (bool, error) {
+	vgVols, err := vg.ListVolumes(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to list volumes in group %q: %w", vg, err)
+	}
+
+	// the vg is allowed to be empty, or have the exact number of volumes
+	if !(len(vgVols) == 0 || len(vgVols) == len(volumes)) {
+		return false, fmt.Errorf(
+			"volume group %q has more or less volumes (%d) than expected (%d)",
+			vg,
+			len(vgVols),
+			len(volumes))
+	}
+
+	vgID, err := vg.GetID(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get name for volume group %q: %w", vg, err)
+	}
+
+	// verify that all volumes are part of the vg, or do not have a group at all
+	matchingGroup, err := mgr.VolumesInSameGroup(ctx, volumes)
+	if err != nil {
+		return false, err
+	} else if !matchingGroup {
+		return false, nil
+	}
+
+	// all volumes are in the same group
+	groupID, err := volumes[0].GetVolumeGroupID(ctx, mgr)
+	if err != nil && !errors.Is(err, rbderrors.ErrGroupNotFound) {
+		return false, fmt.Errorf("failed to get group for volume %q: %w", volumes[0], err)
+	}
+
+	// if none of the volumes is in a group, groupID will be ""
+	if groupID != "" && vgID != groupID {
+		log.DebugLog(ctx, "expecting group %q but volume %q has group %q", vgID, volumes[0], groupID)
+
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// VolumesInSameGroup returns 'true' when all volumes are in the same group, or
+// in no group at all.
+func (mgr *rbdManager) VolumesInSameGroup(ctx context.Context, volumes []types.Volume) (bool, error) {
+	var lastID *string
+	for _, v := range volumes {
+		id, err := v.GetVolumeGroupID(ctx, mgr)
+		if err != nil && !errors.Is(err, rbderrors.ErrGroupNotFound) {
+			return false, fmt.Errorf("failed to get group name for volume %q: %w", v, err)
+		}
+
+		// all volumes should be part of the same group
+		// lastID == nil in the 1st loop
+		if lastID != nil && *lastID != id {
+			return false, fmt.Errorf("volume %q belongs to group %q, but expected %q", v, id, *lastID)
+		}
+
+		lastID = &id
+	}
+
+	return true, nil
+}

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -238,6 +238,21 @@ func (mgr *rbdManager) GetVolumeGroupByID(ctx context.Context, id string) (types
 	return vg, nil
 }
 
+func (mgr *rbdManager) MakeVolumeGroupID(ctx context.Context, poolID int64, name string) (string, error) {
+	clusterID, err := util.GetClusterID(mgr.parameters)
+	if err != nil {
+		return "", fmt.Errorf("failed to get cluster-id: %w", err)
+	}
+
+	// convert the clusterid, poolid and name to an id/handle
+	id, err := journal.MakeVolumeGroupID(clusterID, poolID, name, mgr.getVolumeGroupNamePrefix())
+	if err != nil {
+		return "", fmt.Errorf("failed to convert name %q to a CSI-handle: %w", name, err)
+	}
+
+	return id, nil
+}
+
 func (mgr *rbdManager) CreateVolumeGroup(ctx context.Context, name string) (types.VolumeGroup, error) {
 	creds, err := mgr.getCredentials()
 	if err != nil {

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -83,6 +83,12 @@ func (mgr *rbdManager) getCredentials() (*util.Credentials, error) {
 	return creds, nil
 }
 
+// getVolumeGroupNamePrefix returns the prefix for the volume group if set, or
+// an empty string if none is configured.
+func (mgr *rbdManager) getVolumeGroupNamePrefix() string {
+	return mgr.parameters["volumeGroupNamePrefix"]
+}
+
 func (mgr *rbdManager) getVolumeGroupJournal(clusterID string) (journal.VolumeGroupJournal, error) {
 	if mgr.vgJournal != nil {
 		return mgr.vgJournal, nil
@@ -123,11 +129,13 @@ func (mgr *rbdManager) getVolumeGroupJournal(clusterID string) (journal.VolumeGr
 // 3. an error or nil.
 func (mgr *rbdManager) getGroupUUID(
 	ctx context.Context,
-	clusterID, journalPool, name, prefix string,
+	clusterID, journalPool, name string,
 ) (string, func(), error) {
 	nothingToUndo := func() {
 		// the reservation was not done, no need to undo the reservation
 	}
+
+	prefix := mgr.getVolumeGroupNamePrefix()
 
 	vgJournal, err := mgr.getVolumeGroupJournal(clusterID)
 	if err != nil {
@@ -259,7 +267,7 @@ func (mgr *rbdManager) CreateVolumeGroup(ctx context.Context, name string) (type
 	}
 
 	// volumeGroupNamePrefix is an optional parameter, can be an empty string
-	prefix := mgr.parameters["volumeGroupNamePrefix"]
+	prefix := mgr.getVolumeGroupNamePrefix()
 
 	// check if the journal contains a generated name for the group already
 	vgData, err := vgJournal.CheckReservation(ctx, journalPool, name, prefix)
@@ -347,15 +355,12 @@ func (mgr *rbdManager) GetVolumeGroupSnapshotByName(
 		return nil, errors.New("required 'pool' option missing in volume group parameters")
 	}
 
-	// volumeGroupNamePrefix is an optional parameter, can be an empty string
-	prefix := mgr.parameters["volumeGroupNamePrefix"]
-
 	clusterID, err := util.GetClusterID(mgr.parameters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster-id: %w", err)
 	}
 
-	uuid, freeUUID, err := mgr.getGroupUUID(ctx, clusterID, pool, name, prefix)
+	uuid, freeUUID, err := mgr.getGroupUUID(ctx, clusterID, pool, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a UUID for volume group snapshot %q: %w", name, err)
 	}
@@ -410,15 +415,12 @@ func (mgr *rbdManager) CreateVolumeGroupSnapshot(
 		return nil, err
 	}
 
-	// volumeGroupNamePrefix is an optional parameter, can be an empty string
-	prefix := mgr.parameters["volumeGroupNamePrefix"]
-
 	clusterID, err := vg.GetClusterID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster id for volume group snapshot %q: %w", vg, err)
 	}
 
-	uuid, freeUUID, err := mgr.getGroupUUID(ctx, clusterID, pool, name, prefix)
+	uuid, freeUUID, err := mgr.getGroupUUID(ctx, clusterID, pool, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get a UUID for volume group snapshot %q: %w", vg, err)
 	}

--- a/internal/rbd/manager_test.go
+++ b/internal/rbd/manager_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMakeVolumeGroupID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+
+		// parameters for NewManager()
+		parameters map[string]string
+
+		// arguments for MakeVolumeGroupID()
+		poolID    int64
+		groupName string // should include the "volumeGroupNamePrefix"
+
+		// results
+		volumeGroupID string
+		expectError   bool
+	}{
+		{
+			name:          "no parameters set",
+			parameters:    nil,
+			volumeGroupID: "",
+			expectError:   true,
+		},
+		{
+			name: "missing 'clusterID' parameter",
+			parameters: map[string]string{
+				"pool":    "replicapool",
+				"missing": "clusterID",
+			},
+			poolID:        1,
+			groupName:     "csi-vol-group-my-volume-group",
+			volumeGroupID: "",
+			expectError:   true,
+		},
+		{
+			name: "good volume group with default prefix",
+			parameters: map[string]string{
+				"pool":      "replicapool",
+				"clusterID": "k8s-rook-ceph",
+			},
+			poolID:        1,
+			groupName:     "csi-vol-group-1fac1545-2d0f-4b42-8abb-066ebc39cba9",
+			volumeGroupID: "0001-000d-k8s-rook-ceph-0000000000000001-1fac1545-2d0f-4b42-8abb-066ebc39cba9",
+			expectError:   false,
+		},
+		{
+			name: "volume group with altervative prefix",
+			parameters: map[string]string{
+				"pool":                  "replicapool",
+				"clusterID":             "k8s-rook-ceph",
+				"volumeGroupNamePrefix": "its-a-group-",
+			},
+			poolID:        1,
+			groupName:     "its-a-group-df4a7204-6b06-4eb3-9547-036d845f0cd3",
+			volumeGroupID: "0001-000d-k8s-rook-ceph-0000000000000001-df4a7204-6b06-4eb3-9547-036d845f0cd3",
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.TODO()
+			mgr := NewManager("rbd.example.org", tt.parameters, nil)
+			defer mgr.Destroy(ctx)
+
+			id, err := mgr.MakeVolumeGroupID(ctx, tt.poolID, tt.groupName)
+			if (err != nil) != tt.expectError {
+				t.Logf("mgr: %+v", mgr)
+				t.Errorf("MakeVolumeGroupID failed unexpectedly: %v", err)
+			} else if id != tt.volumeGroupID {
+				t.Errorf("MakeVolumeGroupID returned %q, expected %q", id, tt.volumeGroupID)
+			}
+		})
+	}
+}

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -26,10 +26,15 @@ import (
 )
 
 type journalledObject interface {
-	// GetID returns the ID in the backend storage for the object.
+	// GetID returns the CSI-handle formatted ID of the object. The handle
+	// can be parsed to locate an entry in the journal, which points to the
+	// object in the backend storage (see `GetClusterID`, `GetPool`, and
+	// `GetName`).
 	GetID(ctx context.Context) (string, error)
 
-	// GetName returns the name of the object in the backend storage.
+	// GetName returns the name in the backend storage for the object. The
+	// name is used for accessing the object though the Ceph APIs.
+	// RBD-images and RBD-groups exist in the backend with the given name.
 	GetName(ctx context.Context) (string, error)
 
 	// GetPool returns the name of the pool that holds the object.

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -40,6 +40,18 @@ type VolumeGroupResolver interface {
 	// The poolID and name are details of the Ceph RBD-group for which the
 	// CSI VolumeGroupId should get constructed.
 	MakeVolumeGroupID(ctx context.Context, poolID int64, name string) (string, error)
+
+	// GetVolumeGroupByID uses the CSI-Addons VolumeGroupId to resolve the
+	// returned VolumeGroup.
+	GetVolumeGroupByID(ctx context.Context, id string) (VolumeGroup, error)
+
+	// CompareVolumesInGroup verifies that all the volumes are part of the
+	// given VolumeGroup.
+	CompareVolumesInGroup(ctx context.Context, volumes []Volume, vg VolumeGroup) (bool, error)
+
+	// VolumesInSameGroup verifies that all volumes belong to the same (or
+	// no) VolumeGroup.
+	VolumesInSameGroup(ctx context.Context, volumes []Volume) (bool, error)
 }
 
 // Manager provides a way for other packages to get Volumes and VolumeGroups.
@@ -57,10 +69,6 @@ type Manager interface {
 
 	// Destroy frees all resources that the Manager allocated.
 	Destroy(ctx context.Context)
-
-	// GetVolumeGroupByID uses the CSI-Addons VolumeGroupId to resolve the
-	// returned VolumeGroup.
-	GetVolumeGroupByID(ctx context.Context, id string) (VolumeGroup, error)
 
 	// CreateVolumeGroup allocates a new VolumeGroup in the backend storage
 	// and records details about it in the journal.

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -32,6 +32,16 @@ type SnapshotResolver interface {
 	GetSnapshotByID(ctx context.Context, id string) (Snapshot, error)
 }
 
+// VolumeGroupResolver can be used to construct a VolumeGroup from a CSI VolumeGroupId.
+type VolumeGroupResolver interface {
+	// MakeVolumeGroupID is called by Volume.GetVolumeGroupID to resolve
+	// the CSI VolumeGroupId of the VolumeGroup where the Volume belongs
+	// to.
+	// The poolID and name are details of the Ceph RBD-group for which the
+	// CSI VolumeGroupId should get constructed.
+	MakeVolumeGroupID(ctx context.Context, poolID int64, name string) (string, error)
+}
+
 // Manager provides a way for other packages to get Volumes and VolumeGroups.
 // It handles the operations on the backend, and makes sure the journal
 // reflects the expected state.
@@ -41,6 +51,9 @@ type Manager interface {
 
 	// SnapshotResolver is fully implemented by the Manager.
 	SnapshotResolver
+
+	// VolumeGroupResolver is fully implemented by the Manager.
+	VolumeGroupResolver
 
 	// Destroy frees all resources that the Manager allocated.
 	Destroy(ctx context.Context)

--- a/internal/rbd/types/volume.go
+++ b/internal/rbd/types/volume.go
@@ -36,6 +36,11 @@ type snapshottableVolume interface {
 }
 
 type csiAddonsVolume interface {
+	// GetVolumeGroupID returns the name of the VolumeGroup where this
+	// Volume belongs to. If the rbdVolume does not belong to a
+	// VolumeGroup, a ErrGroupNotFound is returned.
+	GetVolumeGroupID(ctx context.Context, resolver VolumeGroupResolver) (string, error)
+
 	// AddToGroup adds the Volume to the VolumeGroup.
 	AddToGroup(ctx context.Context, vg VolumeGroup) error
 


### PR DESCRIPTION
CSI-Addons Volume Groups makes it possible to create a long-living volume group. This is incompatible with the VolumeGroupSnapshot feature, as that creates a temporary VolumeGroup before creating a snapshot of it. When a Volume is already part of a different Volume Group, things will fail.

In order to make both features compatible with each other, the following things are required:
- VolumeGroupSnapshot functions may need to reuse an existing VolumeGroup
- VolumeGroup creation should verify that all Volumes are in the same existing VolumeGroup, or no group at all
- existing VolumeGroups should be inspected and the volumes in the group should match the volumes in the VolumeGroupSnapshot request
- if a VolumeGroupSnapshot request reuses an existing VolumeGroup, the VolumeGroup should not be deleted after creating the snapshots

Depends-on: #5184