### PR TITLE
ci: update pull request commenter for 1.33

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -19,15 +19,24 @@ jobs:
     strategy:
       matrix:
         branch: [release-v3.13, release-v3.14, devel]
-        k8s: ["1.29", "1.30", "1.31", "1.32"]
+        k8s: ["1.29", "1.30", "1.31", "1.32", "1.33"]
         exclude:
           - k8s: "1.32"
+            branch: "release-v3.13"
+
+          - k8s: "1.33"
             branch: "release-v3.13"
 
           - k8s: "1.29"
             branch: "release-v3.14"
 
+          - k8s: "1.33"
+            branch: "release-v3.14"
+
           - k8s: "1.29"
+            branch: "devel"
+
+          - k8s: "1.30"
             branch: "devel"
 
     # watch out, matrix.branch can not be used in this if-statement :-/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -62,15 +62,15 @@ queue_rules:
               - or:
                   - label=ci/skip/e2e
                   - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.30"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.30"
+                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.30"
+                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
                       - "status-success=ci/centos/mini-e2e/k8s-1.31"
                       - "status-success=ci/centos/mini-e2e/k8s-1.32"
+                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
                       - "status-success=ci/centos/upgrade-tests-cephfs"
                       - "status-success=ci/centos/upgrade-tests-rbd"
           - and:
@@ -134,15 +134,15 @@ pull_request_rules:
       - or:
           - label=ci/skip/e2e
           - and:
-              - "status-success=ci/centos/k8s-e2e-external-storage/1.30"
               - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
               - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-              - "status-success=ci/centos/mini-e2e-helm/k8s-1.30"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
               - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
               - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-              - "status-success=ci/centos/mini-e2e/k8s-1.30"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
               - "status-success=ci/centos/mini-e2e/k8s-1.31"
               - "status-success=ci/centos/mini-e2e/k8s-1.32"
+              - "status-success=ci/centos/mini-e2e/k8s-1.33"
               - "status-success=ci/centos/upgrade-tests-cephfs"
               - "status-success=ci/centos/upgrade-tests-rbd"
     actions:
@@ -238,15 +238,15 @@ pull_request_rules:
               - or:
                   - label=ci/skip/e2e
                   - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.30"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.30"
+                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.30"
+                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
                       - "status-success=ci/centos/mini-e2e/k8s-1.31"
                       - "status-success=ci/centos/mini-e2e/k8s-1.32"
+                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
                       - "status-success=ci/centos/upgrade-tests-cephfs"
                       - "status-success=ci/centos/upgrade-tests-rbd"
     actions:


### PR DESCRIPTION
Add 1.33 to matrix to run only for devel branch
and skip this in release 3.13 and 3.14 branch

Remove 1.30 from testing from devel branch as
its EOL is 2025-06-28.

depends-on: #5380