### PR TITLE
Nvmeof/provisioner add controller publish volume

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -168,7 +168,7 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	// Validate required parameters
 	params := req.GetParameters()
 	requiredParams := []string{
-		"subsystemNQN", "hostNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
+		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
 		"listenerIpAddress", "listenerPort", "listenerHostname",
 	}
 	for _, param := range requiredParams {
@@ -255,7 +255,6 @@ func createNVMeoFResources(
 		SubsystemNQN:  params["subsystemNQN"],
 		NamespaceID:   0,  // will be set after namespace creation,
 		NamespaceUUID: "", // will be set after namespace creation
-		HostNQN:       params["hostNQN"],
 		ListenerInfo: nvmeof.ListenerDetails{
 			GatewayAddress: nvmeof.GatewayAddress{
 				Address: params["listenerIpAddress"],
@@ -311,12 +310,6 @@ func createNVMeoFResources(
 	}
 	nvmeofData.NamespaceUUID = uuid
 
-	// Step 6: Add host to subsystem
-	if err := gateway.AddHost(ctx, nvmeofData.SubsystemNQN, nvmeofData.HostNQN); err != nil {
-		return nil, fmt.Errorf("host addition failed: %w", err)
-	}
-	log.DebugLog(ctx, "Host added: %s to subsystem %s", nvmeofData.HostNQN, nvmeofData.SubsystemNQN)
-
 	return nvmeofData, nil
 }
 
@@ -345,21 +338,14 @@ func cleanupNVMeoFResources(
 	// there is no relevant to continue , will make it simple ?
 	// instead of check in the std error if "not found"..
 
-	// Step 2: Remove host from subsystem
-	if err := gateway.RemoveHost(ctx, nvmeofData.SubsystemNQN, nvmeofData.HostNQN); err != nil {
-		return fmt.Errorf("failed to remove host %s from subsystem %s: %w",
-			nvmeofData.HostNQN, nvmeofData.SubsystemNQN, err)
-	}
-	log.DebugLog(ctx, "Host %s removed from subsystem %s", nvmeofData.HostNQN, nvmeofData.SubsystemNQN)
-
-	// Step 3: Delete namespace
+	// Step 2: Delete namespace
 	if err := gateway.DeleteNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID); err != nil {
 		return fmt.Errorf("failed to delete namespace %d for subsystem %s: %w",
 			nvmeofData.NamespaceID, nvmeofData.SubsystemNQN, err)
 	}
 	log.DebugLog(ctx, "Namespace %d deleted for subsystem %s", nvmeofData.NamespaceID, nvmeofData.SubsystemNQN)
 
-	// Step 4: Delete listener
+	// Step 3: Delete listener
 	err = gateway.DeleteListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo)
 	if err != nil {
 		return fmt.Errorf("failed to delete listener for subsystem %s: %w", nvmeofData.SubsystemNQN, err)
@@ -367,7 +353,7 @@ func cleanupNVMeoFResources(
 	log.DebugLog(ctx, "Listener deleted for subsystem %s at %s", nvmeofData.SubsystemNQN,
 		nvmeofData.ListenerInfo)
 
-	// Step 5: Cleanup empty subsystem
+	// Step 4: Cleanup empty subsystem
 	if err := cleanupEmptySubsystem(ctx, gateway, nvmeofData.SubsystemNQN); err != nil {
 		return fmt.Errorf("failed to cleanup empty subsystem %s: %w", nvmeofData.SubsystemNQN, err)
 	}
@@ -410,7 +396,6 @@ func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) {
 	volume.VolumeContext[vcSubsystemNQN] = data.SubsystemNQN
 	volume.VolumeContext[vcNamespaceID] = strconv.FormatUint(uint64(data.NamespaceID), 10)
 	volume.VolumeContext[vcNamespaceUUID] = data.NamespaceUUID
-	volume.VolumeContext[vcHostNQN] = data.HostNQN
 	volume.VolumeContext[vcListenerAddress] = data.ListenerInfo.Address
 	volume.VolumeContext[vcListenerPort] = listenerPortStr
 	volume.VolumeContext[vcListenerHostname] = data.ListenerInfo.Hostname
@@ -445,7 +430,6 @@ func (cs *Server) storeNVMeoFMetadata(
 		toRBDMetadataKey(vcSubsystemNQN):  nvmeofData.SubsystemNQN,
 		toRBDMetadataKey(vcNamespaceID):   strconv.FormatUint(uint64(nvmeofData.NamespaceID), 10),
 		toRBDMetadataKey(vcNamespaceUUID): nvmeofData.NamespaceUUID,
-		toRBDMetadataKey(vcHostNQN):       nvmeofData.HostNQN,
 
 		// Listener info
 		toRBDMetadataKey(vcListenerAddress):  nvmeofData.ListenerInfo.Address,
@@ -502,7 +486,6 @@ func (cs *Server) getNVMeoFMetadata(
 		toRBDMetadataKey(vcSubsystemNQN),
 		toRBDMetadataKey(vcNamespaceID),
 		toRBDMetadataKey(vcNamespaceUUID),
-		toRBDMetadataKey(vcHostNQN),
 		toRBDMetadataKey(vcListenerAddress),
 		toRBDMetadataKey(vcListenerPort),
 		toRBDMetadataKey(vcListenerHostname),
@@ -541,7 +524,6 @@ func (cs *Server) getNVMeoFMetadata(
 		SubsystemNQN:  metadata[toRBDMetadataKey(vcSubsystemNQN)],
 		NamespaceID:   uint32(nsid),
 		NamespaceUUID: metadata[toRBDMetadataKey(vcNamespaceUUID)],
-		HostNQN:       metadata[toRBDMetadataKey(vcHostNQN)],
 		ListenerInfo: nvmeof.ListenerDetails{
 			GatewayAddress: nvmeof.GatewayAddress{
 				Address: metadata[toRBDMetadataKey(vcListenerAddress)],

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -146,7 +146,7 @@ func (cs *Server) DeleteVolume(
 	defer cs.volumeLocks.Release(volumeID)
 
 	// Get NVMe-oF metadata for cleanup
-	nvmeofData, err := cs.getNVMeoFMetadata(ctx, req, volumeID)
+	nvmeofData, err := cs.getNVMeoFMetadata(ctx, req.GetSecrets(), volumeID)
 	if err != nil {
 		log.DebugLog(ctx, "No NVMe-oF metadata found, skipping NVMe-oF cleanup: %v", err)
 	} else {
@@ -464,11 +464,11 @@ func (cs *Server) storeNVMeoFMetadata(
 // getNVMeoFMetadata retrieves all NVMe-oF data from RBD volume metadata.
 func (cs *Server) getNVMeoFMetadata(
 	ctx context.Context,
-	req *csi.DeleteVolumeRequest,
+	secrets map[string]string,
 	volumeID string,
 ) (*nvmeof.NVMeoFVolumeData, error) {
 	// Create RBD manager
-	mgr := rbdutil.NewManager(cs.backendServer.Driver.GetInstanceID(), nil, req.GetSecrets())
+	mgr := rbdutil.NewManager(cs.backendServer.Driver.GetInstanceID(), nil, secrets)
 	defer mgr.Destroy(ctx)
 
 	// Get RBD volume

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -32,6 +33,7 @@ import (
 	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
 	rbddriver "github.com/ceph/ceph-csi/internal/rbd/driver"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
@@ -162,6 +164,84 @@ func (cs *Server) DeleteVolume(
 	return cs.backendServer.DeleteVolume(ctx, req)
 }
 
+// ControllerPublishVolume handles the publishing of a volume (run Add host GRPC).
+func (cs *Server) ControllerPublishVolume(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+) (*csi.ControllerPublishVolumeResponse, error) {
+	// Validate request
+	if err := validatePublishVolumeRequest(req); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "request validation failed: %v", err)
+	}
+
+	volumeID := req.GetVolumeId()
+	if acquired := cs.volumeLocks.TryAcquire(volumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer cs.volumeLocks.Release(volumeID)
+
+	// Publish NVMe-oF resources
+	hostNqn, err := publishResources(ctx, req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to publish resources: %v", err)
+	}
+
+	// populate publish context
+	publishContext := populatePublishContext(req, hostNqn)
+
+	return &csi.ControllerPublishVolumeResponse{
+		PublishContext: publishContext,
+	}, nil
+}
+
+func (cs *Server) ControllerUnpublishVolume(
+	ctx context.Context,
+	req *csi.ControllerUnpublishVolumeRequest,
+) (*csi.ControllerUnpublishVolumeResponse, error) {
+	// Validate request
+	if err := util.ValidateControllerUnpublishVolumeRequest(req); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "request validation failed: %v", err)
+	}
+
+	volumeID := req.GetVolumeId()
+	nodeID := req.GetNodeId()
+	if acquired := cs.volumeLocks.TryAcquire(volumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer cs.volumeLocks.Release(volumeID)
+
+	// Since ControllerUnpublishVolume doesn't receive volume context,
+	// we need to retrieve it from the volume metadata stored during CreateVolume
+	secrets := req.GetSecrets()
+	if secrets == nil {
+		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(req.GetVolumeId(), util.RBDType)
+		if err != nil {
+			log.WarningLog(ctx, "controller publish secret not found: %v", err)
+
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+
+		secrets, err = k8s.GetSecret(secretName, secretNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get controller publish secret from k8s: %w", err)
+		}
+	}
+
+	nvmeofData, err := cs.getNVMeoFMetadata(ctx, secrets, volumeID)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to get NVMe-oF metadata for volumeID %s: %v", volumeID, err)
+
+		return nil, status.Errorf(codes.Internal, "failed to get NVMe-oF metadata: %v", err)
+	}
+
+	// Unpublish NVMe-oF resources
+	if err := unpublishResources(ctx, nvmeofData, nodeID); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to unpublish resources: %v", err)
+	}
+
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
+}
+
 // validateCreateVolumeRequest validates the incoming request for nvmeof.
 // the rest of the parameters are validated by RBD.
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
@@ -178,6 +258,22 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	}
 
 	return nil
+}
+
+// validatePublishVolumeRequest validates the incoming request for publishing a volume.
+func validatePublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
+	volumeContext := req.GetVolumeContext()
+	requiredParams := []string{
+		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
+		"listenerIpAddress", "listenerPort", "listenerHostname",
+	}
+	for _, param := range requiredParams {
+		if volumeContext[param] == "" {
+			return fmt.Errorf("missing required parameter: %s", param)
+		}
+	}
+
+	return util.ValidateControllerPublishVolumeRequest(req)
 }
 
 // ensureSubsystem checks if the subsystem exists, and creates it if not.
@@ -362,6 +458,99 @@ func cleanupNVMeoFResources(
 	return nil
 }
 
+// publishResources publishes the HostNQN to be allowed to see the Volume.
+func publishResources(ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+) (string, error) {
+	nodeID := req.GetNodeId()
+	hostNQN, err := extractHostNQNFromNodeID(nodeID)
+	if err != nil {
+		return "", status.Errorf(codes.InvalidArgument, "invalid nodeID format: %v", err)
+	}
+	// Get volume context from the volume (contains subsystem info from CreateVolume)
+	volumeContext := req.GetVolumeContext()
+	subsystemNQN := volumeContext[vcSubsystemNQN]
+	gatewayAddr := volumeContext[vcGatewayAddress]
+	gatewayPortStr := volumeContext[vcGatewayPort]
+
+	// Convert gateway port from string to uint32
+	gatewayPort, err := strconv.ParseUint(gatewayPortStr, 10, 32)
+	if err != nil {
+		return "", fmt.Errorf("invalid gateway port %s: %w", gatewayPortStr, err)
+	}
+	// Connect to gateway and add host
+	config := &nvmeof.GatewayConfig{
+		Address: gatewayAddr,
+		Port:    uint32(gatewayPort),
+	}
+	gateway, err := connectGateway(ctx, config)
+	if err != nil {
+		return "", fmt.Errorf("gateway connection failed: %w", err)
+	}
+	defer func() {
+		if closeErr := gateway.Destroy(); closeErr != nil {
+			log.ErrorLog(ctx, "Warning: failed to close gateway connection: %v", closeErr)
+		}
+	}()
+
+	// Add host to subsystem
+	if err := gateway.AddHost(ctx, subsystemNQN, hostNQN); err != nil {
+		return "", fmt.Errorf("failed to add host %s: %w", hostNQN, err)
+	}
+
+	log.DebugLog(ctx, "Host %s successfully added to subsystem %s", hostNQN, subsystemNQN)
+
+	return hostNQN, nil
+}
+
+// unpublishResources removes the host from the NVMe-oF subsystem.
+func unpublishResources(ctx context.Context, data *nvmeof.NVMeoFVolumeData, nodeID string) error {
+	// Extract host NQN from nodeID
+	hostNQN, err := extractHostNQNFromNodeID(nodeID)
+	if err != nil {
+		return fmt.Errorf("invalid nodeID format: %w", err)
+	}
+	subsystemNQN := data.SubsystemNQN
+	gatewayAddr := data.GatewayManagementInfo.Address
+	gatewayPort := data.GatewayManagementInfo.Port
+
+	// Connect to gateway and add host
+	config := &nvmeof.GatewayConfig{
+		Address: gatewayAddr,
+		Port:    gatewayPort,
+	}
+	gateway, err := connectGateway(ctx, config)
+	if err != nil {
+		return fmt.Errorf("gateway connection failed: %w", err)
+	}
+	defer func() {
+		if closeErr := gateway.Destroy(); closeErr != nil {
+			log.ErrorLog(ctx, "Warning: failed to close gateway connection: %v", closeErr)
+		}
+	}()
+
+	// Remove host from subsystem
+	if err := gateway.RemoveHost(ctx, subsystemNQN, hostNQN); err != nil {
+		return fmt.Errorf("failed to remove host %s from subsystem %s: %w",
+			hostNQN, subsystemNQN, err)
+	}
+	log.DebugLog(ctx, "Host %s removed from subsystem %s", hostNQN, subsystemNQN)
+
+	return nil
+}
+
+// extractHostNQNFromNodeID extracts the host NQN from the node ID.
+func extractHostNQNFromNodeID(nodeID string) (string, error) {
+	// the nodeID has the pattern: <hostname>::<nqn>
+	// TODO: maybe change this separator to rare one.
+	parts := strings.Split(nodeID, "::")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid nodeID format: %s", nodeID)
+	}
+
+	return parts[1], nil
+}
+
 // VolumeContext metadata keys.
 const (
 	// NVMe-oF resource info.
@@ -401,6 +590,17 @@ func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) {
 	volume.VolumeContext[vcListenerHostname] = data.ListenerInfo.Hostname
 	volume.VolumeContext[vcGatewayAddress] = data.GatewayManagementInfo.Address
 	volume.VolumeContext[vcGatewayPort] = gatewayManagementInfoPortStr
+}
+
+// populatePublishContext creates a publish context for the volume.
+func populatePublishContext(req *csi.ControllerPublishVolumeRequest, hostNqn string) map[string]string {
+	publishContext := make(map[string]string)
+	for key, value := range req.GetVolumeContext() {
+		publishContext[key] = value
+	}
+	publishContext[vcHostNQN] = hostNqn
+
+	return publishContext
 }
 
 // storeNVMeoFMetadata stores all NVMe-oF data in RBD volume metadata for cleanup operations.

--- a/internal/nvmeof/tests/nvmeof_test.go
+++ b/internal/nvmeof/tests/nvmeof_test.go
@@ -78,7 +78,6 @@ func TestRealGateway(t *testing.T) {
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
 		SubsystemNQN: testNQN,
 		NamespaceID:  0, // will be set after namespace creation
-		HostNQN:      hostNQN,
 		ListenerInfo: nvmeof.ListenerDetails{
 			GatewayAddress: nvmeof.GatewayAddress{
 				Address: config.Address,
@@ -119,9 +118,9 @@ func TestRealGateway(t *testing.T) {
 	t.Logf("✓ Subsystem created: %s", nvmeofData.SubsystemNQN)
 
 	// Test add host
-	err = client.AddHost(ctx, nvmeofData.SubsystemNQN, nvmeofData.HostNQN)
+	err = client.AddHost(ctx, nvmeofData.SubsystemNQN, hostNQN)
 	require.NoError(t, err)
-	t.Logf("✓ Host added: %s to subsystem %s", nvmeofData.HostNQN, nvmeofData.SubsystemNQN)
+	t.Logf("✓ Host added: %s to subsystem %s", hostNQN, nvmeofData.SubsystemNQN)
 
 	// Test check subsystem exists
 	exists, err := client.SubsystemExists(ctx, nvmeofData.SubsystemNQN)
@@ -140,9 +139,9 @@ func TestRealGateway(t *testing.T) {
 	t.Logf("✓ Listener deleted for subsystem %s at %s", testNQN, config)
 
 	// Test remove host
-	err = client.RemoveHost(ctx, testNQN, nvmeofData.HostNQN)
+	err = client.RemoveHost(ctx, testNQN, hostNQN)
 	require.NoError(t, err)
-	t.Logf("✓ Host removed: %s from subsystem %s", nvmeofData.HostNQN, testNQN)
+	t.Logf("✓ Host removed: %s from subsystem %s", hostNQN, testNQN)
 
 	// Test create namespace
 	// poolName := "mypool"

--- a/internal/nvmeof/volume.go
+++ b/internal/nvmeof/volume.go
@@ -21,7 +21,6 @@ type NVMeoFVolumeData struct {
 	SubsystemNQN          string
 	NamespaceID           uint32
 	NamespaceUUID         string
-	HostNQN               string
 	ListenerInfo          ListenerDetails
 	GatewayManagementInfo GatewayConfig
 }

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (
@@ -5,6 +21,35 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// ValidateControllerPublishVolumeRequest validates the controller publish request.
+func ValidateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	}
+
+	if req.GetVolumeCapability() == nil {
+		return status.Error(codes.InvalidArgument, "volume capability missing in request")
+	}
+	if req.GetNodeId() == "" {
+		return status.Error(codes.InvalidArgument, "node ID missing in request")
+	}
+
+	return nil
+}
+
+// ValidateControllerUnpublishVolumeRequest validates the controller unpublish request.
+func ValidateControllerUnpublishVolumeRequest(req *csi.ControllerUnpublishVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	}
+
+	if req.GetNodeId() == "" {
+		return status.Error(codes.InvalidArgument, "node ID missing in request")
+	}
+
+	return nil
+}
 
 // ValidateNodeStageVolumeRequest validates the node stage request.
 func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This PR implements `ControllerPublishVolume` and `ControllerUnpublishVolume` methods for the NVMe-oF CSI driver, completing the Host attachment/detachment workflow. The implementation moves hosts management from volume creation to the publish/unpublish lifecycle, following proper CSI patterns.
It retrieves the `HostNqn` from `NodeID()`. 

Key changes:
- Implemented `ControllerPublishVolume` to add hosts to NVMe-oF subsystems when pods request volume attachment
- Implemented `ControllerUnpublishVolume` to remove hosts from subsystems during volume detachment  
- Moved host addition logic from `CreateVolume` to `ControllerPublishVolume`
- Added validation functions for publish/unpublish requests in `util ` package. 
- Created helper functions `publishResources` and `unpublishResources` for gateway operations


## Is there anything that requires special attention ##

**Host NQN Extraction**: The implementation assumes NodeID format follows `hostname@@NQN@@nqn.2014-08...` pattern. Node plugin must provide NodeID in this format.




## Related issues ##

Fixes: 
https://github.com/ceph/ceph-csi/issues/5370#issuecomment-3163939133


## Future concerns ##

- Implement host NQN validation with proper regex patterns

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
