### PR TITLE
ci: prevent running multiple e2e suites at the same time

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -79,6 +79,10 @@ queue_rules:
               - "status-success=ci/centos/jjb-validate"
     merge_method: rebase
     update_method: rebase
+    batch_size: 1
+
+merge_queue:
+  max_parallel_checks: 1
 
 pull_request_rules:
   - name: start CI jobs for PRs in the merge queue


### PR DESCRIPTION
Mergify started to batch PRs into a "merge PR". This can cause multiple
e2e suites to run at the same time. As there is a limit on the number of
machines where we run our tests, many jobs get into a waiting state for
reserving a machine.

When different PRs run the e2e suite at the same time, only one result
will be used for merging that particular PR. The results of other PRs
are thrown away, as they need to be rebased and re-tested again.

By preventing batching of PRs, there should be fewer "CI waste", and PRs
can get tested a little more efficiently.

See-also: https://docs.mergify.com/merge-queue/parallel-checks/