### PR TITLE
Add build-time ceph-nvmeof protobuf generation infrastructure

### DIFF
--- a/.github/workflows/check-proto-changes.yml
+++ b/.github/workflows/check-proto-changes.yml
@@ -1,0 +1,67 @@
+# yamllint disable rule:truthy
+---
+name: Check Proto Changes
+
+on:
+  pull_request:
+    paths:
+      - 'internal/nvme/gateway/proto/gateway.proto'
+      - 'build.env'
+  push:
+    branches:
+      - devel
+    paths:
+      - 'internal/nvme/gateway/proto/gateway.proto'
+      - 'build.env'
+
+jobs:
+  check-proto-changes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+
+      - name: Verify committed proto file matches build.env specification
+        # yamllint disable rule:line-length
+        run: |
+          # Source build.env to get version information
+          source build.env
+
+          # Fetch the specific version from ceph-nvmeof based on build.env
+          echo "Fetching proto file from ${PROTO_SOURCE_REPO} branch " \
+            "${PROTO_SOURCE_BRANCH} SHA ${PROTO_SOURCE_SHA}..."
+
+          # Create fetch URL, handle 'latest' case
+          if [[ "${PROTO_SOURCE_SHA}" == "latest" ]]; then
+            # Fetch from branch tip
+            FETCH_URL="${PROTO_SOURCE_REPO}/raw/refs/heads/${PROTO_SOURCE_BRANCH}/control/proto/gateway.proto"
+          else
+            # Fetch from specific SHA
+            FETCH_URL="${PROTO_SOURCE_REPO}/raw/${PROTO_SOURCE_SHA}/control/proto/gateway.proto"
+          fi
+
+          # Fetch proto file
+          curl -fsSL "${FETCH_URL}" -o /tmp/gateway.proto.expected
+
+          # Normalize the committed proto file by removing go_package option
+          echo "Normalizing committed proto file (removing go_package option)..."
+          grep -v "option go_package" internal/nvme/gateway/proto/gateway.proto > \
+            /tmp/gateway.proto.normalized
+
+          # Compare normalized committed file with fetched file
+          if diff -u /tmp/gateway.proto.normalized /tmp/gateway.proto.expected; then
+            echo "✅ Committed proto file matches build.env specification"
+            echo "  Repository: ${PROTO_SOURCE_REPO}"
+            echo "  Branch: ${PROTO_SOURCE_BRANCH}"
+            echo "  SHA: ${PROTO_SOURCE_SHA}"
+            echo "  Note: go_package option is added by the build process"
+          else
+            echo "❌ Committed proto file does not match build.env specification"
+            echo "  Expected: ${PROTO_SOURCE_REPO} branch ${PROTO_SOURCE_BRANCH} SHA " \
+              "${PROTO_SOURCE_SHA}"
+            echo "  Please update the committed proto file to match the build.env specification"
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -168,10 +168,22 @@ commitlint:
 	@test $(REBASE) -eq 0 || git -c user.name=commitlint -c user.email=commitline@localhost rebase FETCH_HEAD
 	commitlint --verbose --from $(GIT_SINCE)
 
-.PHONY: cephcsi
-cephcsi: check-env
+.PHONY: cephcsi generate-proto clean-proto force-generate-proto
+cephcsi: check-env generate-proto
 	if [ ! -d ./vendor ]; then (go mod tidy && go mod vendor); fi
 	GOOS=linux go build $(GO_TAGS) -mod vendor -a -ldflags '$(LDFLAGS)' -o _output/cephcsi ./cmd/
+
+generate-proto: check-env
+	@echo "Generating protobuf stubs..."
+	./scripts/generate-proto.sh
+
+clean-proto: check-env
+	@echo "Cleaning protobuf generated files..."
+	./scripts/generate-proto.sh --clean
+
+force-generate-proto: check-env
+	@echo "Force regenerating protobuf stubs..."
+	./scripts/generate-proto.sh --force
 
 e2e.test: check-env
 	cd e2e && go test $(GO_TAGS) -mod=vendor -c -o ../e2e.test ./
@@ -216,6 +228,9 @@ run-e2e:
 containerized-build: TARGET = cephcsi
 containerized-build: .container-cmd .devel-container-id
 	$(CONTAINER_CMD) run --rm -v $(CURDIR):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make $(TARGET) CONTAINERIZED=yes
+
+containerized-generate-proto: .container-cmd .devel-container-id
+	$(CONTAINER_CMD) run --rm -v $(CURDIR):/go/src/github.com/ceph/ceph-csi$(SELINUX_VOL_FLAG) $(CSI_IMAGE_NAME):devel make generate-proto CONTAINERIZED=yes
 
 containerized-test: TARGET = test
 containerized-test: REBASE ?= 0
@@ -272,6 +287,7 @@ clean:
 	rm -f _output/cephcsi
 	$(RM) scripts/golangci.yml
 	$(RM) e2e.test
+	rm -f internal/nvme/gateway/proto/*.pb.go
 	[ ! -f .devel-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):devel
 	$(RM) .devel-container-id
 	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test

--- a/build.env
+++ b/build.env
@@ -35,6 +35,19 @@ COMMITLINT_VERSION=latest
 # static checks and linters
 GOLANGCI_VERSION=v2.1.5
 
+# protobuf tool versions
+PROTOC_VERSION=3.14.0
+PROTOC_GEN_GO_VERSION=v1.36.6
+PROTOC_GEN_GO_GRPC_VERSION=v1.5.1
+
+# protobuf source configuration
+# Using committed gateway.proto file instead of fetching
+# The committed file should match the current devel branch tip
+PROTO_SOURCE_REPO=https://github.com/ceph/ceph-nvmeof
+PROTO_SOURCE_BRANCH=devel
+PROTO_SOURCE_SHA=latest
+# 'latest' for branch tip, or specific commit SHA for reproducible builds
+
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases
 SNAPSHOT_VERSION=v8.2.0

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -40,14 +40,12 @@ RUN source /build.env && \
 # test if the downloaded version of Golang works (different arch?)
 RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 
-# other/conflicting versions of protobuf get installed as dependency
-RUN dnf -y remove protobuf
-
 RUN dnf -y install --nodocs \
 	librados-devel librbd-devel libcephfs-devel \
 	/usr/bin/cc \
 	make \
 	git \
+	protobuf-compiler \
 	&& dnf clean all \
 	&& rm -rf /var/cache/yum \
     && true
@@ -60,6 +58,10 @@ ENV GOROOT=${GOROOT} \
     ENV_CSI_IMAGE_NAME="${CSI_IMAGE_NAME}" \
     PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 
+# Install Go protobuf plugins using versions from build.env
+RUN source /build.env \
+    && ${GOROOT}/bin/go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} \
+    && ${GOROOT}/bin/go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
 WORKDIR ${SRC_DIR}
 

--- a/internal/nvme/gateway/proto/gateway.proto
+++ b/internal/nvme/gateway/proto/gateway.proto
@@ -1,0 +1,660 @@
+//
+//  Copyright (c) 2021 International Business Machines
+//  All rights reserved.
+//
+//  SPDX-License-Identifier: MIT
+//
+//  Authors: anita.shekar@ibm.com, sandy.kaur@ibm.com
+//
+
+
+syntax = "proto3";
+option go_package = "github.com/ceph/ceph-csi/internal/nvme/gateway/proto;gateway";
+
+enum AddressFamily {
+	ipv4 = 0;
+	ipv6 = 1;
+}
+
+enum LogLevel {
+	ERROR = 0;
+	WARNING = 1;
+	NOTICE = 2;
+	INFO = 3;
+	DEBUG = 4;
+}
+
+enum GwLogLevel {
+	notset = 0;
+	debug = 10;
+	info = 20;
+	warning = 30;
+	error = 40;
+	critical = 50;
+}
+
+service Gateway {
+	// Creates a namespace from an RBD image
+	rpc namespace_add(namespace_add_req) returns (nsid_status) {}
+
+	// Creates a subsystem
+	rpc create_subsystem(create_subsystem_req) returns(subsys_status) {}
+
+	// Deletes a subsystem
+	rpc delete_subsystem(delete_subsystem_req) returns(req_status) {}
+
+	// Changes subsystem key
+	rpc change_subsystem_key(change_subsystem_key_req) returns(req_status) {}
+
+	// List namespaces
+	rpc list_namespaces(list_namespaces_req) returns(namespaces_info) {}
+
+	// Resizes a namespace
+	rpc namespace_resize(namespace_resize_req) returns (req_status) {}
+
+	// Gets namespace's IO stats
+	rpc namespace_get_io_stats(namespace_get_io_stats_req) returns (namespace_io_stats_info) {}
+
+	// Sets namespace's qos limits
+	rpc namespace_set_qos_limits(namespace_set_qos_req) returns (req_status) {}
+
+	// Changes namespace's load balancing group
+	rpc namespace_change_load_balancing_group(namespace_change_load_balancing_group_req) returns (req_status) {}
+
+	// Changes namespace's visibility
+	rpc namespace_change_visibility(namespace_change_visibility_req) returns (req_status) {}
+
+	// Set namespace's RBD trash image flag
+	rpc namespace_set_rbd_trash_image(namespace_set_rbd_trash_image_req) returns (req_status) {}
+
+	// Set namespace's auto resize flag
+	rpc namespace_set_auto_resize(namespace_set_auto_resize_req) returns (req_status) {}
+
+	// Deletes a namespace
+	rpc namespace_delete(namespace_delete_req) returns (req_status) {}
+
+	// Adds a host to a namespace
+	rpc namespace_add_host(namespace_add_host_req) returns (req_status) {}
+
+	// Deletes a host from a namespace
+	rpc namespace_delete_host(namespace_delete_host_req) returns (req_status) {}
+
+	// Adds a host to a subsystem
+	rpc add_host(add_host_req) returns (req_status) {}
+
+	// Removes a host from a subsystem
+	rpc remove_host(remove_host_req) returns (req_status) {}
+
+	// Changes a host inband authentication keys
+	rpc change_host_key(change_host_key_req) returns (req_status) {}
+
+	// List hosts
+	rpc list_hosts(list_hosts_req) returns(hosts_info) {}
+
+	// List connections
+	rpc list_connections(list_connections_req) returns(connections_info) {}
+
+	// Creates a listener for a subsystem at a given IP/Port
+	rpc create_listener(create_listener_req) returns(req_status) {}
+
+	// Deletes a listener from a subsystem at a given IP/Port
+	rpc delete_listener(delete_listener_req) returns(req_status) {}
+
+	// List listeners
+	rpc list_listeners(list_listeners_req) returns(listeners_info) {}
+
+	// List subsystems
+	rpc list_subsystems(list_subsystems_req) returns(subsystems_info_cli) {}
+
+	// Gets subsystems
+	rpc get_subsystems(get_subsystems_req) returns(subsystems_info) {}
+
+	// Set gateway ANA states
+	rpc set_ana_state(ana_info) returns(req_status) {}
+
+	// Gets spdk nvmf log flags and level
+	rpc get_spdk_nvmf_log_flags_and_level(get_spdk_nvmf_log_flags_and_level_req) returns(spdk_nvmf_log_flags_and_level_info) {}
+
+	// Disables spdk nvmf logs
+	rpc disable_spdk_nvmf_logs(disable_spdk_nvmf_logs_req) returns(req_status) {}
+
+	// Set spdk nvmf logs
+	rpc set_spdk_nvmf_logs(set_spdk_nvmf_logs_req) returns(req_status) {}
+
+	// Get gateway info
+	rpc get_gateway_info(get_gateway_info_req) returns(gateway_info) {}
+
+	// Get gateway log level
+	rpc get_gateway_log_level(get_gateway_log_level_req) returns(gateway_log_level_info) {}
+
+	// Set gateway log level
+	rpc set_gateway_log_level(set_gateway_log_level_req) returns(req_status) {}
+
+	// Show gateway listeners info
+	rpc show_gateway_listeners_info(show_gateway_listeners_info_req) returns(gateway_listeners_info) {}
+
+	// Gets gateway's stats
+	rpc get_gateway_stats(get_gateway_stats_req) returns (gateway_stats_info) {}
+}
+
+// Request messages
+
+message namespace_add_req {
+	string rbd_pool_name = 1;
+	string rbd_image_name = 2;
+	string subsystem_nqn = 3;
+	optional uint32 nsid = 4;
+	uint32 block_size = 5;
+	optional string uuid = 6;
+	optional int32 anagrpid = 7;
+	optional bool create_image = 8;
+	optional uint64 size = 9;
+	optional bool force = 10;
+	optional bool no_auto_visible = 11;
+	optional bool trash_image = 12;
+	optional bool disable_auto_resize = 13;
+	optional bool read_only = 14;
+}
+
+message namespace_resize_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	optional string OBSOLETE_uuid = 3;
+	uint64 new_size = 4;
+}
+
+message namespace_get_io_stats_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	optional string OBSOLETE_uuid = 3;
+}
+
+message namespace_set_qos_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	optional string OBSOLETE_uuid = 3;
+	optional uint64 rw_ios_per_second = 4;
+	optional uint64 rw_mbytes_per_second = 5;
+	optional uint64 r_mbytes_per_second = 6;
+	optional uint64 w_mbytes_per_second = 7;
+	optional bool force = 8;
+}
+
+message namespace_change_load_balancing_group_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	optional string OBSOLETE_uuid = 3;
+	int32 anagrpid = 4;
+	optional bool auto_lb_logic = 5;
+}
+
+message namespace_change_visibility_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	bool auto_visible = 3;
+	optional bool force = 4;
+}
+
+message namespace_set_rbd_trash_image_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	bool trash_image = 3;
+}
+
+message namespace_set_auto_resize_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	bool auto_resize = 3;
+}
+
+message namespace_delete_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	optional string OBSOLETE_uuid = 3;
+	optional bool i_am_sure = 4;
+}
+
+message namespace_add_host_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	string host_nqn = 3;
+	optional bool force = 4;
+}
+
+message namespace_delete_host_req {
+	string subsystem_nqn = 1;
+	uint32 nsid = 2;
+	string host_nqn = 3;
+}
+
+message create_subsystem_req {
+	string subsystem_nqn = 1;
+	string serial_number = 2;
+	optional uint32 max_namespaces = 3;
+	bool enable_ha = 4;
+	optional bool no_group_append = 5;
+	optional string dhchap_key = 6;
+	optional bool key_encrypted = 7;
+}
+
+message delete_subsystem_req {
+	string subsystem_nqn = 1;
+	optional bool force = 2;
+}
+
+message change_subsystem_key_req {
+	string subsystem_nqn = 1;
+	optional string dhchap_key = 2;
+}
+
+message list_namespaces_req {
+	string subsystem = 1;
+	optional uint32 nsid = 2;
+	optional string uuid = 3;
+}
+
+message add_host_req {
+	string subsystem_nqn = 1;
+	string host_nqn = 2;
+	optional string psk = 3;
+	optional string dhchap_key = 4;
+	optional bool psk_encrypted = 5;
+	optional bool key_encrypted = 6;
+}
+
+message change_host_key_req {
+	string subsystem_nqn = 1;
+	string host_nqn = 2;
+	optional string dhchap_key = 3;
+}
+
+message remove_host_req {
+	string subsystem_nqn = 1;
+	string host_nqn = 2;
+}
+
+message list_hosts_req {
+	string subsystem = 1;
+	optional bool clear_alerts = 2;
+}
+
+message list_connections_req {
+	string subsystem = 1;
+}
+
+message create_listener_req {
+	string nqn = 1;
+	string host_name = 2;
+	string traddr = 3;
+	optional AddressFamily adrfam = 5;
+	optional uint32 trsvcid = 6;
+	optional bool secure = 7;
+	optional bool verify_host_name = 8;
+}
+
+message delete_listener_req {
+	string nqn = 1;
+	string host_name = 2;
+	string traddr = 3;
+	optional AddressFamily adrfam = 5;
+	optional uint32 trsvcid = 6;
+	optional bool force = 7;
+}
+
+message list_listeners_req {
+	string subsystem = 1;
+}
+
+message list_subsystems_req {
+	optional string subsystem_nqn = 1;
+	optional string serial_number = 2;
+}
+
+message get_subsystems_req {
+}
+
+message get_spdk_nvmf_log_flags_and_level_req {
+	optional bool all_log_flags = 1;
+}
+
+message disable_spdk_nvmf_logs_req {
+	repeated string extra_log_flags = 1;
+}
+
+message set_spdk_nvmf_logs_req {
+	optional LogLevel log_level = 1;
+	optional LogLevel print_level = 2;
+	repeated string extra_log_flags = 3;
+}
+
+message get_gateway_info_req {
+	optional string cli_version = 1;
+}
+
+message get_gateway_log_level_req {
+}
+
+message set_gateway_log_level_req {
+	GwLogLevel log_level = 1;
+}
+
+message show_gateway_listeners_info_req {
+	string subsystem_nqn = 1;
+}
+
+message get_gateway_stats_req {
+}
+
+// From https://nvmexpress.org/wp-content/uploads/NVM-Express-1_4-2019.06.10-Ratified.pdf page 138
+// Asymmetric Namespace Access state for all namespaces in this ANA
+// Group when accessed through this controller.
+// Value Description Reference
+// 01h ANA Optimized state 8.20.3.1
+// 02h ANA Non-Optimized state 8.20.3.2
+// 03h ANA Inaccessible state 8.20.3.3
+// 04h ANA Persistent Loss state 8.20.3.4
+// 0Fh ANA Change state 8.20.3.5
+// All others Reserved
+enum ana_state {
+	UNSET         = 0;
+	OPTIMIZED     = 1;
+	NON_OPTIMIZED = 2;
+	INACCESSIBLE  = 3;
+}
+
+message ana_group_state {
+	uint32     grp_id = 1;  // groupd id
+	ana_state  state  = 2;  // ANA state
+}
+
+message nqn_ana_states {
+	string     nqn                     = 1; // subsystem nqn
+	repeated   ana_group_state  states = 2; // list of group states
+}
+
+message ana_info {
+	repeated nqn_ana_states states = 1; // list of nqn states
+}
+
+// Return messages 
+
+message req_status {
+	int32 status = 1;
+	string error_message = 2;
+}
+
+message subsys_status {
+	int32 status = 1;
+	string error_message = 2;
+	string nqn = 3;
+}
+
+message nsid_status {
+	int32 status = 1;
+	string error_message = 2;
+	uint32 nsid = 3;
+}
+
+message subsystems_info {
+	repeated subsystem subsystems = 1;
+}
+
+message subsystem {
+	string nqn = 1;
+	string subtype = 2;
+	repeated listen_address listen_addresses = 3;
+	repeated host hosts = 4;
+	bool allow_any_host = 5;
+	optional string serial_number = 6;
+	optional string model_number = 7;
+	optional uint32 max_namespaces = 8;
+	optional uint32 min_cntlid = 9;
+	optional uint32 max_cntlid = 10;
+	repeated namespace namespaces = 11;
+	optional bool has_dhchap_key = 12;
+}
+
+message listen_address {
+	string trtype = 1;
+	string adrfam = 2;
+	string traddr = 3;
+	string trsvcid = 4;
+	optional string transport = 5;
+	optional bool secure = 6;
+}
+
+message namespace {
+	uint32 nsid = 1;
+	string name = 2;
+	optional string bdev_name = 3;
+	optional string nguid = 4;
+	optional string uuid = 5;
+	optional uint32 anagrpid = 6;
+	optional string nonce = 7;
+	optional bool auto_visible = 8;
+	repeated string hosts = 9;
+}
+
+message subsystems_info_cli {
+	int32 status = 1;
+	string error_message = 2;
+	repeated subsystem_cli subsystems = 3;
+}
+
+message subsystem_cli {
+	string nqn = 1;
+	bool enable_ha = 2;
+	string serial_number = 3;
+	string model_number = 4;
+	uint32 min_cntlid = 5;
+	uint32 max_cntlid = 6;
+	uint32 namespace_count = 7;
+	string subtype = 8;
+	uint32 max_namespaces = 9;
+	optional bool has_dhchap_key = 10;
+	optional bool allow_any_host = 11;
+	optional bool created_without_key = 12;
+}
+
+message gateway_info {
+	string cli_version = 1;
+	string version = 2;
+	string name = 3;
+	string group = 4;
+	string addr = 5;
+	string port = 6;
+	bool bool_status = 7;
+	int32 status = 8;
+	string error_message = 9;
+	optional string spdk_version = 10;
+	uint32 load_balancing_group = 11;
+	string hostname = 12;
+	optional uint32 max_subsystems = 13;
+	optional uint32 max_namespaces = 14;
+	optional uint32 max_hosts_per_subsystem = 15;
+	optional uint32 max_namespaces_per_subsystem = 16;
+	optional uint32 max_hosts = 17;
+}
+
+message cli_version {
+	int32 status = 1;
+	string error_message = 2;
+	string version = 3;
+}
+
+message gw_version {
+	int32 status = 1;
+	string error_message = 2;
+	string version = 3;
+}
+
+message poll_group_transport_info {
+	string trtype = 1;
+}
+
+message poll_group_info {
+	string name = 1;
+	uint32 admin_qpairs = 2;
+	uint32 io_qpairs = 3;
+	uint32 current_admin_qpairs = 4;
+	uint32 current_io_qpairs = 5;
+	uint64 pending_bdev_io = 6;
+	uint64 completed_nvme_io = 7;
+        repeated poll_group_transport_info transports = 8;
+}
+
+message gateway_stats_info {
+	int32 status = 1;
+	string error_message = 2;
+	uint64 tick_rate = 3;
+        repeated poll_group_info poll_groups = 4;
+}
+
+message listener_info {
+	string host_name = 1;
+	string trtype = 2;
+	AddressFamily adrfam = 3;
+	string traddr = 4;
+	uint32 trsvcid = 5;
+	optional bool secure = 6;
+	optional bool active = 7;
+}
+
+message listeners_info {
+	int32 status = 1;
+	string error_message = 2;
+	repeated listener_info listeners = 3;
+}
+
+message gateway_listener_info {
+	listener_info listener = 1;
+	repeated ana_group_state lb_states = 2;
+}
+
+message gateway_listeners_info {
+	int32 status = 1;
+	string error_message = 2;
+	repeated gateway_listener_info gw_listeners = 3;
+}
+
+message host {
+	string nqn = 1;
+	optional bool use_psk = 2;
+	optional bool use_dhchap = 3;
+	optional bool disconnected_due_to_keepalive_timeout = 4;
+}
+
+message hosts_info {
+	int32 status = 1;
+	string error_message = 2;
+	bool allow_any_host = 3;
+	string subsystem_nqn = 4;
+	repeated host hosts = 5;
+}
+
+message connection {
+	string nqn = 1;
+	string traddr = 2;
+	uint32 trsvcid = 3;
+	string trtype = 4;
+	AddressFamily adrfam = 5;
+	bool connected = 6;
+	int32 qpairs_count = 7;
+	int32 controller_id = 8;
+	optional bool secure = 9;
+	optional bool use_psk = 10;
+	optional bool use_dhchap = 11;
+        optional string subsystem = 12;
+	optional bool disconnected_due_to_keepalive_timeout = 13;
+}
+
+message connections_info {
+	int32 status = 1;
+	string error_message = 2;
+	string subsystem_nqn = 3;
+	repeated connection connections = 4;
+}
+
+message namespace_cli {
+	uint32 nsid = 1;
+	string bdev_name = 2;
+	string rbd_image_name = 3;
+	string rbd_pool_name = 4;
+	uint32 load_balancing_group = 5;
+	uint32 block_size = 6;
+	uint64 rbd_image_size = 7;
+	string uuid = 8;
+	uint64 rw_ios_per_second = 9;
+	uint64 rw_mbytes_per_second = 10;
+	uint64 r_mbytes_per_second = 11;
+	uint64 w_mbytes_per_second = 12;
+	bool auto_visible = 13;
+	repeated string hosts = 14;
+	optional string ns_subsystem_nqn = 15;
+	optional bool trash_image = 16;
+	optional bool disable_auto_resize = 17;
+	optional bool read_only = 18;
+        optional string cluster_name = 19;
+        optional uint32 configured_load_balancing_group = 20;
+}
+
+message namespaces_info {
+	int32 status = 1;
+	string error_message = 2;
+	string subsystem_nqn = 3;
+	repeated namespace_cli namespaces = 4;
+}
+
+message namespace_io_error {
+	string name = 1;
+	uint32 value = 2;
+}
+
+message namespace_io_stats_info {
+	int32 status = 1;
+	string error_message = 2;
+	string subsystem_nqn = 3;
+	uint32 nsid = 4;
+	optional string uuid = 5;
+	string bdev_name = 6;
+	uint64 tick_rate = 7;
+	uint64 ticks = 8;
+	uint64 bytes_read = 9;
+	uint64 num_read_ops = 10;
+	uint64 bytes_written = 11;
+	uint64 num_write_ops = 12;
+	uint64 bytes_unmapped = 13;
+	uint64 num_unmap_ops = 14;
+	uint64 read_latency_ticks = 15;
+	uint64 max_read_latency_ticks = 16;
+	uint64 min_read_latency_ticks = 17;
+	uint64 write_latency_ticks = 18;
+	uint64 max_write_latency_ticks = 19;
+	uint64 min_write_latency_ticks = 20;
+	uint64 unmap_latency_ticks = 21;
+	uint64 max_unmap_latency_ticks = 22;
+	uint64 min_unmap_latency_ticks = 23;
+	uint64 copy_latency_ticks = 24;
+	uint64 max_copy_latency_ticks = 25;
+	uint64 min_copy_latency_ticks = 26;
+	repeated namespace_io_error io_error = 27;
+}
+
+message spdk_log_flag_info {
+	string name = 1;
+	bool enabled = 2;
+}
+
+message spdk_nvmf_log_flags_and_level_info {
+	int32 status = 1;
+	string error_message = 2;
+	repeated spdk_log_flag_info nvmf_log_flags = 3;
+	LogLevel log_level = 4;
+	LogLevel log_print_level = 5;
+}
+
+message gateway_log_level_info {
+	int32 status = 1;
+	string error_message = 2;
+	GwLogLevel log_level = 3;
+}

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -29,9 +29,6 @@ RUN true \
 
 RUN mkdir -p /etc/selinux && touch /etc/selinux/config
 
-# other/conflicting versions of protobuf get installed as dependency
-RUN dnf -y remove protobuf
-
 RUN dnf -y install \
 	git \
 	make \
@@ -39,9 +36,15 @@ RUN dnf -y install \
 	librados-devel \
         libcephfs-devel \
 	librbd-devel \
+	protobuf-compiler \
     && dnf -y --nobest update \
     && dnf clean all \
     && rm -rf /var/cache/yum \
     && true
+
+# Install Go protobuf plugins using versions from build.env
+RUN source /build.env \
+    && go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} \
+    && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
 WORKDIR "/go/src/github.com/ceph/ceph-csi"

--- a/scripts/codespell.conf
+++ b/scripts/codespell.conf
@@ -1,5 +1,5 @@
 [codespell]
 # TODO: enable codespell on retest folder except vendor
-skip = .git,./vendor,./docs/design/proposals/images,./actions/retest/*,./api/vendor,go.sum,./e2e/vendor
+skip = .git,./vendor,./docs/design/proposals/images,./actions/retest/*,./api/vendor,go.sum,./e2e/vendor,./internal/nvme/gateway/proto/*.proto,./internal/nvme/gateway/proto/*.pb.go
 ignore-words-list = ExtraVersion,extraversion,ba,ro,RO
 check-filenames = true

--- a/scripts/generate-proto.sh
+++ b/scripts/generate-proto.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+
+# Copyright 2025 The Ceph-CSI Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to generate protobuf Go stubs from ceph-nvmeof project
+# This script uses committed .proto files and generates Go stubs for gRPC communication
+
+set -euo pipefail
+
+# Source build environment for versions
+if [[ -f "build.env" ]]; then
+    source build.env
+else
+    echo "[ERROR] build.env not found. Please run from project root."
+    exit 1
+fi
+
+# Configuration
+TARGET_DIR="internal/nvme/gateway/proto"
+GENERATED_DIR="${TARGET_DIR}"
+
+# Logging prefixes
+INFO_PREFIX="[INFO]"
+ERROR_PREFIX="[ERROR]"
+WARN_PREFIX="[WARN]"
+
+# Function to log messages
+log_info() {
+    echo "${INFO_PREFIX} $1"
+}
+
+log_error() {
+    echo "${ERROR_PREFIX} $1" >&2
+}
+
+log_warn() {
+    echo "${WARN_PREFIX} $1"
+}
+
+# Function to check if protoc is available
+check_protoc() {
+    if ! command -v protoc >/dev/null 2>&1; then
+        log_error "protoc not found. Please install protobuf-compiler."
+        exit 1
+    fi
+
+    local protoc_version
+    protoc_version=$(protoc --version | cut -d' ' -f2)
+    log_info "Using protoc version: ${protoc_version}"
+}
+
+# Function to check if Go plugins are available
+check_go_plugins() {
+    local missing_plugins=()
+
+    # Add Go bin directory to PATH if not already there
+    if [[ -n "${GOPATH:-}" ]]; then
+        export PATH="${GOPATH}/bin:${PATH}"
+        log_info "Added ${GOPATH}/bin to PATH"
+    elif [[ -d "${HOME}/go/bin" ]]; then
+        export PATH="${HOME}/go/bin:${PATH}"
+        log_info "Added ${HOME}/go/bin to PATH"
+    fi
+
+    if ! command -v protoc-gen-go >/dev/null 2>&1; then
+        missing_plugins+=("protoc-gen-go")
+    fi
+
+    if ! command -v protoc-gen-go-grpc >/dev/null 2>&1; then
+        missing_plugins+=("protoc-gen-go-grpc")
+    fi
+
+    if [[ ${#missing_plugins[@]} -gt 0 ]]; then
+        log_error "Missing Go protobuf plugins: ${missing_plugins[*]}"
+        log_error "Please install: go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}"
+        log_error "Please install: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}"
+        exit 1
+    fi
+
+    log_info "Go protobuf plugins found"
+}
+
+
+
+# Function to add go_package option if missing
+add_go_package_option() {
+    local proto_file="$1"
+    local package_name
+
+    # Extract package name from filename
+    package_name=$(basename "${proto_file}" .proto)
+
+    # Check if go_package option already exists
+    if ! grep -q "option go_package" "${proto_file}"; then
+        log_info "Adding go_package option to ${proto_file}"
+
+        # Add go_package option after the syntax declaration
+        sed -i '/^syntax = "proto3";/a option go_package = "github.com/ceph/ceph-csi/internal/nvme/gateway/proto;'"${package_name}"'";' "${proto_file}"
+
+        log_info "Successfully added go_package option"
+    else
+        log_info "go_package option already exists in ${proto_file}"
+    fi
+}
+
+# Function to generate Go stubs
+generate_go_stubs() {
+    local proto_file="$1"
+    local proto_path
+    proto_path="${TARGET_DIR}/$(basename "${proto_file}")"
+
+    log_info "Generating Go stubs from ${proto_path}..."
+
+    # Ensure we're in the project root for proper import paths
+    cd "$(dirname "$0")/.."
+
+    # Generate Go stubs with proper flags
+    if protoc \
+        --experimental_allow_proto3_optional \
+        --proto_path="${TARGET_DIR}" \
+        --go_out="${GENERATED_DIR}" \
+        --go_opt=paths=source_relative \
+        --go-grpc_out="${GENERATED_DIR}" \
+        --go-grpc_opt=paths=source_relative \
+        "${proto_path}"; then
+
+        log_info "Successfully generated Go stubs for ${proto_file}"
+    else
+        log_error "Failed to generate Go stubs for ${proto_file}"
+        exit 1
+    fi
+}
+
+# Function to process a single proto file
+process_proto_file() {
+    local proto_file="$1"
+
+    log_info "Processing ${proto_file}..."
+
+    # Add go_package option if needed
+    local target_file
+    target_file="${TARGET_DIR}/$(basename "${proto_file}")"
+    add_go_package_option "${target_file}"
+
+    # Generate Go stubs
+    generate_go_stubs "${proto_file}"
+
+    log_info "Successfully processed ${proto_file}"
+}
+
+# Function to clean up generated files
+cleanup_generated_files() {
+    log_info "Cleaning up generated files..."
+
+    if [[ -d "${GENERATED_DIR}" ]]; then
+        find "${GENERATED_DIR}" -name "*.pb.go" -type f -exec rm -f {} \;
+        log_info "Cleaned up generated Go files"
+    fi
+}
+
+# Function to show usage
+show_usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Generate protobuf Go stubs from ceph-nvmeof project.
+
+OPTIONS:
+    -h, --help          Show this help message
+    -c, --clean         Clean up generated files only
+    -f, --force         Force regeneration (clean first)
+    -v, --version       Show version information
+
+ENVIRONMENT:
+    Uses versions from build.env:
+    - PROTOC_VERSION: ${PROTOC_VERSION}
+    - PROTOC_GEN_GO_VERSION: ${PROTOC_GEN_GO_VERSION}
+    - PROTOC_GEN_GO_GRPC_VERSION: ${PROTOC_GEN_GO_GRPC_VERSION}
+
+
+
+EXAMPLES:
+    $0                    # Generate protobuf stubs
+    $0 --clean           # Clean up generated files
+    $0 --force           # Force regeneration
+EOF
+}
+
+# Function to show version
+show_version() {
+    echo "generate-proto.sh version 1.0"
+    echo "Protobuf tool versions:"
+    echo "  protoc: ${PROTOC_VERSION}"
+    echo "  protoc-gen-go: ${PROTOC_GEN_GO_VERSION}"
+    echo "  protoc-gen-go-grpc: ${PROTOC_GEN_GO_GRPC_VERSION}"
+}
+
+# Main execution
+main() {
+    local clean_only=false
+    local force_regeneration=false
+
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            -c|--clean)
+                clean_only=true
+                shift
+                ;;
+            -f|--force)
+                force_regeneration=true
+                shift
+                ;;
+            -v|--version)
+                show_version
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+
+    # Change to script directory for relative paths
+    cd "$(dirname "$0")/.."
+
+    log_info "Starting protobuf generation process..."
+
+    # Check dependencies
+    check_protoc
+    check_go_plugins
+
+    # Show Go version
+    local go_version
+    go_version=$(go version | cut -d' ' -f3)
+    log_info "Using Go version: ${go_version}"
+
+    # Handle clean operation
+    if [[ "${clean_only}" == true ]]; then
+        cleanup_generated_files
+        log_info "Cleanup completed"
+        exit 0
+    fi
+
+    # Handle force regeneration
+    if [[ "${force_regeneration}" == true ]]; then
+        log_info "Force regeneration requested, cleaning first..."
+        cleanup_generated_files
+    fi
+
+    # Process the proto file
+    process_proto_file "gateway.proto"
+
+    log_info "Protobuf generation completed successfully!"
+    log_info "Generated files are available in: ${GENERATED_DIR}"
+}
+
+# Run main function with all arguments
+main "$@"


### PR DESCRIPTION
# Add build-time ceph-nvmeof protobuf generation infrastructure

## Summary

This PR implements protobuf stubs generation infrastructure that uses committed `gateway.proto` files and generates Go stubs when needed. 

## Changes

* **`build.env`**: Added protobuf tool versions and configurable proto source (repo, branch, SHA)
* **`scripts/generate-proto.sh`**: Protobuf stub generation, logging, and error handling
* **`Makefile`**: Added `generate-proto`, `clean-proto`, `force-generate-proto` targets and updated `clean` target
* **`scripts/Dockerfile.devel`**: Updated to install protobuf tooling using versions from `build.env`
* **`deploy/cephcsi/image/Dockerfile`**: Added protobuf dependencies for CI builds
* **`.github/workflows/check-proto-changes.yml`**: New CI workflow to validate proto file matches `build.env` specification

## Configuration

The system uses `build.env` for centralized configuration:

```bash
# Proto source configuration
PROTO_SOURCE_REPO=https://github.com/ceph/ceph-nvmeof
PROTO_SOURCE_BRANCH=devel
PROTO_SOURCE_SHA=latest  # or specific SHA

# Protobuf tool versions
PROTOC_VERSION=3.14.0
PROTOC_GEN_GO_VERSION=v1.31.0
PROTOC_GEN_GO_GRPC_VERSION=v1.3.0
```

## File Structure

```
internal/nvme/gateway/proto/
├── gateway.proto          # Committed source file
├── gateway.pb.go          # Generated Go stubs
└── gateway_grpc.pb.go     # Generated gRPC stubs
```

## Usage

### Containerized Generation (Recommended)
```bash
# Generate protobuf stubs in a container (no local setup required)
make containerized-generate-proto
```

### Local Development
```bash
# Install dependencies first (use versions from build.env)
sudo apt-get install protobuf-compiler  # Ubuntu/Debian
# For CentOS: sudo yum install protobuf-compiler
go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0

# Generate stubs
make generate-proto
```

### Available Makefile Targets
```bash
# Generate protobuf stubs from committed files
make generate-proto

# Clean generated files only
make clean-proto

# Force regeneration (clean first, then generate)
make force-generate-proto

# Containerized generation
make containerized-generate-proto

# Full build with proto generation
make cephcsi
```

## For Developers (IDE Development)

If you've just cloned the codebase and want to generate protobuf stubs for your IDE:

### Quick Start (Recommended)
```bash
# Generate protobuf stubs in a container (no local setup required)
make containerized-generate-proto
```

This will:
* Build the development container with all dependencies
* Use committed `gateway.proto` from the repository
* Generate Go stubs in `internal/nvme/gateway/proto/`
* Make your IDE happy with proper gRPC type recognition

## See also

* https://github.com/ceph/ceph-nvmeof/issues/1360

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
