### PR TITLE
ci: run upgrade tests with Kubernetes 1.32

### DIFF
--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.28'
+    k8s_version: '1.32'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

The call to `./scripts/get_patch_release.py --version=1.28` returns an error. Kubernetes 1.28 is really old, so it is good to move to v1.32 now.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit d3a76a1fad0835b83f5fad43e701ba58cfd17a97)

---
Few days ago, I mistakenly pushed my ci/centos changes directly to upstream fork _(which by the happened because of no branch protection being set)_. However, I did discuss with @nixpanic and we were fine with it since the change was not that critical. Now, I see that my direct push missed one of the commit from PR https://github.com/ceph/ceph-csi/pull/5211#issuecomment-2747572194.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
