### PR TITLE
ci: update ci rules for 1.34

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         branch: [release-v3.14, release-v3.15, devel]
-        k8s: ["1.30", "1.31", "1.32", "1.33"]
+        k8s: ["1.30", "1.31", "1.32", "1.33", "1.34"]
         exclude:
           - k8s: "1.33"
             branch: "release-v3.14"
@@ -27,8 +27,18 @@ jobs:
           - k8s: "1.30"
             branch: "release-v3.15"
 
+          - k8s: "1.34"
+            branch: "release-v3.14"
+
+          - k8s: "1.34"
+            branch: "release-v3.15"
+
           - k8s: "1.30"
             branch: "devel"
+
+          - k8s: "1.31"
+            branch: "devel"
+
 
     # watch out, matrix.branch can not be used in this if-statement :-/
     if: >

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -72,15 +72,15 @@ queue_rules:
               - or:
                   - label=ci/skip/e2e
                   - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
+                      - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.31"
+                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
                       - "status-success=ci/centos/mini-e2e/k8s-1.32"
                       - "status-success=ci/centos/mini-e2e/k8s-1.33"
+                      - "status-success=ci/centos/mini-e2e/k8s-1.34"
                       - "status-success=ci/centos/upgrade-tests-cephfs"
                       - "status-success=ci/centos/upgrade-tests-rbd"
           - and:
@@ -148,15 +148,15 @@ pull_request_rules:
       - or:
           - label=ci/skip/e2e
           - and:
-              - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
               - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
               - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-              - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
               - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
               - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-              - "status-success=ci/centos/mini-e2e/k8s-1.31"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
               - "status-success=ci/centos/mini-e2e/k8s-1.32"
               - "status-success=ci/centos/mini-e2e/k8s-1.33"
+              - "status-success=ci/centos/mini-e2e/k8s-1.34"
               - "status-success=ci/centos/upgrade-tests-cephfs"
               - "status-success=ci/centos/upgrade-tests-rbd"
     actions:
@@ -252,15 +252,15 @@ pull_request_rules:
               - or:
                   - label=ci/skip/e2e
                   - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
+                      - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.31"
+                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
                       - "status-success=ci/centos/mini-e2e/k8s-1.32"
                       - "status-success=ci/centos/mini-e2e/k8s-1.33"
+                      - "status-success=ci/centos/mini-e2e/k8s-1.34"
                       - "status-success=ci/centos/upgrade-tests-cephfs"
                       - "status-success=ci/centos/upgrade-tests-rbd"
     actions:


### PR DESCRIPTION
Updating the pull request commenter and the mergify rules to use kubernetes 1.34 for devel branch.

depends on: #5601