### PR TITLE
flattenClonedRbdImages may require namespace

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -634,6 +634,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			children,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {
@@ -669,6 +670,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			children,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -825,12 +825,13 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 func flattenClonedRbdImages(
 	ctx context.Context,
 	children []string,
-	pool, monitors, rbdImageName string,
+	pool, monitors, radosNamespace, rbdImageName string,
 	cr *util.Credentials,
 ) error {
 	rv := &rbdVolume{}
 	rv.Monitors = monitors
 	rv.Pool = pool
+	rv.RadosNamespace = radosNamespace
 	rv.RbdImageName = rbdImageName
 
 	defer rv.Destroy(ctx)


### PR DESCRIPTION
# Describe what this PR does #
`PrepareVolumeForSnapshot()` or `flattenParentImage()` requires rbd image flattening, that is performed in function `flattenClonedRbdImages()`. This function is lacking namespace support. This was undetected before because ceph local installs, used as tests, provides a default namespace and it's not common behaviour to create new ones.

The underlying bug is very critical : snapshots are performed but flattening are never performed, leading to accumulation of data.


## Is there anything that requires special attention ##

**Do you have any questions?** no

**Is the change backward compatible?** yes

**Are there concerns around backward compatibility?** this code was tested with non-default namespaces but should be tested proactively in all situations.

## Future concerns ##

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

This is my first PR on this project, let me know if I missed something.