### PR TITLE
util, ParseClientIP: support compressed ipv6 addresses

### DIFF
--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -68,7 +68,7 @@ func TestFetchIP(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			clientInfo:  "client.4305 2001:0db8:85a3:0000:0000:8a2e:0370:7334:0/422650892",
+			clientInfo:  "client.4305 [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:0/422650892",
 			expectedIP:  "2001:db8:85a3::8a2e:370:7334",
 			expectedErr: false,
 		},

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -302,24 +302,18 @@ func GetVolumeContext(parameters map[string]string) map[string]string {
 // Handles both IPv4 and IPv6 addresses.
 // Example: "10.244.0.1:0/2686266785" returns "10.244.0.1".
 func ParseClientIP(addr string) (string, error) {
-	// Attempt to extract the IP address using a regular expression
-	// the regular expression aims to match either a complete IPv6
-	// address or a complete IPv4 address follows by any prefix (v1 or v2)
-	// if exists
-	// (?:v[0-9]+:): this allows for an optional prefix starting with "v"
-	// followed by one or more digits and a colon.
-	// The ? outside the group makes the entire prefix section optional.
-	// (?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}: this allows to check for
-	// standard IPv6 address.
-	// |: Alternation operator to allow matching either the IPv6 pattern
-	// with a prefix or the IPv4 pattern.
-	// '(?:\d+\.){3}\d+: This part matches a standard IPv4 address.
-	re := regexp.MustCompile(`(?:v[0-9]+:)?([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){7}|(?:\d+\.){3}\d+)`)
-	ipMatches := re.FindStringSubmatch(addr)
+	versionPrefixRe := regexp.MustCompile(`(?:v\d+:)`)
+	for hostPair := range strings.SplitSeq(addr, " ") {
+		hostPair = versionPrefixRe.ReplaceAllString(hostPair, "")
 
-	if len(ipMatches) > 0 {
-		ip := net.ParseIP(ipMatches[1])
-		if ip != nil {
+		host, _, err := net.SplitHostPort(hostPair)
+		if err != nil {
+			// We might fail if there is no port specified, in that case continue
+			// as if it's just an IP address and try to parse it.
+			host = hostPair
+		}
+
+		if ip := net.ParseIP(host); ip != nil {
 			return ip.String(), nil
 		}
 	}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -300,8 +300,14 @@ func TestParseClientIP(t *testing.T) {
 		},
 		{
 			name:    "IPv6 address",
-			addr:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334:0/2686266785",
+			addr:    "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:0/2686266785",
 			want:    "2001:db8:85a3::8a2e:370:7334",
+			wantErr: false,
+		},
+		{
+			name:    "Compressed IPv6 address",
+			addr:    "[fd98::4]:0/2686266785",
+			want:    "fd98::4",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
Previously ParseClientIP would use regex to match addresses which was too strict and could only correctly match complete ipv4 and ipv6 addresses.

This commit changes the ParseClientIP function to use Go's net package to correctly parse all valid ip forms.

## Is there anything that requires special attention ##

Do you have any questions?
No

Is the change backward compatible?
Yes

Are there concerns around backward compatibility?
No

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
