### PR TITLE
ci: use ceph-csi-bot for Mergify actions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,13 @@
 ---
+defaults:
+  actions:
+    update:
+      bot_account: ceph-csi-bot
+    rebase:
+      bot_account: ceph-csi-bot
+    merge:
+      merge_bot_account: ceph-csi-bot
+
 queue_rules:
   - name: default
     merge_conditions:


### PR DESCRIPTION
Mergify complains that it can not queue PRs anymore:

> The PR cannot be merged because of GitHub restrictions. You must set
> up a bot_account to automatically queue and merge PRs created by a
> GitHub App, or modify the GitHub Actions workflows.

The `bot_account` used to be a non-free option for Mergify, but that seems to have changed.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
