### PR TITLE
ci: add `ok-to-test` label after Mergify rephrase

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -91,7 +91,7 @@ pull_request_rules:
       - not:
           status-success~=^ci/centos
       - or:
-          - "check-pending=Queue: Embarked in merge train"
+          - "check-pending=Queue: Embarked in merge queue"
           - author=mergify[bot]
     actions:
       label:


### PR DESCRIPTION
Mergify rephrased the status when a PR is the 1st in the queue. Instead of the "Queue: Embarked in merge train", the status is now reported as "Queue: Embarked in merge queue".

Because the status did not match the rule in the configuration anymore, the `ok-to-test` label was not automatically added.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
