### PR TITLE
build: remove `ceph_preview` build-tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ endif
 GO_PROJECT=github.com/ceph/ceph-csi
 
 CEPH_VERSION ?= $(shell . $(CURDIR)/build.env ; echo $${CEPH_VERSION})
-# TODO: ceph_preview tag required for FSQuiesce API
-GO_TAGS_LIST ?= $(CEPH_VERSION) ceph_preview
+# The 'ceph_preview' tag may be needed for unstable/unreleased APIs.
+GO_TAGS_LIST ?= $(CEPH_VERSION)
 
 # CephCSI currently has 4 modules in these directories.
 GO_MODULES_LIST = ./ e2e/ api/ actions/retest


### PR DESCRIPTION
go-ceph v0.35 contains all APIs that are needed to build Ceph-CSI, there
is no need for unreleased APIs that are exposed only with the
`ceph_preview` tag.
