### PR TITLE
rbd: fix bug where volumereplication promote/demote would fail

### DIFF
--- a/internal/rbd/group/util.go
+++ b/internal/rbd/group/util.go
@@ -434,8 +434,9 @@ func (cvg *commonVolumeGroup) GetCreationTime(ctx context.Context) (*time.Time, 
 // volumegroups should continue based on the type of error encountered.
 //
 // It checks if the given error matches any of the following known errors:
-//   - ErrPoolNotFound: The rbd pool where the volumegroup/omap is expected doesn't exist.
-//   - ErrGroupNotFound: The volumegroup doesn't exist in the rbd pool.
+//   - util.ErrPoolNotFound: The rbd pool where the volumegroup/omap is expected doesn't exist.
+//   - util.ErrConfigNotFound: No configuration exists for the cluster ID associated with the volumegroup.
+//   - rbderrors.ErrGroupNotFound: The volumegroup doesn't exist in the rbd pool.
 //   - rados.ErrPermissionDenied: Permissions to access the pool is denied.
 //
 // If any of these errors are encountered, the function returns `true`, indicating
@@ -451,6 +452,7 @@ func ShouldRetryVolumeGroupGeneration(err error) bool {
 	}
 	// Continue searching for specific known errors
 	return (errors.Is(err, util.ErrPoolNotFound) ||
+		errors.Is(err, util.ErrConfigNotFound) ||
 		errors.Is(err, rbderrors.ErrGroupNotFound) ||
 		errors.Is(err, rados.ErrPermissionDenied))
 }

--- a/internal/rbd/group/util_test.go
+++ b/internal/rbd/group/util_test.go
@@ -47,6 +47,11 @@ func Test_shouldRetryVolumeGroupGeneration(t *testing.T) {
 			want: true, // Known error, continue searching
 		},
 		{
+			name: "ErrConfigNotFound (continue searching)",
+			args: args{err: util.ErrConfigNotFound},
+			want: true, // Known error, continue searching
+		},
+		{
 			name: "ErrRBDGroupNotFound (continue searching)",
 			args: args{err: rbderrors.ErrGroupNotFound},
 			want: true, // Known error, continue searching

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1260,6 +1260,7 @@ func generateVolumeFromVolumeID(
 // It checks if the given error matches any of the following known errors:
 //   - util.ErrKeyNotFound: The key required to locate the volume is missing in Rados omap.
 //   - util.ErrPoolNotFound: The rbd pool where the volume/omap is expected doesn't exist.
+//   - util.ErrConfigNotFound: No configuration exists for the cluster ID associated with the volume.
 //   - ErrImageNotFound: The image doesn't exist in the rbd pool.
 //   - rados.ErrPermissionDenied: Permissions to access the pool is denied.
 //
@@ -1277,6 +1278,7 @@ func ShouldRetryVolumeGeneration(err error) bool {
 	// Continue searching for specific known errors
 	return (errors.Is(err, util.ErrKeyNotFound) ||
 		errors.Is(err, util.ErrPoolNotFound) ||
+		errors.Is(err, util.ErrConfigNotFound) ||
 		errors.Is(err, rbderrors.ErrImageNotFound) ||
 		errors.Is(err, rados.ErrPermissionDenied))
 }

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -415,6 +415,11 @@ func Test_shouldRetryVolumeGeneration(t *testing.T) {
 			want: true, // Known error, continue searching
 		},
 		{
+			name: "ErrConfigNotFound (continue searching)",
+			args: args{err: util.ErrConfigNotFound},
+			want: true, // Known error, continue searching
+		},
+		{
 			name: "ErrImageNotFound (continue searching)",
 			args: args{err: rbderrors.ErrImageNotFound},
 			want: true, // Known error, continue searching

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -83,7 +83,7 @@ func readClusterInfo(pathToConfig, clusterID string) (*kubernetes.ClusterInfo, e
 		}
 	}
 
-	return nil, fmt.Errorf("missing configuration for cluster ID %q", clusterID)
+	return nil, fmt.Errorf("%w: %q", ErrConfigNotFound, clusterID)
 }
 
 // Mons returns a comma separated MON list from the csi config for the given clusterID.

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -34,4 +34,6 @@ var (
 	ErrClusterIDNotSet = errors.New("clusterID must be set")
 	// ErrMissingConfigForMonitor is returned when clusterID is not found for the mon.
 	ErrMissingConfigForMonitor = errors.New("missing configuration of cluster ID for monitor")
+	// ErrConfigNotFound is returned when no configuration is found for a cluster ID.
+	ErrConfigNotFound = errors.New("missing configuration for cluster ID")
 )


### PR DESCRIPTION
If the source and destination clusters use different clusterIDs, promoting/demoting a volumereplication would fail due to the clusterIDmapping logic not running.

This fix enables clusterIDmapping during volume generation to fix it.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This PR fixes https://github.com/ceph/ceph-csi/issues/5529. 

Importing a PVC to run a disaster recovery procedure would fail if the clusterID of the 2 clusters were different.

For example, if Ceph-CSI is installed through Rook, the clusterID is that of the deployment namespace. There's already a mapping logic that takes care of that, but in the context of promotion/demotions from primary/secondary, it simply wasn't called.

## Is there anything that requires special attention ##

Is the change backward compatible? Yes

Are there concerns around backward compatibility? No

## Related issues ##

Fixes: https://github.com/ceph/ceph-csi/issues/5529


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
