### PR TITLE
 rbd: add support for changed block tracking RPCs

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,6 +5,7 @@
 ## Features
 
 - helm: Support VolumeSnapshotClass and VolumeGroupSnapshotClass
+- rbd: add support for [CSI Snapshot Metadata Service RPCs](https://github.com/container-storage-interface/spec/blob/master/spec.md#snapshot-metadata-service-rpcs)
 
 ## NOTE
 

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -550,3 +550,36 @@ kubectl edit cm ceph-config
 
 This will update the `ceph.conf` of the underlying ceph cluster to enable
 librbd logs in `csi-rbdplugin` container.
+
+## Changed Block Tracking (CBT)
+
+> **Warning**: Requires Ceph version that supports RBD snap diff by ID feature.
+For details, see ceph tracker:
+["diff-iterate by snap ID"](https://tracker.ceph.com/issues/65720).
+
+Ceph-CSI implements Changed Block Tracking (CBT) for RBD volumes using
+the SnapshotMetadataService (SMS) APIs. This feature enables efficient
+and reliable differential backup of data stored in CSI volumes.
+
+The feature is exposed through the CSI Controller Server's
+SnapshotMetadataService APIs with two primary operations:
+
+* `GetMetadataAllocated`:
+
+   * Streams metadata about allocated blocks in a snapshot
+   * Useful for full backup operations
+   * Returns block ranges that contain actual data
+
+* `GetMetadataDelta`:
+
+   * Streams metadata about block differences between two snapshots
+   * Optimal for incremental backups
+   * Returns only blocks that changed between snapshots
+
+Additional Resources:
+
+* CSI Differential Snapshot for Block Volumes KEP:
+  [kep-3314](https://github.com/kubernetes/enhancements/issues/3314)
+
+* External Snapshot Metadata sidecar project:
+  [repository](https://github.com/kubernetes-csi/external-snapshot-metadata)

--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -30,6 +30,7 @@ import (
 type DefaultControllerServer struct {
 	csi.UnimplementedControllerServer
 	csi.UnimplementedGroupControllerServer
+	csi.UnimplementedSnapshotMetadataServer
 	Driver *CSIDriver
 }
 

--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -42,10 +42,11 @@ type NonBlockingGRPCServer interface {
 
 // Servers holds the list of servers.
 type Servers struct {
-	IS csi.IdentityServer
-	CS csi.ControllerServer
-	NS csi.NodeServer
-	GS csi.GroupControllerServer
+	IS  csi.IdentityServer
+	CS  csi.ControllerServer
+	NS  csi.NodeServer
+	GS  csi.GroupControllerServer
+	SMS csi.SnapshotMetadataServer
 }
 
 // NewNonBlockingGRPCServer return non-blocking GRPC.
@@ -120,6 +121,9 @@ func (s *nonBlockingGRPCServer) serve(
 	}
 	if srv.GS != nil {
 		csi.RegisterGroupControllerServer(server, srv.GS)
+	}
+	if srv.SMS != nil {
+		csi.RegisterSnapshotMetadataServer(server, srv.SMS)
 	}
 
 	log.DefaultLog("Listening for connections on address: %#v", listener.Addr())

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -190,10 +190,11 @@ func (r *Driver) Run(conf *util.Config) {
 
 	s := csicommon.NewNonBlockingGRPCServer()
 	srv := &csicommon.Servers{
-		IS: r.ids,
-		CS: r.cs,
-		NS: r.ns,
-		GS: r.cs,
+		IS:  r.ids,
+		CS:  r.cs,
+		NS:  r.ns,
+		GS:  r.cs,
+		SMS: r.cs,
 	}
 	s.Start(conf.Endpoint, srv, csicommon.MiddlewareServerOptionConfig{
 		LogSlowOpInterval: conf.LogSlowOpInterval,

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -82,8 +82,6 @@ const (
 // luks2HeaderSizeKey, so the default value is returned in that case
 // i.e, DefaultLuks2HeaderSize.
 // If the image is not block encrypted, 0 is returned.
-//
-//nolint:unused // Unused code will be used in future.
 func (ri *rbdImage) getLuksHeaderSizeMetadata() (uint64, error) {
 	if !ri.isBlockEncrypted() {
 		return 0, nil

--- a/internal/rbd/errors/errors.go
+++ b/internal/rbd/errors/errors.go
@@ -68,3 +68,11 @@ var (
 	// ErrGroupNotFound is returned when group is not found in the cluster on the given pool and/or namespace.
 	ErrGroupNotFound = fmt.Errorf("%w: RBD group not found", librbd.ErrNotFound)
 )
+
+// ErrorCode is an interface that defines a method to return an error code.
+// This interface is used to provide a consistent way to retrieve error codes
+// from functions that is expected to return an error with specific codes.
+type ErrorCode interface {
+	// ErrorCode returns the error code.
+	ErrorCode() int
+}

--- a/internal/rbd/features/features.go
+++ b/internal/rbd/features/features.go
@@ -31,6 +31,10 @@ var (
 	groupGetSnapInfoOnce      sync.Once
 	errGroupGetSnapInfo       error
 	groupGetSnapInfoSupported = false
+
+	rbdSnapDiffByIDOnce      sync.Once
+	errRBDSnapDiffByID       error
+	rbdSnapDiffByIDSupported = false
 )
 
 // SupportsGroupSnapGetInfo detects if librbd has the rbd_group_snap_get_info
@@ -55,4 +59,28 @@ func SupportsGroupSnapGetInfo() (bool, error) {
 	})
 
 	return groupGetSnapInfoSupported, errGroupGetSnapInfo
+}
+
+// SupportsRBDSnapDiffByID detects if librbd has the rbd_diff_iterate3
+// function.
+func SupportsRBDSnapDiffByID() (bool, error) {
+	rbdSnapDiffByIDOnce.Do(func() {
+		// make sure librbd.so.x is loaded, might not (yet) be the case
+		// if no rbd functions are called
+		var opts C.rbd_image_options_t
+		//nolint:gocritic // ignore result of rbd_image_options functions
+		C.rbd_image_options_create(&opts)
+		C.rbd_image_options_destroy(opts)
+
+		// check for rbd_diff_iterate3() in loaded libs/symbols
+		errRBDSnapDiffByID = dlsym("rbd_diff_iterate3")
+
+		if errRBDSnapDiffByID == nil {
+			rbdSnapDiffByIDSupported = true
+		} else if strings.Contains(errRBDSnapDiffByID.Error(), "undefined symbol") {
+			errRBDSnapDiffByID = nil
+		}
+	})
+
+	return rbdSnapDiffByIDSupported, errRBDSnapDiffByID
 }

--- a/internal/rbd/identityserver.go
+++ b/internal/rbd/identityserver.go
@@ -21,6 +21,7 @@ import (
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/rbd/features"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
@@ -62,7 +63,9 @@ func (is *IdentityServer) GetPluginCapabilities(
 
 	// GroupSnapGetInfo is used within the VolumeGroupSnapshot implementation
 	vgsSupported, err := features.SupportsGroupSnapGetInfo()
-	if err == nil && vgsSupported {
+	if err != nil {
+		log.WarningLog(ctx, "error checking for group snapshot support: %s", err)
+	} else if vgsSupported {
 		gcs := csi.PluginCapability{
 			Type: &csi.PluginCapability_Service_{
 				Service: &csi.PluginCapability_Service{
@@ -71,6 +74,21 @@ func (is *IdentityServer) GetPluginCapabilities(
 			},
 		}
 		caps = append(caps, &gcs)
+	}
+
+	// RBDSnapDiffByID is used within the SnapshotMetadata service
+	rbdSnapDiffByIDSupported, err := features.SupportsRBDSnapDiffByID()
+	if err != nil {
+		log.WarningLog(ctx, "error checking for snapshot diff by ID support: %s", err)
+	} else if rbdSnapDiffByIDSupported {
+		snapDiffCaps := csi.PluginCapability{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE,
+				},
+			},
+		}
+		caps = append(caps, &snapDiffCaps)
 	}
 
 	return &csi.GetPluginCapabilitiesResponse{

--- a/internal/rbd/sms_controllerserver.go
+++ b/internal/rbd/sms_controllerserver.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"errors"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/features"
+	"github.com/ceph/ceph-csi/internal/util/log"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// defaultMaxResults is the internal limit for max results in metadata streaming
+	// This is set to a reasonable value to prevent excessive memory usage
+	// and ensure efficient processing of metadata requests.
+	// TODO: Consider making this configurable via a cmdline flag.
+	defaultMaxResults int32 = 128
+)
+
+// normalizeMaxResults normalizes the maxResults parameter. It handles zero values,
+// applies internal limits, and provides logging for debugging.
+func normalizeMaxResults(ctx context.Context, requestedMaxResults int32) int32 {
+	// Handle zero case - user wants default behavior
+	if requestedMaxResults == 0 {
+		log.DebugLog(ctx, "maxResults was 0, using internal default: %d", defaultMaxResults)
+
+		return defaultMaxResults
+	}
+
+	// Apply internal max limit for memory management
+	if requestedMaxResults > defaultMaxResults {
+		log.DebugLog(ctx, "maxResults limited from %d to %d (internal max limit)",
+			requestedMaxResults, defaultMaxResults)
+
+		return defaultMaxResults
+	}
+	log.DebugLog(ctx, "using requested maxResults: %d", requestedMaxResults)
+
+	return requestedMaxResults
+}
+
+func validateMetadataAllocatedReq(req *csi.GetMetadataAllocatedRequest) error {
+	if req.GetSnapshotId() == "" {
+		return status.Error(codes.InvalidArgument, "snapshot ID cannot be empty")
+	}
+
+	if req.GetSecrets() == nil || len(req.GetSecrets()) == 0 {
+		return status.Error(codes.InvalidArgument, "secrets cannot be nil or empty")
+	}
+
+	if req.GetMaxResults() < 0 {
+		return status.Error(codes.InvalidArgument, "max results cannot be negative")
+	}
+
+	if req.GetStartingOffset() < 0 {
+		return status.Error(codes.OutOfRange, "starting offset cannot be negative")
+	}
+
+	return nil
+}
+
+// GetMetadataAllocated streams the allocated block metadata for a snapshot.
+func (cs *ControllerServer) GetMetadataAllocated(
+	req *csi.GetMetadataAllocatedRequest,
+	stream csi.SnapshotMetadata_GetMetadataAllocatedServer,
+) error {
+	ctx := stream.Context()
+	rbdSnapDiffByIDSupported, err := features.SupportsRBDSnapDiffByID()
+	if err != nil {
+		log.ErrorLog(ctx, "error checking for snapshot diff by ID support: %s", err)
+
+		return status.Error(codes.Internal, err.Error())
+	} else if !rbdSnapDiffByIDSupported {
+		log.ErrorLog(ctx, "snapshot diff by ID feature is not supported")
+
+		return status.Error(codes.Unimplemented, "snapshot diff by ID feature is not supported")
+	}
+
+	err = validateMetadataAllocatedReq(req)
+	if err != nil {
+		return err
+	}
+
+	snapshotID := req.GetSnapshotId()
+
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
+	rbdSnap, err := mgr.GetSnapshotByID(ctx, snapshotID)
+	if err != nil {
+		if errors.Is(err, rbderrors.ErrImageNotFound) {
+			log.ErrorLog(ctx, "snapshot %q not found: %v", snapshotID, err)
+
+			return status.Errorf(codes.NotFound, "snapshot %q not found: %v", snapshotID, err)
+		}
+
+		return status.Error(codes.Internal, err.Error())
+	}
+	defer rbdSnap.Destroy(ctx)
+
+	volSize := rbdSnap.GetSize()
+
+	startingOffset := req.GetStartingOffset()
+	if startingOffset >= volSize {
+		return status.Errorf(codes.OutOfRange, "starting offset %d is out of range for volume size %d",
+			startingOffset, volSize)
+	}
+
+	maxResults := normalizeMaxResults(ctx, req.GetMaxResults())
+
+	sendResponse := func(changedBlocks []*csi.BlockMetadata) error {
+		return stream.Send(&csi.GetMetadataAllocatedResponse{
+			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+			VolumeCapacityBytes: volSize,
+			BlockMetadata:       changedBlocks,
+		})
+	}
+
+	err = rbdSnap.ProcessMetadata(ctx, startingOffset, maxResults, nil, sendResponse)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to stream metadata allocated: %v", err)
+
+		return status.Error(codes.Internal, err.Error())
+	}
+	log.DebugLog(ctx, "successfully streamed metadata allocated")
+
+	return nil
+}
+
+func validateMetadataDeltaReq(req *csi.GetMetadataDeltaRequest) error {
+	if req.GetBaseSnapshotId() == "" {
+		return status.Error(codes.InvalidArgument, "base snapshot ID cannot be empty")
+	}
+
+	if req.GetTargetSnapshotId() == "" {
+		return status.Error(codes.InvalidArgument, "target snapshot ID cannot be empty")
+	}
+
+	if req.GetSecrets() == nil || len(req.GetSecrets()) == 0 {
+		return status.Error(codes.InvalidArgument, "secrets cannot be nil or empty")
+	}
+
+	if req.GetMaxResults() < 0 {
+		return status.Error(codes.InvalidArgument, "max results cannot be negative")
+	}
+
+	if req.GetStartingOffset() < 0 {
+		return status.Error(codes.OutOfRange, "starting offset cannot be negative")
+	}
+
+	return nil
+}
+
+// GetMetadataDelta streams the block metadata delta between two snapshots.
+func (cs *ControllerServer) GetMetadataDelta(
+	req *csi.GetMetadataDeltaRequest,
+	stream csi.SnapshotMetadata_GetMetadataDeltaServer,
+) error {
+	ctx := stream.Context()
+	rbdSnapDiffByIDSupported, err := features.SupportsRBDSnapDiffByID()
+	if err != nil {
+		log.ErrorLog(ctx, "failed to check for snapshot diff by ID support: %s", err)
+
+		return status.Error(codes.Internal, err.Error())
+	} else if !rbdSnapDiffByIDSupported {
+		log.ErrorLog(ctx, "snapshot diff by ID feature is not supported")
+
+		return status.Error(codes.Unimplemented, "snapshot diff by ID feature is not supported")
+	}
+
+	err = validateMetadataDeltaReq(req)
+	if err != nil {
+		return err
+	}
+
+	baseSnapshotID := req.GetBaseSnapshotId()
+	targetSnapshotID := req.GetTargetSnapshotId()
+
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
+	baseRBDSnap, err := mgr.GetSnapshotByID(ctx, baseSnapshotID)
+	if err != nil {
+		if errors.Is(err, rbderrors.ErrImageNotFound) {
+			log.ErrorLog(ctx, "snapshot %q not found: %v", baseSnapshotID, err)
+
+			return status.Errorf(codes.NotFound, "snapshot %q not found: %v", baseSnapshotID, err)
+		}
+
+		return status.Error(codes.Internal, err.Error())
+	}
+	defer baseRBDSnap.Destroy(ctx)
+
+	targetRBDSnap, err := mgr.GetSnapshotByID(ctx, targetSnapshotID)
+	if err != nil {
+		if errors.Is(err, rbderrors.ErrImageNotFound) {
+			log.ErrorLog(ctx, "snapshot %q not found: %v", targetSnapshotID, err)
+
+			return status.Errorf(codes.NotFound, "snapshot %q not found: %v", targetSnapshotID, err)
+		}
+
+		return status.Error(codes.Internal, err.Error())
+	}
+	defer targetRBDSnap.Destroy(ctx)
+
+	volSize := targetRBDSnap.GetSize()
+
+	startingOffset := req.GetStartingOffset()
+	if startingOffset >= volSize {
+		return status.Errorf(codes.OutOfRange, "starting offset %d is out of range for volume size %d",
+			startingOffset, volSize)
+	}
+
+	maxResults := normalizeMaxResults(ctx, req.GetMaxResults())
+
+	sendResponse := func(changedBlocks []*csi.BlockMetadata) error {
+		return stream.Send(&csi.GetMetadataDeltaResponse{
+			BlockMetadataType:   csi.BlockMetadataType_VARIABLE_LENGTH,
+			VolumeCapacityBytes: volSize,
+			BlockMetadata:       changedBlocks,
+		})
+	}
+
+	err = targetRBDSnap.ProcessMetadata(ctx, startingOffset, maxResults, baseRBDSnap, sendResponse)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to stream metadata delta: %v", err)
+
+		return status.Error(codes.Internal, err.Error())
+	}
+	log.DebugLog(ctx, "successfully streamed metadata delta")
+
+	return nil
+}

--- a/internal/rbd/sms_controllerserver_test.go
+++ b/internal/rbd/sms_controllerserver_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+func Test_validateMetadataAllocatedReq(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		req *csi.GetMetadataAllocatedRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			args: args{
+				req: &csi.GetMetadataAllocatedRequest{
+					SnapshotId:     "snap-12345",
+					StartingOffset: int64(0),
+					MaxResults:     int32(100),
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid request - missing snapshot ID",
+			args: args{
+				req: &csi.GetMetadataAllocatedRequest{
+					SnapshotId:     "",
+					StartingOffset: int64(0),
+					MaxResults:     int32(100),
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid request - negative starting offset",
+			args: args{
+				req: &csi.GetMetadataAllocatedRequest{
+					SnapshotId:     "snap-12345",
+					StartingOffset: int64(-1),
+					MaxResults:     int32(100),
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid request - negative max results",
+			args: args{
+				req: &csi.GetMetadataAllocatedRequest{
+					SnapshotId:     "snap-12345",
+					StartingOffset: int64(0),
+					MaxResults:     int32(-100), // MaxResults should be greater than 0
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid request - empty secrets",
+			args: args{
+				req: &csi.GetMetadataAllocatedRequest{
+					SnapshotId:     "snap-12345",
+					StartingOffset: int64(0),
+					MaxResults:     int32(100),
+					Secrets:        map[string]string{},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateMetadataAllocatedReq(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMetadataAllocatedReq() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_validateMetadataDeltaReq(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		req *csi.GetMetadataDeltaRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			args: args{
+				req: &csi.GetMetadataDeltaRequest{
+					BaseSnapshotId:   "base-snap-12345",
+					TargetSnapshotId: "target-snap-67890",
+					StartingOffset:   int64(0),
+					MaxResults:       int32(100),
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid request - missing base snapshot ID",
+			args: args{
+				req: &csi.GetMetadataDeltaRequest{
+					BaseSnapshotId:   "",
+					TargetSnapshotId: "target-snap-67890",
+					StartingOffset:   int64(0),
+					MaxResults:       int32(100),
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid request - missing target snapshot ID",
+			args: args{
+				req: &csi.GetMetadataDeltaRequest{
+					BaseSnapshotId:   "base-snap-12345",
+					TargetSnapshotId: "",
+					StartingOffset:   int64(0),
+					MaxResults:       int32(100),
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid request - negative starting offset",
+			args: args{
+				req: &csi.GetMetadataDeltaRequest{
+					BaseSnapshotId:   "base-snap-12345",
+					TargetSnapshotId: "target-snap-67890",
+					StartingOffset:   int64(-1),
+					MaxResults:       int32(100),
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid request - negative max results",
+			args: args{
+				req: &csi.GetMetadataDeltaRequest{
+					BaseSnapshotId:   "base-snap-12345",
+					TargetSnapshotId: "target-snap-67890",
+					StartingOffset:   int64(0),
+					MaxResults:       int32(-100), // MaxResults should be greater than 0
+					Secrets: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid request - empty secrets",
+			args: args{
+				req: &csi.GetMetadataDeltaRequest{
+					BaseSnapshotId:   "base-snap-12345",
+					TargetSnapshotId: "target-snap-67890",
+					StartingOffset:   int64(0),
+					MaxResults:       int32(100),
+					Secrets:          map[string]string{},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateMetadataDeltaReq(tt.args.req); (err != nil) != tt.wantErr {
+				t.Errorf("validateMetadataDeltaReq() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_normalizeMaxResults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		requestedMaxResults int32
+		want                int32
+	}{
+		{
+			name:                "zero value returns default",
+			requestedMaxResults: 0,
+			want:                defaultMaxResults,
+		},
+		{
+			name:                "value exceeding maximum gets capped",
+			requestedMaxResults: defaultMaxResults + 100,
+			want:                defaultMaxResults,
+		},
+		{
+			name:                "valid value within limits returns as-is",
+			requestedMaxResults: 50,
+			want:                50,
+		},
+		{
+			name:                "value equal to maximum returns maximum",
+			requestedMaxResults: defaultMaxResults,
+			want:                defaultMaxResults,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			got := normalizeMaxResults(ctx, tt.requestedMaxResults)
+			if got != tt.want {
+				t.Errorf("normalizeMaxResults() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rbd/snap_diff.go
+++ b/internal/rbd/snap_diff.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util/log"
+
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+)
+
+// ProcessMetadata streams the block metadata for a snapshot.
+// If baseRBDSnap is provided, it calculates the delta between the
+// current snapshot and the base snapshot.
+func (rbdSnap *rbdSnapshot) ProcessMetadata(
+	ctx context.Context,
+	startingOffset int64,
+	maxResults int32,
+	baseSnap types.Snapshot,
+	sendResponse types.MetadataCallback,
+) error {
+	var fromSnapID uint64
+
+	image, err := rbdSnap.open()
+	if err != nil {
+		return fmt.Errorf("failed to open image %q: %w", rbdSnap, err)
+	}
+	defer func() {
+		cErr := image.Close()
+		if cErr != nil {
+			log.WarningLog(ctx, "resource leak, failed to close image: %v", cErr)
+		}
+	}()
+
+	snapID, err := rbdSnap.getRBDSnapID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot ID of %q: %w", rbdSnap, err)
+	}
+
+	err = image.SetSnapByID(snapID)
+	if err != nil {
+		return fmt.Errorf("failed to set snapshot %q by ID %d: %w",
+			rbdSnap, snapID, err)
+	}
+
+	if baseSnap != nil {
+		baseRBDSnap, err := rbdSnapFromSnapshot(baseSnap)
+		if err != nil {
+			return fmt.Errorf("failed to convert base snapshot to rbdSnapshot: %w", err)
+		}
+		fromSnapID, err = baseRBDSnap.getRBDSnapID(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get ID of base snapshot ID: %w", err)
+		}
+	}
+
+	luksHeaderPadding, err := rbdSnap.getLuksHeaderSizeMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to get LUKS header size from metadata: %w", err)
+	}
+	// We need to adjust the starting offset to account for the LUKS header padding.
+	startingOffset += int64(luksHeaderPadding)
+
+	// If the starting offset is greater than the volume size after adding padding,
+	// we can return early since there are no changed blocks to report.
+	if startingOffset > rbdSnap.VolSize {
+		return nil
+	}
+
+	changedBlocks := make([]*csi.BlockMetadata, 0)
+	cb := createDiffIterateByIDCB(
+		ctx,
+		&changedBlocks,
+		maxResults,
+		luksHeaderPadding,
+		sendResponse,
+	)
+	diffIterateByIDConfig := librbd.DiffIterateByIDConfig{
+		Offset:   uint64(startingOffset),
+		Length:   uint64(rbdSnap.VolSize),
+		Callback: cb,
+	}
+	if baseSnap != nil {
+		// If a base snapshot is provided, set the FromSnapID to
+		// the base snapshot ID to get the delta between the two snapshots.
+		diffIterateByIDConfig.FromSnapID = fromSnapID
+	}
+
+	diffIterateErr := image.DiffIterateByID(diffIterateByIDConfig)
+	err = handleDiffIterateError(diffIterateErr)
+	if err != nil {
+		return fmt.Errorf("failed to get diff: %w", err)
+	}
+
+	if len(changedBlocks) != 0 {
+		// Send any remaining changed blocks after the loop.
+		err = sendResponse(changedBlocks)
+		if err != nil {
+			return fmt.Errorf("failed to send response: %w", err)
+		}
+	}
+	// Successfully completed the diff operation.
+	return nil
+}
+
+// handleDiffIterateError checks the error returned by DiffIterateByID.
+// It handles specific error codes and returns a formatted error message
+// for unrecognized error codes.
+func handleDiffIterateError(err error) error {
+	if err == nil {
+		// No error, return nil.
+		return nil
+	}
+	// Check if the error implements ErrorCode to handle specific error codes.
+	var errCode rbderrors.ErrorCode
+	ok := errors.As(err, &errCode)
+	if !ok {
+		// The error does not implement ErrorCode, return a generic internal error.
+		return fmt.Errorf("failed to get diff: %w", err)
+	}
+
+	switch errCode.ErrorCode() {
+	case int(codes.OK):
+		// No error, the diff operation completed successfully.
+		return nil
+	case int(codes.Canceled):
+		// The stream was closed by the client.
+		// This is not an error, just a normal termination of the stream.
+		// Log the closure for debugging purposes.
+		return nil
+	case int(codes.Unknown):
+		// An error occurred while sending the response.
+		return fmt.Errorf("failed to send response: %w", err)
+	}
+
+	// An unexpected error occurred.
+	return fmt.Errorf("failed to get diff: %w, unrecognized error code: %d", err, errCode)
+}
+
+// createDiffIterateByIDCB creates a DiffIterateCallback function that collects
+// changed blocks and sends them to the stream when the maxResults limit is reached.
+func createDiffIterateByIDCB(
+	ctx context.Context,
+	changedBlocks *[]*csi.BlockMetadata,
+	maxResults int32,
+	luksHeaderPadding uint64,
+	sendResponse types.MetadataCallback,
+) librbd.DiffIterateCallback {
+	return func(offset, sizeBytes uint64, _ int, _ interface{}) int {
+		select {
+		case <-ctx.Done():
+			return int(codes.Canceled)
+		default:
+			// subtract the LUKS header padding from the offset
+			// since user data starts after the LUKS header.
+			offset -= luksHeaderPadding
+			*changedBlocks = append(*changedBlocks,
+				&csi.BlockMetadata{
+					ByteOffset: int64(offset),
+					SizeBytes:  int64(sizeBytes),
+				},
+			)
+		}
+		if len(*changedBlocks) < int(maxResults) {
+			// If we haven't reached the maxResults limit, continue collecting changed blocks.
+			return int(codes.OK)
+		}
+
+		// Send the current batch of changed blocks to the stream since
+		// we have reached the maxResults limit.
+		err := sendResponse(*changedBlocks)
+		if err != nil {
+			return int(codes.Unknown)
+		}
+		// Reset the changedBlocks slice for the next batch.
+		*changedBlocks = (*changedBlocks)[:0]
+
+		return int(codes.OK)
+	}
+}

--- a/internal/rbd/snap_diff_test.go
+++ b/internal/rbd/snap_diff_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+type mockError struct {
+	code int
+	msg  string
+}
+
+func (e *mockError) Error() string {
+	return fmt.Sprintf("%s: code %d", e.msg, e.code)
+}
+
+func (e *mockError) ErrorCode() int {
+	return e.code
+}
+
+func newMockError(code int, msg string) *mockError {
+	return &mockError{
+		code: code,
+		msg:  msg,
+	}
+}
+
+func Test_handleDiffIterateError(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx context.Context
+		err error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "nil error",
+			args: args{
+				ctx: t.Context(),
+				err: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "stream closed",
+			args: args{
+				ctx: t.Context(),
+				err: newMockError(int(codes.Canceled), "stream closed"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "response send failure",
+			args: args{
+				ctx: t.Context(),
+				err: newMockError(int(codes.Unknown), "failed to send response"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "unrecognized error code",
+			args: args{
+				ctx: t.Context(),
+				err: newMockError(999, "unrecognized error code"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-ErrorCode error",
+			args: args{
+				ctx: t.Context(),
+				err: errors.New("generic error"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "ok error code",
+			args: args{
+				ctx: t.Context(),
+				err: newMockError(int(codes.OK), "ok error code"),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := handleDiffIterateError(tt.args.err); (err != nil) != tt.wantErr {
+				t.Errorf("handleDiffIterateError() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -400,3 +400,48 @@ func (rbdSnap *rbdSnapshot) SetVolumeGroup(ctx context.Context, cr *util.Credent
 
 	return nil
 }
+
+// GetSize returns the size of the snapshot in bytes.
+func (rbdSnap *rbdSnapshot) GetSize() int64 {
+	return rbdSnap.VolSize
+}
+
+// rbdSnapFromSnapshot converts a types.Snapshot to a *rbdSnapshot.
+// It returns an error if the snapshot is nil or not of type *rbdSnapshot.
+func rbdSnapFromSnapshot(snap types.Snapshot) (*rbdSnapshot, error) {
+	if snap == nil {
+		return nil, errors.New("nil snapshot provided")
+	}
+
+	rbdSnap, ok := snap.(*rbdSnapshot)
+	if !ok {
+		return nil, errors.New("snapshot object is not of type rbdSnapshot")
+	}
+
+	return rbdSnap, nil
+}
+
+// getRBDSnapID returns the associated rbd snapshot ID.
+func (rbdSnap *rbdSnapshot) getRBDSnapID(ctx context.Context) (uint64, error) {
+	vol := rbdSnap.toVolume()
+	vol.conn = rbdSnap.conn.Copy()
+	defer vol.Destroy(ctx)
+
+	image, err := vol.open()
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		cErr := image.Close()
+		if cErr != nil {
+			log.WarningLog(ctx, "resource leak, failed to close image: %v", cErr)
+		}
+	}()
+
+	parentInfo, err := image.GetParent()
+	if err != nil {
+		return 0, err
+	}
+
+	return parentInfo.Snap.ID, nil
+}

--- a/internal/rbd/snapshot_test.go
+++ b/internal/rbd/snapshot_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package rbd
 
 import (
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/ceph/ceph-csi/internal/rbd/types"
 )
 
 func TestToCSISnapshot(t *testing.T) {
@@ -78,7 +81,72 @@ func TestToCSISnapshot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if _, err := tt.rs.ToCSI(t.Context()); (err != nil) != tt.wantErr {
-				t.Errorf("ToCSI() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ToCSI() error = %v, unrecogniswantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_rbdSnapFromSnapshot(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		snap types.Snapshot
+	}
+
+	// Create test data
+	validRbdSnap := &rbdSnapshot{
+		rbdImage: rbdImage{
+			VolID:     "testVolID",
+			Pool:      "testPool",
+			ClusterID: "testClusterID",
+		},
+	}
+
+	// Mock types.Snapshot that's not an rbdSnapshot
+	mockSnap := struct{ types.Snapshot }{}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    *rbdSnapshot
+		wantErr bool
+	}{
+		{
+			name: "valid rbdSnapshot",
+			args: args{
+				snap: validRbdSnap,
+			},
+			want:    validRbdSnap,
+			wantErr: false,
+		},
+		{
+			name: "nil snapshot",
+			args: args{
+				snap: nil,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid snapshot type",
+			args: args{
+				snap: &mockSnap,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := rbdSnapFromSnapshot(tt.args.snap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("rbdSnapFromSnapshot() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("rbdSnapFromSnapshot() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/rbd/types/snapshot.go
+++ b/internal/rbd/types/snapshot.go
@@ -25,6 +25,9 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 )
 
+// MetadataCallback is a function type for sending responses in the SMS controller server.
+type MetadataCallback func([]*csi.BlockMetadata) error
+
 type Snapshot interface {
 	journalledObject
 
@@ -37,4 +40,16 @@ type Snapshot interface {
 
 	// SetVolumeGroup sets the CSI volume group ID in the snapshot.
 	SetVolumeGroup(ctx context.Context, creds *util.Credentials, vgID string) error
+
+	// GetSize returns the size of the snapshot in bytes.
+	GetSize() int64
+
+	// ProcessMetadata processes the block metadata for a snapshot.
+	// If baseRBDSnap is provided, the delta between the
+	// current snapshot and the base snapshot is processed.
+	ProcessMetadata(ctx context.Context,
+		startingOffset int64,
+		maxResults int32,
+		baseRBDSnap Snapshot,
+		sendResponse MetadataCallback) error
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
rbd: add support for changed block tracking RPCs

This commit adds support for GetMetadataAllocated
and GetMetadataDelta RPCs.
[CSI Snapshot Metadata Service RPCs](https://github.com/container-storage-interface/spec/blob/master/spec.md#snapshot-metadata-service-rpcs)

Updates: #5346 

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
