### PR TITLE
build: log the Go version in build/test containers

### DIFF
--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -14,8 +14,10 @@ COPY build.env /
 RUN source /build.env \
     && \
     ( test -n "${GOARCH}" && exit 0; echo -e "\n\nMissing GOARCH argument for building image, install Golang or run: make containerized-build GOARCH=amd64\n\n"; exit 1 ) \
-    && mkdir -p /usr/local/go \
-    && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1
+    && mkdir -p ${GOROOT} \
+    && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz | tar xzf - -C ${GOROOT} --strip-components=1 \
+    && go version \
+    && true
 
 # TODO: remove the following cmd, when issues
 # https://github.com/ceph/ceph-container/issues/2034

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -53,6 +53,7 @@ RUN source /build.env \
     && mkdir -p ${GOROOT} \
     && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz  \
        | tar xzf - -C ${GOROOT} --strip-components=1 \
+    && go version \
     && curl -sf "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_VERSION}/install.sh" \
        | bash -s -- -b ${GOPATH}/bin "${GOLANGCI_VERSION}" \
     && curl -L "${HELM_SCRIPT}" | bash -s -- --version "${HELM_VERSION}" \


### PR DESCRIPTION
In case there is a CI failure, it is useful to verify what Go version is
used for building. Go may still download an other version based on the
`toolchain` directive in `go.mod`, but that is logged separately
already.
