### PR TITLE
rbd: volume demote after unpublish call

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -548,6 +548,12 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 
 	// demote image to secondary
 	if info.IsPrimary() {
+		// If volume is demoted first, ControllerUnpublishVolume will fail to remove metadata
+		// since the image will be Read-only.
+		// Ensure volume is unpublished before demotion.
+		if err := checkVolumeUnpublished(ctx, rs.Driver.GetNodeID(), rbdVol); err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "volume cannot be demoted: %v", err)
+		}
 		// store the image creation time for resync
 		_, err = rbdVol.GetMetadata(imageCreationTimeKey)
 		if err != nil && errors.Is(err, librbd.ErrNotFound) {
@@ -992,4 +998,30 @@ func getCurrentReplicationStatus(ctx context.Context, mirrorGlobalStatus types.G
 	}
 
 	return resp, desc
+}
+
+// checkVolumeUnpublished verifies that the volume has been properly unpublished
+// by checking that clientaddress and userId mapping metadata is not present.
+func checkVolumeUnpublished(ctx context.Context, nodeId string, rv types.Volume) error {
+	volumeId, err := rv.GetID(ctx)
+	if err != nil {
+		return err
+	}
+
+	clientMetadataKeys := []string{
+		corerbd.GetClientAddressKey(volumeId, nodeId),
+		corerbd.GetUserIDMappingKey(volumeId, nodeId),
+	}
+
+	for _, key := range clientMetadataKeys {
+		_, err := rv.GetMetadata(key)
+		if err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			return err
+		}
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return fmt.Errorf("metadata %q is still present on the image %q", key, rv)
+		}
+	}
+
+	return nil
 }

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -190,6 +190,7 @@ func GetIDFromReplication(req interface{}) string {
 	}
 }
 
+//nolint:gocyclo,cyclop // TODO: reduce complexity
 func getReqID(req interface{}) string {
 	// if req is nil empty string will be returned
 	reqID := ""
@@ -206,6 +207,11 @@ func getReqID(req interface{}) string {
 		reqID = r.GetSnapshotId()
 
 	case *csi.ControllerExpandVolumeRequest:
+		reqID = r.GetVolumeId()
+
+	case *csi.ControllerPublishVolumeRequest:
+		reqID = r.GetVolumeId()
+	case *csi.ControllerUnpublishVolumeRequest:
 		reqID = r.GetVolumeId()
 
 	case *csi.NodeStageVolumeRequest:

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -49,6 +49,12 @@ func TestGetReqID(t *testing.T) {
 		&csi.ControllerExpandVolumeRequest{
 			VolumeId: fakeID,
 		},
+		&csi.ControllerPublishVolumeRequest{
+			VolumeId: fakeID,
+		},
+		&csi.ControllerUnpublishVolumeRequest{
+			VolumeId: fakeID,
+		},
 		&csi.NodeStageVolumeRequest{
 			VolumeId: fakeID,
 		},

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1835,7 +1835,7 @@ func (cs *ControllerServer) removeUserIdMapping(
 		return errors.New("nodeId cannot be empty")
 	}
 
-	metadataKey := getUserIDMappingKey(rv.VolID, nodeId)
+	metadataKey := GetUserIDMappingKey(rv.VolID, nodeId)
 	err := rv.RemoveMetadata(metadataKey)
 	if err != nil && !errors.Is(err, librbd.ErrNotExist) {
 		return fmt.Errorf("failed to remove user ID mapping for node %s on image %s: %w", nodeId, rv, err)
@@ -1875,7 +1875,7 @@ func (cs *ControllerServer) fenceNode(
 		return errors.New("nodeId cannot be empty")
 	}
 
-	metadataKey := getClientAddressKey(rv.VolID, nodeId)
+	metadataKey := GetClientAddressKey(rv.VolID, nodeId)
 	isOutOfService, err := k8s.IsNodeOutOfService(nodeId)
 	if err != nil {
 		return fmt.Errorf("failed to check if node %s is out of service: %w", nodeId, err)
@@ -1947,7 +1947,7 @@ func (cs *ControllerServer) unfenceNode(
 		return nil
 	}
 
-	metadataKey := getClientAddressKey(rv.VolID, nodeId)
+	metadataKey := GetClientAddressKey(rv.VolID, nodeId)
 	clientAddress, err := rv.GetMetadata(metadataKey)
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -452,7 +452,7 @@ func (ns *NodeServer) setUserIdMapping(
 	}
 
 	nodeId := ns.Driver.GetNodeID()
-	metadataKey := getUserIDMappingKey(rv.VolID, nodeId)
+	metadataKey := GetUserIDMappingKey(rv.VolID, nodeId)
 	err := rv.SetMetadata(metadataKey, cr.ID)
 	if err != nil {
 		return fmt.Errorf("failed to set client address for %s: %w", rv, err)
@@ -479,7 +479,7 @@ func (ns *NodeServer) setClientAddress(
 	}
 
 	nodeId := ns.Driver.GetNodeID()
-	metadataKey := getClientAddressKey(rv.VolID, nodeId)
+	metadataKey := GetClientAddressKey(rv.VolID, nodeId)
 	monitors, _ /* clusterID*/, err := util.GetMonsAndClusterID(ctx, rv.ClusterID, false)
 	if err != nil {
 		return fmt.Errorf("failed to get monitors for cluster %s: %w", rv.ClusterID, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -286,13 +286,13 @@ var (
 	}
 )
 
-// getClientAddressKey returns the key for storing client address metadata for a specific node.
-func getClientAddressKey(volumeId, nodeId string) string {
+// GetClientAddressKey returns the key for storing client address metadata for a specific node.
+func GetClientAddressKey(volumeId, nodeId string) string {
 	return fmt.Sprintf("%s/%s/%s", clientAddressKey, volumeId, nodeId)
 }
 
-// getUserIDMappingKey returns the key for storing user ID mapping metadata for a specific node.
-func getUserIDMappingKey(volumeID, nodeID string) string {
+// GetUserIDMappingKey returns the key for storing user ID mapping metadata for a specific node.
+func GetUserIDMappingKey(volumeID, nodeID string) string {
 	return fmt.Sprintf("%s/%s/%s", userIdMappingKey, volumeID, nodeID)
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Problem: Pod deletion followed by immediate volume demotion can
create a race where the volume becomes read-only (secondary)
before ControllerUnpublishVolume can remove client metadata,
causing cleanup failures.

Solution: Validate that client metadata has been removed before
allowing volume demotion, ensuring proper unpublish first.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
