### PR TITLE
nfs: return success if export already exists

### DIFF
--- a/internal/nfs/controller/volume.go
+++ b/internal/nfs/controller/volume.go
@@ -166,6 +166,8 @@ func (nv *NFSVolume) CreateExport(backend *csi.Volume) error {
 	switch {
 	case err == nil:
 		return nil
+	case strings.Contains(err.Error(), "Export already exists"):
+		return nil
 	case strings.Contains(err.Error(), "rados: ret=-2"): // try with the old command
 		break
 	default: // any other error


### PR DESCRIPTION
Incase of restart etc the export might have already created, we need to return success in that case.

fixes: #5371

