### PR TITLE
nvmeof: provisioner add features

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -252,9 +252,10 @@ func createNVMeoFResources(
 		return nil, fmt.Errorf("invalid nvmeofGatewayPort %s: %w", nvmeofGatewayPortStr, err)
 	}
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
-		SubsystemNQN: params["subsystemNQN"],
-		NamespaceID:  0, // will be set after namespace creation
-		HostNQN:      params["hostNQN"],
+		SubsystemNQN:  params["subsystemNQN"],
+		NamespaceID:   0,  // will be set after namespace creation,
+		NamespaceUUID: "", // will be set after namespace creation
+		HostNQN:       params["hostNQN"],
 		ListenerInfo: nvmeof.ListenerDetails{
 			GatewayAddress: nvmeof.GatewayAddress{
 				Address: params["listenerIpAddress"],
@@ -303,6 +304,12 @@ func createNVMeoFResources(
 	}
 	log.DebugLog(ctx, "Namespace created: %s/%s with NSID: %d", rbdPoolName, rbdImageName, nsid)
 	nvmeofData.NamespaceID = nsid
+
+	uuid, err := gateway.GetUUIDBySubsystemAndNameSpaceID(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID)
+	if err != nil {
+		return nil, fmt.Errorf("get namespace uuid failed: %w", err)
+	}
+	nvmeofData.NamespaceUUID = uuid
 
 	// Step 6: Add host to subsystem
 	if err := gateway.AddHost(ctx, nvmeofData.SubsystemNQN, nvmeofData.HostNQN); err != nil {
@@ -371,9 +378,10 @@ func cleanupNVMeoFResources(
 
 const (
 	// NVMe-oF resource info.
-	mdSubsystemNQN = ".rbd.nvmeof.SubsystemNQN"
-	mdNamespaceID  = ".rbd.nvmeof.NamespaceID"
-	mdHostNQN      = ".rbd.nvmeof.HostNQN"
+	mdSubsystemNQN  = ".rbd.nvmeof.SubsystemNQN"
+	mdNamespaceID   = ".rbd.nvmeof.NamespaceID"
+	mdNamespaceUUID = ".rbd.nvmeof.NamespaceUUID"
+	mdHostNQN       = ".rbd.nvmeof.HostNQN"
 
 	// Listener info.
 	mdListenerAddress  = ".rbd.nvmeof.ListenerAddress"
@@ -395,6 +403,7 @@ func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) {
 
 	volume.VolumeContext[mdSubsystemNQN] = data.SubsystemNQN
 	volume.VolumeContext[mdNamespaceID] = strconv.FormatUint(uint64(data.NamespaceID), 10)
+	volume.VolumeContext[mdNamespaceUUID] = data.NamespaceUUID
 	volume.VolumeContext[mdHostNQN] = data.HostNQN
 	volume.VolumeContext[mdListenerAddress] = data.ListenerInfo.Address
 	volume.VolumeContext[mdListenerPort] = listenerPortStr
@@ -427,9 +436,10 @@ func (cs *Server) storeNVMeoFMetadata(
 	// Prepare all metadata entries
 	metadata := map[string]string{
 		// NVMe-oF resource info
-		mdSubsystemNQN: nvmeofData.SubsystemNQN,
-		mdNamespaceID:  strconv.FormatUint(uint64(nvmeofData.NamespaceID), 10),
-		mdHostNQN:      nvmeofData.HostNQN,
+		mdSubsystemNQN:  nvmeofData.SubsystemNQN,
+		mdNamespaceID:   strconv.FormatUint(uint64(nvmeofData.NamespaceID), 10),
+		mdNamespaceUUID: nvmeofData.NamespaceUUID,
+		mdHostNQN:       nvmeofData.HostNQN,
 
 		// Listener info
 		mdListenerAddress:  nvmeofData.ListenerInfo.Address,
@@ -485,6 +495,7 @@ func (cs *Server) getNVMeoFMetadata(
 	requiredKeys := []string{
 		mdSubsystemNQN,
 		mdNamespaceID,
+		mdNamespaceUUID,
 		mdHostNQN,
 		mdListenerAddress,
 		mdListenerPort,
@@ -521,9 +532,10 @@ func (cs *Server) getNVMeoFMetadata(
 	}
 	// Construct NVMe-oF volume data
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
-		SubsystemNQN: metadata[mdSubsystemNQN],
-		NamespaceID:  uint32(nsid),
-		HostNQN:      metadata[mdHostNQN],
+		SubsystemNQN:  metadata[mdSubsystemNQN],
+		NamespaceID:   uint32(nsid),
+		NamespaceUUID: metadata[mdNamespaceUUID],
+		HostNQN:       metadata[mdHostNQN],
 		ListenerInfo: nvmeof.ListenerDetails{
 			GatewayAddress: nvmeof.GatewayAddress{
 				Address: metadata[mdListenerAddress],

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -376,22 +376,28 @@ func cleanupNVMeoFResources(
 	return nil
 }
 
+// VolumeContext metadata keys.
 const (
 	// NVMe-oF resource info.
-	mdSubsystemNQN  = ".rbd.nvmeof.SubsystemNQN"
-	mdNamespaceID   = ".rbd.nvmeof.NamespaceID"
-	mdNamespaceUUID = ".rbd.nvmeof.NamespaceUUID"
-	mdHostNQN       = ".rbd.nvmeof.HostNQN"
+	vcSubsystemNQN  = "SubsystemNQN"
+	vcNamespaceID   = "NamespaceID"
+	vcNamespaceUUID = "NamespaceUUID"
+	vcHostNQN       = "HostNQN"
 
 	// Listener info.
-	mdListenerAddress  = ".rbd.nvmeof.ListenerAddress"
-	mdListenerPort     = ".rbd.nvmeof.ListenerPort"
-	mdListenerHostname = ".rbd.nvmeof.ListenerHostname"
+	vcListenerAddress  = "ListenerAddress"
+	vcListenerPort     = "ListenerPort"
+	vcListenerHostname = "ListenerHostname"
 
 	// Gateway management info.
-	mdGatewayAddress = ".rbd.nvmeof.GatewayAddress"
-	mdGatewayPort    = ".rbd.nvmeof.GatewayPort"
+	vcGatewayAddress = "GatewayAddress"
+	vcGatewayPort    = "GatewayPort"
 )
+
+// toRBDMetadataKey converts clean volume context key to prefixed RBD metadata key.
+func toRBDMetadataKey(vcKey string) string {
+	return ".rbd.nvmeof." + vcKey
+}
 
 // populateVolumeContext adds NVMe-oF information to volume context for NodeServer.
 func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) {
@@ -401,15 +407,15 @@ func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) {
 	listenerPortStr := strconv.FormatUint(uint64(data.ListenerInfo.Port), 10)
 	gatewayManagementInfoPortStr := strconv.FormatUint(uint64(data.GatewayManagementInfo.Port), 10)
 
-	volume.VolumeContext[mdSubsystemNQN] = data.SubsystemNQN
-	volume.VolumeContext[mdNamespaceID] = strconv.FormatUint(uint64(data.NamespaceID), 10)
-	volume.VolumeContext[mdNamespaceUUID] = data.NamespaceUUID
-	volume.VolumeContext[mdHostNQN] = data.HostNQN
-	volume.VolumeContext[mdListenerAddress] = data.ListenerInfo.Address
-	volume.VolumeContext[mdListenerPort] = listenerPortStr
-	volume.VolumeContext[mdListenerHostname] = data.ListenerInfo.Hostname
-	volume.VolumeContext[mdGatewayAddress] = data.GatewayManagementInfo.Address
-	volume.VolumeContext[mdGatewayPort] = gatewayManagementInfoPortStr
+	volume.VolumeContext[vcSubsystemNQN] = data.SubsystemNQN
+	volume.VolumeContext[vcNamespaceID] = strconv.FormatUint(uint64(data.NamespaceID), 10)
+	volume.VolumeContext[vcNamespaceUUID] = data.NamespaceUUID
+	volume.VolumeContext[vcHostNQN] = data.HostNQN
+	volume.VolumeContext[vcListenerAddress] = data.ListenerInfo.Address
+	volume.VolumeContext[vcListenerPort] = listenerPortStr
+	volume.VolumeContext[vcListenerHostname] = data.ListenerInfo.Hostname
+	volume.VolumeContext[vcGatewayAddress] = data.GatewayManagementInfo.Address
+	volume.VolumeContext[vcGatewayPort] = gatewayManagementInfoPortStr
 }
 
 // storeNVMeoFMetadata stores all NVMe-oF data in RBD volume metadata for cleanup operations.
@@ -436,19 +442,19 @@ func (cs *Server) storeNVMeoFMetadata(
 	// Prepare all metadata entries
 	metadata := map[string]string{
 		// NVMe-oF resource info
-		mdSubsystemNQN:  nvmeofData.SubsystemNQN,
-		mdNamespaceID:   strconv.FormatUint(uint64(nvmeofData.NamespaceID), 10),
-		mdNamespaceUUID: nvmeofData.NamespaceUUID,
-		mdHostNQN:       nvmeofData.HostNQN,
+		toRBDMetadataKey(vcSubsystemNQN):  nvmeofData.SubsystemNQN,
+		toRBDMetadataKey(vcNamespaceID):   strconv.FormatUint(uint64(nvmeofData.NamespaceID), 10),
+		toRBDMetadataKey(vcNamespaceUUID): nvmeofData.NamespaceUUID,
+		toRBDMetadataKey(vcHostNQN):       nvmeofData.HostNQN,
 
 		// Listener info
-		mdListenerAddress:  nvmeofData.ListenerInfo.Address,
-		mdListenerPort:     listenerInfoPortStr,
-		mdListenerHostname: nvmeofData.ListenerInfo.Hostname,
+		toRBDMetadataKey(vcListenerAddress):  nvmeofData.ListenerInfo.Address,
+		toRBDMetadataKey(vcListenerPort):     listenerInfoPortStr,
+		toRBDMetadataKey(vcListenerHostname): nvmeofData.ListenerInfo.Hostname,
 
 		// Gateway management info
-		mdGatewayAddress: nvmeofData.GatewayManagementInfo.Address,
-		mdGatewayPort:    gatewayManagementInfoPortStr,
+		toRBDMetadataKey(vcGatewayAddress): nvmeofData.GatewayManagementInfo.Address,
+		toRBDMetadataKey(vcGatewayPort):    gatewayManagementInfoPortStr,
 	}
 
 	// Store all metadata entries
@@ -493,15 +499,15 @@ func (cs *Server) getNVMeoFMetadata(
 
 	// Required metadata keys
 	requiredKeys := []string{
-		mdSubsystemNQN,
-		mdNamespaceID,
-		mdNamespaceUUID,
-		mdHostNQN,
-		mdListenerAddress,
-		mdListenerPort,
-		mdListenerHostname,
-		mdGatewayAddress,
-		mdGatewayPort,
+		toRBDMetadataKey(vcSubsystemNQN),
+		toRBDMetadataKey(vcNamespaceID),
+		toRBDMetadataKey(vcNamespaceUUID),
+		toRBDMetadataKey(vcHostNQN),
+		toRBDMetadataKey(vcListenerAddress),
+		toRBDMetadataKey(vcListenerPort),
+		toRBDMetadataKey(vcListenerHostname),
+		toRBDMetadataKey(vcGatewayAddress),
+		toRBDMetadataKey(vcGatewayPort),
 	}
 
 	// Retrieve all metadata values
@@ -517,35 +523,35 @@ func (cs *Server) getNVMeoFMetadata(
 	}
 
 	// Parse namespace ID
-	nsid, err := strconv.ParseUint(metadata[mdNamespaceID], 10, 32)
+	nsid, err := strconv.ParseUint(metadata[toRBDMetadataKey(vcNamespaceID)], 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid namespace ID: %w", err)
 	}
 
-	listenerInfoPort, err := strconv.ParseUint(metadata[mdListenerPort], 10, 32)
+	listenerInfoPort, err := strconv.ParseUint(metadata[toRBDMetadataKey(vcListenerPort)], 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid listener port: %w", err)
 	}
-	gatewayPort, err := strconv.ParseUint(metadata[mdGatewayPort], 10, 32)
+	gatewayPort, err := strconv.ParseUint(metadata[toRBDMetadataKey(vcGatewayPort)], 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid gateway port: %w", err)
 	}
 	// Construct NVMe-oF volume data
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
-		SubsystemNQN:  metadata[mdSubsystemNQN],
+		SubsystemNQN:  metadata[toRBDMetadataKey(vcSubsystemNQN)],
 		NamespaceID:   uint32(nsid),
-		NamespaceUUID: metadata[mdNamespaceUUID],
-		HostNQN:       metadata[mdHostNQN],
+		NamespaceUUID: metadata[toRBDMetadataKey(vcNamespaceUUID)],
+		HostNQN:       metadata[toRBDMetadataKey(vcHostNQN)],
 		ListenerInfo: nvmeof.ListenerDetails{
 			GatewayAddress: nvmeof.GatewayAddress{
-				Address: metadata[mdListenerAddress],
+				Address: metadata[toRBDMetadataKey(vcListenerAddress)],
 				Port:    uint32(listenerInfoPort),
 			},
-			Hostname: metadata[mdListenerHostname],
+			Hostname: metadata[toRBDMetadataKey(vcListenerHostname)],
 		},
 		// Store gateway management info separately
 		GatewayManagementInfo: nvmeof.GatewayConfig{
-			Address: metadata[mdGatewayAddress],
+			Address: metadata[toRBDMetadataKey(vcGatewayAddress)],
 			Port:    uint32(gatewayPort),
 		},
 	}

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -288,21 +288,21 @@ func createNVMeoFResources(
 		return nil, fmt.Errorf("subsystem setup failed: %w", err)
 	}
 
-	// Step 4: Create namespace
-	nsid, err := gateway.CreateNamespace(ctx, nvmeofData.SubsystemNQN, rbdPoolName, rbdImageName)
-	if err != nil {
-		return nil, fmt.Errorf("namespace creation failed: %w", err)
-	}
-	log.DebugLog(ctx, "Namespace created: %s/%s with NSID: %d", rbdPoolName, rbdImageName, nsid)
-	nvmeofData.NamespaceID = nsid
-
-	// Step 5: Create listeners
+	// Step 4: Create listeners
 	err = gateway.CreateListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo)
 	if err != nil {
 		return nil, fmt.Errorf("listener creation failed: %w", err)
 	}
 	log.DebugLog(ctx, "Listener created for subsystem %s at %s", nvmeofData.SubsystemNQN,
 		nvmeofData.ListenerInfo)
+
+	// Step 5: Create namespace and set its uuid
+	nsid, err := gateway.CreateNamespace(ctx, nvmeofData.SubsystemNQN, rbdPoolName, rbdImageName)
+	if err != nil {
+		return nil, fmt.Errorf("namespace creation failed: %w", err)
+	}
+	log.DebugLog(ctx, "Namespace created: %s/%s with NSID: %d", rbdPoolName, rbdImageName, nsid)
+	nvmeofData.NamespaceID = nsid
 
 	// Step 6: Add host to subsystem
 	if err := gateway.AddHost(ctx, nvmeofData.SubsystemNQN, nvmeofData.HostNQN); err != nil {
@@ -345,20 +345,20 @@ func cleanupNVMeoFResources(
 	}
 	log.DebugLog(ctx, "Host %s removed from subsystem %s", nvmeofData.HostNQN, nvmeofData.SubsystemNQN)
 
-	// Step 3: Delete listener
+	// Step 3: Delete namespace
+	if err := gateway.DeleteNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID); err != nil {
+		return fmt.Errorf("failed to delete namespace %d for subsystem %s: %w",
+			nvmeofData.NamespaceID, nvmeofData.SubsystemNQN, err)
+	}
+	log.DebugLog(ctx, "Namespace %d deleted for subsystem %s", nvmeofData.NamespaceID, nvmeofData.SubsystemNQN)
+
+	// Step 4: Delete listener
 	err = gateway.DeleteListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo)
 	if err != nil {
 		return fmt.Errorf("failed to delete listener for subsystem %s: %w", nvmeofData.SubsystemNQN, err)
 	}
 	log.DebugLog(ctx, "Listener deleted for subsystem %s at %s", nvmeofData.SubsystemNQN,
 		nvmeofData.ListenerInfo)
-
-	// Step 4: Delete namespace
-	if err := gateway.DeleteNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID); err != nil {
-		return fmt.Errorf("failed to delete namespace %d for subsystem %s: %w",
-			nvmeofData.NamespaceID, nvmeofData.SubsystemNQN, err)
-	}
-	log.DebugLog(ctx, "Namespace %d deleted for subsystem %s", nvmeofData.NamespaceID, nvmeofData.SubsystemNQN)
 
 	// Step 5: Cleanup empty subsystem
 	if err := cleanupEmptySubsystem(ctx, gateway, nvmeofData.SubsystemNQN); err != nil {

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -52,16 +52,6 @@ type ListenerDetails struct {
 // Config holds gateway client configuration.
 type GatewayConfig = GatewayAddress
 
-// NVMeoFVolumeData holds the data required for an NVMe-oF volume.
-type NVMeoFVolumeData struct {
-	SubsystemNQN          string
-	NamespaceID           uint32
-	NamespaceUUID         string
-	HostNQN               string
-	ListenerInfo          ListenerDetails
-	GatewayManagementInfo GatewayConfig
-}
-
 // GatewayClient wraps the gRPC client and connection details.
 type GatewayRpcClient struct {
 	config    *GatewayConfig

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -56,6 +56,7 @@ type GatewayConfig = GatewayAddress
 type NVMeoFVolumeData struct {
 	SubsystemNQN          string
 	NamespaceID           uint32
+	NamespaceUUID         string
 	HostNQN               string
 	ListenerInfo          ListenerDetails
 	GatewayManagementInfo GatewayConfig
@@ -168,6 +169,39 @@ func (gw *GatewayRpcClient) DeleteNamespace(ctx context.Context, subsystemNQN st
 
 	return fmt.Errorf("gateway NamespaceDelete returned error (status=%d): %s",
 		status.GetStatus(), status.GetErrorMessage())
+}
+
+// GetUUIDBySubsystemAndNameSpaceID get the uuid of namespace by given subsystem and ns-id.
+func (gw *GatewayRpcClient) GetUUIDBySubsystemAndNameSpaceID(
+	ctx context.Context,
+	subsystemNQN string,
+	namespaceID uint32,
+) (string, error) {
+	req := &pb.ListNamespacesReq{
+		Subsystem: subsystemNQN,
+		Nsid:      &namespaceID,
+	}
+	resp, err := gw.client.ListNamespaces(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	// Check if response is valid
+	if resp == nil {
+		return "", fmt.Errorf("received nil response from subsystem %s nsid %d", subsystemNQN, namespaceID)
+	}
+
+	// Check if any namespaces found
+	if len(resp.GetNamespaces()) == 0 {
+		return "", fmt.Errorf("no namespaces found for subsystem %s nsid %d", subsystemNQN, namespaceID)
+	}
+	// extra validation
+	for _, ns := range resp.GetNamespaces() {
+		if ns.GetNsid() == namespaceID {
+			return ns.GetUuid(), nil
+		}
+	}
+
+	return "", fmt.Errorf("namespace with nsid %d not found", namespaceID)
 }
 
 // CreateSubsystem creates an NVMe-oF subsystem on the gateway.

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -132,10 +132,12 @@ func (gw *GatewayRpcClient) CreateNamespace(ctx context.Context, subsystemNQN, p
 	}
 
 	resp, err := gw.client.NamespaceAdd(ctx, req)
-	if err != nil {
+	switch {
+	case err != nil:
 		return 0, fmt.Errorf("failed to create namespace for %s/%s: %w", poolName, imageName, err)
-	}
-	if resp.GetStatus() != 0 {
+	case resp.GetStatus() == int32(syscall.EEXIST):
+		return gw.findExistingNamespace(ctx, subsystemNQN, poolName, imageName)
+	case resp.GetStatus() != 0:
 		return 0, fmt.Errorf("gateway NamespaceAdd returned error: %s", resp.GetErrorMessage())
 	}
 	log.DebugLog(ctx, "Namespace created with NSID: %d", resp.GetNsid())
@@ -225,10 +227,13 @@ func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN st
 	}
 
 	status, err := gw.client.CreateSubsystem(ctx, req)
-	if err != nil {
+	switch {
+	case err != nil:
 		return fmt.Errorf("failed to create subsystem %s: %w", subsystemNQN, err)
-	}
-	if status.GetStatus() != 0 {
+	case status.GetStatus() == int32(syscall.EEXIST):
+		// subsystem was already created
+		return nil
+	case status.GetStatus() != 0:
 		return fmt.Errorf("gateway CreateSubsystem returned error: %s", status.GetErrorMessage())
 	}
 
@@ -306,12 +311,18 @@ func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN s
 	if err != nil {
 		return fmt.Errorf("failed to add host %s to subsystem %s: %w", hostNQN, subsystemNQN, err)
 	}
-	if resp.GetStatus() != 0 {
-		return fmt.Errorf("gateway AddHost returned error (status=%d): %s", resp.GetStatus(), resp.GetErrorMessage())
-	}
-	log.DebugLog(ctx, "Host added successfully: %s to subsystem %s", hostNQN, subsystemNQN)
+	if resp.GetStatus() == 0 {
+		log.DebugLog(ctx, "Host added successfully: %s to subsystem %s", hostNQN, subsystemNQN)
 
-	return nil
+		return nil
+	}
+	if resp.GetStatus() == int32(syscall.EEXIST) { // EEXIST
+		log.DebugLog(ctx, "Host %s already added to subsystem %s", hostNQN, subsystemNQN)
+
+		return nil // Host already added, no error
+	}
+
+	return fmt.Errorf("gateway AddHost returned error (status=%d): %s", resp.GetStatus(), resp.GetErrorMessage())
 }
 
 func (gw *GatewayRpcClient) CreateListener(ctx context.Context, subsystemNQN string, listenerInfo ListenerDetails,
@@ -332,10 +343,14 @@ func (gw *GatewayRpcClient) CreateListener(ctx context.Context, subsystemNQN str
 	if err != nil {
 		return fmt.Errorf("failed to add listener %s to subsystem %s: %w", listenerInfo.Address, subsystemNQN, err)
 	}
+	if resp.GetStatus() == int32(syscall.EEXIST) { // EEXIST
+		log.DebugLog(ctx, "Listener %s already created for subsystem %s", listenerInfo.Address, subsystemNQN)
+
+		return nil // Listener already created, no error
+	}
 	if resp.GetStatus() != 0 {
 		return fmt.Errorf("gateway AddListener returned error (status=%d): %s", resp.GetStatus(), resp.GetErrorMessage())
 	}
-
 	log.DebugLog(ctx, "Listener added successfully: %s to subsystem %s", listenerInfo.Address, subsystemNQN)
 
 	return nil
@@ -449,4 +464,36 @@ func (c *GatewayRpcClient) generateSerialNumber() (string, error) {
 	serial := n.Int64() + RandomNumberOffset
 
 	return fmt.Sprintf("Ceph%d", serial), nil
+}
+
+// findExistingNamespace searches for a namespace matching the given pool and image names
+// Returns the NSID if found, or an error if not found or on failure.
+func (gw *GatewayRpcClient) findExistingNamespace(
+	ctx context.Context,
+	subsystemNQN,
+	poolName,
+	imageName string,
+) (uint32, error) {
+	r, err := gw.client.ListNamespaces(ctx, &pb.ListNamespacesReq{Subsystem: subsystemNQN})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get namespaces in subsystem %s: %w", subsystemNQN, err)
+	}
+
+	if r.GetStatus() != 0 {
+		return 0, fmt.Errorf("could not get namespaces in subsystem %s (status=%d): %s",
+			subsystemNQN, r.GetStatus(), r.GetErrorMessage())
+	}
+
+	if len(r.GetNamespaces()) == 0 {
+		return 0, fmt.Errorf("no existing namespaces in subsystem %s", subsystemNQN)
+	}
+
+	for _, ns := range r.GetNamespaces() {
+		if ns.GetRbdPoolName() == poolName && ns.GetRbdImageName() == imageName {
+			return ns.GetNsid(), nil
+		}
+	}
+
+	return 0, fmt.Errorf("could not find existing namespace for %s/%s in subsystem %s",
+		poolName, imageName, subsystemNQN)
 }

--- a/internal/nvmeof/volume.go
+++ b/internal/nvmeof/volume.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvmeof
+
+// NVMeoFVolumeData holds the data required for an NVMe-oF volume.
+type NVMeoFVolumeData struct {
+	SubsystemNQN          string
+	NamespaceID           uint32
+	NamespaceUUID         string
+	HostNQN               string
+	ListenerInfo          ListenerDetails
+	GatewayManagementInfo GatewayConfig
+}


### PR DESCRIPTION
# Describe what this PR does #

This PR introduces foundational improvements to the NVMe-oF CSI provisioner, focusing on metadata handling, operation ordering, and API consistency. 

## Is there anything that requires special attention ##

- This PR still in progress!!
- **Volume context key changes**: This modifies the CSI interface contract. Node plugin now expects clean keys like `subsystemNQN` instead of `.rbd.nvmeof.SubsystemNQN`
- **Idempotent operations**: Gateway operations now handle "already exists" scenarios as success rather than error

## Key Changes:
- **Metadata restructuring**: Moved `NVMeoFVolumeData` to dedicated `volume.go` file and added namespace UUID tracking
- **Volume context cleanup**: Removed `.rbd.nvmeof.` prefix from CSI volume context keys while maintaining prefixed keys for internal RBD metadata storage
- **Operation ordering fix**: Reordered gateway operations to create listeners before namespaces for proper resource dependency handling
- **Idempotent operations**: Made core gateway operations (`AddHost`, `CreateListener`, `CreateSubsystem`, `AddNamespace`) idempotent to handle retry scenarios gracefully


## Related issues ##

https://github.com/ceph/ceph-csi/issues/5370

## Future concerns (mentioned in issue above) ##

- Multiple listener support (noted in TODO comments)
- Comprehensive cleanup/rollback mechanisms for failed operations are implemented here https://github.com/ceph/ceph-csi/pull/5538

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
