### PR TITLE
nvmeof: controller publish volume fix hostnqn pattern 

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -530,7 +529,7 @@ func publishResources(ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest,
 ) (string, error) {
 	nodeID := req.GetNodeId()
-	hostNQN, err := extractHostNQNFromNodeID(nodeID)
+	hostNQN, err := getHostNQNFromNodeID(nodeID)
 	if err != nil {
 		return "", status.Errorf(codes.InvalidArgument, "invalid nodeID format: %v", err)
 	}
@@ -573,7 +572,7 @@ func publishResources(ctx context.Context,
 // unpublishResources removes the host from the NVMe-oF subsystem.
 func unpublishResources(ctx context.Context, data *nvmeof.NVMeoFVolumeData, nodeID string) error {
 	// Extract host NQN from nodeID
-	hostNQN, err := extractHostNQNFromNodeID(nodeID)
+	hostNQN, err := getHostNQNFromNodeID(nodeID)
 	if err != nil {
 		return fmt.Errorf("invalid nodeID format: %w", err)
 	}
@@ -620,16 +619,18 @@ func unpublishResources(ctx context.Context, data *nvmeof.NVMeoFVolumeData, node
 	return nil
 }
 
-// extractHostNQNFromNodeID extracts the host NQN from the node ID.
-func extractHostNQNFromNodeID(nodeID string) (string, error) {
-	// the nodeID has the pattern: <hostname>::<nqn>
-	// TODO: maybe change this separator to rare one.
-	parts := strings.Split(nodeID, "::")
-	if len(parts) != 2 {
+// getHostNQNFromNodeID constructs the host NQN from the nodeID. just concatenate the prefix
+// with the nodeID. the hostnqn format is nqn.<YOUR-DATE>.<YOUR-REVERSE-DOMAIN>:<user-part>,
+// we use the default prefix (nqn.2014-08.org.nvmexpress:)
+// and append the nodeID as user-part. Also there is no need to add an UUID as user-part,
+// as the nodeID is already unique.
+func getHostNQNFromNodeID(nodeID string) (string, error) {
+	const prefix = "nqn.2014-08.org.nvmexpress:"
+	if nodeID == "" {
 		return "", fmt.Errorf("invalid nodeID format: %s", nodeID)
 	}
 
-	return parts[1], nil
+	return prefix + nodeID, nil
 }
 
 // VolumeContext metadata keys.

--- a/internal/nvmeof/controller/controllerserver_test.go
+++ b/internal/nvmeof/controller/controllerserver_test.go
@@ -27,31 +27,30 @@ import (
 	"github.com/ceph/ceph-csi/internal/nvmeof"
 )
 
-func TestExtractHostNQNFromNodeID(t *testing.T) {
+func TestGetHostNQNFromNodeID(t *testing.T) {
 	t.Parallel()
 
-	//nolint:lll // these tests just contain long strings
 	tests := []struct {
 		nodeID     string
 		hostNQN    string
 		shouldFail bool
 	}{
 		{
-			nodeID:  "ip-10-0-79-198.us-east-2.compute.internal::nqn.2025-08.io.ceph:ip-10-0-79-198.us-east-2.compute.internal",
-			hostNQN: "nqn.2025-08.io.ceph:ip-10-0-79-198.us-east-2.compute.internal",
+			nodeID:  "ip-10-0-79-198.us-east-2.compute.internal",
+			hostNQN: "nqn.2014-08.org.nvmexpress:ip-10-0-79-198.us-east-2.compute.internal",
 		},
 		{
-			nodeID:  "ip-10-0-79-198.us-east-2.compute.internal::nqn.2014-08.org.nvmexpress:uuid:8d018d47-1a5b-40cc-b26c-4ec9351d6723",
-			hostNQN: "nqn.2014-08.org.nvmexpress:uuid:8d018d47-1a5b-40cc-b26c-4ec9351d6723",
+			nodeID:  "ip-10-0-79-198.us-east-2.compute.internal",
+			hostNQN: "nqn.2014-08.org.nvmexpress:ip-10-0-79-198.us-east-2.compute.internal",
 		},
 		{
-			nodeID:     "ip-10-0-79-198.us-east-2.compute.internal",
+			nodeID:     "",
 			shouldFail: true,
 		},
 	}
 
 	for _, test := range tests {
-		hostNQN, err := extractHostNQNFromNodeID(test.nodeID)
+		hostNQN, err := getHostNQNFromNodeID(test.nodeID)
 		if test.shouldFail {
 			require.Error(t, err)
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

the overriding of node_id() function in the nodeserver is no longer exists. node_id() return the default value.
We use this value as hostnqn. the valid pattern of hostnqn is:
`nqn.<YOUR-DATE>.<YOUR-REVERSE-DOMAIN>:<user-part>`

We use the default value for date and domain (like the value in the default /etc/nvme/hostnqn file): 
`nqn.2014-08.org.nvmexpress`
So, the constructing of the host NQN is from the nodeID and concatenating the prefix.


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
