### PR TITLE
rbd: return replication status and status message in case of error

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -916,7 +916,7 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 	lastSyncInfo, err := remoteStatus.GetLastSyncInfo(ctx)
 	if err != nil {
 		if errors.Is(err, rbderrors.ErrLastSyncTimeNotFound) {
-			return nil, status.Errorf(codes.NotFound, "failed to get last sync info: %v", err)
+			return nil, status.Errorf(codes.FailedPrecondition, "failed to get last sync info: %v", err)
 		}
 
 		return nil, status.Errorf(codes.Internal, "failed to get last sync info: %v", err)
@@ -933,12 +933,7 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 		resp.LastSyncDuration = durationpb.New(*lastDuration)
 	}
 
-	replicationStatus, statusMessage, err := getCurrentReplicationStatus(ctx, mirrorStatus)
-	if err != nil {
-		log.ErrorLog(ctx, err.Error())
-
-		return nil, status.Errorf(codes.Internal, "failed to get local status: %v", err)
-	}
+	replicationStatus, statusMessage := getCurrentReplicationStatus(ctx, mirrorStatus)
 
 	resp.Status = replicationStatus
 	resp.StatusMessage = statusMessage
@@ -962,11 +957,13 @@ func checkVolumeResyncStatus(ctx context.Context, localStatus types.SiteStatus) 
 }
 
 func getCurrentReplicationStatus(ctx context.Context, mirrorGlobalStatus types.GlobalStatus,
-) (replication.GetVolumeReplicationInfoResponse_Status, string, error) {
+) (replication.GetVolumeReplicationInfoResponse_Status, string) {
 	// get image local status
 	localStatus, err := mirrorGlobalStatus.GetLocalSiteStatus()
 	if err != nil {
-		return replication.GetVolumeReplicationInfoResponse_UNKNOWN, "", err
+		log.ErrorLog(ctx, err.Error())
+
+		return replication.GetVolumeReplicationInfoResponse_UNKNOWN, "status not found"
 	}
 
 	// parse only the message from the description of the image/group status
@@ -977,7 +974,7 @@ func getCurrentReplicationStatus(ctx context.Context, mirrorGlobalStatus types.G
 	isUp := localStatus.IsUP()
 
 	if !isUp {
-		return replication.GetVolumeReplicationInfoResponse_DEGRADED, desc, nil
+		return replication.GetVolumeReplicationInfoResponse_DEGRADED, desc
 	}
 
 	resp := replication.GetVolumeReplicationInfoResponse_UNKNOWN
@@ -994,5 +991,5 @@ func getCurrentReplicationStatus(ctx context.Context, mirrorGlobalStatus types.G
 			localStatus.GetState(), desc)
 	}
 
-	return resp, desc, nil
+	return resp, desc
 }

--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -775,10 +775,7 @@ func Test_getCurrentReplicationStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			respStatus, respStatusMsg, err := getCurrentReplicationStatus(ctx, tt.args)
-			if err != nil {
-				t.Errorf("getCurrentReplicationStatus() returned error = %v", err)
-			}
+			respStatus, respStatusMsg := getCurrentReplicationStatus(ctx, tt.args)
 			if !reflect.DeepEqual(tt.status, respStatus) {
 				t.Errorf("getCurrentReplicationStatus() returned status = %v, want = %v", respStatus, tt.status)
 			}


### PR DESCRIPTION
# Describe what this PR does #

We should return the status and status message even if we fail to fetch the local status of the volume/group so that the error/state can be propagated to the VR/VGR in csi-addons.
For ex, if the local mirror status is `down+unknown` when rbd is not able to fetch the mirror status, we should report the same on the VR/VGR i.e, the `state` being `unknown` and the message being `status not found`.

Also, it seems more logical to return a `FailedPreCondition` error code if `sync info not found` error is hit.
