### PR TITLE
ci: use Deployment instead of DeploymentConfig for container registry

### DIFF
--- a/deploy/container-registry.yaml
+++ b/deploy/container-registry.yaml
@@ -27,20 +27,23 @@ stringData:
       }
     }
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: container-registry
   labels:
     app: container-registry
 spec:
-  triggers:
-    - type: ConfigChange
   replicas: 1
+  selector:
+    matchLabels:
+      app: container-registry
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
-        name: container-registry
+        app: container-registry
     spec:
       restartPolicy: Always
       containers:
@@ -79,7 +82,7 @@ spec:
       protocol: TCP
       targetPort: 5000
   selector:
-    name: container-registry
+    app: container-registry
 ---
 apiVersion: route.openshift.io/v1
 kind: Route


### PR DESCRIPTION
The DeploymentConfig type is deprecated.