### PR TITLE
ci: use minikube v1.37.0

### DIFF
--- a/build.env
+++ b/build.env
@@ -51,7 +51,7 @@ HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 HELM_VERSION=v3.14.3
 
 # minikube settings
-MINIKUBE_VERSION=v1.35.0
+MINIKUBE_VERSION=v1.37.0
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 


### PR DESCRIPTION
Minikube 1.37.0 has been released last week, let's use that from now on.

See-also: https://github.com/kubernetes/minikube/releases/tag/v1.37.0