### PR TITLE
rbd: prevent restarting mirror resync when the mirror is syncing already

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -18,7 +18,6 @@ package rbd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -891,11 +890,8 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "failed to get remote status: %v", err)
 	}
 
-	description := remoteStatus.GetDescription()
-	resp, err := getLastSyncInfo(ctx, description)
+	lastSyncInfo, err := remoteStatus.GetLastSyncInfo(ctx)
 	if err != nil {
-		log.ErrorLog(ctx, "failed to parse last sync info from %q: %v", description, err)
-
 		if errors.Is(err, rbderrors.ErrLastSyncTimeNotFound) {
 			return nil, status.Errorf(codes.NotFound, "failed to get last sync info: %v", err)
 		}
@@ -903,73 +899,18 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "failed to get last sync info: %v", err)
 	}
 
-	return resp, nil
-}
-
-// This function gets the local snapshot time, last sync snapshot seconds
-// and last sync bytes from the description of localStatus and convert
-// it into required types.
-func getLastSyncInfo(ctx context.Context, description string) (*replication.GetVolumeReplicationInfoResponse, error) {
-	// Format of the description will be as followed:
-	// description = `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,
-	// "last_snapshot_bytes":81920,"last_snapshot_sync_seconds":0,
-	// "local_snapshot_timestamp":1684675261,
-	// "remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`
-	// In case there is no last snapshot bytes returns 0 as the
-	// LastSyncBytes is optional.
-	// In case there is no last snapshot sync seconds, it returns nil as the
-	// LastSyncDuration is optional.
-	// In case there is no local snapshot timestamp return an error as the
-	// LastSyncTime is required.
-
-	var response replication.GetVolumeReplicationInfoResponse
-
-	if description == "" {
-		return nil, fmt.Errorf("empty description: %w", rbderrors.ErrLastSyncTimeNotFound)
-	}
-	log.DebugLog(ctx, "description: %s", description)
-	splittedString := strings.SplitN(description, ",", 2)
-	if len(splittedString) == 1 {
-		return nil, fmt.Errorf("no snapshot details: %w", rbderrors.ErrLastSyncTimeNotFound)
-	}
-	type localStatus struct {
-		LocalSnapshotTime    int64  `json:"local_snapshot_timestamp"`
-		LastSnapshotBytes    int64  `json:"last_snapshot_bytes"`
-		LastSnapshotDuration *int64 `json:"last_snapshot_sync_seconds"`
+	resp := replication.GetVolumeReplicationInfoResponse{
+		LastSyncTime:  timestamppb.New(lastSyncInfo.GetLastSyncTime()),
+		LastSyncBytes: lastSyncInfo.GetLastSyncBytes(),
 	}
 
-	var localSnapInfo localStatus
-	err := json.Unmarshal([]byte(splittedString[1]), &localSnapInfo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal local snapshot info: %w", err)
+	// lastDuration is optional, can be nil
+	lastDuration := lastSyncInfo.GetLastSyncDuration()
+	if lastDuration != nil {
+		resp.LastSyncDuration = durationpb.New(*lastDuration)
 	}
 
-	// If the json unmarsal is successful but the local snapshot time is 0, we
-	// need to consider it as an error as the LastSyncTime is required.
-	if localSnapInfo.LocalSnapshotTime == 0 {
-		return nil, fmt.Errorf("empty local snapshot timestamp: %w", rbderrors.ErrLastSyncTimeNotFound)
-	}
-	if localSnapInfo.LastSnapshotDuration != nil {
-		// converts localSnapshotDuration of type int64 to string format with
-		// appended `s` seconds required  for time.ParseDuration
-		lastDurationTime := fmt.Sprintf("%ds", *localSnapInfo.LastSnapshotDuration)
-		// parse Duration from the lastDurationTime string
-		lastDuration, err := time.ParseDuration(lastDurationTime)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse last snapshot duration: %w", err)
-		}
-		// converts time.Duration to *durationpb.Duration
-		response.LastSyncDuration = durationpb.New(lastDuration)
-	}
-
-	// converts localSnapshotTime of type int64 to time.Time
-	lastUpdateTime := time.Unix(localSnapInfo.LocalSnapshotTime, 0)
-	lastSyncTime := timestamppb.New(lastUpdateTime)
-
-	response.LastSyncTime = lastSyncTime
-	response.LastSyncBytes = localSnapInfo.LastSnapshotBytes
-
-	return &response, nil
+	return &resp, nil
 }
 
 func checkVolumeResyncStatus(ctx context.Context, localStatus types.SiteStatus) error {
@@ -977,13 +918,11 @@ func checkVolumeResyncStatus(ctx context.Context, localStatus types.SiteStatus) 
 	// started or not, if we dont see local_snapshot_timestamp in the
 	// description of localStatus, we are returning error. if we see the local
 	// snapshot timestamp in the description we return resyncing started.
-	description := localStatus.GetDescription()
-	resp, err := getLastSyncInfo(ctx, description)
+	//
+	// Note: without a local_snapshot_timestamp, GetLastSyncInfo() returns an error.
+	_, err := localStatus.GetLastSyncInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get last sync info: %w", err)
-	}
-	if resp.GetLastSyncTime() == nil {
-		return errors.New("last sync time is nil")
 	}
 
 	return nil

--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -718,7 +718,13 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 			return nil, status.Errorf(codes.Internal, "failed to parse image creation time: %s", sErr.Error())
 		}
 		log.DebugLog(ctx, "image %s, savedImageTime=%v, currentImageTime=%v", rbdVol, st, creationTime)
-		if req.GetForce() && st.Equal(*creationTime) {
+
+		syncInfo, sErr := localStatus.GetLastSyncInfo(ctx)
+		if sErr != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get last sync info: %s", sErr.Error())
+		}
+
+		if req.GetForce() && st.Equal(*creationTime) && !syncInfo.IsSyncing() {
 			err = mirror.Resync(ctx)
 			if err != nil {
 				return nil, getGRPCError(err)

--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -32,12 +30,9 @@ import (
 
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
-	"github.com/csi-addons/spec/lib/go/replication"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestValidateSchedulingInterval(t *testing.T) {
@@ -413,147 +408,6 @@ func TestCheckRemoteSiteStatus(t *testing.T) {
 			t.Parallel()
 			if ready := checkRemoteSiteStatus(context.TODO(), tt.args.GetAllSitesStatus()); ready != tt.wantReady {
 				t.Errorf("checkRemoteSiteStatus() ready = %v, expect ready = %v", ready, tt.wantReady)
-			}
-		})
-	}
-}
-
-func TestValidateLastSyncInfo(t *testing.T) {
-	t.Parallel()
-	ctx := context.TODO()
-	duration, err := time.ParseDuration(strconv.Itoa(int(56743)) + "s")
-	if err != nil {
-		t.Errorf("failed to parse duration)")
-	}
-
-	tests := []struct {
-		name        string
-		description string
-		info        *replication.GetVolumeReplicationInfoResponse
-		expectedErr string
-	}{
-		{
-			name: "valid description",
-			//nolint:lll // sample output cannot be split into multiple lines.
-			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_bytes":81920,"last_snapshot_sync_seconds":56743,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncTime:     timestamppb.New(time.Unix(1684675261, 0)),
-				LastSyncDuration: durationpb.New(duration),
-				LastSyncBytes:    81920,
-			},
-			expectedErr: "",
-		},
-		{
-			name:        "empty description",
-			description: "",
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncTime:     nil,
-				LastSyncDuration: nil,
-				LastSyncBytes:    0,
-			},
-			expectedErr: rbderrors.ErrLastSyncTimeNotFound.Error(),
-		},
-		{
-			name: "description without last_snapshot_bytes",
-			//nolint:lll // sample output cannot be split into multiple lines.
-			description: `replaying, {"bytes_per_second":0.0,"last_snapshot_sync_seconds":56743,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncDuration: durationpb.New(duration),
-				LastSyncTime:     timestamppb.New(time.Unix(1684675261, 0)),
-				LastSyncBytes:    0,
-			},
-			expectedErr: "",
-		},
-		{
-			name: "description without local_snapshot_time",
-			//nolint:lll // sample output cannot be split into multiple lines.
-			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_bytes":81920,"last_snapshot_sync_seconds":56743,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncDuration: nil,
-				LastSyncTime:     nil,
-				LastSyncBytes:    0,
-			},
-			expectedErr: rbderrors.ErrLastSyncTimeNotFound.Error(),
-		},
-		{
-			name: "description without last_snapshot_sync_seconds",
-			//nolint:lll // sample output cannot be split into multiple lines.
-			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_bytes":81920,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncDuration: nil,
-				LastSyncTime:     timestamppb.New(time.Unix(1684675261, 0)),
-				LastSyncBytes:    81920,
-			},
-			expectedErr: "",
-		},
-		{
-			name: "description with last_snapshot_sync_seconds = 0",
-			//nolint:lll // sample output cannot be split into multiple lines.
-			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_sync_seconds":0,
-			"last_snapshot_bytes":81920,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncDuration: durationpb.New(time.Duration(0)),
-				LastSyncTime:     timestamppb.New(time.Unix(1684675261, 0)),
-				LastSyncBytes:    81920,
-			},
-			expectedErr: "",
-		},
-		{
-			name: "description with invalid JSON",
-			//nolint:lll // sample output cannot be split into multiple lines.
-			description: `replaying,{"bytes_per_second":0.0,"last_snapshot_bytes":81920","bytes_per_snapshot":149504.0","remote_snapshot_timestamp":1662655501`,
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncDuration: nil,
-				LastSyncTime:     nil,
-				LastSyncBytes:    0,
-			},
-			expectedErr: "failed to unmarshal",
-		},
-		{
-			name:        "description with no JSON",
-			description: `replaying`,
-			info: &replication.GetVolumeReplicationInfoResponse{
-				LastSyncDuration: nil,
-				LastSyncTime:     nil,
-				LastSyncBytes:    0,
-			},
-			expectedErr: rbderrors.ErrLastSyncTimeNotFound.Error(),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			teststruct, err := getLastSyncInfo(ctx, tt.description)
-			if err != nil && !strings.Contains(err.Error(), tt.expectedErr) {
-				// returned error
-				t.Errorf("getLastSyncInfo() returned error, expected: %v, got: %v",
-					tt.expectedErr, err)
-			}
-			if teststruct != nil {
-				if teststruct.GetLastSyncTime().GetSeconds() != tt.info.GetLastSyncTime().GetSeconds() {
-					t.Errorf("name: %v, getLastSyncInfo() %v, expected %v",
-						tt.name,
-						teststruct.GetLastSyncTime(),
-						tt.info.GetLastSyncTime())
-				}
-				if tt.info.GetLastSyncDuration() == nil && teststruct.GetLastSyncDuration() != nil {
-					t.Errorf("name: %v, getLastSyncInfo() %v, expected %v",
-						tt.name,
-						teststruct.GetLastSyncDuration(),
-						tt.info.GetLastSyncDuration())
-				}
-				if teststruct.GetLastSyncDuration().GetSeconds() != tt.info.GetLastSyncDuration().GetSeconds() {
-					t.Errorf("name: %v, getLastSyncInfo() %v, expected %v",
-						tt.name,
-						teststruct.GetLastSyncDuration(),
-						tt.info.GetLastSyncDuration())
-				}
-				if teststruct.GetLastSyncBytes() != tt.info.GetLastSyncBytes() {
-					t.Errorf("name: %v, getLastSyncInfo() %v, expected %v",
-						tt.name,
-						teststruct.GetLastSyncBytes(),
-						tt.info.GetLastSyncBytes())
-				}
 			}
 		})
 	}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1024,7 +1024,14 @@ func (cs *ControllerServer) DeleteVolume(
 func cleanupRBDImage(ctx context.Context,
 	rbdVol *rbdVolume, cr *util.Credentials,
 ) (*csi.DeleteVolumeResponse, error) {
-	info, err := rbdVol.GetMirroringInfo(ctx)
+	rm, err := rbdVol.ToMirror()
+	if err != nil {
+		log.ErrorLog(ctx, err.Error())
+
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	info, err := rm.GetMirroringInfo(ctx)
 	if err != nil {
 		log.ErrorLog(ctx, err.Error())
 
@@ -1043,7 +1050,7 @@ func cleanupRBDImage(ctx context.Context,
 		// the image on all the remote (secondary) clusters will get
 		// auto-deleted. This helps in garbage collecting the OMAP, PVC and PV
 		// objects after failback operation.
-		sts, rErr := rbdVol.GetGlobalMirroringStatus(ctx)
+		sts, rErr := rm.GetGlobalMirroringStatus(ctx)
 		if rErr != nil {
 			return nil, status.Error(codes.Internal, rErr.Error())
 		}

--- a/internal/rbd/group.go
+++ b/internal/rbd/group.go
@@ -101,7 +101,3 @@ func (rv *rbdVolume) GetVolumeGroupID(ctx context.Context, resolver types.Volume
 
 	return resolver.MakeVolumeGroupID(ctx, info.PoolID, info.Name)
 }
-
-func (rv *rbdVolume) ToMirror() (types.Mirror, error) {
-	return rv, nil
-}

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -17,7 +17,9 @@ package rbd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
@@ -326,4 +328,76 @@ func (status SiteMirrorImageStatus) IsUP() bool {
 func (status SiteMirrorImageStatus) GetLastUpdate() time.Time {
 	// convert the last update time to UTC
 	return time.Unix(status.LastUpdate, 0).UTC()
+}
+
+func (status SiteMirrorImageStatus) GetLastSyncInfo(ctx context.Context) (types.SyncInfo, error) {
+	return newSyncInfo(ctx, status.Description)
+}
+
+type syncInfo struct {
+	LocalSnapshotTime    int64  `json:"local_snapshot_timestamp"`
+	LastSnapshotBytes    int64  `json:"last_snapshot_bytes"`
+	LastSnapshotDuration *int64 `json:"last_snapshot_sync_seconds"`
+}
+
+// Type assertion for ensuring an implementation of the full SyncInfo interface.
+var _ types.SyncInfo = &syncInfo{}
+
+func newSyncInfo(ctx context.Context, description string) (types.SyncInfo, error) {
+	// Format of the description will be as followed:
+	// description = `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,
+	// "last_snapshot_bytes":81920,"last_snapshot_sync_seconds":0,
+	// "local_snapshot_timestamp":1684675261,
+	// "remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`
+	// In case there is no last snapshot bytes returns 0 as the
+	// LastSyncBytes is optional.
+	// In case there is no last snapshot sync seconds, it returns nil as the
+	// LastSyncDuration is optional.
+	// In case there is no local snapshot timestamp return an error as the
+	// LastSyncTime is required.
+
+	if description == "" {
+		return nil, fmt.Errorf("empty description: %w", rbderrors.ErrLastSyncTimeNotFound)
+	}
+	log.DebugLog(ctx, "description: %s", description)
+	splittedString := strings.SplitN(description, ",", 2)
+	if len(splittedString) == 1 {
+		return nil, fmt.Errorf("no snapshot details: %w", rbderrors.ErrLastSyncTimeNotFound)
+	}
+
+	var localSnapInfo syncInfo
+	err := json.Unmarshal([]byte(splittedString[1]), &localSnapInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal description %q into syncInfo: %w", description, err)
+	}
+
+	// If the json unmarsal is successful but the local snapshot time is 0, we
+	// need to consider it as an error as the LastSyncTime is required.
+	if localSnapInfo.LocalSnapshotTime == 0 {
+		return nil, fmt.Errorf("empty local snapshot timestamp: %w", rbderrors.ErrLastSyncTimeNotFound)
+	}
+
+	return &localSnapInfo, nil
+}
+
+func (si *syncInfo) GetLastSyncTime() time.Time {
+	// converts localSnapshotTime of type int64 to time.Time
+	return time.Unix(si.LocalSnapshotTime, 0)
+}
+
+func (si *syncInfo) GetLastSyncBytes() int64 {
+	return si.LastSnapshotBytes
+}
+
+func (si *syncInfo) GetLastSyncDuration() *time.Duration {
+	var duration time.Duration
+
+	if si.LastSnapshotDuration == nil {
+		duration = time.Duration(0)
+	} else {
+		// time.Duration is in nanoseconds
+		duration = time.Duration(*si.LastSnapshotDuration) * time.Second
+	}
+
+	return &duration
 }

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -18,6 +18,7 @@ package rbd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -209,8 +210,12 @@ func (rm *rbdMirror) Demote(_ context.Context) error {
 	return nil
 }
 
-// Resync resync image to correct the split-brain.
-func (rm *rbdMirror) Resync(_ context.Context) error {
+// Resync resync image to correct the split-brain. It may take some time for
+// the RBD-mirror daemon to start syncing the image. After the resync operation
+// is executed, the status of the resync is checked with a small delay to
+// prevent subsequent resync calls from re-starting the resync quickly after
+// each other.
+func (rm *rbdMirror) Resync(ctx context.Context) error {
 	image, err := rm.open()
 	if err != nil {
 		return fmt.Errorf("failed to open image %q with error: %w", rm, err)
@@ -219,6 +224,43 @@ func (rm *rbdMirror) Resync(_ context.Context) error {
 	err = image.MirrorResync()
 	if err != nil {
 		return fmt.Errorf("failed to resync image %q with error: %w", rm, err)
+	}
+
+	// delay until the state is syncing, or until 1+2+4+8+16 seconds passed
+	delay := 1 * time.Second
+	for {
+		time.Sleep(delay)
+
+		sts, dErr := rm.GetGlobalMirroringStatus(ctx)
+		if dErr != nil {
+			// the image gets recreated after issuing resync
+			if errors.Is(dErr, rbderrors.ErrImageNotFound) {
+				continue
+			}
+			log.ErrorLog(ctx, dErr.Error())
+
+			return dErr
+		}
+
+		localStatus, dErr := sts.GetLocalSiteStatus()
+		if dErr != nil {
+			log.ErrorLog(ctx, dErr.Error())
+
+			return fmt.Errorf("failed to get local status: %w", dErr)
+		}
+
+		syncInfo, dErr := localStatus.GetLastSyncInfo(ctx)
+		if dErr != nil {
+			return fmt.Errorf("failed to get last sync info: %w", dErr)
+		}
+		if syncInfo.IsSyncing() {
+			return nil
+		}
+
+		delay = 2 * delay
+		if delay > 30 {
+			break
+		}
 	}
 
 	// If we issued a resync, return a non-final error as image needs to be recreated

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -335,10 +335,18 @@ func (status SiteMirrorImageStatus) GetLastSyncInfo(ctx context.Context) (types.
 }
 
 type syncInfo struct {
-	LocalSnapshotTime    int64  `json:"local_snapshot_timestamp"`
-	LastSnapshotBytes    int64  `json:"last_snapshot_bytes"`
-	LastSnapshotDuration *int64 `json:"last_snapshot_sync_seconds"`
+	LocalSnapshotTime    int64       `json:"local_snapshot_timestamp"`
+	LastSnapshotBytes    int64       `json:"last_snapshot_bytes"`
+	LastSnapshotDuration *int64      `json:"last_snapshot_sync_seconds"`
+	ReplayState          replayState `json:"replay_state"`
 }
+
+type replayState string
+
+const (
+	idle    replayState = "idle"
+	syncing replayState = "syncing"
+)
 
 // Type assertion for ensuring an implementation of the full SyncInfo interface.
 var _ types.SyncInfo = &syncInfo{}
@@ -400,4 +408,8 @@ func (si *syncInfo) GetLastSyncDuration() *time.Duration {
 	}
 
 	return &duration
+}
+
+func (si *syncInfo) IsSyncing() bool {
+	return si.ReplayState == syncing
 }

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -66,82 +66,99 @@ func (rv *rbdVolume) HandleParentImageExistence(
 	if err != nil {
 		return fmt.Errorf("failed to get parent of image %s: %w", rv, err)
 	}
-	parentMirroringInfo, err := parent.GetMirroringInfo(ctx)
+
+	pm, err := parent.ToMirror()
+	if err != nil {
+		return fmt.Errorf("failed to convert parent image %s to mirror type: %w", parent, err)
+	}
+
+	parentMirroringInfo, err := pm.GetMirroringInfo(ctx)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to get mirroring info of parent %q of image %q: %w",
-			parent, rv, err)
+			pm, rv, err)
 	}
 	if parentMirroringInfo.GetState() != librbd.MirrorImageEnabled.String() {
 		return fmt.Errorf("%w: failed to enable mirroring on image %q: "+
 			"parent image %q is not enabled for mirroring",
-			rbderrors.ErrFailedPrecondition, rv, parent)
+			rbderrors.ErrFailedPrecondition, rv, pm)
 	}
 
 	return nil
 }
 
+// rbdMirror is an extended rbdImage type that implements the types.Mirror interface.
+type rbdMirror struct {
+	rbdImage
+}
+
 // check that rbdVolume implements the types.Mirror interface.
-var _ types.Mirror = &rbdVolume{}
+var _ types.Mirror = &rbdMirror{}
+
+func (ri *rbdImage) ToMirror() (types.Mirror, error) {
+	return &rbdMirror{
+		rbdImage: *ri,
+	}, nil
+}
 
 // EnableMirroring enables mirroring on an image.
-func (ri *rbdImage) EnableMirroring(_ context.Context, mode librbd.ImageMirrorMode) error {
-	image, err := ri.open()
+func (rm *rbdMirror) EnableMirroring(_ context.Context, mode librbd.ImageMirrorMode) error {
+	image, err := rm.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
 	defer image.Close()
 
 	err = image.MirrorEnable(mode)
 	if err != nil {
-		return fmt.Errorf("failed to enable mirroring on %q with error: %w", ri, err)
+		return fmt.Errorf("failed to enable mirroring on %q with error: %w", rm, err)
 	}
 
 	return nil
 }
 
 // DisableMirroring disables mirroring on an image.
-func (ri *rbdImage) DisableMirroring(_ context.Context, force bool) error {
-	image, err := ri.open()
+func (rm *rbdMirror) DisableMirroring(_ context.Context, force bool) error {
+	image, err := rm.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
 	defer image.Close()
 
 	err = image.MirrorDisable(force)
 	if err != nil {
-		return fmt.Errorf("failed to disable mirroring on %q with error: %w", ri, err)
+		return fmt.Errorf("failed to disable mirroring on %q with error: %w", rm, err)
 	}
 
 	return nil
 }
 
 // GetMirroringInfo gets mirroring information of an image.
-func (ri *rbdImage) GetMirroringInfo(_ context.Context) (types.MirrorInfo, error) {
-	image, err := ri.open()
+func (rm *rbdMirror) GetMirroringInfo(_ context.Context) (types.MirrorInfo, error) {
+	image, err := rm.open()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open image %q with error: %w", ri, err)
+		return nil, fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
 	defer image.Close()
 
 	info, err := image.GetMirrorImageInfo()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get mirroring info of %q with error: %w", ri, err)
+		return nil, fmt.Errorf("failed to get mirroring info of %q with error: %w", rm, err)
 	}
 
 	return ImageStatus{MirrorImageInfo: info}, nil
 }
 
 // Promote promotes image to primary.
-func (ri *rbdImage) Promote(_ context.Context, force bool) error {
-	image, err := ri.open()
+func (rm *rbdMirror) Promote(_ context.Context, force bool) error {
+	image, err := rm.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
 	defer image.Close()
 	err = image.MirrorPromote(force)
 	if err != nil {
-		return fmt.Errorf("failed to promote image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to promote image %q with error: %w", rm, err)
 	}
 
 	return nil
@@ -150,13 +167,13 @@ func (ri *rbdImage) Promote(_ context.Context, force bool) error {
 // ForcePromote promotes image to primary with force option with 2 minutes
 // timeout. If there is no response within 2 minutes,the rbd CLI process will be
 // killed and an error is returned.
-func (rv *rbdVolume) ForcePromote(ctx context.Context, cr *util.Credentials) error {
+func (rm *rbdMirror) ForcePromote(ctx context.Context, cr *util.Credentials) error {
 	promoteArgs := []string{
 		"mirror", "image", "promote",
-		rv.String(),
+		rm.String(),
 		"--force",
 		"--id", cr.ID,
-		"-m", rv.Monitors,
+		"-m", rm.Monitors,
 		"--keyfile=" + cr.KeyFile,
 	}
 	_, stderr, err := util.ExecCommandWithTimeout(
@@ -167,41 +184,41 @@ func (rv *rbdVolume) ForcePromote(ctx context.Context, cr *util.Credentials) err
 		promoteArgs...,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to promote image %q with error: %w", rv, err)
+		return fmt.Errorf("failed to promote image %q with error: %w", rm, err)
 	}
 
 	if stderr != "" {
-		return fmt.Errorf("failed to promote image %q with stderror: %s", rv, stderr)
+		return fmt.Errorf("failed to promote image %q with stderror: %s", rm, stderr)
 	}
 
 	return nil
 }
 
 // Demote demotes image to secondary.
-func (ri *rbdImage) Demote(_ context.Context) error {
-	image, err := ri.open()
+func (rm *rbdMirror) Demote(_ context.Context) error {
+	image, err := rm.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
 	defer image.Close()
 	err = image.MirrorDemote()
 	if err != nil {
-		return fmt.Errorf("failed to demote image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to demote image %q with error: %w", rm, err)
 	}
 
 	return nil
 }
 
 // Resync resync image to correct the split-brain.
-func (ri *rbdImage) Resync(_ context.Context) error {
-	image, err := ri.open()
+func (rm *rbdMirror) Resync(_ context.Context) error {
+	image, err := rm.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
 	defer image.Close()
 	err = image.MirrorResync()
 	if err != nil {
-		return fmt.Errorf("failed to resync image %q with error: %w", ri, err)
+		return fmt.Errorf("failed to resync image %q with error: %w", rm, err)
 	}
 
 	// If we issued a resync, return a non-final error as image needs to be recreated
@@ -211,15 +228,15 @@ func (ri *rbdImage) Resync(_ context.Context) error {
 }
 
 // GetGlobalMirroringStatus get the mirroring status of an image.
-func (ri *rbdImage) GetGlobalMirroringStatus(_ context.Context) (types.GlobalStatus, error) {
-	image, err := ri.open()
+func (rm *rbdMirror) GetGlobalMirroringStatus(_ context.Context) (types.GlobalStatus, error) {
+	image, err := rm.open()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open image %q with error: %w", ri, err)
+		return nil, fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
 	defer image.Close()
 	statusInfo, err := image.GetGlobalMirrorStatus()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get image mirroring status %q with error: %w", ri, err)
+		return nil, fmt.Errorf("failed to get image mirroring status %q with error: %w", rm, err)
 	}
 
 	return GlobalMirrorStatus{GlobalMirrorImageStatus: statusInfo}, nil

--- a/internal/rbd/mirror_test.go
+++ b/internal/rbd/mirror_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+)
+
+func TestValidateLastSyncInfo(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+	duration := int64(56743)
+	zero := int64(0)
+
+	tests := []struct {
+		name        string
+		description string
+		info        types.SyncInfo
+		expectedErr string
+	}{
+		{
+			name: "valid description",
+			//nolint:lll // sample output cannot be split into multiple lines.
+			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_bytes":81920,"last_snapshot_sync_seconds":56743,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
+			info: &syncInfo{
+				LocalSnapshotTime:    1684675261,
+				LastSnapshotDuration: &duration,
+				LastSnapshotBytes:    81920,
+			},
+			expectedErr: "",
+		},
+		{
+			name:        "empty description",
+			description: "",
+			info: &syncInfo{
+				LastSnapshotDuration: nil,
+				LastSnapshotBytes:    0,
+			},
+			expectedErr: rbderrors.ErrLastSyncTimeNotFound.Error(),
+		},
+		{
+			name: "description without last_snapshot_bytes",
+			//nolint:lll // sample output cannot be split into multiple lines.
+			description: `replaying, {"bytes_per_second":0.0,"last_snapshot_sync_seconds":56743,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
+			info: &syncInfo{
+				LastSnapshotDuration: &duration,
+				LocalSnapshotTime:    1684675261,
+				LastSnapshotBytes:    0,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "description without local_snapshot_time",
+			//nolint:lll // sample output cannot be split into multiple lines.
+			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_bytes":81920,"last_snapshot_sync_seconds":56743,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
+			info: &syncInfo{
+				LastSnapshotDuration: nil,
+				LastSnapshotBytes:    0,
+			},
+			expectedErr: rbderrors.ErrLastSyncTimeNotFound.Error(),
+		},
+		{
+			name: "description without last_snapshot_sync_seconds",
+			//nolint:lll // sample output cannot be split into multiple lines.
+			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_bytes":81920,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
+			info: &syncInfo{
+				LastSnapshotDuration: nil,
+				LocalSnapshotTime:    1684675261,
+				LastSnapshotBytes:    81920,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "description with last_snapshot_sync_seconds = 0",
+			//nolint:lll // sample output cannot be split into multiple lines.
+			description: `replaying, {"bytes_per_second":0.0,"bytes_per_snapshot":81920.0,"last_snapshot_sync_seconds":0,
+			"last_snapshot_bytes":81920,"local_snapshot_timestamp":1684675261,"remote_snapshot_timestamp":1684675261,"replay_state":"idle"}`,
+			info: &syncInfo{
+				LastSnapshotDuration: &zero,
+				LocalSnapshotTime:    1684675261,
+				LastSnapshotBytes:    81920,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "description with invalid JSON",
+			//nolint:lll // sample output cannot be split into multiple lines.
+			description: `replaying,{"bytes_per_second":0.0,"last_snapshot_bytes":81920","bytes_per_snapshot":149504.0","remote_snapshot_timestamp":1662655501`,
+			info: &syncInfo{
+				LastSnapshotDuration: nil,
+				LastSnapshotBytes:    0,
+			},
+			expectedErr: "failed to unmarshal",
+		},
+		{
+			name:        "description with no JSON",
+			description: `replaying`,
+			info: &syncInfo{
+				LastSnapshotDuration: nil,
+				LastSnapshotBytes:    0,
+			},
+			expectedErr: rbderrors.ErrLastSyncTimeNotFound.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			teststruct, err := newSyncInfo(ctx, tt.description)
+			if err != nil && !strings.Contains(err.Error(), tt.expectedErr) {
+				// returned error
+				t.Errorf("newSyncInfo() returned error, expected: %v, got: %v",
+					tt.expectedErr, err)
+			}
+			if teststruct != nil {
+				if teststruct.GetLastSyncTime().Unix() != tt.info.GetLastSyncTime().Unix() {
+					t.Errorf("name: %v, got %v, expected %v",
+						tt.name,
+						teststruct.GetLastSyncTime().Unix(),
+						tt.info.GetLastSyncTime().Unix())
+				}
+
+				ttLastSyncDuration := tt.info.GetLastSyncDuration()
+				tsLastSyncDuration := teststruct.GetLastSyncDuration()
+				if ttLastSyncDuration == nil && tsLastSyncDuration != nil {
+					t.Errorf("name: %v, got %v, expected %v",
+						tt.name,
+						ttLastSyncDuration,
+						tsLastSyncDuration)
+				}
+				if ttLastSyncDuration != nil && tsLastSyncDuration != nil {
+					ttLastSyncDurationSecs := ttLastSyncDuration.Seconds()
+					tsLastSyncDurationSecs := tsLastSyncDuration.Seconds()
+					if ttLastSyncDurationSecs != tsLastSyncDurationSecs {
+						t.Errorf("name: %v, got %v, expected %v",
+							tt.name,
+							ttLastSyncDuration,
+							tsLastSyncDuration)
+					}
+				}
+
+				if teststruct.GetLastSyncBytes() != tt.info.GetLastSyncBytes() {
+					t.Errorf("name: %v, got %v, expected %v",
+						tt.name,
+						teststruct.GetLastSyncBytes(),
+						tt.info.GetLastSyncBytes())
+				}
+			}
+		})
+	}
+}

--- a/internal/rbd/types/mirror.go
+++ b/internal/rbd/types/mirror.go
@@ -110,4 +110,8 @@ type SyncInfo interface {
 	// case there is no last snapshot bytes returns 0 as the LastSyncBytes is
 	// optional.
 	GetLastSyncBytes() int64
+
+	// IsSyncing returns true if the SyncInfo for the SiteStatus is actively
+	// syncing.
+	IsSyncing() bool
 }

--- a/internal/rbd/types/mirror.go
+++ b/internal/rbd/types/mirror.go
@@ -92,4 +92,22 @@ type SiteStatus interface {
 	GetDescription() string
 	// GetLastUpdate returns the last update time
 	GetLastUpdate() time.Time
+	// GetLastSyncInfo returns the last SyncInfo details for the site
+	GetLastSyncInfo(ctx context.Context) (SyncInfo, error)
+}
+
+// SyncInfo is the interface for fetching more details about a SiteStatus object.
+type SyncInfo interface {
+	// GetLastSyncDuration returns the last snapshot sync duration. In case
+	// there is no last snapshot sync seconds, it returns nil as the
+	// LastSyncDuration is optional.
+	GetLastSyncDuration() *time.Duration
+
+	// GetLastSyncTime returns the local snapshot timestamp.
+	GetLastSyncTime() time.Time
+
+	// GetLastSyncBytes returns the last snapshot bytes of the last sync. In
+	// case there is no last snapshot bytes returns 0 as the LastSyncBytes is
+	// optional.
+	GetLastSyncBytes() int64
 }


### PR DESCRIPTION
There have been occasional reports where syncing an image never completes. The cause seems to come from Ceph-CSI, as it may call `mirror.Resync()` even when the image is in a `syncing` state. Every time Ceph-CSI calls `mirror.Resync()`, the resync is started from scratch. If this is called often enough, the resync is never able to complete.

This PR introduces two improvements:

1. only start a resync if the status is not set to syncing already
2. after starting a resync, wait with responding to the caller, until the status is syncing

There are a few cleanups done as well, these make it simpler to implement the proposed changes.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
