### PR TITLE
helm: mark userID and userKey required in secret

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,6 +2,9 @@
 
 ## Breaking Changes
 
+- Support for `secret.adminID` and `secret.adminKey` has been deprecated and removed
+  from Helm charts. Please use `secret.userID` and `secret.userKey` instead.
+
 ## Features
 
 ## NOTE

--- a/charts/ceph-csi-cephfs/templates/secret.yaml
+++ b/charts/ceph-csi-cephfs/templates/secret.yaml
@@ -14,6 +14,6 @@ metadata:
     heritage: {{ .Release.Service }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 stringData:
-  userID: {{ .Values.secret.userID }}
-  userKey: {{ .Values.secret.userKey }}
+  userID: {{ required "A valid userID must be specified in secret" .Values.secret.userID }}
+  userKey: {{ required "A valid userKey must be specified in secret" .Values.secret.userKey }}
 {{- end -}}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This patch marks `userID` and `userKey` required in helm values.

A release note has been added for the same as well.

Ref:  https://github.com/ceph/ceph-csi/issues/5282