### PR TITLE
Implement ListSnapshots RPC for CephFS and RBD

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -974,6 +974,62 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 	return nil
 }
 
+func (cs *ControllerServer) ListSnapshots(
+	ctx context.Context,
+	req *csi.ListSnapshotsRequest,
+) (*csi.ListSnapshotsResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS); err != nil {
+		log.ErrorLog(ctx, "invalid list snapshot req: %v", protosanitizer.StripSecrets(req))
+
+		return nil, err
+	}
+
+	cr, err := util.NewAdminCredentials(req.GetSecrets())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	defer cr.DeleteCredentials()
+
+	snapshotID := req.GetSnapshotId()
+	if snapshotID == "" {
+		return nil, status.Error(codes.InvalidArgument, "snapshot ID cannot be empty")
+	}
+
+	volOpt, _, sid, err := store.NewSnapshotOptionsFromID(ctx, snapshotID, cr,
+		req.GetSecrets(), cs.ClusterName, cs.SetMetadata)
+	if err != nil {
+		switch {
+		case errors.Is(err, cerrors.ErrSnapNotFound):
+			return nil, status.Error(codes.NotFound, err.Error())
+		default:
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+	}
+	defer volOpt.Destroy()
+
+	subVolClient := core.NewSubVolume(volOpt.GetConnection(), &volOpt.SubVolume,
+		volOpt.ClusterID, cs.ClusterName, cs.SetMetadata)
+	info, err := subVolClient.GetSubVolumeInfo(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &csi.ListSnapshotsResponse{
+		Entries: []*csi.ListSnapshotsResponse_Entry{
+			{
+				Snapshot: &csi.Snapshot{
+					SizeBytes:      info.BytesQuota,
+					SnapshotId:     sid.SnapshotID,
+					SourceVolumeId: req.GetSourceVolumeId(),
+					CreationTime:   sid.CreationTime,
+					ReadyToUse:     true,
+				},
+			},
+		},
+	}, nil
+}
+
 // DeleteSnapshot deletes the snapshot in backend and removes the
 // snapshot metadata from store.
 func (cs *ControllerServer) DeleteSnapshot(

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -136,6 +136,7 @@ func (fs *Driver) Run(conf *util.Config) {
 		fs.cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -354,6 +355,56 @@ func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSna
 	}
 
 	return nil
+}
+
+func (cs *ControllerServer) ListSnapshots(
+	ctx context.Context,
+	req *csi.ListSnapshotsRequest,
+) (*csi.ListSnapshotsResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS); err != nil {
+		log.ErrorLog(ctx, "invalid list snapshot req: %v", protosanitizer.StripSecrets(req))
+
+		return nil, err
+	}
+
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
+	snap, err := mgr.GetSnapshotByID(ctx, req.GetSnapshotId())
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "failed to find snapshot with ID %q: %s", req.GetSnapshotId(), err.Error())
+	}
+	defer snap.Destroy(ctx)
+
+	// We need type casting here as SourceVolumeID is unset
+	// We fetch the source volume ID from the request and return
+	// that in the response
+	rbdSnap, ok := snap.(*rbdSnapshot)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "failed to cast to rbdSnapshot instance for snap: %s", req.GetSnapshotId())
+	}
+	defer rbdSnap.Destroy(ctx)
+
+	snapCreationTime, err := rbdSnap.GetCreationTime(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &csi.ListSnapshotsResponse{
+		Entries: []*csi.ListSnapshotsResponse_Entry{
+			{
+				Snapshot: &csi.Snapshot{
+					SizeBytes:       rbdSnap.VolSize,
+					SnapshotId:      rbdSnap.VolID,
+					SourceVolumeId:  req.GetSourceVolumeId(),
+					CreationTime:    timestamppb.New(*snapCreationTime),
+					ReadyToUse:      true,
+					GroupSnapshotId: rbdSnap.groupID,
+				},
+			},
+		},
+	}, nil
 }
 
 // CreateVolume creates the volume in backend.

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -110,6 +110,7 @@ func (r *Driver) Run(conf *util.Config) {
 		r.cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		})


### PR DESCRIPTION
# Describe what this PR does #

This patch implements `ListSnapshots` RPC which is required by the `external-snapshotter` to properly update status for `VolumeSnapshots/Contents`

