### PR TITLE
nvmeof: prevent concurrent adding/removing of hosts to the gateway

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -48,18 +48,18 @@ type ControllerServer struct {
 	*csicommon.DefaultControllerServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID/volume name) return an Aborted error
-	VolumeLocks *util.VolumeLocks
+	VolumeLocks *util.IDLocker
 
 	// A map storing all snapshots with ongoing operations so that additional operations
 	// for that same snapshot (as defined by SnapshotID/snapshot name) return an Aborted error
-	SnapshotLocks *util.VolumeLocks
+	SnapshotLocks *util.IDLocker
 
 	// A map storing all volumes/snapshots with ongoing operations.
 	OperationLocks *util.OperationLock
 
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by volumegroup ID/volumegroup name) return an Aborted error
-	VolumeGroupLocks *util.VolumeLocks
+	VolumeGroupLocks *util.IDLocker
 
 	// Cluster name
 	ClusterName string

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -61,9 +61,9 @@ func NewIdentityServer(d *csicommon.CSIDriver) *IdentityServer {
 func NewControllerServer(d *csicommon.CSIDriver) *ControllerServer {
 	return &ControllerServer{
 		DefaultControllerServer: csicommon.NewDefaultControllerServer(d),
-		VolumeLocks:             util.NewVolumeLocks(),
-		SnapshotLocks:           util.NewVolumeLocks(),
-		VolumeGroupLocks:        util.NewVolumeLocks(),
+		VolumeLocks:             util.NewIDLocker(),
+		SnapshotLocks:           util.NewIDLocker(),
+		VolumeGroupLocks:        util.NewIDLocker(),
 		OperationLocks:          util.NewOperationLock(),
 	}
 }
@@ -79,7 +79,7 @@ func NewNodeServer(
 	cliReadAffinityMapOptions := util.ConstructReadAffinityMapOption(crushLocationMap)
 	ns := &NodeServer{
 		DefaultNodeServer:  csicommon.NewDefaultNodeServer(d, t, cliReadAffinityMapOptions, topology, nodeLabels),
-		VolumeLocks:        util.NewVolumeLocks(),
+		VolumeLocks:        util.NewIDLocker(),
 		kernelMountOptions: kernelMountOptions,
 		fuseMountOptions:   fuseMountOptions,
 		healthChecker:      hc.NewHealthCheckManager(),

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -49,7 +49,7 @@ type NodeServer struct {
 	*csicommon.DefaultNodeServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID) return an Aborted error
-	VolumeLocks        *util.VolumeLocks
+	VolumeLocks        *util.IDLocker
 	kernelMountOptions string
 	fuseMountOptions   string
 	healthChecker      hc.Manager

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -43,7 +43,7 @@ import (
 type ReconcilePersistentVolume struct {
 	client client.Client
 	config ctrl.Config
-	Locks  *util.VolumeLocks
+	Locks  *util.IDLocker
 }
 
 var (
@@ -164,7 +164,7 @@ func newPVReconciler(mgr manager.Manager, config ctrl.Config) reconcile.Reconcil
 	r := &ReconcilePersistentVolume{
 		client: mgr.GetClient(),
 		config: config,
-		Locks:  util.NewVolumeLocks(),
+		Locks:  util.NewIDLocker(),
 	}
 
 	return r

--- a/internal/controller/volumegroup/volumegroupreplicationcontent.go
+++ b/internal/controller/volumegroup/volumegroupreplicationcontent.go
@@ -44,7 +44,7 @@ import (
 type ReconcileVGRContent struct {
 	client client.Client
 	config ctrl.Config
-	Locks  *util.VolumeLocks
+	Locks  *util.IDLocker
 }
 
 var (
@@ -76,7 +76,7 @@ func newVGRContentReconciler(mgr manager.Manager, config ctrl.Config) reconcile.
 	r := &ReconcileVGRContent{
 		client: mgr.GetClient(),
 		config: config,
-		Locks:  util.NewVolumeLocks(),
+		Locks:  util.NewIDLocker(),
 	}
 
 	return r

--- a/internal/csi-addons/rbd/encryptionkeyrotation.go
+++ b/internal/csi-addons/rbd/encryptionkeyrotation.go
@@ -34,10 +34,10 @@ import (
 type EncryptionKeyRotationServer struct {
 	*ekr.UnimplementedEncryptionKeyRotationControllerServer
 	driverInstance string
-	volLock        *util.VolumeLocks
+	volLock        *util.IDLocker
 }
 
-func NewEncryptionKeyRotationServer(driverInstance string, volLock *util.VolumeLocks) *EncryptionKeyRotationServer {
+func NewEncryptionKeyRotationServer(driverInstance string, volLock *util.IDLocker) *EncryptionKeyRotationServer {
 	return &EncryptionKeyRotationServer{
 		driverInstance: driverInstance,
 		volLock:        volLock,

--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -40,14 +40,14 @@ type ReclaimSpaceControllerServer struct {
 	*rs.UnimplementedReclaimSpaceControllerServer
 
 	driverInstance string
-	volumeLocks    *util.VolumeLocks
+	volumeLocks    *util.IDLocker
 }
 
 // NewReclaimSpaceControllerServer creates a new ReclaimSpaceControllerServer which handles
 // the ReclaimSpace Service requests from the CSI-Addons specification.
 func NewReclaimSpaceControllerServer(
 	driverInstance string,
-	volumeLocks *util.VolumeLocks,
+	volumeLocks *util.IDLocker,
 ) *ReclaimSpaceControllerServer {
 	return &ReclaimSpaceControllerServer{
 		driverInstance: driverInstance,
@@ -104,12 +104,12 @@ func (rscs *ReclaimSpaceControllerServer) ControllerReclaimSpace(
 // of CSI-addons reclaimspace controller service spec.
 type ReclaimSpaceNodeServer struct {
 	*rs.UnimplementedReclaimSpaceNodeServer
-	volumeLocks *util.VolumeLocks
+	volumeLocks *util.IDLocker
 }
 
 // NewReclaimSpaceNodeServer creates a new IdentityServer which handles the
 // Identity Service requests from the CSI-Addons specification.
-func NewReclaimSpaceNodeServer(volumeLocks *util.VolumeLocks) *ReclaimSpaceNodeServer {
+func NewReclaimSpaceNodeServer(volumeLocks *util.IDLocker) *ReclaimSpaceNodeServer {
 	return &ReclaimSpaceNodeServer{volumeLocks: volumeLocks}
 }
 

--- a/internal/csi-addons/rbd/reclaimspace_test.go
+++ b/internal/csi-addons/rbd/reclaimspace_test.go
@@ -31,7 +31,7 @@ import (
 func TestControllerReclaimSpace(t *testing.T) {
 	t.Parallel()
 
-	controller := NewReclaimSpaceControllerServer("test.driver", util.NewVolumeLocks())
+	controller := NewReclaimSpaceControllerServer("test.driver", util.NewIDLocker())
 
 	req := &rs.ControllerReclaimSpaceRequest{
 		VolumeId: "",
@@ -48,7 +48,7 @@ func TestControllerReclaimSpace(t *testing.T) {
 func TestNodeReclaimSpace(t *testing.T) {
 	t.Parallel()
 
-	node := NewReclaimSpaceNodeServer(&util.VolumeLocks{})
+	node := NewReclaimSpaceNodeServer(&util.IDLocker{})
 
 	req := &rs.NodeReclaimSpaceRequest{
 		VolumeId:         "",

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -48,6 +48,10 @@ type Server struct {
 	// the gateway during ControllerPublishVolume and ControllerUnpublishVolume.
 	hostLocks *util.VolumeLocks
 
+	// subsystemLocks prevents concurrent calls from deleting an "empty but not empty
+	// anymore" subsystem (and listeners).
+	subsystemLocks *util.VolumeLocks
+
 	// backendServer handles the RBD requests
 	backendServer *rbd.ControllerServer
 }
@@ -55,9 +59,10 @@ type Server struct {
 // NewControllerServer initialize a controller server for nvmeof CSI driver.
 func NewControllerServer(d *csicommon.CSIDriver) (*Server, error) {
 	return &Server{
-		volumeLocks:   util.NewVolumeLocks(),
-		hostLocks:     util.NewVolumeLocks(),
-		backendServer: rbddriver.NewControllerServer(d),
+		volumeLocks:    util.NewVolumeLocks(),
+		hostLocks:      util.NewVolumeLocks(),
+		subsystemLocks: util.NewVolumeLocks(),
+		backendServer:  rbddriver.NewControllerServer(d),
 	}, nil
 }
 
@@ -133,7 +138,7 @@ func (cs *Server) CreateVolume(
 	rbdPoolName := res.GetVolume().GetVolumeContext()["pool"]
 
 	// Step 2: Setup NVMe-oF resources
-	nvmeofData, err := createNVMeoFResources(ctx, req, rbdPoolName, rbdImageName)
+	nvmeofData, err := cs.createNVMeoFResources(ctx, req, rbdPoolName, rbdImageName)
 	if err != nil {
 		log.ErrorLog(ctx, "NVMe-oF resource setup failed for volumeID %s: %v", volumeID, err)
 
@@ -145,7 +150,7 @@ func (cs *Server) CreateVolume(
 			return
 		}
 
-		cleanupErr := cleanupNVMeoFResources(ctx, nvmeofData)
+		cleanupErr := cs.cleanupNVMeoFResources(ctx, nvmeofData)
 		if cleanupErr != nil {
 			log.ErrorLog(ctx, "failed to cleanup NVMe-oF resources for volume  %q: %v", volumeID, cleanupErr)
 		}
@@ -188,7 +193,7 @@ func (cs *Server) DeleteVolume(
 		log.DebugLog(ctx, "No NVMe-oF metadata found, skipping NVMe-oF cleanup: %v", err)
 	} else {
 		// Clean up NVMe-oF resources
-		if err := cleanupNVMeoFResources(ctx, nvmeofData); err != nil {
+		if err := cs.cleanupNVMeoFResources(ctx, nvmeofData); err != nil {
 			log.ErrorLog(ctx, "NVMe-oF cleanup failed (continuing with RBD deletion): %v", err)
 
 			return nil, status.Errorf(codes.Internal, "NVMe-oF cleanup failed: %v", err)
@@ -430,7 +435,7 @@ func cleanupEmptySubsystem(
 
 // createNVMeoFResources sets up the NVMe-oF resources for the given RBD volume.
 // TODO - need to support multiple listeners.
-func createNVMeoFResources(
+func (cs *Server) createNVMeoFResources(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
 	rbdPoolName,
@@ -476,6 +481,14 @@ func createNVMeoFResources(
 		}
 	}()
 
+	// TODO: replace util.VolumeOperationAlreadyExistsFmt
+	if acquired := cs.subsystemLocks.TryAcquire(nvmeofData.SubsystemNQN); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+
+		return nil, fmt.Errorf(util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+	}
+	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
+
 	// Step 3: Ensure subsystem exists (and listener)
 	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo); err != nil {
 		return nil, fmt.Errorf("subsystem setup failed: %w", err)
@@ -503,7 +516,7 @@ func createNVMeoFResources(
 
 // cleanupNVMeoFResources cleans up NVMe-oF resources associated with the volume.
 // This includes removing the host, listener, namespace, and potentially the subsystem.
-func cleanupNVMeoFResources(
+func (cs *Server) cleanupNVMeoFResources(
 	ctx context.Context,
 	nvmeofData *nvmeof.NVMeoFVolumeData,
 ) error {
@@ -524,6 +537,14 @@ func cleanupNVMeoFResources(
 	// TODO: maybe just check before if the subsystem exists, if not ,
 	// there is no relevant to continue , will make it simple ?
 	// instead of check in the std error if "not found"..
+
+	// TODO: replace util.VolumeOperationAlreadyExistsFmt
+	if acquired := cs.subsystemLocks.TryAcquire(nvmeofData.SubsystemNQN); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+
+		return fmt.Errorf(util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+	}
+	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
 
 	// Step 2: Delete namespace
 	if err := gateway.DeleteNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID); err != nil {

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -44,6 +44,10 @@ type Server struct {
 	// for that same volume (as defined by VolumeID/volume name) return an Aborted error
 	volumeLocks *util.VolumeLocks
 
+	// hostLocks protects against concurrently adding hosts to, and removing hosts from
+	// the gateway during ControllerPublishVolume and ControllerUnpublishVolume.
+	hostLocks *util.VolumeLocks
+
 	// backendServer handles the RBD requests
 	backendServer *rbd.ControllerServer
 }
@@ -52,6 +56,7 @@ type Server struct {
 func NewControllerServer(d *csicommon.CSIDriver) (*Server, error) {
 	return &Server{
 		volumeLocks:   util.NewVolumeLocks(),
+		hostLocks:     util.NewVolumeLocks(),
 		backendServer: rbddriver.NewControllerServer(d),
 	}, nil
 }
@@ -210,6 +215,12 @@ func (cs *Server) ControllerPublishVolume(
 	}
 	defer cs.volumeLocks.Release(volumeID)
 
+	nodeID := req.GetNodeId()
+	if acquired := cs.hostLocks.TryAcquire(nodeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer cs.hostLocks.Release(nodeID)
+
 	// Publish NVMe-oF resources
 	hostNqn, err := publishResources(ctx, req)
 	if err != nil {
@@ -234,11 +245,16 @@ func (cs *Server) ControllerUnpublishVolume(
 	}
 
 	volumeID := req.GetVolumeId()
-	nodeID := req.GetNodeId()
 	if acquired := cs.volumeLocks.TryAcquire(volumeID); !acquired {
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer cs.volumeLocks.Release(volumeID)
+
+	nodeID := req.GetNodeId()
+	if acquired := cs.hostLocks.TryAcquire(nodeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer cs.hostLocks.Release(nodeID)
 
 	// Since ControllerUnpublishVolume doesn't receive volume context,
 	// we need to retrieve it from the volume metadata stored during CreateVolume

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -42,15 +42,15 @@ type Server struct {
 
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID/volume name) return an Aborted error
-	volumeLocks *util.VolumeLocks
+	volumeLocks *util.IDLocker
 
 	// hostLocks protects against concurrently adding hosts to, and removing hosts from
 	// the gateway during ControllerPublishVolume and ControllerUnpublishVolume.
-	hostLocks *util.VolumeLocks
+	hostLocks *util.IDLocker
 
 	// subsystemLocks prevents concurrent calls from deleting an "empty but not empty
 	// anymore" subsystem (and listeners).
-	subsystemLocks *util.VolumeLocks
+	subsystemLocks *util.IDLocker
 
 	// backendServer handles the RBD requests
 	backendServer *rbd.ControllerServer
@@ -59,9 +59,9 @@ type Server struct {
 // NewControllerServer initialize a controller server for nvmeof CSI driver.
 func NewControllerServer(d *csicommon.CSIDriver) (*Server, error) {
 	return &Server{
-		volumeLocks:    util.NewVolumeLocks(),
-		hostLocks:      util.NewVolumeLocks(),
-		subsystemLocks: util.NewVolumeLocks(),
+		volumeLocks:    util.NewIDLocker(),
+		hostLocks:      util.NewIDLocker(),
+		subsystemLocks: util.NewIDLocker(),
 		backendServer:  rbddriver.NewControllerServer(d),
 	}, nil
 }

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -46,18 +46,18 @@ type ControllerServer struct {
 	*csicommon.DefaultControllerServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID/volume name) return an Aborted error
-	VolumeLocks *util.VolumeLocks
+	VolumeLocks *util.IDLocker
 
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same snapshot (as defined by SnapshotID/snapshot name) return an Aborted error
-	SnapshotLocks *util.VolumeLocks
+	SnapshotLocks *util.IDLocker
 
 	// A map storing all volumes/snapshots with ongoing operations.
 	OperationLocks *util.OperationLock
 
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by volumegroup ID/volumegroup name) return an Aborted error
-	VolumeGroupLocks *util.VolumeLocks
+	VolumeGroupLocks *util.IDLocker
 
 	// Cluster name
 	ClusterName string

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -60,9 +60,9 @@ func NewIdentityServer(d *csicommon.CSIDriver) *rbd.IdentityServer {
 func NewControllerServer(d *csicommon.CSIDriver) *rbd.ControllerServer {
 	return &rbd.ControllerServer{
 		DefaultControllerServer: csicommon.NewDefaultControllerServer(d),
-		VolumeLocks:             util.NewVolumeLocks(),
-		SnapshotLocks:           util.NewVolumeLocks(),
-		VolumeGroupLocks:        util.NewVolumeLocks(),
+		VolumeLocks:             util.NewIDLocker(),
+		SnapshotLocks:           util.NewIDLocker(),
+		VolumeGroupLocks:        util.NewIDLocker(),
 		OperationLocks:          util.NewOperationLock(),
 	}
 }
@@ -76,7 +76,7 @@ func NewNodeServer(
 	cliReadAffinityMapOptions := util.ConstructReadAffinityMapOption(crushLocationMap)
 	ns := rbd.NodeServer{
 		DefaultNodeServer: csicommon.NewDefaultNodeServer(d, t, cliReadAffinityMapOptions, topology, nodeLabels),
-		VolumeLocks:       util.NewVolumeLocks(),
+		VolumeLocks:       util.NewIDLocker(),
 	}
 
 	return &ns

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -49,7 +49,7 @@ type NodeServer struct {
 	*csicommon.DefaultNodeServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID) return an Aborted error
-	VolumeLocks *util.VolumeLocks
+	VolumeLocks *util.IDLocker
 
 	// ext4HasPrezeroedSupport indicates whether the ext4 filesystem has support for pre-zeroed blocks.
 	ext4HasPrezeroedSupport featureFlag

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -31,6 +31,10 @@ const (
 
 	// TargetPathOperationAlreadyExistsFmt string format to return for concurrent operation on target path.
 	TargetPathOperationAlreadyExistsFmt = "an operation with the given target path %s already exists"
+
+	// HostOperationAlreadyExistsFmt is used for reporting an in-progress operaton that modifies the
+	// NVMe-oF gateway configuration for a prticular host.
+	HostOperationAlreadyExistsFmt = "an operation that modifies the gateway for Host ID %s already exists"
 )
 
 // VolumeLocks implements a map with atomic operations. It stores a set of all volume IDs

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -32,43 +32,43 @@ const (
 	// TargetPathOperationAlreadyExistsFmt string format to return for concurrent operation on target path.
 	TargetPathOperationAlreadyExistsFmt = "an operation with the given target path %s already exists"
 
-	// HostOperationAlreadyExistsFmt is used for reporting an in-progress operaton that modifies the
+	// HostOperationAlreadyExistsFmt is used for reporting an in-progress operation that modifies the
 	// NVMe-oF gateway configuration for a prticular host.
 	HostOperationAlreadyExistsFmt = "an operation that modifies the gateway for Host ID %s already exists"
 )
 
-// VolumeLocks implements a map with atomic operations. It stores a set of all volume IDs
-// with an ongoing operation.
-type VolumeLocks struct {
+// IDLocker implements a map with atomic operations. It stores an ID/key in a set while the lock is held
+// during an operation that needs exclusive access to resources.
+type IDLocker struct {
 	locks sets.Set[string]
 	mux   sync.Mutex
 }
 
-// NewVolumeLocks returns new VolumeLocks.
-func NewVolumeLocks() *VolumeLocks {
-	return &VolumeLocks{
+// NewIDLocker creates a new IDLocker.
+func NewIDLocker() *IDLocker {
+	return &IDLocker{
 		locks: sets.New[string](),
 	}
 }
 
-// TryAcquire tries to acquire the lock for operating on volumeID and returns true if successful.
-// If another operation is already using volumeID, returns false.
-func (vl *VolumeLocks) TryAcquire(volumeID string) bool {
+// TryAcquire tries to acquire the lock on the ID and returns true if successful.
+// If another operation is already using the ID, returns false.
+func (vl *IDLocker) TryAcquire(id string) bool {
 	vl.mux.Lock()
 	defer vl.mux.Unlock()
-	if vl.locks.Has(volumeID) {
+	if vl.locks.Has(id) {
 		return false
 	}
-	vl.locks.Insert(volumeID)
+	vl.locks.Insert(id)
 
 	return true
 }
 
-// Release deletes the lock on volumeID.
-func (vl *VolumeLocks) Release(volumeID string) {
+// Release deletes the lock on an ID.
+func (vl *IDLocker) Release(id string) {
 	vl.mux.Lock()
 	defer vl.mux.Unlock()
-	vl.locks.Delete(volumeID)
+	vl.locks.Delete(id)
 }
 
 type operation string

--- a/internal/util/idlocker_test.go
+++ b/internal/util/idlocker_test.go
@@ -24,7 +24,7 @@ import (
 func TestIDLocker(t *testing.T) {
 	t.Parallel()
 	fakeID := "fake-id"
-	locks := NewVolumeLocks()
+	locks := NewIDLocker()
 	// acquire lock for fake-id
 	ok := locks.TryAcquire(fakeID)
 


### PR DESCRIPTION
When a host is added to or removed from the gateway, a lock protects
concurrent adding/removing of the same host in ControllerPublishVolume
or ControllerUnpublishVolume.

In case a 2nd gRPC operation is blocked due to the locking, an error is
returned to the caller. The caller will have to retry the operation at a
later time (usually Kubernetes retries with a very short delay).

Modifications to a subsystem in the gateway are now done under a lock,
so that only a single CreateVolume or DeleteVolume changes the
configuration at a time. This prevents conflicts where a DeleteVolume
removes listeners or even the subsystem from the gateway, when a
CreateVolume assumed everything was in place, so skipped the creation of
the subsystem and adding of listeners.

The VolumeLock structs and NewVoluemLocks() function provide a locking
API that isn't restricted to volumes only. The implementation is very
generic, and can be used by other parts of the code that need to lock
operations based on others resources.

By renaming VolumeLocks to IDLocker (it is already in the idlocker.go
file), the genericness of the locking API is expressed better.

Users of the API are recommended to call their IDLocker object with an
understandable name. VolumeLocks for locking resources related to
volumes, HostLocks for locking resources related to hosts, and so on.

Updates: #5370