### PR TITLE
ci: add 1.34 kubernetes for testing

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -12,6 +12,8 @@
           only_run_on_request: true
       - '1.33':
           only_run_on_request: true
+      - '1.34':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -12,6 +12,8 @@
           only_run_on_request: true
       - '1.33':
           only_run_on_request: true
+      - '1.34':
+          only_run_on_request: true
     test_type:
       - 'cephfs'
       - 'rbd'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.32'
+    k8s_version: '1.34'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
Adding an option to run the e2e test on kubernetes 1.34

