### PR TITLE
util: explicitly set the Luks2 header size

### DIFF
--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -21,10 +21,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/ceph/ceph-csi/internal/util/cryptsetup"
 	"github.com/ceph/ceph-csi/pkg/util/kernel"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -637,6 +639,18 @@ func validateEncryptedImage(f *framework.Framework, rbdImageSpec, pvName, appNam
 	}
 	if encryptedState != "encrypted" {
 		return fmt.Errorf("%v not equal to encrypted", encryptedState)
+	}
+
+	headerSizeValue, err := getImageMeta(rbdImageSpec, "rbd.csi.ceph.com/luks2HeaderSize", f)
+	if err != nil {
+		return err
+	}
+	headerSize, parseErr := strconv.ParseUint(headerSizeValue, 10, 64)
+	if parseErr != nil {
+		return fmt.Errorf("failed to parse luks2 header size for %s: %w", rbdImageSpec, parseErr)
+	}
+	if headerSize != cryptsetup.Luks2HeaderSize {
+		return fmt.Errorf("luks2 header size for %s is %d, expected %d", rbdImageSpec, headerSize, cryptsetup.Luks2HeaderSize)
 	}
 
 	pod, err := f.ClientSet.CoreV1().Pods(f.UniqueName).Get(context.TODO(), appName, metav1.GetOptions{})

--- a/e2e/vendor/github.com/ceph/ceph-csi/internal/util/cryptsetup/cryptsetup.go
+++ b/e2e/vendor/github.com/ceph/ceph-csi/internal/util/cryptsetup/cryptsetup.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2019 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cryptsetup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ceph/ceph-csi/internal/util/file"
+	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/internal/util/stripsecrets"
+
+	"k8s.io/cloud-provider/volume/helpers"
+)
+
+const (
+	// Maximum time to wait for cryptsetup commands to complete.
+	ExecutionTimeout = 2*time.Minute + 30*time.Second
+
+	// Limit memory used by Argon2i PBKDF to 32 MiB.
+	cryptsetupPBKDFMemoryLimit = 32 << 10 // 32768 KiB
+	luks2MetadataSize          = 32 << 7  // 4096 KiB
+	luks2KeySlotsSize          = 32 << 8  // 8192 KiB
+
+	// The LUKS2 header size is variable and it can be adjusted
+	// on creation by using the `--luks2-metadata-size` and
+	// `--luks2-keyslots-size` options. By default, the header size is
+	// 16MiB.
+	DefaultLuks2HeaderSize = 16 * helpers.MiB
+	Luks2HeaderSize = uint64((((2 * luks2MetadataSize) + luks2KeySlotsSize) * helpers.KiB))
+)
+
+// LuksWrapper is a struct that provides a context-aware wrapper around cryptsetup commands.
+type LUKSWrapper interface {
+	Format(devicePath, passphrase string) (string, string, error)
+	Open(devicePath, mapperFile, passphrase string) (string, string, error)
+	Close(mapperFile string) (string, string, error)
+	AddKey(devicePath, passphrase, newPassphrase, slot string) error
+	RemoveKey(devicePath, passphrase, slot string) error
+	Resize(mapperFile string) (string, string, error)
+	VerifyKey(devicePath, passphrase, slot string) (bool, error)
+	Status(mapperFile string) (string, string, error)
+}
+
+// luksWrapper is a type that implements LUKSWrapper interface
+// and provides a shared context for its methods.
+type luksWrapper struct {
+	ctx context.Context
+}
+
+// NewLUKSWrapper creates a new LUKSWrapper instance with the provided context.
+// The context is used to control the lifetime of the cryptsetup commands.
+func NewLUKSWrapper(ctx context.Context) LUKSWrapper {
+	return &luksWrapper{ctx: ctx}
+}
+
+// LuksFormat sets up volume as an encrypted LUKS partition.
+func (l *luksWrapper) Format(devicePath, passphrase string) (string, string, error) {
+	return l.execCryptsetupCommand(
+		&passphrase,
+		"-q",
+		"luksFormat",
+		"--type",
+		"luks2",
+		"--hash",
+		"sha256",
+		"--luks2-metadata-size",
+		strconv.Itoa(luks2MetadataSize)+"k",
+		"--luks2-keyslots-size",
+		strconv.Itoa(luks2KeySlotsSize)+"k",
+		"--pbkdf-memory",
+		strconv.Itoa(cryptsetupPBKDFMemoryLimit),
+		devicePath,
+		"-d",
+		"-")
+}
+
+// LuksOpen opens LUKS encrypted partition and sets up a mapping.
+func (l *luksWrapper) Open(devicePath, mapperFile, passphrase string) (string, string, error) {
+	// cryptsetup option --disable-keyring (introduced with cryptsetup v2.0.0)
+	// will be ignored with luks1
+	return l.execCryptsetupCommand(
+		&passphrase,
+		"luksOpen",
+		devicePath,
+		mapperFile,
+		"--disable-keyring",
+		"-d",
+		"-")
+}
+
+// LuksResize resizes LUKS encrypted partition.
+func (l *luksWrapper) Resize(mapperFile string) (string, string, error) {
+	return l.execCryptsetupCommand(nil, "resize", mapperFile)
+}
+
+// LuksClose removes existing mapping.
+func (l *luksWrapper) Close(mapperFile string) (string, string, error) {
+	return l.execCryptsetupCommand(nil, "luksClose", mapperFile)
+}
+
+// LuksStatus returns encryption status of a provided device.
+func (l *luksWrapper) Status(mapperFile string) (string, string, error) {
+	return l.execCryptsetupCommand(nil, "status", mapperFile)
+}
+
+// LuksAddKey adds a new key to the specified slot.
+func (l *luksWrapper) AddKey(devicePath, passphrase, newPassphrase, slot string) error {
+	passFile, err := file.CreateTempFile("luks-", passphrase)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(passFile.Name()) //nolint:errcheck // failed to delete temp file :-(
+
+	newPassFile, err := file.CreateTempFile("luks-", newPassphrase)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(newPassFile.Name()) //nolint:errcheck // failed to delete temp file :-(
+
+	_, stderr, err := l.execCryptsetupCommand(
+		nil,
+		"--verbose",
+		"--key-file="+passFile.Name(),
+		"--key-slot="+slot,
+		"luksAddKey",
+		devicePath,
+		newPassFile.Name(),
+	)
+
+	// Return early if no error to save us some time
+	if err == nil {
+		return nil
+	}
+
+	// Possible scenarios
+	// 1. The provided passphrase to unlock the disk is wrong
+	// 2. The key slot is already in use
+	// 	  If so, check if the key we want to add to the slot is already there
+	//    If not, remove it and then add the new key to the slot
+	if strings.Contains(stderr, fmt.Sprintf("Key slot %s is full", slot)) {
+		// The given slot already has a key
+		// Check if it is the one that we want to update with
+		exists, fErr := l.VerifyKey(devicePath, newPassphrase, slot)
+		if fErr != nil {
+			return fErr
+		}
+
+		// Verification passed, return early
+		if exists {
+			return nil
+		}
+
+		// Else, we remove the key from the given slot and add the new one
+		// Note: we use existing passphrase here as we are not yet sure if
+		// the newPassphrase is present in the headers
+		fErr = l.RemoveKey(devicePath, passphrase, slot)
+		if fErr != nil {
+			return fErr
+		}
+
+		// Now the slot is free, add the new key to it
+		fErr = l.AddKey(devicePath, passphrase, newPassphrase, slot)
+		if fErr != nil {
+			return fErr
+		}
+
+		// No errors, we good.
+		return nil
+	}
+
+	// The existing passphrase is wrong and the slot is empty
+	return err
+}
+
+// LuksRemoveKey removes the key by killing the specified slot.
+func (l *luksWrapper) RemoveKey(devicePath, passphrase, slot string) error {
+	keyFile, err := file.CreateTempFile("luks-", passphrase)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(keyFile.Name()) //nolint:errcheck // failed to delete temp file :-(
+
+	_, stderr, err := l.execCryptsetupCommand(
+		nil,
+		"--verbose",
+		"--key-file="+keyFile.Name(),
+		"luksKillSlot",
+		devicePath,
+		slot,
+	)
+	if err != nil {
+		// If a slot is not active, don't treat that as an error
+		if !strings.Contains(stderr, fmt.Sprintf("Keyslot %s is not active.", slot)) {
+			return fmt.Errorf("failed to kill slot %s for device %s: %w", slot, devicePath, err)
+		}
+	}
+
+	return nil
+}
+
+// LuksVerifyKey verifies that a key exists in a given slot.
+func (l *luksWrapper) VerifyKey(devicePath, passphrase, slot string) (bool, error) {
+	// Create a temp file that we will use to open the device
+	keyFile, err := file.CreateTempFile("luks-", passphrase)
+	if err != nil {
+		return false, err
+	}
+	defer os.Remove(keyFile.Name()) //nolint:errcheck // failed to delete temp file :-(
+
+	_, stderr, err := l.execCryptsetupCommand(
+		nil,
+		"--verbose",
+		"--key-file="+keyFile.Name(),
+		"--key-slot="+slot,
+		"luksChangeKey",
+		devicePath,
+		keyFile.Name(),
+	)
+	if err != nil {
+		// If the passphrase doesn't match the key in given slot
+		if strings.Contains(stderr, "No key available with this passphrase.") {
+			// No match, no error
+			return false, nil
+		}
+
+		// Otherwise it was something else, return the wrapped error
+		log.ErrorLogMsg("failed to verify key in slot %s. stderr: %s. err: %v", slot, stderr, err)
+
+		return false, fmt.Errorf("failed to verify key in slot %s for device %s: %w", slot, devicePath, err)
+	}
+
+	return true, nil
+}
+
+func (l *luksWrapper) execCryptsetupCommand(stdin *string, args ...string) (string, string, error) {
+	var (
+		program       = "cryptsetup"
+		cmd           = exec.CommandContext(l.ctx, program, args...) // #nosec:G204, commands executing not vulnerable.
+		sanitizedArgs = stripsecrets.InArgs(args)
+		stdoutBuf     bytes.Buffer
+		stderrBuf     bytes.Buffer
+	)
+
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	if stdin != nil {
+		cmd.Stdin = strings.NewReader(*stdin)
+	}
+	err := cmd.Run()
+	stdout := stdoutBuf.String()
+	stderr := stderrBuf.String()
+
+	if errors.Is(l.ctx.Err(), context.DeadlineExceeded) {
+		return stdout, stderr, fmt.Errorf("timeout occurred while running %s args: %v", program, sanitizedArgs)
+	}
+
+	if err != nil {
+		return stdout, stderr, fmt.Errorf("an error (%v)"+
+			" occurred while running %s args: %v", err, program, sanitizedArgs)
+	}
+
+	return stdout, stderr, err
+}

--- a/e2e/vendor/github.com/ceph/ceph-csi/internal/util/file/file.go
+++ b/e2e/vendor/github.com/ceph/ceph-csi/internal/util/file/file.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"fmt"
+	"os"
+)
+
+// CreateTempFile create a temporary file with the given string
+// content and returns the reference to the file.
+// The caller is responsible for disposing the file.
+func CreateTempFile(prefix, contents string) (*os.File, error) {
+	// Create a temp file
+	file, err := os.CreateTemp("", prefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary file: %w", err)
+	}
+
+	// In case of error, remove the file if it was created
+	defer func() {
+		if err != nil {
+			//nolint:errcheck // temporary file failed to remove, shrug
+			_ = os.Remove(file.Name())
+		}
+	}()
+
+	// Write the contents
+	var c int
+	c, err = file.WriteString(contents)
+	if err != nil || c != len(contents) {
+		return nil, fmt.Errorf("failed to write temporary file: %w", err)
+	}
+
+	// Close the handle
+	if err = file.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temporary file: %w", err)
+	}
+
+	return file, nil
+}
+
+// CreateSpareFile makes `file` a sparse file of size `sizeMB`.
+func CreateSparseFile(file *os.File, sizeMB int64) error {
+	sizeBytes := sizeMB * 1024 * 1024
+
+	// seek to the end of the file.
+	if _, err := file.Seek(sizeBytes-1, 0); err != nil {
+		return fmt.Errorf("failed to seek to the end of the file: %w", err)
+	}
+
+	// write a single byte, effectively making it a sparse file.
+	if _, err := file.Write([]byte{0}); err != nil {
+		return fmt.Errorf("failed to write to the end of the file: %w", err)
+	}
+
+	return nil
+}

--- a/e2e/vendor/github.com/ceph/ceph-csi/internal/util/stripsecrets/stripsecrets.go
+++ b/e2e/vendor/github.com/ceph/ceph-csi/internal/util/stripsecrets/stripsecrets.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2019 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stripsecrets
+
+import (
+	"strings"
+)
+
+const (
+	keyArg              = "--key="
+	keyFileArg          = "--keyfile="
+	secretArg           = "secret="
+	optionsArgSeparator = ','
+	strippedKey         = "--key=***stripped***"
+	strippedKeyFile     = "--keyfile=***stripped***"
+	strippedSecret      = "secret=***stripped***"
+)
+
+// InArgs strips values of either "--key"/"--keyfile" or "secret=".
+// `args` is left unchanged.
+// Expects only one occurrence of either "--key"/"--keyfile" or "secret=".
+func InArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+
+	if !stripKey(out) {
+		stripSecret(out)
+	}
+
+	return out
+}
+
+func stripKey(out []string) bool {
+	for i := range out {
+		if strings.HasPrefix(out[i], keyArg) {
+			out[i] = strippedKey
+
+			return true
+		}
+
+		if strings.HasPrefix(out[i], keyFileArg) {
+			out[i] = strippedKeyFile
+
+			return true
+		}
+	}
+
+	return false
+}
+
+func stripSecret(out []string) bool {
+	for i := range out {
+		arg := out[i]
+		begin := strings.Index(arg, secretArg)
+
+		if begin == -1 {
+			continue
+		}
+
+		end := strings.IndexByte(arg[begin+len(secretArg):], optionsArgSeparator)
+
+		out[i] = arg[:begin] + strippedSecret
+		if end != -1 {
+			out[i] += arg[end+len(secretArg):]
+		}
+
+		return true
+	}
+
+	return false
+}

--- a/e2e/vendor/modules.txt
+++ b/e2e/vendor/modules.txt
@@ -25,7 +25,10 @@ github.com/blang/semver/v4
 github.com/cenkalti/backoff/v4
 # github.com/ceph/ceph-csi v2.0.1+incompatible => ../
 ## explicit; go 1.24.0
+github.com/ceph/ceph-csi/internal/util/cryptsetup
+github.com/ceph/ceph-csi/internal/util/file
 github.com/ceph/ceph-csi/internal/util/log
+github.com/ceph/ceph-csi/internal/util/stripsecrets
 github.com/ceph/ceph-csi/pkg/util/crypto
 github.com/ceph/ceph-csi/pkg/util/kernel
 # github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000 => ../api

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -62,6 +62,9 @@ const (
 	metadataDEK    = "rbd.csi.ceph.com/dek"
 	oldMetadataDEK = ".rbd.csi.ceph.com/dek"
 
+	// luks2 header size metadata key.
+	luks2HeaderSizeKey = "rbd.csi.ceph.com/luks2HeaderSize"
+
 	encryptionPassphraseSize = 20
 
 	// rbdDefaultEncryptionType is the default to use when the
@@ -73,6 +76,35 @@ const (
 	luksSlot0 = "0"
 	luksSlot1 = "1"
 )
+
+// getLuksHeaderSizeMetadata retrieves the LUKS header size from the
+// image metadata. Older images (<=3.14) did not set the metadata
+// luks2HeaderSizeKey, so the default value is returned in that case
+// i.e, DefaultLuks2HeaderSize.
+// If the image is not block encrypted, 0 is returned.
+//
+//nolint:unused // Unused code will be used in future.
+func (ri *rbdImage) getLuksHeaderSizeMetadata() (uint64, error) {
+	if !ri.isBlockEncrypted() {
+		return 0, nil
+	}
+
+	value, err := ri.GetMetadata(luks2HeaderSizeKey)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return 0, fmt.Errorf("failed to get %s metadata on image %s: %w", luks2HeaderSizeKey, ri, err)
+		}
+
+		return cryptsetup.DefaultLuks2HeaderSize, nil
+	}
+
+	headerSize, parseErr := strconv.ParseUint(value, 10, 64)
+	if parseErr != nil {
+		return 0, fmt.Errorf("failed to parse %s metadata on image %s: %w", luks2HeaderSizeKey, ri, parseErr)
+	}
+
+	return headerSize, nil
+}
 
 // checkRbdImageEncrypted verifies if rbd image was encrypted when created.
 func (ri *rbdImage) checkRbdImageEncrypted(ctx context.Context) (rbdEncryptionState, error) {
@@ -97,6 +129,11 @@ func (ri *rbdImage) ensureEncryptionMetadataSet(status rbdEncryptionState) error
 	err := ri.SetMetadata(encryptionMetaKey, string(status))
 	if err != nil {
 		return fmt.Errorf("failed to save encryption status for %s: %w", ri, err)
+	}
+
+	headerSize := strconv.FormatUint(cryptsetup.Luks2HeaderSize, 10)
+	if err := ri.SetMetadata(luks2HeaderSizeKey, headerSize); err != nil {
+		return fmt.Errorf("failed to save luks2 header size for %s: %w", ri, err)
 	}
 
 	return nil

--- a/internal/util/cryptsetup/cryptsetup.go
+++ b/internal/util/cryptsetup/cryptsetup.go
@@ -30,6 +30,8 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/file"
 	"github.com/ceph/ceph-csi/internal/util/log"
 	"github.com/ceph/ceph-csi/internal/util/stripsecrets"
+
+	"k8s.io/cloud-provider/volume/helpers"
 )
 
 const (
@@ -37,7 +39,19 @@ const (
 	ExecutionTimeout = 2*time.Minute + 30*time.Second
 
 	// Limit memory used by Argon2i PBKDF to 32 MiB.
-	pkdbfMemoryLimit = 32 << 10 // 32768 KiB
+	cryptsetupPBKDFMemoryLimit = 32 << 10 // 32768 KiB
+	luks2MetadataSize          = 32 << 7  // 4096 KiB
+	luks2KeySlotsSize          = 32 << 8  // 8192 KiB
+
+	// The LUKS2 header size is variable and it can be adjusted
+	// on creation by using the `--luks2-metadata-size` and
+	// `--luks2-keyslots-size` options.
+	Luks2HeaderSize = uint64((((2 * luks2MetadataSize) + luks2KeySlotsSize) * helpers.KiB))
+
+	// Older Images provisioned (with <=3.14 Ceph-CSI) didn't use the
+	// `--luks2-metadata-size` and `--luks2-keyslots-size` options
+	// during luksFormat, So the header size will be default 16MiB.
+	DefaultLuks2HeaderSize = 16 * helpers.MiB
 )
 
 // LuksWrapper is a struct that provides a context-aware wrapper around cryptsetup commands.
@@ -74,8 +88,12 @@ func (l *luksWrapper) Format(devicePath, passphrase string) (string, string, err
 		"luks2",
 		"--hash",
 		"sha256",
+		"--luks2-metadata-size",
+		strconv.Itoa(luks2MetadataSize)+"k",
+		"--luks2-keyslots-size",
+		strconv.Itoa(luks2KeySlotsSize)+"k",
 		"--pbkdf-memory",
-		strconv.Itoa(pkdbfMemoryLimit),
+		strconv.Itoa(cryptsetupPBKDFMemoryLimit),
 		devicePath,
 		"-d",
 		"-")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

[util: explicitly set the Luks2 header size](https://github.com/ceph/ceph-csi/commit/bbb07c4f9a146cd44f34f14c35e80ec69c59135b) 

The LUKS2 header size is variable and it can be adjusted
on creation by using the `--luks2-metadata-size` and
`--luks2-keyslots-size` options. By default, the header size is
16MiB.

This commit explicitly uses the options to define the default
header size.

Ref 10.10: https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/FAQ.md

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
