### PR TITLE
doc: Update cephfs caps

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -28,7 +28,7 @@ capabilities:
 
 ```
 mgr "allow rw"
-osd "allow rw tag cephfs metadata=cephfs, allow rw tag cephfs data=cephfs"
+osd "allow rwx tag cephfs metadata=cephfs, allow rw tag cephfs data=cephfs"
 mds "allow r fsname=cephfs path=/volumes, allow rws fsname=cephfs path=/volumes/csi"
 mon "allow r fsname=cephfs"
 ```
@@ -63,7 +63,7 @@ FS_NAME=cephfs
 SUB_VOL=csi
 ceph auth get-or-create client.$USER \
   mgr "allow rw" \
-  osd "allow rw tag cephfs metadata=$FS_NAME, allow rw tag cephfs data=$FS_NAME" \
+  osd "allow rwx tag cephfs metadata=$FS_NAME, allow rw tag cephfs data=$FS_NAME" \
   mds "allow r fsname=$FS_NAME path=/volumes, allow rws fsname=$FS_NAME path=/volumes/$SUB_VOL" \
   mon "allow r fsname=$FS_NAME"
 ```


### PR DESCRIPTION
When cephfs is used with encryption an exclusive lock is acquired. This needs the execute permission on the metadata pool.

Fixes #4728

## Future concerns ##
- It might be necessary to add a e2e test for an encrypted cephfs to avoid issues like #4728 in the future.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
