### PR TITLE
build: use Go 1.24.4

### DIFF
--- a/build.env
+++ b/build.env
@@ -26,7 +26,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v19.2.2
 CEPH_VERSION=squid
 
 # standard Golang options
-GOLANG_VERSION=1.24.2
+GOLANG_VERSION=1.24.4
 GO111MODULE=on
 
 # commitlint version


### PR DESCRIPTION
While building Ceph-CSI the Go toolchain always downloads Go 1.24.4. It
saves time (and bandwidth) when that version is installed from the
start.

Dependabot seems to have removed the toolchain directive, maybe the
automatic downloading does not happen (always) anymore?