### PR TITLE
rbd: add additional logging details for stream server

### DIFF
--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -107,8 +107,10 @@ func (s *nonBlockingGRPCServer) serve(
 		klog.Fatalf("Failed to listen: %v", err)
 	}
 
-	server := grpc.NewServer(NewMiddlewareServerOption(middlewareConfig))
-	s.server = server
+	middleWareServerOption := NewMiddlewareServerOption(middlewareConfig)
+	middleWareStreamServerOption := NewMiddlewareStreamServerOption()
+
+	server := grpc.NewServer(middleWareServerOption, middleWareStreamServerOption)
 
 	if srv.IS != nil {
 		csi.RegisterIdentityServer(server, srv.IS)

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -142,6 +142,12 @@ func NewMiddlewareServerOption(config MiddlewareServerOptionConfig) grpc.ServerO
 	return grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(middleWare...))
 }
 
+// NewMiddlewareStreamServerOptions creates a new Stream Server specific grpc.ServerOption
+// that configures a common format for log messages and other gRPC related handlers.
+func NewMiddlewareStreamServerOption() grpc.ServerOption {
+	return grpc.StreamInterceptor(streamInterceptor)
+}
+
 // GetIDFromReplication returns the volumeID for Replication.
 func GetIDFromReplication(req interface{}) string {
 	getID := func(r interface {
@@ -260,6 +266,70 @@ func contextIDInjector(
 	}
 
 	return handler(ctx, req)
+}
+
+// wrapper Server Stream wraps around grpc.ServerStream
+// to inject ID, ReqID and additional logging.
+type wrapperServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+// Context returns the wrapperServerStream's ctx,
+// overwriting the nested grpc.ServerStream.Context().
+func (s *wrapperServerStream) Context() context.Context {
+	return s.ctx
+}
+
+// RecvMsg wraps around grpc.ServerStream.RecvMsg to inject
+// ReqID and log request details.
+func (s *wrapperServerStream) RecvMsg(req interface{}) error {
+	err := s.ServerStream.RecvMsg(req)
+
+	// reqID is intentionally extracted after .RecvMsg(req) as the req
+	// object is only populated after the call to .RecvMsg(req).
+	reqID := ""
+	switch r := req.(type) {
+	case *csi.GetMetadataAllocatedRequest:
+		reqID = r.GetSnapshotId()
+	case *csi.GetMetadataDeltaRequest:
+		reqID = r.GetTargetSnapshotId()
+	}
+	s.ctx = context.WithValue(s.ctx, log.ReqID, reqID)
+	log.TraceLog(s.ctx, "GRPC request: %s", protosanitizer.StripSecrets(req))
+
+	if err != nil {
+		klog.Errorf(log.Log(s.ctx, "GRPC error: %v"), err)
+	}
+
+	return err
+}
+
+// streamInterceptor intercepts and wraps server stream to inject
+// additional logging details.
+func streamInterceptor(
+	srv any,
+	stream grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) error {
+	atomic.AddUint64(&id, 1)
+	ctx := stream.Context()
+	ctx = context.WithValue(ctx, log.CtxKey, id)
+
+	log.ExtendedLog(ctx, "GRPC call: %s", info.FullMethod)
+
+	streamWithID := &wrapperServerStream{
+		ServerStream: stream,
+		ctx:          ctx,
+	}
+
+	err := handler(srv, streamWithID)
+	if err != nil {
+		klog.Errorf(log.Log(ctx, "GRPC error: %v"), err)
+	}
+
+	return err
 }
 
 func logGRPC(


### PR DESCRIPTION
# Describe what this PR does #

This commit adds stream server interceptor
for logging purposes.

## Related issues ##

Updated: #5346 
Depends-on: #5347 

Example logs:
```
I0703 11:24:29.955375       1 utils.go:328] ID: 22 GRPC call: /csi.v1.SnapshotMetadata/GetMetadataDelta
I0703 11:24:29.964025       1 utils.go:306] ID: 22 Req-ID: 0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b GRPC GetMetadataAllocatedRequest: {"base_snapshot_id":"0001-0009-rook-ceph-0000000000000001-a97e2e4f-5037-4e54-bda8-72c64d99c3f8","max_results":10,"secrets":"**stripped**","starting_offset":123213,"target_snapshot_id":"0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b"}
I0703 11:24:29.964097       1 utils.go:309] ID: 22 Req-ID: 0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b GRPC request: {"base_snapshot_id":"0001-0009-rook-ceph-0000000000000001-a97e2e4f-5037-4e54-bda8-72c64d99c3f8","max_results":10,"secrets":"**stripped**","starting_offset":123213,"target_snapshot_id":"0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b"}
I0703 11:24:30.048654       1 omap.go:89] ID: 22 Req-ID: 0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b got omap values: (pool="replicapool", namespace="", name="csi.snap.a97e2e4f-5037-4e54-bda8-72c64d99c3f8"): map[csi.imageid:142a23f27e1c5 csi.imagename:csi-snap-a97e2e4f-5037-4e54-bda8-72c64d99c3f8 csi.snapname:snapshot-cdb2d067-2a23-49df-9dc0-0ea92fbda35f csi.source:csi-vol-ec868036-7a20-4daa-ba78-c3e6013fd623 csi.volume.encryptKMS:metadata csi.volume.encryptionType:block csi.volume.owner:default]
I0703 11:24:30.134643       1 omap.go:89] ID: 22 Req-ID: 0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b got omap values: (pool="replicapool", namespace="", name="csi.snap.c5512d55-9590-4943-a562-2d3484fc083b"): map[csi.imageid:142a28525e576 csi.imagename:csi-snap-c5512d55-9590-4943-a562-2d3484fc083b csi.snapname:snapshot-6310f9a1-b46e-4e3c-b0a7-cdc934bd3af7 csi.source:csi-vol-ec868036-7a20-4daa-ba78-c3e6013fd623 csi.volume.encryptKMS:metadata csi.volume.encryptionType:block csi.volume.owner:default]
I0703 11:24:30.188244       1 sms_controllerserver.go:56] ID: 22 Req-ID: 0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b using requested maxResults: 10
I0703 11:24:30.378853       1 sms_controllerserver.go:223] ID: 22 Req-ID: 0001-0009-rook-ceph-0000000000000001-c5512d55-9590-4943-a562-2d3484fc083b successfully streamed metadata delta
```

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
