### PR TITLE
rbd: cleanup and improve read-only volume handling

### DIFF
--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -93,6 +93,14 @@ func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) 
 		}
 	}
 
+	// add "ro" in case the capabilities indicate READER_ONLY
+	rOnly := "ro"
+	if IsReaderOnly([]*csi.VolumeCapability{volCap}) {
+		if !MountOptionContains(mountOptions, rOnly) {
+			mountOptions = append(mountOptions, rOnly)
+		}
+	}
+
 	return mountOptions
 }
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -165,10 +165,12 @@ func (ns *NodeServer) populateRbdVol(
 ) (*rbdVolume, error) {
 	var err error
 	volID := req.GetVolumeId()
-	isBlock := req.GetVolumeCapability().GetBlock() != nil
+
+	isBlock, isMultiNode := csicommon.IsBlockMultiNode([]*csi.VolumeCapability{req.GetVolumeCapability()})
 	disableInUseChecks := false
+
 	// MULTI_NODE_MULTI_WRITER is supported by default for Block access type volumes
-	if req.GetVolumeCapability().GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
+	if isMultiNode {
 		if !isBlock {
 			log.WarningLog(
 				ctx,
@@ -216,6 +218,7 @@ func (ns *NodeServer) populateRbdVol(
 	}
 
 	rv.DisableInUseChecks = disableInUseChecks
+	rv.readOnly = csicommon.IsReaderOnly([]*csi.VolumeCapability{req.GetVolumeCapability()})
 
 	err = rv.Connect(cr)
 	if err != nil {
@@ -403,13 +406,6 @@ func (ns *NodeServer) stageTransaction(
 	transaction := &stageTransaction{}
 
 	var err error
-
-	// Allow image to be mounted on multiple nodes if it is ROX
-	if req.GetVolumeCapability().GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
-		log.ExtendedLog(ctx, "setting disableInUseChecks on rbd volume to: %v", req.GetVolumeId)
-		volOptions.DisableInUseChecks = true
-		volOptions.readOnly = true
-	}
 
 	err = flattenImageBeforeMapping(ctx, volOptions)
 	if err != nil {
@@ -760,7 +756,6 @@ func (ns *NodeServer) mountVolumeToStagePath(
 	stagingPath, devicePath string,
 	fileEncryption bool,
 ) error {
-	readOnly := false
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
 	diskMounter := &mount.SafeFormatAndMount{Interface: ns.Mounter, Exec: utilexec.New()}
 	// rbd images are thin-provisioned and return zeros for unwritten areas.  A freshly created
@@ -784,18 +779,7 @@ func (ns *NodeServer) mountVolumeToStagePath(
 	opt = append(opt, "_netdev")
 	opt = csicommon.ConstructMountOptions(opt, req.GetVolumeCapability())
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
-	rOnly := "ro"
-
-	mode := req.GetVolumeCapability().GetAccessMode().GetMode()
-	if mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY ||
-		mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
-		if !csicommon.MountOptionContains(opt, rOnly) {
-			opt = append(opt, rOnly)
-		}
-	}
-	if csicommon.MountOptionContains(opt, rOnly) {
-		readOnly = true
-	}
+	readOnly := csicommon.IsReaderOnly([]*csi.VolumeCapability{req.GetVolumeCapability()})
 
 	if existingFormat == "" && !staticVol && !readOnly && !isBlock {
 		args := ns.getMkfsArgs(fsType)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -474,13 +474,16 @@ func (ns *NodeServer) stageTransaction(
 		}
 	}
 
-	// As we are supporting the restore of a volume to a bigger size and
-	// creating bigger size clone from a volume, we need to check filesystem
-	// resize is required, if required resize filesystem.
-	// in case of encrypted block PVC resize only the LUKS device.
-	err = resizeNodeStagePath(ctx, isBlock, transaction, req.GetVolumeId(), stagingTargetPath)
-	if err != nil {
-		return transaction, err
+	// if the volume is read-only, no resize should be done
+	if !volOptions.readOnly {
+		// As we are supporting the restore of a volume to a bigger size and
+		// creating bigger size clone from a volume, we need to check filesystem
+		// resize is required, if required resize filesystem.
+		// in case of encrypted block PVC resize only the LUKS device.
+		err = resizeNodeStagePath(ctx, isBlock, transaction, req.GetVolumeId(), stagingTargetPath)
+		if err != nil {
+			return transaction, err
+		}
 	}
 
 	return transaction, err


### PR DESCRIPTION
There are two components in this PR that are all related to the read-only handling while staging an RBD-image that is expected to be read-only:

1. use helper functions from csi-common for VolumeCapability checking
  The internal/csi-common package offers helper functions like
  `IsReaderOnly()` and `IsBlockMultiNode()`. These should be used instead
  of checking the VolumeCapability that is passed in a request in
  different places.
  This also suggested that adding the "ro" mount option in
  `NodeServer.mountVolumeToStagePath()` is not appropriate, as the
  csi-common helper `ConstructMountOptions()` can take care of that
  already too.

2. Volumes that were requested with a read-only capability should not be resized.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
