### PR TITLE
nvmeof: fix remove host in ControllerUnpublishVolume

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -565,6 +565,20 @@ func unpublishResources(ctx context.Context, data *nvmeof.NVMeoFVolumeData, node
 		}
 	}()
 
+	// check if there are more namespaces in this subsystem with this host, if so, do not remove the host.
+	namespaces, err := gateway.ListNamespaces(ctx, subsystemNQN)
+	if err != nil {
+		return fmt.Errorf("failed to list namespaces for subsystem %s: %w", subsystemNQN, err)
+	}
+	for _, ns := range namespaces.GetNamespaces() {
+		for _, host := range ns.GetHosts() {
+			if host == hostNQN {
+				log.DebugLog(ctx, "Host %s is still using namespace %s, not removing", hostNQN, ns.GetNsid())
+
+				return nil
+			}
+		}
+	}
 	// Remove host from subsystem
 	if err := gateway.RemoveHost(ctx, subsystemNQN, hostNQN); err != nil {
 		return fmt.Errorf("failed to remove host %s from subsystem %s: %w",


### PR DESCRIPTION
validate if the host is not needed before remove

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

**Fix little bug:** 
NVMe-oF CSI driver incorrectly removes hosts from subsystems during ControllerUnpublishVolume even when the host is still using other namespaces in the same subsystem, causing connectivity issues for remaining volumes.

**solution:**
Host should only be removed from subsystem when no namespaces are actively using it.

## Is there anything that requires special attention ##

## Related issues ##

## Future concerns ##

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
