### PR TITLE
e2e: `Skip()` inside a test case causes other cases to be skipped

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -5219,7 +5219,8 @@ var _ = Describe("RBD", func() {
 					framework.Failf("failed to check for VolumeGroupSnapshot support: %v", err)
 				}
 				if !supported {
-					Skip("librbd does not support required VolumeGroupSnapshot function(s)")
+					framework.Logf("SKIPPING: librbd does not support required VolumeGroupSnapshot function(s)")
+					return
 				}
 
 				scName := "csi-rbd-sc"


### PR DESCRIPTION
The Ginkgo `Skip()` function does not only skip the current `By()`, but
it's parent `It()` function. That means other `By()` tests will not be
run after a `Skip()` was called.

Replacing the `Skip()` with an early return of the function makes sure
that all `By()` tests are executed.