### PR TITLE
ci: install awk in Fedora test container-image

### DIFF
--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -33,6 +33,7 @@ RUN source /build.env \
 	make \
 	gcc \
 	findutils \
+	awk \
 	librados-devel \
         libcephfs-devel \
 	librbd-devel \


### PR DESCRIPTION
Fedora 42 has been released, and its container-image does not seem to include `awk` anymore. `awk` is used during the preparation phase of the golangci-lint test, and possibly others.

By installing `awk` in the test container-image, all scripts seem to work well with the Fedora 42 container-image.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
