### PR TITLE
build: use Go 1.24.2

### DIFF
--- a/build.env
+++ b/build.env
@@ -26,7 +26,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v19.2.2
 CEPH_VERSION=squid
 
 # standard Golang options
-GOLANG_VERSION=1.23.4
+GOLANG_VERSION=1.24.2
 GO111MODULE=on
 
 # commitlint version


### PR DESCRIPTION
While building Ceph-CSI the Go toolchain always downloads Go 1.24.2. It
saves time (and bandwidth) when that version is installed from the
start.
