### PR TITLE
e2e: Set security context for all the applications

### DIFF
--- a/build.env
+++ b/build.env
@@ -71,5 +71,5 @@ CSI_NODE_DRIVER_REGISTRAR_VERSION=v2.13.0
 # - enable CEPH_CSI_RUN_ALL_TESTS when running tests with if it has root
 #   permissions on the host
 #CEPH_CSI_RUN_ALL_TESTS=true
-E2E_TIMEOUT=150m
+E2E_TIMEOUT=180m
 DEPLOY_TIMEOUT=10

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -1125,7 +1125,7 @@ var _ = Describe(cephfsType, func() {
 					cmd,
 					app.Namespace,
 					&opt)
-				readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
+				readOnlyErr := fmt.Sprintf("%s: Read-only file system", filePath)
 				if !strings.Contains(stdErr, readOnlyErr) {
 					logAndFail("failed to execute command %s: stdOut:%s stdErr:%v", cmd, stdOut, stdErr)
 				}
@@ -2458,7 +2458,7 @@ var _ = Describe(cephfsType, func() {
 					cmd,
 					app.Namespace,
 					&opt)
-				readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
+				readOnlyErr := fmt.Sprintf("%s: Read-only file system", filePath)
 				if !strings.Contains(stdErr, readOnlyErr) {
 					logAndFail("failed to execute command %s: stdOut:%s stdErr:%v", cmd, stdOut, stdErr)
 				}

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -667,7 +667,7 @@ var _ = Describe("nfs", func() {
 					cmd,
 					app.Namespace,
 					&opt)
-				readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
+				readOnlyErr := fmt.Sprintf("%s: Read-only file system", filePath)
 				if !strings.Contains(stdErr, readOnlyErr) {
 					logAndFail("failed to execute command %s: output:%s stdErr:%v", cmd, output, stdErr)
 				}

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -373,12 +373,20 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, ex
 				return false, nil
 			}
 
-			return false, fmt.Errorf("failed to get app: %w", err)
+			return false, fmt.Errorf("failed to get pod: %w", err)
 		}
+
 		switch pod.Status.Phase {
 		case v1.PodRunning:
 			return true, nil
 		case v1.PodFailed, v1.PodSucceeded:
+			framework.Logf(
+				"%s pod is in %s phase: message %v: reason %v",
+				name,
+				pod.Status.Phase,
+				pod.Status.Message,
+				pod.Status.Reason,
+			)
 			return false, conditions.ErrPodCompleted
 		case v1.PodPending:
 			if expectedError != "" {
@@ -396,9 +404,11 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, ex
 			}
 		case v1.PodUnknown:
 			framework.Logf(
-				"%s app  is in %s phase expected to be in Running  state (%d seconds elapsed)",
+				"%s pod is in %s phase expected to be in Running state: message %v: reason: %v. (%d seconds elapsed)",
 				name,
 				pod.Status.Phase,
+				pod.Status.Message,
+				pod.Status.Reason,
 				int(time.Since(start).Seconds()))
 		}
 

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -364,7 +364,10 @@ func createAppErr(c kubernetes.Interface, app *v1.Pod, timeout int, errString st
 func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, expectedError string) error {
 	timeout := time.Duration(t) * time.Minute
 	start := time.Now()
-	framework.Logf("Waiting up to %v to be in Running state", name)
+	framework.Logf(
+		"Waiting for %s pod is in Running phase (%d seconds elapsed)",
+		name,
+		int(time.Since(start).Seconds()))
 
 	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(ctx context.Context) (bool, error) {
 		pod, err := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
@@ -375,18 +378,18 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, ex
 
 			return false, fmt.Errorf("failed to get pod: %w", err)
 		}
+		framework.Logf(
+			"%s pod is in %s phase: message %v: reason: %v. (%d seconds elapsed)",
+			name,
+			pod.Status.Phase,
+			pod.Status.Message,
+			pod.Status.Reason,
+			int(time.Since(start).Seconds()))
 
 		switch pod.Status.Phase {
 		case v1.PodRunning:
 			return true, nil
 		case v1.PodFailed, v1.PodSucceeded:
-			framework.Logf(
-				"%s pod is in %s phase: message %v: reason %v",
-				name,
-				pod.Status.Phase,
-				pod.Status.Message,
-				pod.Status.Reason,
-			)
 			return false, conditions.ErrPodCompleted
 		case v1.PodPending:
 			if expectedError != "" {
@@ -402,14 +405,6 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, ex
 					return true, err
 				}
 			}
-		case v1.PodUnknown:
-			framework.Logf(
-				"%s pod is in %s phase expected to be in Running state: message %v: reason: %v. (%d seconds elapsed)",
-				name,
-				pod.Status.Phase,
-				pod.Status.Message,
-				pod.Status.Reason,
-				int(time.Since(start).Seconds()))
 		}
 
 		return false, nil
@@ -424,7 +419,7 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 		return fmt.Errorf("failed to delete app: %w", err)
 	}
 	start := time.Now()
-	framework.Logf("Waiting for pod %v to be deleted", name)
+	framework.Logf("Waiting for pod %v to be deleted (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
 
 	return wait.PollUntilContextTimeout(ctx, poll, timeout, true, func(ctx context.Context) (bool, error) {
 		_, err := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
@@ -435,10 +430,11 @@ func deletePod(name, ns string, c kubernetes.Interface, t int) error {
 			if apierrs.IsNotFound(err) {
 				return true, nil
 			}
-			framework.Logf("%s app  to be deleted (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
 
 			return false, fmt.Errorf("failed to get app: %w", err)
 		}
+
+		framework.Logf("%s app  to be deleted (%d seconds elapsed)", name, int(time.Since(start).Seconds()))
 
 		return false, nil
 	})

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -3430,7 +3430,7 @@ var _ = Describe("RBD", func() {
 						cmd,
 						appClone.Namespace,
 						&opt)
-					readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
+					readOnlyErr := fmt.Sprintf("%s: Read-only file system", filePath)
 					if !strings.Contains(stdErr, readOnlyErr) {
 						logAndFail("failed to execute command %s: stdOut=%v stdErr:%v", cmd, stdOut, stdErr)
 					}
@@ -3546,7 +3546,7 @@ var _ = Describe("RBD", func() {
 						cmd,
 						appClone.Namespace,
 						&opt)
-					readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
+					readOnlyErr := fmt.Sprintf("%s: Read-only file system", filePath)
 					if !strings.Contains(stdErr, readOnlyErr) {
 						framework.Logf("command %q failed: stdOut:%s stdErr:%s", cmd, stdOut, stdErr)
 					}
@@ -4200,7 +4200,7 @@ var _ = Describe("RBD", func() {
 					cmd,
 					app.Namespace,
 					&opt)
-				readOnlyErr := fmt.Sprintf("cannot create %s: Read-only file system", filePath)
+				readOnlyErr := fmt.Sprintf("%s: Read-only file system", filePath)
 				if !strings.Contains(stdErr, readOnlyErr) {
 					logAndFail("failed to execute command %s: stdOut:%s stdErr:%v", cmd, stdOut, stdErr)
 				}

--- a/e2e/templates/rbd-fs-deployment.yaml
+++ b/e2e/templates/rbd-fs-deployment.yaml
@@ -16,8 +16,9 @@ spec:
         app: pod-fs-rx-volume
     spec:
       containers:
-        - name: web-server
-          image: docker.io/library/nginx:latest
+        - name: centos
+          image: "quay.io/centos/centos:latest"
+          command: ["/bin/sleep", "infinity"]
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: mypvc

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -659,6 +659,7 @@ func validateNormalUserPVCAccessFunc(
 		return err
 	}
 	var user int64 = 2000
+	runAsNonRoot := true
 	app := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -672,15 +673,29 @@ func validateNormalUserPVCAccessFunc(
 			},
 		},
 		Spec: v1.PodSpec{
-			SecurityContext: &v1.PodSecurityContext{FSGroup: &user},
+			SecurityContext: &v1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRoot,
+				FSGroup:      &user,
+				SeccompProfile: &v1.SeccompProfile{
+					Type: v1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 			Containers: []v1.Container{
 				{
 					Name:    "write-pod",
 					Image:   "quay.io/centos/centos:latest",
 					Command: []string{"/bin/sleep", "999999"},
 					SecurityContext: &v1.SecurityContext{
-						RunAsUser: &user,
+						RunAsNonRoot: &runAsNonRoot,
+						RunAsUser:    &user,
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{"ALL"},
+						},
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
+					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts: []v1.VolumeMount{
 						{
 							MountPath: "/target",

--- a/e2e/volumegroupsnapshot_base.go
+++ b/e2e/volumegroupsnapshot_base.go
@@ -225,6 +225,9 @@ func (v *volumeGroupSnapshotterBase) CreatePVCClones(
 
 func (v *volumeGroupSnapshotterBase) CreatePods(pvcs []*v1.PersistentVolumeClaim) ([]*v1.Pod, error) {
 	pods := make([]*v1.Pod, len(pvcs))
+	var user int64 = 2000
+	runAsNonRoot := true
+	allowPrivilegeEscalation := false
 	for i, p := range pvcs {
 		pods[i] = &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -232,11 +235,30 @@ func (v *volumeGroupSnapshotterBase) CreatePods(pvcs []*v1.PersistentVolumeClaim
 				Namespace: p.Namespace,
 			},
 			Spec: v1.PodSpec{
+				SecurityContext: &v1.PodSecurityContext{
+					RunAsNonRoot: &runAsNonRoot,
+					FSGroup:      &user,
+					SeccompProfile: &v1.SeccompProfile{
+						Type: v1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []v1.Container{
 					{
 						Name:    "container",
 						Image:   "quay.io/centos/centos:latest",
 						Command: []string{"/bin/sleep", "999999"},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+							RunAsNonRoot:             &runAsNonRoot,
+							RunAsUser:                &user,
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{"ALL"},
+							},
+							SeccompProfile: &v1.SeccompProfile{
+								Type: v1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
+						ImagePullPolicy: v1.PullIfNotPresent,
 					},
 				},
 			},

--- a/examples/cephfs/deployment.yaml
+++ b/examples/cephfs/deployment.yaml
@@ -4,20 +4,36 @@ kind: Deployment
 metadata:
   name: csi-cephfs-demo-depl
   labels:
-    app: web-server
+    app: centos
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: web-server
+      app: centos
   template:
     metadata:
       labels:
-        app: web-server
+        app: centos
     spec:
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: web-server
-          image: docker.io/library/nginx:latest
+        - name: centos
+          image: quay.io/centos/centos:latest
+          command: ["/bin/sleep", "infinity"]
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: mypvc
               mountPath: /var/lib/www/html

--- a/examples/cephfs/pod-clone.yaml
+++ b/examples/cephfs/pod-clone.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-cephfs-clone-demo-app
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 2000
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/cephfs/pod-ephemeral.yaml
+++ b/examples/cephfs/pod-ephemeral.yaml
@@ -4,9 +4,25 @@ apiVersion: v1
 metadata:
   name: csi-cephfs-demo-ephemeral-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - mountPath: /myspace
           name: mypvc

--- a/examples/cephfs/pod-restore.yaml
+++ b/examples/cephfs/pod-restore.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-cephfs-restore-demo-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/cephfs/pod-rwop.yaml
+++ b/examples/cephfs/pod-rwop.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-cephfs-demo-rwop-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/cephfs/pod.yaml
+++ b/examples/cephfs/pod.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-cephfs-demo-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/nfs/pod-clone.yaml
+++ b/examples/nfs/pod-clone.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-nfs-clone-demo-app
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/nfs/pod-restore.yaml
+++ b/examples/nfs/pod-restore.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-nfs-restore-demo-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/nfs/pod-rwop.yaml
+++ b/examples/nfs/pod-rwop.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-nfs-demo-rwop-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/nfs/pod.yaml
+++ b/examples/nfs/pod.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: cephcsi-nfs-demo-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www

--- a/examples/rbd/block-pod-clone.yaml
+++ b/examples/rbd/block-pod-clone.yaml
@@ -8,6 +8,7 @@ spec:
     - name: centos
       image: quay.io/centos/centos:latest
       command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
       volumeDevices:
         - name: data
           devicePath: /dev/xvda

--- a/examples/rbd/pod-block-restore.yaml
+++ b/examples/rbd/pod-block-restore.yaml
@@ -8,6 +8,7 @@ spec:
     - name: centos
       image: quay.io/centos/centos:latest
       command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
       volumeDevices:
         - name: data
           devicePath: /dev/xvda

--- a/examples/rbd/pod-clone.yaml
+++ b/examples/rbd/pod-clone.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-rbd-clone-demo-app
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/pod-ephemeral.yaml
+++ b/examples/rbd/pod-ephemeral.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-rbd-demo-ephemeral-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - mountPath: /myspace
           name: mypvc

--- a/examples/rbd/pod-restore.yaml
+++ b/examples/rbd/pod-restore.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-rbd-restore-demo-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/pod-rwop.yaml
+++ b/examples/rbd/pod-rwop.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-rbd-demo-fs-rwop-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/pod.yaml
+++ b/examples/rbd/pod.yaml
@@ -4,9 +4,25 @@ kind: Pod
 metadata:
   name: csi-rbd-demo-pod
 spec:
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: web-server
-      image: docker.io/library/nginx:latest
+    - name: centos
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: mypvc
           mountPath: /var/lib/www/html

--- a/examples/rbd/raw-block-pod-rwop.yaml
+++ b/examples/rbd/raw-block-pod-rwop.yaml
@@ -8,6 +8,7 @@ spec:
     - name: centos
       image: quay.io/centos/centos:latest
       command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
       volumeDevices:
         - name: data
           devicePath: /dev/xvda

--- a/examples/rbd/raw-block-pod.yaml
+++ b/examples/rbd/raw-block-pod.yaml
@@ -8,6 +8,7 @@ spec:
     - name: centos
       image: quay.io/centos/centos:latest
       command: ["/bin/sleep", "infinity"]
+      imagePullPolicy: IfNotPresent
       volumeDevices:
         - name: data
           devicePath: /dev/xvda


### PR DESCRIPTION
Some applications are still using the root user which is not good to have, setting the security context for all the applications to follow the kubernetes security suggestions and same will be tested in the CI.