### PR TITLE
rbd: do not start the healer for NBD on non-Kubernetes platforms

### DIFF
--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -201,7 +201,7 @@ func (r *Driver) Run(conf *util.Config) {
 
 	r.startProfiling(conf)
 
-	if conf.IsNodeServer {
+	if conf.IsNodeServer && k8s.RunsOnKubernetes() {
 		go func() {
 			// TODO: move the healer to csi-addons
 			err := rbd.RunVolumeHealer(r.ns, conf)


### PR DESCRIPTION
When running on Docker Swarm, the RBD-healer fails with an error like:

> healer had failures, err failed to get cluster config: unable to load
> in-cluster configuration, KUBERNETES_SERVICE_HOST and
> KUBERNETES_SERVICE_PORT must be defined

Before starting the healer, check if KUBERNETES_SERVICE_HOST is set in
the environment variables so that non-Kubernetes platforms do not get
confusing warnings.

Updates: #3769