### PR TITLE
rbd: add check before calling Destroy

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -168,26 +168,24 @@ func (ns *NodeServer) populateRbdVol(
 	volID := req.GetVolumeId()
 
 	isBlock, isMultiNode := csicommon.IsBlockMultiNode([]*csi.VolumeCapability{req.GetVolumeCapability()})
-	disableInUseChecks := false
+	// disableInUseChecks is set to true if the volume is MultiNode Block volume or else false.
+	disableInUseChecks := isMultiNode && isBlock
 
 	// MULTI_NODE_MULTI_WRITER is supported by default for Block access type volumes
-	if isMultiNode {
-		if !isBlock {
-			log.WarningLog(
-				ctx,
-				"MULTI_NODE_MULTI_WRITER currently only supported with volumes of access type `block`,"+
-					"invalid AccessMode for volume: %v",
-				req.GetVolumeId(),
-			)
+	if isMultiNode && !isBlock {
+		log.WarningLog(
+			ctx,
+			"MULTI_NODE_MULTI_WRITER currently only supported with volumes of access type `block`,"+
+				"invalid AccessMode for volume: %v",
+			req.GetVolumeId(),
+		)
 
-			return nil, status.Error(
-				codes.InvalidArgument,
-				"rbd: RWX access mode request is only valid for volumes with access type `block`",
-			)
-		}
-
-		disableInUseChecks = true
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"rbd: RWX access mode request is only valid for volumes with access type `block`",
+		)
 	}
+
 	var rv *rbdVolume
 
 	isStaticVol := parseBoolOption(ctx, req.GetVolumeContext(), staticVol, false)
@@ -254,14 +252,8 @@ func (ns *NodeServer) populateRbdVol(
 		return nil, err
 	}
 
-	rv.LogDir = req.GetVolumeContext()["cephLogDir"]
-	if rv.LogDir == "" {
-		rv.LogDir = defaultLogDir
-	}
-	rv.LogStrategy = req.GetVolumeContext()["cephLogStrategy"]
-	if rv.LogStrategy == "" {
-		rv.LogStrategy = defaultLogStrategy
-	}
+	rv.LogDir = defaultIfEmpty(req.GetVolumeContext()["cephLogDir"], defaultLogDir)
+	rv.LogStrategy = defaultIfEmpty(req.GetVolumeContext()["cephLogStrategy"], defaultLogStrategy)
 
 	return rv, err
 }
@@ -312,6 +304,14 @@ func initDynamicVol(
 	rv.VolID = volID
 
 	return rv, nil
+}
+
+func defaultIfEmpty(value, defaultVal string) string {
+	if value == "" {
+		return defaultVal
+	}
+
+	return value
 }
 
 // appendReadAffinityMapOptions appends readAffinityMapOptions to mapOptions

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -194,28 +194,12 @@ func (ns *NodeServer) populateRbdVol(
 	// get rbd image name from the volume journal
 	// for static volumes, the image name is actually the volume ID itself
 	if isStaticVol {
-		if req.GetVolumeContext()[intreeMigrationKey] == intreeMigrationLabel {
-			// if migration static volume, use imageName as volID
-			volID = req.GetVolumeContext()["imageName"]
-		}
-		rv, err = genVolFromVolumeOptions(ctx, req.GetVolumeContext(), disableInUseChecks, true)
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		rv.RbdImageName = volID
+		rv, err = initStaticVol(ctx, volID, req.GetVolumeContext(), disableInUseChecks)
 	} else {
-		rv, err = GenVolFromVolID(ctx, volID, cr, req.GetSecrets())
-		if err != nil {
-			rv.Destroy(ctx)
-			log.ErrorLog(ctx, "error generating volume %s: %v", volID, err)
-
-			return nil, status.Errorf(codes.Internal, "error generating volume %s: %v", volID, err)
-		}
-		rv.DataPool = req.GetVolumeContext()["dataPool"]
-		var ok bool
-		if rv.Mounter, ok = req.GetVolumeContext()["mounter"]; !ok {
-			rv.Mounter = rbdDefaultMounter
-		}
+		rv, err = initDynamicVol(ctx, volID, cr, req.GetSecrets(), req.GetVolumeContext())
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	rv.DisableInUseChecks = disableInUseChecks
@@ -270,8 +254,6 @@ func (ns *NodeServer) populateRbdVol(
 		return nil, err
 	}
 
-	rv.VolID = volID
-
 	rv.LogDir = req.GetVolumeContext()["cephLogDir"]
 	if rv.LogDir == "" {
 		rv.LogDir = defaultLogDir
@@ -282,6 +264,54 @@ func (ns *NodeServer) populateRbdVol(
 	}
 
 	return rv, err
+}
+
+func initStaticVol(
+	ctx context.Context,
+	volID string,
+	volCtx map[string]string,
+	disableInUseChecks bool,
+) (*rbdVolume, error) {
+	if volCtx[intreeMigrationKey] == intreeMigrationLabel {
+		volID = volCtx["imageName"]
+	}
+
+	rv, err := genVolFromVolumeOptions(ctx, volCtx, disableInUseChecks, true)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	rv.RbdImageName = volID
+	rv.VolID = volID
+
+	return rv, nil
+}
+
+func initDynamicVol(
+	ctx context.Context,
+	volID string,
+	cr *util.Credentials,
+	secrets map[string]string,
+	volCtx map[string]string,
+) (*rbdVolume, error) {
+	rv, err := GenVolFromVolID(ctx, volID, cr, secrets)
+	if err != nil {
+		if rv != nil {
+			rv.Destroy(ctx)
+		}
+		log.ErrorLog(ctx, "error generating volume %s: %v", volID, err)
+
+		return nil, status.Errorf(codes.Internal, "error generating volume %s: %v", volID, err)
+	}
+
+	rv.DataPool = volCtx["dataPool"]
+	if mounter, ok := volCtx["mounter"]; ok {
+		rv.Mounter = mounter
+	} else {
+		rv.Mounter = rbdDefaultMounter
+	}
+	rv.VolID = volID
+
+	return rv, nil
 }
 
 // appendReadAffinityMapOptions appends readAffinityMapOptions to mapOptions


### PR DESCRIPTION
It seems possible that the .Destroy() function is called on a nil pointer. This would cause a panic in the node-plugin.

Depending on how far GenVolFromVolID() comes, the returned rbdVolume can be connected. If an error occurs, the
rbdVolume should not be connected at all, so call the .Destroy() function in those cases too.

small part of https://github.com/ceph/ceph-csi/pull/4564 taken to fix the exact problem for now.

Fixes: #4562

