### PR TITLE
helm: use CSIDriver.seLinuxMount parameter in templates

### DIFF
--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -12,4 +12,4 @@ spec:
   attachRequired: false
   podInfoOnMount: false
   fsGroupPolicy: {{ .Values.CSIDriver.fsGroupPolicy }}
-  seLinuxMount: true
+  seLinuxMount: {{ .Values.CSIDriver.seLinuxMount }}

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -12,4 +12,4 @@ spec:
   attachRequired: true
   podInfoOnMount: false
   fsGroupPolicy: {{ .Values.CSIDriver.fsGroupPolicy }}
-  seLinuxMount: true
+  seLinuxMount: {{ .Values.CSIDriver.seLinuxMount }}


### PR DESCRIPTION
Commit 88ce2c625bafaaf73fcbe52db5a73979777cf398 removed a EOL kubernetes version check, but also the usage of Values.CSIDriver.seLinuxMount.

This commit makes CSIDriver.seLinuxMount configurable from helm parameter, since the default for csidrivers.storage.k8s.io.spec.seLinuxMount is false, but do not change the template default value which is set to true in values.yaml.