### PR TITLE
util: add modprobe helper for loading kernel modules

### DIFF
--- a/internal/cephfs/mounter/kernel.go
+++ b/internal/cephfs/mounter/kernel.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/kmod"
 )
 
 const (
@@ -80,7 +81,7 @@ func (m *kernelMounter) mountKernel(
 	volOptions *store.VolumeOptions,
 ) error {
 	if m.needsModprobe {
-		if err := execCommandErr(ctx, "modprobe", kernelModule); err != nil {
+		if err := kmod.Modprobe(ctx, kernelModule); err != nil {
 			return err
 		}
 

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
 	"github.com/ceph/ceph-csi/pkg/util/kernel"
 
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/kmod"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/avast/retry-go/v4"
@@ -239,19 +239,13 @@ func waitForPath(
 // SetRbdNbdToolFeatures sets features available with rbd-nbd, and NBD module
 // loaded status.
 func SetRbdNbdToolFeatures() {
-	var stderr string
-	// check if the module is loaded or compiled in
-	_, err := os.Stat("/sys/module/" + moduleNbd)
-	if os.IsNotExist(err) {
-		// try to load the module
-		_, stderr, err = util.ExecCommand(context.TODO(), "modprobe", moduleNbd)
-		if err != nil {
-			hasNBD = false
-			log.WarningLogMsg("nbd modprobe failed (%v): %q", err, stderr)
+	err := kmod.Modprobe(context.TODO(), moduleNbd)
+	if err != nil {
+		hasNBD = false
 
-			return
-		}
+		return
 	}
+
 	log.DefaultLog("nbd module loaded")
 
 	// fetch the current running kernel info

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -35,6 +35,7 @@ import (
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/kmod"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/ceph/go-ceph/rados"
@@ -322,7 +323,6 @@ func prepareKrbdFeatureAttrs() (uint64, error) {
 // GetKrbdSupportedFeatures load the module if needed and return supported
 // features attribute as a string.
 func GetKrbdSupportedFeatures() (string, error) {
-	var stderr string
 	// check if the module is loaded or compiled in
 	_, err := os.Stat(krbdSupportedFeaturesFile)
 	if err != nil {
@@ -332,10 +332,8 @@ func GetKrbdSupportedFeatures() (string, error) {
 			return "", err
 		}
 		// try to load the module
-		_, stderr, err = util.ExecCommand(context.TODO(), "modprobe", rbdDefaultMounter)
+		err = kmod.Modprobe(context.TODO(), rbdDefaultMounter)
 		if err != nil {
-			log.ErrorLogMsg("modprobe failed (%v): %q", err, stderr)
-
 			return "", err
 		}
 	}

--- a/internal/util/kmod/modprobe.go
+++ b/internal/util/kmod/modprobe.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmod
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+// Modprobe will check if the module is already available for use, and if that
+// is not the case, it will try to load it.
+func Modprobe(ctx context.Context, kmod string) error {
+	_, err := os.Stat("/sys/module/" + kmod)
+	if err == nil {
+		// module already loaded (or compiled into the kernel)
+		return nil
+	}
+
+	if !os.IsNotExist(err) {
+		// something went really wrong
+		err = fmt.Errorf("failed to check availability of kernel module %q: %w", kmod, err)
+		log.WarningLog(ctx, err.Error())
+
+		return err
+	}
+
+	// try to load the module
+	_, stderr, err := util.ExecCommand(ctx, "modprobe", kmod)
+	if err != nil {
+		err = fmt.Errorf("modprobe of kernel module %q failed (%w): %s", kmod, err, stderr)
+		log.WarningLog(ctx, err.Error())
+
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
There are several places where kernel modules are loaded, reduce the
duplication of the code by introducing the new `kmod.Modprobe()`
function.