### PR TITLE
fix: Tracevol now correctly parses hexadecimal pool id

### DIFF
--- a/troubleshooting/tools/tracevol.py
+++ b/troubleshooting/tools/tracevol.py
@@ -401,7 +401,7 @@ def get_pool_name(arg, vol_id, is_rbd):
         else:
             pool_id = pool_id[3]
         for pool in pools:
-            if int(pool_id) is int(pool['poolnum']):
+            if int(pool_id, 16) is int(pool['poolnum']):
                 return pool['poolname']
     else:
         for pool in pools:


### PR DESCRIPTION
Pool id is a hex string, the previous `int(pool_id)` call fails when there is more than 10 pools in the cluster.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Fix the parsing of pool id in tracevol.py utility

**Checklist:**

* [X] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [X] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [X] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [X] Documentation has been updated, if necessary.
* [X] Unit tests have been added, if necessary.
* [X] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
