### PR TITLE
util: fix bug in health checker

### DIFF
--- a/internal/health-checker/manager.go
+++ b/internal/health-checker/manager.go
@@ -137,7 +137,8 @@ func (hcm *healthCheckManager) startStatChecker(volumeID, path string, shared bo
 // are key'd by theit volumeID+path.
 func (hcm *healthCheckManager) startChecker(cc ConditionChecker, volumeID, path string, shared bool) error {
 	key := volumeID
-	if shared {
+	if !shared {
+		// if it is non-shared checker, try to use the path as well.
 		key = fallbackKey(volumeID, path)
 	}
 

--- a/internal/health-checker/manager_test.go
+++ b/internal/health-checker/manager_test.go
@@ -18,12 +18,15 @@ package healthchecker
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+const volumeID = "fake-volume-id"
 
 func TestManager(t *testing.T) {
 	t.Parallel()
 
-	volumeID := "fake-volume-id"
 	volumePath := t.TempDir()
 	mgr := NewHealthCheckManager()
 
@@ -52,7 +55,6 @@ func TestManager(t *testing.T) {
 func TestSharedChecker(t *testing.T) {
 	t.Parallel()
 
-	volumeID := "fake-volume-id"
 	volumePath := t.TempDir()
 	mgr := NewHealthCheckManager()
 
@@ -82,4 +84,54 @@ func TestSharedChecker(t *testing.T) {
 
 	t.Log("stop the checker")
 	mgr.StopSharedChecker(volumeID)
+}
+
+func TestTwoNonSharedChecker(t *testing.T) {
+	t.Parallel()
+
+	// create two different paths for same volumeID
+	// to test if the checkers are independent
+	firstVolumePath := t.TempDir()
+	secondVolumePath := t.TempDir()
+	mgr := NewHealthCheckManager()
+
+	t.Log("start the first checker")
+	err := mgr.StartChecker(volumeID, firstVolumePath, StatCheckerType)
+	if err != nil {
+		t.Fatalf("ConditionChecker could not get started: %v", err)
+	}
+
+	t.Log("check health for first path, should be healthy")
+	healthy, msg := mgr.IsHealthy(volumeID, firstVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("check health for second path, should error out since checker is not started")
+	_, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	require.ErrorContains(t, msg, "no ConditionChecker for volume-id")
+
+	t.Log("start the second checker")
+	err = mgr.StartChecker(volumeID, secondVolumePath, StatCheckerType)
+	if err != nil {
+		t.Fatalf("ConditionChecker could not get started: %v", err)
+	}
+
+	t.Log("check health, should be healthy")
+	healthy, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("stop the first checker")
+	mgr.StopChecker(volumeID, firstVolumePath)
+
+	t.Log("check health of second path, should still be healthy")
+	healthy, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("stop the second checker")
+	mgr.StopChecker(volumeID, secondVolumePath)
 }


### PR DESCRIPTION
# Describe what this PR does #

This commit fixes a bug in health checker that
caused shared checker to get keyed with volumeID+volumepath instead of just volumeID and the other way around
for non-shared checkers.

unit test runs:
```
rakshithr4@fedora:~/Workspace/github.com/ceph/ceph-csi$ /usr/local/go/bin/go test -timeout 30s -tags ceph_preview -run ^TestTwoNonSharedChecker$ githu
b.com/ceph/ceph-csi/internal/health-checker -v
=== RUN   TestTwoNonSharedChecker
=== PAUSE TestTwoNonSharedChecker
=== CONT  TestTwoNonSharedChecker
    manager_test.go:99: start the first checker
    manager_test.go:105: check health for first path, should be healthy
    manager_test.go:111: check health for second path, should error out since checker is not started
    manager_test.go:113: 
                Error Trace:    /home/rakshithr4/Workspace/github.com/ceph/ceph-csi/internal/health-checker/manager_test.go:113
                Error:          An error is expected but got nil.
                Test:           TestTwoNonSharedChecker
    manager_test.go:115: start the second checker
    manager_test.go:121: check health, should be healthy
    manager_test.go:127: stop the first checker
    manager_test.go:130: check health of second path, should still be healthy
    manager_test.go:136: stop the second checker
--- FAIL: TestTwoNonSharedChecker (0.00s)
FAIL
FAIL    github.com/ceph/ceph-csi/internal/health-checker        0.005s
FAIL
rakshithr4@fedora:~/Workspace/github.com/ceph/ceph-csi$ git diff
diff --git a/internal/health-checker/manager.go b/internal/health-checker/manager.go
index ed78ec6fa..6a08e6b3d 100644
--- a/internal/health-checker/manager.go
+++ b/internal/health-checker/manager.go
@@ -137,7 +137,8 @@ func (hcm *healthCheckManager) startStatChecker(volumeID, path string, shared bo
 // are key'd by theit volumeID+path.
 func (hcm *healthCheckManager) startChecker(cc ConditionChecker, volumeID, path string, shared bool) error {
        key := volumeID
-       if shared {
+       if !shared {
+               // if it is non-shared checker, try to use the path as well.
                key = fallbackKey(volumeID, path)
        }
 
diff --git a/internal/health-checker/manager_test.go b/internal/health-checker/manager_test.go
rakshithr4@fedora:~/Workspace/github.com/ceph/ceph-csi$ /usr/local/go/bin/go test -timeout 30s -tags ceph_preview -run ^TestTwoNonSharedChecker$ github.com/ceph/ceph-csi/internal/health-checker -v
=== RUN   TestTwoNonSharedChecker
=== PAUSE TestTwoNonSharedChecker
=== CONT  TestTwoNonSharedChecker
    manager_test.go:99: start the first checker
    manager_test.go:105: check health for first path, should be healthy
    manager_test.go:111: check health for second path, should error out since checker is not started
    manager_test.go:115: start the second checker
    manager_test.go:121: check health, should be healthy
    manager_test.go:127: stop the first checker
    manager_test.go:130: check health of second path, should still be healthy
    manager_test.go:136: stop the second checker
--- PASS: TestTwoNonSharedChecker (0.00s)
PASS
ok      github.com/ceph/ceph-csi/internal/health-checker        0.005s
```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
