### PR TITLE
rbd: cleanup volume info from group if the image is not part of group anymore

### DIFF
--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -255,11 +255,10 @@ func (vg *volumeGroup) RemoveVolume(ctx context.Context, vol types.Volume) error
 
 	err := vol.RemoveFromGroup(ctx, vg)
 	if err != nil {
-		if errors.Is(err, librbd.ErrNotExist) {
-			return nil
+		if !errors.Is(err, librbd.ErrNotExist) {
+			return fmt.Errorf("failed to remove volume %q from volume group %q: %w", vol, vg, err)
 		}
-
-		return fmt.Errorf("failed to remove volume %q from volume group %q: %w", vol, vg, err)
+		log.DebugLog(ctx, "volume %q doesn't exist in group", vol)
 	}
 
 	// toRemove contain the ID of the volume that is removed from the group


### PR DESCRIPTION
We should continue to cleanup the volume info like the omap data, mappings from the group if the image is not part of the goup anymore.