### PR TITLE
util: fix read affinity activation by command flags

### DIFF
--- a/internal/util/read_affinity.go
+++ b/internal/util/read_affinity.go
@@ -62,11 +62,7 @@ func GetReadAffinityMapOptions(
 		return "", err
 	}
 
-	if !configReadAffinityEnabled {
-		return "", nil
-	}
-
-	if configCrushLocationLabels == "" {
+	if !configReadAffinityEnabled || configCrushLocationLabels == "" {
 		return cliReadAffinityMapOptions, nil
 	}
 


### PR DESCRIPTION
# Describe what this PR does #

Two mechanisms are offered to enable read affinity and configure CRUSH location labels:
- command flags `--enable-read-affinity` and `--crush-location-labels`
- cluster configuration attributes `readAffinity.enabled` and `readAffinity.crushLocationLabels`

It is expected that both could be used to enable the feature, with the possibility of one having precedence over the other.

When parsing the cluster configuration, a missing `readAffinity.enabled` key gets unmarshalled as a non-nullable bool and set to `false`. As a result, `GetReadAffinityMapOptions()` never considered CLI flags when the JSON file was missing read affinity settings.

This PR fixes the fallback logic so that command flags get some authority on enabling read affinity.
Further improvement would require `readAffinity.enabled` to be unmarshalled as a nullable type.

## Is there anything that requires special attention ##

Do you have any questions?
No

Is the change backward compatible?
Yes

Are there concerns around backward compatibility?
Maybe

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>

