### PR TITLE
nvmeof: provisioner multiple listeners

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -147,7 +148,9 @@ func (cs *Server) CreateVolume(
 	}()
 
 	// step 3: Populate volume context for NodeServer
-	populateVolumeContext(backend, nvmeofData)
+	if err := populateVolumeContext(backend, nvmeofData); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to populate volume context: %v", err)
+	}
 
 	// Step 4: Store NVMe-oF metadata in the volume context
 	if err := cs.storeNVMeoFMetadata(ctx, req, volumeID, nvmeofData); err != nil {
@@ -277,12 +280,17 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	params := req.GetParameters()
 	requiredParams := []string{
 		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
-		"listenerIpAddress", "listenerPort", "listenerHostname",
+		"listeners",
 	}
 	for _, param := range requiredParams {
 		if params[param] == "" {
 			return fmt.Errorf("missing required parameter: %s", param)
 		}
+	}
+	// Validate listeners JSON
+	_, err := parseListeners(params["listeners"])
+	if err != nil {
+		return fmt.Errorf("invalid listeners parameter: %w", err)
 	}
 
 	return nil
@@ -292,8 +300,7 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 func validatePublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
 	volumeContext := req.GetVolumeContext()
 	requiredParams := []string{
-		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
-		"listenerIpAddress", "listenerPort", "listenerHostname",
+		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort", "listeners",
 	}
 	for _, param := range requiredParams {
 		if volumeContext[param] == "" {
@@ -304,13 +311,33 @@ func validatePublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error
 	return util.ValidateControllerPublishVolumeRequest(req)
 }
 
+func parseListeners(listenersJSON string) ([]nvmeof.ListenerDetails, error) {
+	var listeners []nvmeof.ListenerDetails
+	if err := json.Unmarshal([]byte(listenersJSON), &listeners); err != nil {
+		return nil, fmt.Errorf("failed to parse listeners JSON: %w", err)
+	}
+
+	if len(listeners) == 0 { // TODO: when auto listener will be implemented , make listeners optional
+		return nil, errors.New("at least one listener must be specified")
+	}
+
+	// Validate each listener
+	for i, listener := range listeners {
+		if listener.Address == "" || listener.Port == 0 || listener.Hostname == "" {
+			return nil, fmt.Errorf("listener %d: missing required fields (address, port, hostname)", i)
+		}
+	}
+
+	return listeners, nil
+}
+
 // ensureSubsystem checks if the subsystem exists, and creates it if not.
 // then creates the listener.
 func ensureSubsystem(
 	ctx context.Context,
 	gateway *nvmeof.GatewayRpcClient,
 	subsystemNQN string,
-	listenerInfo nvmeof.ListenerDetails,
+	listeners []nvmeof.ListenerDetails,
 ) error {
 	exists, err := gateway.SubsystemExists(ctx, subsystemNQN)
 	if err != nil {
@@ -325,9 +352,15 @@ func ensureSubsystem(
 		return err
 	}
 
-	// Create listeners
+	// Create all listeners
+	for i, listener := range listeners {
+		log.DebugLog(ctx, "Creating listener %d: %s", i, listener.String())
+		if err := gateway.CreateListener(ctx, subsystemNQN, listener); err != nil {
+			return fmt.Errorf("failed to create listener %d (%s): %w", i, listener.String(), err)
+		}
+	}
 
-	return gateway.CreateListener(ctx, subsystemNQN, listenerInfo)
+	return nil
 }
 
 // cleanupEmptySubsystem checks if the subsystem is empty (no namespaces), if so,
@@ -336,7 +369,7 @@ func cleanupEmptySubsystem(
 	ctx context.Context,
 	gateway *nvmeof.GatewayRpcClient,
 	subsystemNQN string,
-	listenerInfo nvmeof.ListenerDetails,
+	listeners []nvmeof.ListenerDetails,
 ) error {
 	if subsystemNQN == "" {
 		return nil
@@ -363,9 +396,11 @@ func cleanupEmptySubsystem(
 	}
 
 	// subsystem is empty delete listener first
-	err = gateway.DeleteListener(ctx, subsystemNQN, listenerInfo)
-	if err != nil {
-		return fmt.Errorf("failed to delete listener for subsystem %s: %w", subsystemNQN, err)
+	for i, listener := range listeners {
+		if err := gateway.DeleteListener(ctx, subsystemNQN, listener); err != nil {
+			return fmt.Errorf("failed to delete listener %d (%s) for subsystem %s: %w",
+				i, listener.String(), subsystemNQN, err)
+		}
 	}
 
 	log.DebugLog(ctx, "Subsystem %s is empty, deleting", subsystemNQN)
@@ -388,11 +423,13 @@ func createNVMeoFResources(
 ) (*nvmeof.NVMeoFVolumeData, error) {
 	// Step 1: Extract parameters (already validated)
 	params := req.GetParameters()
-	listenerPortStr := params["listenerPort"]
-	listenerPort, err := strconv.ParseUint(listenerPortStr, 10, 32)
+
+	// Parse listeners from JSON
+	listeners, err := parseListeners(params["listeners"])
 	if err != nil {
-		return nil, fmt.Errorf("invalid listenerPort %s: %w", listenerPortStr, err)
+		return nil, fmt.Errorf("failed to parse listeners: %w", err)
 	}
+
 	nvmeofGatewayPortStr := params["nvmeofGatewayPort"]
 	nvmeofGatewayPort, err := strconv.ParseUint(nvmeofGatewayPortStr, 10, 32)
 	if err != nil {
@@ -402,13 +439,7 @@ func createNVMeoFResources(
 		SubsystemNQN:  params["subsystemNQN"],
 		NamespaceID:   0,  // will be set after namespace creation,
 		NamespaceUUID: "", // will be set after namespace creation
-		ListenerInfo: nvmeof.ListenerDetails{
-			GatewayAddress: nvmeof.GatewayAddress{
-				Address: params["listenerIpAddress"],
-				Port:    uint32(listenerPort),
-			},
-			Hostname: params["listenerHostname"],
-		},
+		ListenerInfo:  listeners,
 		GatewayManagementInfo: nvmeof.GatewayConfig{
 			Address: params["nvmeofGatewayAddress"],
 			Port:    uint32(nvmeofGatewayPort),
@@ -609,10 +640,8 @@ const (
 	vcNamespaceUUID = "NamespaceUUID"
 	vcHostNQN       = "HostNQN"
 
-	// Listener info.
-	vcListenerAddress  = "ListenerAddress"
-	vcListenerPort     = "ListenerPort"
-	vcListenerHostname = "ListenerHostname"
+	// Multiple listeners stored as JSON.
+	vcListeners = "listeners"
 
 	// Gateway management info.
 	vcGatewayAddress = "GatewayAddress"
@@ -625,21 +654,26 @@ func toRBDMetadataKey(vcKey string) string {
 }
 
 // populateVolumeContext adds NVMe-oF information to volume context for NodeServer.
-func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) {
+func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) error {
 	if volume.VolumeContext == nil {
 		volume.VolumeContext = make(map[string]string)
 	}
-	listenerPortStr := strconv.FormatUint(uint64(data.ListenerInfo.Port), 10)
 	gatewayManagementInfoPortStr := strconv.FormatUint(uint64(data.GatewayManagementInfo.Port), 10)
 
 	volume.VolumeContext[vcSubsystemNQN] = data.SubsystemNQN
 	volume.VolumeContext[vcNamespaceID] = strconv.FormatUint(uint64(data.NamespaceID), 10)
 	volume.VolumeContext[vcNamespaceUUID] = data.NamespaceUUID
-	volume.VolumeContext[vcListenerAddress] = data.ListenerInfo.Address
-	volume.VolumeContext[vcListenerPort] = listenerPortStr
-	volume.VolumeContext[vcListenerHostname] = data.ListenerInfo.Hostname
 	volume.VolumeContext[vcGatewayAddress] = data.GatewayManagementInfo.Address
 	volume.VolumeContext[vcGatewayPort] = gatewayManagementInfoPortStr
+
+	// Store listeners as JSON
+	listenersJSON, err := json.Marshal(data.ListenerInfo)
+	if err != nil {
+		return fmt.Errorf("failed to marshal listener info: %w", err)
+	}
+	volume.VolumeContext[vcListeners] = string(listenersJSON)
+
+	return nil
 }
 
 // populatePublishContext creates a publish context for the volume.
@@ -672,7 +706,12 @@ func (cs *Server) storeNVMeoFMetadata(
 	defer rbdVol.Destroy(ctx)
 
 	gatewayManagementInfoPortStr := strconv.FormatUint(uint64(nvmeofData.GatewayManagementInfo.Port), 10)
-	listenerInfoPortStr := strconv.FormatUint(uint64(nvmeofData.ListenerInfo.Port), 10)
+
+	// Serialize listeners to JSON
+	listenersJSON, err := json.Marshal(nvmeofData.ListenerInfo)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to serialize listeners: %v", err)
+	}
 
 	// Prepare all metadata entries
 	metadata := map[string]string{
@@ -681,10 +720,8 @@ func (cs *Server) storeNVMeoFMetadata(
 		toRBDMetadataKey(vcNamespaceID):   strconv.FormatUint(uint64(nvmeofData.NamespaceID), 10),
 		toRBDMetadataKey(vcNamespaceUUID): nvmeofData.NamespaceUUID,
 
-		// Listener info
-		toRBDMetadataKey(vcListenerAddress):  nvmeofData.ListenerInfo.Address,
-		toRBDMetadataKey(vcListenerPort):     listenerInfoPortStr,
-		toRBDMetadataKey(vcListenerHostname): nvmeofData.ListenerInfo.Hostname,
+		// Listeners as JSON
+		toRBDMetadataKey(vcListeners): string(listenersJSON),
 
 		// Gateway management info
 		toRBDMetadataKey(vcGatewayAddress): nvmeofData.GatewayManagementInfo.Address,
@@ -736,9 +773,7 @@ func (cs *Server) getNVMeoFMetadata(
 		toRBDMetadataKey(vcSubsystemNQN),
 		toRBDMetadataKey(vcNamespaceID),
 		toRBDMetadataKey(vcNamespaceUUID),
-		toRBDMetadataKey(vcListenerAddress),
-		toRBDMetadataKey(vcListenerPort),
-		toRBDMetadataKey(vcListenerHostname),
+		toRBDMetadataKey(vcListeners),
 		toRBDMetadataKey(vcGatewayAddress),
 		toRBDMetadataKey(vcGatewayPort),
 	}
@@ -761,26 +796,23 @@ func (cs *Server) getNVMeoFMetadata(
 		return nil, fmt.Errorf("invalid namespace ID: %w", err)
 	}
 
-	listenerInfoPort, err := strconv.ParseUint(metadata[toRBDMetadataKey(vcListenerPort)], 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("invalid listener port: %w", err)
-	}
 	gatewayPort, err := strconv.ParseUint(metadata[toRBDMetadataKey(vcGatewayPort)], 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid gateway port: %w", err)
 	}
+
+	// Parse listeners from JSON
+	var listeners []nvmeof.ListenerDetails
+	if err := json.Unmarshal([]byte(metadata[toRBDMetadataKey(vcListeners)]), &listeners); err != nil {
+		return nil, fmt.Errorf("failed to parse listeners JSON: %w", err)
+	}
+
 	// Construct NVMe-oF volume data
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
 		SubsystemNQN:  metadata[toRBDMetadataKey(vcSubsystemNQN)],
 		NamespaceID:   uint32(nsid),
 		NamespaceUUID: metadata[toRBDMetadataKey(vcNamespaceUUID)],
-		ListenerInfo: nvmeof.ListenerDetails{
-			GatewayAddress: nvmeof.GatewayAddress{
-				Address: metadata[toRBDMetadataKey(vcListenerAddress)],
-				Port:    uint32(listenerInfoPort),
-			},
-			Hostname: metadata[toRBDMetadataKey(vcListenerHostname)],
-		},
+		ListenerInfo:  listeners,
 		// Store gateway management info separately
 		GatewayManagementInfo: nvmeof.GatewayConfig{
 			Address: metadata[toRBDMetadataKey(vcGatewayAddress)],

--- a/internal/nvmeof/controller/controllerserver_test.go
+++ b/internal/nvmeof/controller/controllerserver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -76,12 +77,14 @@ func TestPolulateVolumeContext(t *testing.T) {
 		SubsystemNQN:  "nqn.2014-08.org.nvmexpress:uuid:e61ecd13-2727-42a3-947e-2127d63abacc",
 		NamespaceID:   42,
 		NamespaceUUID: "c1a0223f-a9ba-4f10-89c2-7496ad50e026",
-		ListenerInfo: nvmeof.ListenerDetails{
-			GatewayAddress: nvmeof.GatewayAddress{
-				Address: "127.0.0.1",
-				Port:    4420,
+		ListenerInfo: []nvmeof.ListenerDetails{
+			{
+				GatewayAddress: nvmeof.GatewayAddress{
+					Address: "127.0.0.1",
+					Port:    4420,
+				},
+				Hostname: "localhost",
 			},
-			Hostname: "localhost",
 		},
 		GatewayManagementInfo: nvmeof.GatewayConfig{
 			Address: "127.0.0.2",
@@ -89,14 +92,24 @@ func TestPolulateVolumeContext(t *testing.T) {
 		},
 	}
 
-	populateVolumeContext(volume, config)
+	err := populateVolumeContext(volume, config)
+	require.NoError(t, err)
 
 	require.Equal(t, config.SubsystemNQN, volume.GetVolumeContext()["SubsystemNQN"])
 	require.Equal(t, strconv.FormatUint(uint64(config.NamespaceID), 10), volume.GetVolumeContext()["NamespaceID"])
 	require.Equal(t, config.NamespaceUUID, volume.GetVolumeContext()["NamespaceUUID"])
-	require.Equal(t, config.ListenerInfo.Address, volume.GetVolumeContext()["ListenerAddress"])
-	require.Equal(t, strconv.FormatUint(uint64(config.ListenerInfo.Port), 10), volume.GetVolumeContext()["ListenerPort"])
-	require.Equal(t, config.ListenerInfo.Hostname, volume.GetVolumeContext()["ListenerHostname"])
+	listenersJSON := volume.GetVolumeContext()["listeners"]
+	require.NotEmpty(t, listenersJSON)
+
+	// Parse and validate the JSON
+	var storedListeners []nvmeof.ListenerDetails
+	err = json.Unmarshal([]byte(listenersJSON), &storedListeners)
+	require.NoError(t, err)
+	require.Len(t, storedListeners, 1)
+	require.Equal(t, config.ListenerInfo[0].Address, storedListeners[0].Address)
+	require.Equal(t, config.ListenerInfo[0].Port, storedListeners[0].Port)
+	require.Equal(t, config.ListenerInfo[0].Hostname, storedListeners[0].Hostname)
+
 	require.Equal(t, config.GatewayManagementInfo.Address, volume.GetVolumeContext()["GatewayAddress"])
 	require.Equal(t,
 		strconv.FormatUint(uint64(config.GatewayManagementInfo.Port), 10),

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -337,12 +337,19 @@ func (gw *GatewayRpcClient) CreateListener(ctx context.Context, subsystemNQN str
 	if err != nil {
 		return fmt.Errorf("failed to add listener %s to subsystem %s: %w", listenerInfo.Address, subsystemNQN, err)
 	}
-	if resp.GetStatus() == int32(syscall.EEXIST) { // EEXIST
+	switch resp.GetStatus() {
+	case int32(syscall.EEXIST):
 		log.DebugLog(ctx, "Listener %s already created for subsystem %s", listenerInfo.Address, subsystemNQN)
 
 		return nil // Listener already created, no error
-	}
-	if resp.GetStatus() != 0 {
+	case int32(syscall.EREMOTE): // Handle the stashed listener case
+		log.DebugLog(ctx, "Listener %s stashed for subsystem %s (will be active when %s gateway comes up)",
+			listenerInfo.Address, subsystemNQN, listenerInfo.Hostname)
+
+		return nil // Treat as success
+	case 0:
+		// break
+	default: // resp.GetStatus() != 0
 		return fmt.Errorf("gateway AddListener returned error (status=%d): %s", resp.GetStatus(), resp.GetErrorMessage())
 	}
 	log.DebugLog(ctx, "Listener added successfully: %s to subsystem %s", listenerInfo.Address, subsystemNQN)

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -49,6 +49,10 @@ type ListenerDetails struct {
 	Hostname string `json:"hostname"`
 }
 
+func (ga ListenerDetails) String() string {
+	return fmt.Sprintf("%s:%d (%s)", ga.Address, ga.Port, ga.Hostname)
+}
+
 // Config holds gateway client configuration.
 type GatewayConfig = GatewayAddress
 

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -35,8 +35,8 @@ import (
 // This is used to connect to the gateway server.
 // It is also used to specify the address and port of listeners.
 type GatewayAddress struct {
-	Address string
-	Port    uint32
+	Address string `json:"address"`
+	Port    uint32 `json:"port"`
 }
 
 func (ga GatewayAddress) String() string {
@@ -46,7 +46,7 @@ func (ga GatewayAddress) String() string {
 // ListenerDetails holds the listener information for a subsystem.
 type ListenerDetails struct {
 	GatewayAddress
-	Hostname string
+	Hostname string `json:"hostname"`
 }
 
 // Config holds gateway client configuration.

--- a/internal/nvmeof/tests/nvmeof_test.go
+++ b/internal/nvmeof/tests/nvmeof_test.go
@@ -78,12 +78,14 @@ func TestRealGateway(t *testing.T) {
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
 		SubsystemNQN: testNQN,
 		NamespaceID:  0, // will be set after namespace creation
-		ListenerInfo: nvmeof.ListenerDetails{
-			GatewayAddress: nvmeof.GatewayAddress{
-				Address: config.Address,
-				Port:    uint32(nvmeofListenerPort),
+		ListenerInfo: []nvmeof.ListenerDetails{
+			{
+				GatewayAddress: nvmeof.GatewayAddress{
+					Address: config.Address,
+					Port:    uint32(nvmeofListenerPort),
+				},
+				Hostname: hostname,
 			},
-			Hostname: hostname,
 		},
 		GatewayManagementInfo: *config,
 	}
@@ -97,7 +99,7 @@ func TestRealGateway(t *testing.T) {
 		}
 
 		// 2. Delete listener (if it exists)
-		if err := client.DeleteListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo); err != nil {
+		if err := client.DeleteListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo[0]); err != nil {
 			t.Logf("Cleanup warning: failed to delete listener: %v", err)
 		}
 
@@ -129,12 +131,12 @@ func TestRealGateway(t *testing.T) {
 	t.Logf("✓ Subsystem exists: %s", nvmeofData.SubsystemNQN)
 
 	// Test create listener
-	err = client.CreateListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo)
+	err = client.CreateListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo[0])
 	require.NoError(t, err)
 	t.Logf("✓ Listener created for subsystem %s at %s", testNQN, config)
 
 	// Test delete listener
-	err = client.DeleteListener(ctx, testNQN, nvmeofData.ListenerInfo)
+	err = client.DeleteListener(ctx, testNQN, nvmeofData.ListenerInfo[0])
 	require.NoError(t, err)
 	t.Logf("✓ Listener deleted for subsystem %s at %s", testNQN, config)
 

--- a/internal/nvmeof/volume.go
+++ b/internal/nvmeof/volume.go
@@ -21,6 +21,6 @@ type NVMeoFVolumeData struct {
 	SubsystemNQN          string
 	NamespaceID           uint32
 	NamespaceUUID         string
-	ListenerInfo          ListenerDetails
+	ListenerInfo          []ListenerDetails
 	GatewayManagementInfo GatewayConfig
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This PR adds support for multiple NVMe-oF listeners in the NVMe-oF CSI driver. Previously, the driver only supported a single listener per subsystem.

The changes include:
- Modified `NVMeoFVolumeData` struct to support a slice of `ListenerDetails` instead of a single listener
- Updated StorageClass parameter format to accept listeners as JSON array
- Added JSON marshaling tags to `GatewayAddress` and `ListenerDetails` structs
- Enhanced validation functions to parse and validate multiple listeners
- Updated metadata storage/retrieval to serialize listeners as JSON
- Modified subsystem creation/cleanup logic to handle multiple listeners
- Updated unit tests to validate the new JSON-based listener format

## Is there anything that requires special attention ##

**Backward Compatibility**: This is a breaking change for the StorageClass format. The old individual listener parameters (`listenerIpAddress`, `listenerPort`, `listenerHostname`) are replaced with a single `listeners` JSON parameter.

**Migration Path**: Existing StorageClasses will need to be updated to use the new JSON format:
```yaml
# Old format (no longer supported)
listenerIpAddress: 10.242.64.32
listenerPort: "4420"
listenerHostname: "cephnvme-vm9"

# New format
listeners: |
  [
    {
      "address": "10.242.64.32",
      "port": 4420,
      "hostname": "cephnvme-vm9"
    }
  ]
```
**Volume Context Changes**: The volume context no longer includes individual listener fields but stores all listeners as JSON under the listeners key.

## Related issues ##

https://github.com/ceph/ceph-csi/issues/5370


## Future concerns ##

- Once Auto Listener feature will be merged https://github.com/ceph/ceph-nvmeof/pull/1381 need to reconsider the way of how to create the listeners.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
