### PR TITLE
util: pass Servers by reference to serve()

### DIFF
--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -66,7 +66,7 @@ func (s *nonBlockingGRPCServer) Start(
 	middlewareConfig MiddlewareServerOptionConfig,
 ) {
 	s.wg.Add(1)
-	go s.serve(endpoint, *srv, middlewareConfig)
+	go s.serve(endpoint, srv, middlewareConfig)
 }
 
 // Wait blocks until the WaitGroup counter.
@@ -86,7 +86,7 @@ func (s *nonBlockingGRPCServer) ForceStop() {
 
 func (s *nonBlockingGRPCServer) serve(
 	endpoint string,
-	srv Servers,
+	srv *Servers,
 	middlewareConfig MiddlewareServerOptionConfig,
 ) {
 	proto, addr, err := parseEndpoint(endpoint)


### PR DESCRIPTION
This commit modifies nonBlockingGRPCServer.serve() to accept Servers parameter by reference rather
than value to prevent copy of a large struct.

related-to : #5351 

Missed in #5351 
linter is still failing at https://github.com/ceph/ceph-csi/actions/runs/15466994254/job/43541315936?pr=5347

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
