### PR TITLE
rbd: support set qos max limit for rbdVol

### DIFF
--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -74,11 +74,17 @@ make image-cephcsi
 | `stripeCount`                                                                                       | no                   | objects to stripe over before looping                                                                                                                                                                                                                                                              |
 | `objectSize`                                                                                        | no                   | object size in bytes                                                                                                                                                                                                                                                                               |
 | `baseIops`                                                                                          | no                   | the base limit of operations per second |
+| `maxIops`                                                                                           | no                   | the max limit of operations per second  |
 | `baseReadIops`                                                                                      | no                   | the base limit of read operations per second |
+| `maxReadIops`                                                                                       | no                   | the max limit of read operations per second |
 | `baseWriteIops`                                                                                     | no                   | the base limit of write operations per second |
+| `maxWriteIops`                                                                                      | no                   | the max limit of write operations per second |
 | `baseBps`                                                                                           | no                   | the base limit of bytes per second |
+| `maxBps`                                                                                            | no                   | the max limit of bytes per second |
 | `baseReadBps`                                                                                       | no                   | the base limit of read bytes per second |
+| `maxReadBps`                                                                                        | no                   | the max limit of read bytes per second |
 | `baseWriteBps`                                                                                      | no                   | the base limit of write bytes per second |
+| `maxWriteBps`                                                                                       | no                   | the max limit of write bytes per second |
 | `iopsPerGiB`                                                                                        | no                   | the limit of operations per GiB |
 | `readIopsPerGiB`                                                                                    | no                   | the limit of read operations per GiB |
 | `writeIopsPerGiB`                                                                                   | no                   | the limit of write operations per GiB |

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -4714,12 +4714,22 @@ var _ = Describe("RBD", func() {
 
 			By("validate rbd image qos", func() {
 				var (
+					baseIops         = "3000"
+					maxIops          = "15000"
 					baseReadIops     = "2000"
+					maxReadIops      = "10000"
 					baseWriteIops    = "1000"
+					maxWriteIops     = "5000"
+					baseBps          = "314572800"
+					maxBps           = "1572864000"
 					baseReadBps      = "209715200"
+					maxReadBps       = "1048576000"
 					baseWriteBps     = "104857600"
+					maxWriteBps      = "524288000"
+					iopsPerGiB       = "30"
 					readIopsPerGiB   = "20"
 					writeIopsPerGiB  = "10"
+					bpsPerGiB        = "3145728"
 					readBpsPerGiB    = "2097152"
 					writeBpsPerGiB   = "1048576"
 					baseVolSizeBytes = "21474836480"
@@ -4983,6 +4993,105 @@ var _ = Describe("RBD", func() {
 				err = deletePVCAndValidatePV(f.ClientSet, pvcSmartClone, deployTimeout)
 				if err != nil {
 					logAndFail("failed to delete PVC: %v", err)
+				}
+
+				qosParameters = map[string]string{
+					"baseIops":         baseIops,
+					"maxIops":          maxIops,
+					"baseReadIops":     baseReadIops,
+					"maxReadIops":      maxReadIops,
+					"baseWriteIops":    baseWriteIops,
+					"maxWriteIops":     maxWriteIops,
+					"baseBps":          baseBps,
+					"maxBps":           maxBps,
+					"baseReadBps":      baseReadBps,
+					"maxReadBps":       maxReadBps,
+					"baseWriteBps":     baseWriteBps,
+					"maxWriteBps":      maxWriteBps,
+					"iopsPerGiB":       iopsPerGiB,
+					"readIopsPerGiB":   readIopsPerGiB,
+					"writeIopsPerGiB":  writeIopsPerGiB,
+					"bpsPerGiB":        bpsPerGiB,
+					"readBpsPerGiB":    readBpsPerGiB,
+					"writeBpsPerGiB":   writeBpsPerGiB,
+					"baseVolSizeBytes": baseVolSizeBytes,
+				}
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					logAndFail("failed to delete storageclass: %v", err)
+				}
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					qosParameters,
+					deletePolicy)
+				if err != nil {
+					logAndFail("failed to create storageclass: %v", err)
+				}
+				pvc, err = loadPVC(pvcPath)
+				if err != nil {
+					logAndFail("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+				pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse("200Gi")
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create PVC and application: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+				validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+
+				wants3 := map[string]string{
+					"rbd_qos_iops_limit":       "8400",
+					"rbd_qos_read_iops_limit":  "5600",
+					"rbd_qos_write_iops_limit": "2800",
+					"rbd_qos_bps_limit":        "880803840",
+					"rbd_qos_read_bps_limit":   "587202560",
+					"rbd_qos_write_bps_limit":  "293601280",
+				}
+				err = validateQOS(f, pvc, wants3)
+				if err != nil {
+					logAndFail("failed to validate qos: %v", err)
+				}
+
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					framework.Failf("failed to delete PVC: %v", err)
+				}
+
+				pvc, err = loadPVC(pvcPath)
+				if err != nil {
+					framework.Failf("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+				pvc.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse("600Gi")
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					framework.Failf("failed to create PVC and application: %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 1, defaultRBDPool)
+				validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+
+				wants4 := map[string]string{
+					"rbd_qos_iops_limit":       "15000",
+					"rbd_qos_read_iops_limit":  "10000",
+					"rbd_qos_write_iops_limit": "5000",
+					"rbd_qos_bps_limit":        "1572864000",
+					"rbd_qos_read_bps_limit":   "1048576000",
+					"rbd_qos_write_bps_limit":  "524288000",
+				}
+				err = validateQOS(f, pvc, wants4)
+				if err != nil {
+					logAndFail("failed to validate qos: %v", err)
+				}
+
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					framework.Failf("failed to delete PVC: %v", err)
 				}
 
 				// END: validate created backend rbd images

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -178,16 +178,28 @@ parameters:
    # For more details
    # (optional) the base limit of operations per second.
    # baseIops: <>
+   # (optional) the max limit of operations per second.
+   # maxIops: <>
    # (optional) the base limit of read operations per second.
    # baseReadIops: <>
+   # (optional) the max limit of read operations per second.
+   # maxReadIops: <>
    # (optional) the base limit of write operations per second.
    # baseWriteIops: <>
+   # (optional) the max limit of write operations per second.
+   # maxWriteIops: <>
    # (optional) the base limit of bytes per second.
    # baseBps: <>
+   # (optional) the max limit of bytes per second.
+   # maxBps: <>
    # (optional) the base limit of read bytes per second.
    # baseReadBps: <>
+   # (optional) the max limit of read bytes per second.
+   # maxReadBps: <>
    # (optional) the base limit of write bytes per second.
    # baseWriteBps: <>
+   # (optional) the max limit of write bytes per second.
+   # maxWriteBps: <>
    # (optional) the limit of operations per GiB.
    # iopsPerGiB: <>
    # (optional) the limit of read operations per GiB.

--- a/internal/rbd/qos.go
+++ b/internal/rbd/qos.go
@@ -29,11 +29,17 @@ import (
 const (
 	// Qos parameters name of StorageClass.
 	baseIops         = "baseIops"
+	maxIops          = "maxIops"
 	baseReadIops     = "baseReadIops"
+	maxReadIops      = "maxReadIops"
 	baseWriteIops    = "baseWriteIops"
+	maxWriteIops     = "maxWriteIops"
 	baseBps          = "baseBps"
+	maxBps           = "maxBps"
 	baseReadBps      = "baseReadBps"
+	maxReadBps       = "maxReadBps"
 	baseWriteBps     = "baseWriteBps"
+	maxWriteBps      = "maxWriteBps"
 	iopsPerGiB       = "iopsPerGiB"
 	readIopsPerGiB   = "readIopsPerGiB"
 	writeIopsPerGiB  = "writeIopsPerGiB"
@@ -53,11 +59,17 @@ const (
 
 	// The params use to calc qos based on capacity.
 	baseQosIopsLimit      = "rbd_base_qos_iops_limit"
+	maxQosIopsLimit       = "rbd_max_qos_iops_limit"
 	baseQosReadIopsLimit  = "rbd_base_qos_read_iops_limit"
+	maxQosReadIopsLimit   = "rbd_max_qos_read_iops_limit"
 	baseQosWriteIopsLimit = "rbd_base_qos_write_iops_limit"
+	maxQosWriteIopsLimit  = "rbd_max_qos_write_iops_limit"
 	baseQosBpsLimit       = "rbd_base_qos_bps_limit"
+	maxQosBpsLimit        = "rbd_max_qos_bps_limit"
 	baseQosReadBpsLimit   = "rbd_base_qos_read_bps_limit"
+	maxQosReadBpsLimit    = "rbd_max_qos_read_bps_limit"
 	baseQosWriteBpsLimit  = "rbd_base_qos_write_bps_limit"
+	maxQosWriteBpsLimit   = "rbd_max_qos_write_bps_limit"
 	iopsPerGiBLimit       = "rbd_iops_per_gib_limit"
 	readIopsPerGiBLimit   = "rbd_read_iops_per_gib_limit"
 	writeIopsPerGiBLimit  = "rbd_write_iops_per_gib_limit"
@@ -72,6 +84,8 @@ type qosSpec struct {
 	baseLimit       string
 	perGiBLimitType string
 	perGiBLimit     string
+	maxLimitType    string
+	maxLimit        string
 	present         bool
 }
 
@@ -79,12 +93,12 @@ func parseQosParams(
 	scParams map[string]string,
 ) map[string]*qosSpec {
 	rbdQosParameters := map[string]*qosSpec{
-		baseIops:      {iopsLimit, "", iopsPerGiB, "", false},
-		baseReadIops:  {readIopsLimit, "", readIopsPerGiB, "", false},
-		baseWriteIops: {writeIopsLimit, "", writeIopsPerGiB, "", false},
-		baseBps:       {bpsLimit, "", bpsPerGiB, "", false},
-		baseReadBps:   {readBpsLimit, "", readBpsPerGiB, "", false},
-		baseWriteBps:  {writeBpsLimit, "", writeBpsPerGiB, "", false},
+		baseIops:      {iopsLimit, "", iopsPerGiB, "", maxIops, "", false},
+		baseReadIops:  {readIopsLimit, "", readIopsPerGiB, "", maxReadIops, "", false},
+		baseWriteIops: {writeIopsLimit, "", writeIopsPerGiB, "", maxWriteIops, "", false},
+		baseBps:       {bpsLimit, "", bpsPerGiB, "", maxBps, "", false},
+		baseReadBps:   {readBpsLimit, "", readBpsPerGiB, "", maxReadBps, "", false},
+		baseWriteBps:  {writeBpsLimit, "", writeBpsPerGiB, "", maxWriteBps, "", false},
 	}
 	for k, v := range scParams {
 		if qos, ok := rbdQosParameters[k]; ok && v != "" {
@@ -92,6 +106,9 @@ func parseQosParams(
 			qos.present = true
 			if perGiBLimit, ok := scParams[qos.perGiBLimitType]; ok && perGiBLimit != "" {
 				qos.perGiBLimit = perGiBLimit
+			}
+			if maxLimit, ok := scParams[qos.maxLimitType]; ok && maxLimit != "" {
+				qos.maxLimit = maxLimit
 			}
 		}
 	}
@@ -111,7 +128,7 @@ func (rv *rbdVolume) SetQOS(
 	rbdQosParameters := parseQosParams(scParams)
 	for _, qos := range rbdQosParameters {
 		if qos.present {
-			err := rv.calcQosBasedOnCapacity(ctx, *qos)
+			err := rv.calcQosBasedOnCapacity(ctx, qos)
 			if err != nil {
 				return err
 			}
@@ -138,7 +155,7 @@ func (rv *rbdVolume) ApplyQOS(
 
 func (rv *rbdVolume) calcQosBasedOnCapacity(
 	ctx context.Context,
-	qos qosSpec,
+	qos *qosSpec,
 ) error {
 	if rv.QosParameters == nil {
 		rv.QosParameters = make(map[string]string)
@@ -157,31 +174,46 @@ func (rv *rbdVolume) calcQosBasedOnCapacity(
 
 	// if present qosPerGB and baseVolSize, we will set qos based on capacity,
 	// otherwise, we only set base qos limit.
-	if qos.perGiBLimit != "" && rv.BaseVolSize != "" {
-		perGiBLimit, err := strconv.ParseInt(qos.perGiBLimit, 10, 64)
-		if err != nil {
-			log.ErrorLog(ctx, "failed to parse %s: %s. %v", qos.perGiBLimitType, qos.perGiBLimit, err)
-
-			return err
-		}
-
-		baseVolSize, err := strconv.ParseInt(rv.BaseVolSize, 10, 64)
-		if err != nil {
-			log.ErrorLog(ctx, "failed to parse %s: %s. %v", baseVolSizeBytes, rv.BaseVolSize, err)
-
-			return err
-		}
-
-		if rv.RequestedVolSize <= baseVolSize {
-			rv.QosParameters[qos.baseLimitType] = qos.baseLimit
-		} else {
-			capacityQos := (rv.RequestedVolSize - baseVolSize) / int64(oneGB) * perGiBLimit
-			finalQosLimit := baseLimit + capacityQos
-			rv.QosParameters[qos.baseLimitType] = strconv.FormatInt(finalQosLimit, 10)
-		}
-	} else {
+	if qos.perGiBLimit == "" || rv.BaseVolSize == "" {
 		rv.QosParameters[qos.baseLimitType] = qos.baseLimit
+
+		return nil
 	}
+
+	perGiBLimit, err := strconv.ParseInt(qos.perGiBLimit, 10, 64)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to parse %s: %s. %v", qos.perGiBLimitType, qos.perGiBLimit, err)
+
+		return err
+	}
+
+	baseVolSize, err := strconv.ParseInt(rv.BaseVolSize, 10, 64)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to parse %s: %s. %v", baseVolSizeBytes, rv.BaseVolSize, err)
+
+		return err
+	}
+
+	if rv.RequestedVolSize <= baseVolSize {
+		rv.QosParameters[qos.baseLimitType] = qos.baseLimit
+
+		return nil
+	}
+
+	capacityQos := (rv.RequestedVolSize - baseVolSize) / int64(oneGB) * perGiBLimit
+	finalQosLimit := baseLimit + capacityQos
+	if qos.maxLimit != "" {
+		maxLimit, err := strconv.ParseInt(qos.maxLimit, 10, 64)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to parse %s: %s. %v", qos.maxLimitType, qos.maxLimit, err)
+
+			return err
+		}
+		if finalQosLimit > maxLimit {
+			finalQosLimit = maxLimit
+		}
+	}
+	rv.QosParameters[qos.baseLimitType] = strconv.FormatInt(finalQosLimit, 10)
 
 	return nil
 }
@@ -192,11 +224,17 @@ func (rv *rbdVolume) SaveQOS(
 ) error {
 	needSaveQosParameters := map[string]string{
 		baseIops:         baseQosIopsLimit,
+		maxIops:          maxQosIopsLimit,
 		baseReadIops:     baseQosReadIopsLimit,
+		maxReadIops:      maxQosReadIopsLimit,
 		baseWriteIops:    baseQosWriteIopsLimit,
+		maxWriteIops:     maxQosWriteIopsLimit,
 		baseBps:          baseQosBpsLimit,
+		maxBps:           maxQosBpsLimit,
 		baseReadBps:      baseQosReadBpsLimit,
+		maxReadBps:       maxQosReadBpsLimit,
 		baseWriteBps:     baseQosWriteBpsLimit,
+		maxWriteBps:      maxQosWriteBpsLimit,
 		iopsPerGiB:       iopsPerGiBLimit,
 		readIopsPerGiB:   readIopsPerGiBLimit,
 		writeIopsPerGiB:  writeIopsPerGiBLimit,
@@ -225,13 +263,14 @@ func (rv *rbdVolume) getRbdImageQOS(
 	QosParams := map[string]struct {
 		rbdQosType       string
 		rbdQosPerGiBType string
+		rbdQosMaxType    string
 	}{
-		baseQosIopsLimit:      {iopsLimit, iopsPerGiBLimit},
-		baseQosReadIopsLimit:  {readIopsLimit, readIopsPerGiBLimit},
-		baseQosWriteIopsLimit: {writeIopsLimit, writeIopsPerGiBLimit},
-		baseQosBpsLimit:       {bpsLimit, bpsPerGiBLimit},
-		baseQosReadBpsLimit:   {readBpsLimit, readBpsPerGiBLimit},
-		baseQosWriteBpsLimit:  {writeBpsLimit, writeBpsPerGiBLimit},
+		baseQosIopsLimit:      {iopsLimit, iopsPerGiBLimit, maxQosIopsLimit},
+		baseQosReadIopsLimit:  {readIopsLimit, readIopsPerGiBLimit, maxQosReadIopsLimit},
+		baseQosWriteIopsLimit: {writeIopsLimit, writeIopsPerGiBLimit, maxQosWriteIopsLimit},
+		baseQosBpsLimit:       {bpsLimit, bpsPerGiBLimit, maxQosBpsLimit},
+		baseQosReadBpsLimit:   {readBpsLimit, readBpsPerGiBLimit, maxQosReadBpsLimit},
+		baseQosWriteBpsLimit:  {writeBpsLimit, writeBpsPerGiBLimit, maxQosWriteBpsLimit},
 	}
 	rbdQosParameters := make(map[string]qosSpec)
 	for k, param := range QosParams {
@@ -251,7 +290,20 @@ func (rv *rbdVolume) getRbdImageQOS(
 
 			return nil, err
 		}
-		rbdQosParameters[k] = qosSpec{param.rbdQosType, baseLimit, param.rbdQosPerGiBType, perGiBLimit, true}
+		maxLimit, err := rv.GetMetadata(param.rbdQosMaxType)
+		if err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			log.ErrorLog(ctx, "failed to get metadata: %s. %v", param.rbdQosMaxType, err)
+
+			return nil, err
+		}
+		rbdQosParameters[k] = qosSpec{
+			param.rbdQosType,
+			baseLimit,
+			param.rbdQosPerGiBType,
+			perGiBLimit,
+			param.rbdQosMaxType,
+			maxLimit, true,
+		}
 	}
 
 	baseVolSize, err := rv.GetMetadata(baseQosVolSize)
@@ -273,7 +325,7 @@ func (rv *rbdVolume) AdjustQOS(
 		return err
 	}
 	for _, param := range rbdQosParameters {
-		err = rv.calcQosBasedOnCapacity(ctx, param)
+		err = rv.calcQosBasedOnCapacity(ctx, &param)
 		if err != nil {
 			return err
 		}

--- a/internal/rbd/qos_test.go
+++ b/internal/rbd/qos_test.go
@@ -130,4 +130,57 @@ func TestSetQOS(t *testing.T) {
 		t.Errorf("SetQOS failed: %v", err)
 	}
 	checkQOS(t, rv.QosParameters, wants)
+
+	tests = map[string]string{
+		baseIops:         "3000",
+		maxIops:          "15000",
+		baseReadIops:     "2000",
+		maxReadIops:      "10000",
+		baseWriteIops:    "1000",
+		maxWriteIops:     "5000",
+		baseBps:          "314572800",
+		maxBps:           "1572864000",
+		baseReadBps:      "209715200",
+		maxReadBps:       "1048576000",
+		baseWriteBps:     "104857600",
+		maxWriteBps:      "524288000",
+		iopsPerGiB:       "30",
+		readIopsPerGiB:   "20",
+		writeIopsPerGiB:  "10",
+		bpsPerGiB:        "3145728",
+		readBpsPerGiB:    "2097152",
+		writeBpsPerGiB:   "1048576",
+		baseVolSizeBytes: "21474836480",
+	}
+	wants = map[string]string{
+		iopsLimit:      "8400",
+		readIopsLimit:  "5600",
+		writeIopsLimit: "2800",
+		bpsLimit:       "880803840",
+		readBpsLimit:   "587202560",
+		writeBpsLimit:  "293601280",
+	}
+	rv = rbdVolume{}
+	rv.RequestedVolSize = int64(oneGB) * 200
+	err = rv.SetQOS(ctx, tests)
+	if err != nil {
+		t.Errorf("SetQOS failed: %v", err)
+	}
+	checkQOS(t, rv.QosParameters, wants)
+
+	wants = map[string]string{
+		iopsLimit:      "15000",
+		readIopsLimit:  "10000",
+		writeIopsLimit: "5000",
+		bpsLimit:       "1572864000",
+		readBpsLimit:   "1048576000",
+		writeBpsLimit:  "524288000",
+	}
+	rv = rbdVolume{}
+	rv.RequestedVolSize = int64(oneGB) * 600
+	err = rv.SetQOS(ctx, tests)
+	if err != nil {
+		t.Errorf("SetQOS failed: %v", err)
+	}
+	checkQOS(t, rv.QosParameters, wants)
 }


### PR DESCRIPTION
rbdVol already support qos base on capacity, in reality, performance doesn't always scale linearly with capacity. To address this, we've added max configurations to allow users to set a maximum QoS limit for a volume. Once the maximum limit is reached, further capacity increases will no longer improve performance. These configurations as below:
- maxIops
- maxReadIops
- maxWriteIops
- maxBps
- maxReadBps
- maxWriteBps

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
