### PR TITLE
e2e: add NVMe-oF gateway deployment

### DIFF
--- a/e2e/deployment.go
+++ b/e2e/deployment.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -203,10 +204,13 @@ type yamlResource struct {
 
 	// allowMissing prevents a failure in case the file is missing.
 	allowMissing bool
+
+	// generic replacing of key with value
+	replace map[string]string
 }
 
 func (yr *yamlResource) Do(action kubectlAction) error {
-	data, err := os.ReadFile(yr.filename)
+	rawData, err := os.ReadFile(yr.filename)
 	if err != nil {
 		if os.IsNotExist(err) && yr.allowMissing {
 			return nil
@@ -215,12 +219,17 @@ func (yr *yamlResource) Do(action kubectlAction) error {
 		return fmt.Errorf("failed to read content from %q: %w", yr.filename, err)
 	}
 
+	data := string(rawData)
+	for key, value := range yr.replace {
+		data = strings.ReplaceAll(data, key, value)
+	}
+
 	ns := cephCSINamespace
 	if yr.namespace != "" {
 		ns = yr.namespace
 	}
 
-	err = retryKubectlInput(ns, action, string(data), deployTimeout)
+	err = retryKubectlInput(ns, action, data, deployTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to %s resource %q: %w", action, yr.filename, err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -37,12 +37,14 @@ func init() {
 	flag.BoolVar(&deployCephFS, "deploy-cephfs", true, "deploy cephFS csi driver")
 	flag.BoolVar(&deployRBD, "deploy-rbd", true, "deploy rbd csi driver")
 	flag.BoolVar(&deployNFS, "deploy-nfs", false, "deploy nfs csi driver")
+	flag.BoolVar(&deployNVMeoF, "deploy-nvmeof", false, "deploy nvmeof csi driver")
 	flag.BoolVar(&testCephFS, "test-cephfs", true, "test cephFS csi driver")
 	flag.BoolVar(&testCephFSFscrypt, "test-cephfs-fscrypt", false, "test CephFS csi driver fscrypt support")
 	flag.BoolVar(&testRBD, "test-rbd", true, "test rbd csi driver")
 	flag.BoolVar(&testRBDFSCrypt, "test-rbd-fscrypt", false, "test rbd csi driver fscrypt support")
 	flag.BoolVar(&testNBD, "test-nbd", false, "test rbd csi driver with rbd-nbd mounter")
 	flag.BoolVar(&testNFS, "test-nfs", false, "test nfs csi driver")
+	flag.BoolVar(&testNVMeoF, "test-nvmeof", false, "test nvmeof csi driver")
 	flag.BoolVar(&helmTest, "helm-test", false, "tests running on deployment via helm")
 	flag.BoolVar(&upgradeTesting, "upgrade-testing", false, "perform upgrade testing")
 	flag.StringVar(&upgradeVersion, "upgrade-version", "v3.5.1", "target version for upgrade testing")
@@ -91,6 +93,10 @@ func handleFlags() {
 	if testCephFS {
 		testNFS = testCephFS
 		deployNFS = deployCephFS
+	}
+
+	if testNVMeoF {
+		deployNVMeoF = true
 	}
 
 	if operatorDeployment {

--- a/e2e/nvmeof-gateway.go
+++ b/e2e/nvmeof-gateway.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	e2eGatewayPath = "nvmeof/"
+
+	e2eGatewaySecurityContext = e2eGatewayPath + "scc.yaml"
+	e2eGatewayServiceAccount  = e2eGatewayPath + "serviceaccount.yaml"
+	e2eGatewayConfig          = e2eGatewayPath + "config.yaml"
+	e2eGatewayDeployment      = e2eGatewayPath + "deployment.yaml"
+)
+
+func createORDeleteGateway(action kubectlAction) {
+	var resources []ResourceDeployer
+
+	if isOpenShift {
+		resources = append(resources, &yamlResource{
+			filename: e2eGatewaySecurityContext,
+			// The SCC contains the namespace:serviceaccount string. Everything should
+			// be deployed in the "rook-ceph" namespace.
+			replace: map[string]string{
+				// replace the namespace for the service account
+				":rook-ceph:": ":" + rookNamespace + ":",
+			},
+		})
+	}
+
+	resources = append(resources,
+		&yamlResourceNamespaced{
+			filename:  e2eGatewayServiceAccount,
+			namespace: rookNamespace,
+		},
+		&yamlResourceNamespaced{
+			filename:  e2eGatewayConfig,
+			namespace: rookNamespace,
+		},
+		&yamlResourceNamespaced{
+			filename:   e2eGatewayDeployment,
+			namespace:  rookNamespace,
+			oneReplica: true,
+		},
+	)
+
+	for _, r := range resources {
+		err := r.Do(action)
+		Expect(err).ShouldNot(HaveOccurred())
+	}
+}
+
+func deployGateway(f *framework.Framework, deployTimeout int) {
+	// a gateway gets deployed with a pool, the pool needs to exist
+	framework.Logf("going to create pool %q with help from the Rook Toolbox", nvmeofPool)
+	err := createPool(f, nvmeofPool)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	createORDeleteGateway(kubectlCreate)
+
+	err = waitForDeploymentInAvailableState(f.ClientSet, "ceph-nvmeof-gateway", rookNamespace, deployTimeout)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	opt := &metav1.ListOptions{
+		LabelSelector: "app=ceph-nvmeof-gateway",
+	}
+
+	pod, _, err := findPodAndContainerName(f, rookNamespace, "", opt)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	err = waitForPodInRunningState(pod, rookNamespace, f.ClientSet, deployTimeout, noError)
+	Expect(err).ShouldNot(HaveOccurred())
+}
+
+func deleteGateway(f *framework.Framework) {
+	createORDeleteGateway(kubectlDelete)
+
+	err := deletePool(nvmeofPool, false, f)
+	Expect(err).ShouldNot(HaveOccurred())
+}

--- a/e2e/nvmeof.go
+++ b/e2e/nvmeof.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/pod-security-admission/api"
+)
+
+const (
+	nvmeofPool = "nvmeofpool"
+)
+
+var _ = Describe("nvmeof", func() {
+	f := framework.NewDefaultFramework("nvmeof")
+	f.NamespacePodSecurityEnforceLevel = api.LevelPrivileged
+
+	BeforeEach(func() {
+		if !testNVMeoF {
+			Skip("Skipping NVMe-oF E2E")
+		}
+
+		if deployNVMeoF {
+			deployGateway(f, deployTimeout)
+		}
+	})
+
+	AfterEach(func() {
+		if !testNVMeoF {
+			Skip("Skipping NVMe E2E")
+		}
+
+		if deployNVMeoF {
+			deleteGateway(f)
+		}
+	})
+
+	Context("Test NVMe CSI", func() {
+		if !testNVMeoF {
+			return
+		}
+
+		It("Test NVMe-oF CSI", func() {
+			Skip("no NVMe-oF test cases yet")
+		})
+	})
+})

--- a/e2e/nvmeof/config.yaml
+++ b/e2e/nvmeof/config.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: ceph-nvmeof-gateway
+  name: ceph-nvmeof-config
+data:
+  config: |-
+    # heavily based on tests/ceph-nvmeof.no-huge.conf
+    # Changes are annotated with "TODO:".
+    #
+    #  Copyright (c) 2021 International Business Machines
+    #  All rights reserved.
+    #
+    #  SPDX-License-Identifier: LGPL-3.0-or-later
+    #
+    #  Authors: anita.shekar@ibm.com, sandy.kaur@ibm.com
+    #
+
+    [gateway]
+    # TODO: name, group and addr could be more dynamic
+    name = @@POD_NAME@@
+    #name = ceph-nvmeof-gateway.rook-ceph.svc.cluster.local
+    group = @@ANA_GROUP@@
+    addr = @@POD_IP@@
+    #addr = 0.0.0.0
+    port = 5500
+    enable_auth = False
+    state_update_notify = True
+    state_update_timeout_in_msec = 2000
+    state_update_interval_sec = 5
+    enable_spdk_discovery_controller = False
+    encryption_key = /etc/ceph/encryption.key
+    rebalance_period_sec = 7
+    max_gws_in_grp = 16
+    max_ns_to_change_lb_grp = 8
+    #omap_file_lock_duration = 20
+    #omap_file_lock_retries = 30
+    #omap_file_lock_retry_sleep_interval = 1.0
+    #omap_file_update_reloads = 10
+    #enable_prometheus_exporter = True
+    #prometheus_exporter_ssl = True
+    #prometheus_port = 10008
+    #prometheus_bdev_pools = rbd
+    #prometheus_stats_interval = 10
+    #verify_nqns = True
+    #verify_keys = True
+    #verify_listener_ip = True
+    # TODO: does this make it work with a Kubernetes Service?
+    verify_listener_ip = False
+    #allowed_consecutive_spdk_ping_failures = 1
+    #spdk_ping_interval_in_seconds = 2.0
+    #max_hosts_per_namespace = 8
+    #max_namespaces_with_netmask = 1000
+    #max_subsystems = 128
+    #max_hosts = 2048
+    #max_namespaces = 2048
+    #max_namespaces_per_subsystem = 256
+    #max_hosts_per_subsystem = 128
+
+    [gateway-logs]
+    log_level=debug
+    #log_files_enabled = True
+    #log_files_rotation_enabled = True
+    #verbose_log_messages = True
+    #max_log_file_size_in_mb=10
+    #max_log_files_count=20
+    #max_log_directory_backups=10
+    #
+    # Notice that if you change the log directory the log files will only be
+    # visible inside the container
+    #
+    #log_directory = /var/log/ceph/
+
+    [discovery]
+    #addr = @@POD_IP@@
+    addr = 0.0.0.0
+    port = 8009
+
+    [ceph]
+    # TODO: create a dedicated user, make pool dynamic/replaceable.
+    id = admin
+    pool = nvmeofpool
+    config_file = /etc/ceph/ceph.conf
+
+    [mtls]
+    server_key = ./server.key
+    client_key = ./client.key
+    server_cert = ./server.crt
+    client_cert = ./client.crt
+
+    [spdk]
+    bdevs_per_cluster = 32
+    mem_size=4096
+    tgt_path = /usr/local/bin/nvmf_tgt
+    #rpc_socket_dir = /var/tmp/
+    #rpc_socket_name = spdk.sock
+    #tgt_cmd_extra_args = --env-context="--no-huge -m1024" --iova-mode=va
+    timeout = 60.0
+    #log_level =
+    #protocol_log_level = WARNING
+    #log_file_dir =
+
+    # Example value: -m 0x3 -L all
+    # tgt_cmd_extra_args =
+
+    # transports = tcp
+
+    # Example value: {"small_pool_count" : 8192, "large_pool_count" : 1024,
+    # "small_bufsize" : 8192, "large_bufsize" : 135168}
+    # iobuf_options =
+
+    # qos_timeslice_in_usecs = 0
+
+    [monitor]
+    #timeout = 1.0
+    #log_file_dir =

--- a/e2e/nvmeof/deployment.yaml
+++ b/e2e/nvmeof/deployment.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ceph-nvmeof-gateway
+  name: ceph-nvmeof-gateway
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ceph-nvmeof-gateway
+  template:
+    metadata:
+      labels:
+        app: ceph-nvmeof-gateway
+      name: ceph-nvmeof-gateway
+    spec:
+      containers:
+        - args:
+            - -c
+            - /etc/ceph/nvmeof.conf
+          env:
+            - name: CEPH_MON_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: mon_host
+                  name: rook-ceph-config
+            - name: CEPH_ARGS
+              value: --mon-host $(CEPH_MON_HOST) --keyring /etc/ceph/keyring
+          image: quay.io/ceph/nvmeof:1.5
+          imagePullPolicy: IfNotPresent
+          name: nvmeof-gateway
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - ALL
+          ports:
+            - containerPort: 4420
+              name: io
+              protocol: TCP
+            - containerPort: 5500
+              name: gateway
+              protocol: TCP
+            - containerPort: 5499
+              name: monitor
+              protocol: TCP
+            - containerPort: 8009
+              name: discovery
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: etc-ceph
+      initContainers:
+        - command:
+            - /bin/bash
+            - -c
+            - |2
+
+              set -xEeuo pipefail
+
+              cat << EOF > /etc/ceph/ceph.conf
+              [global]
+              mon_host = $(CEPH_MON_HOST)
+              #debug_rados = 20/5
+              log_to_stderr = true
+
+              keyring = /etc/ceph/keyring
+              EOF
+
+              cp /tmp/ceph/keyring /etc/ceph
+
+              chmod 444 /etc/ceph/ceph.conf
+              chmod 440 /etc/ceph/keyring
+
+              cat /etc/ceph/ceph.conf
+
+              # funky "sed -e .. -e" to prevent long line
+              sed -e "s/@@POD_NAME@@/${POD_NAME}/g" \
+                  -e "s/@@ANA_GROUP@@/${ANA_GROUP}/g" \
+                  -e "s/@@POD_IP@@/${POD_IP}/g" \
+                  < /config/ceph-nvmeof.conf > /etc/ceph/nvmeof.conf
+
+              # add the gateway to the Ceph configuration
+              ceph nvme-gw create ${POD_NAME} nvmeofpool ${ANA_GROUP}
+              ceph nvme-gw show nvmeofpool ${ANA_GROUP}
+          env:
+            - name: CEPH_MON_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: mon_host
+                  name: rook-ceph-config
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ANA_GROUP
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: quay.io/ceph/ceph:v19
+          imagePullPolicy: IfNotPresent
+          name: generate-minimal-ceph-conf
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+          volumeMounts:
+            - mountPath: /tmp/ceph/
+              name: ceph-admin-keyring
+              readOnly: true
+            - mountPath: /config
+              name: gateway-config
+              readOnly: true
+            - mountPath: /etc/ceph
+              name: etc-ceph
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      serviceAccount: ceph-nvmeof-gateway
+      serviceAccountName: ceph-nvmeof-gateway
+      volumes:
+        - name: ceph-admin-keyring
+          secret:
+            items:
+              - key: keyring
+                path: keyring
+                mode: 292
+            secretName: rook-ceph-admin-keyring
+        - name: etc-ceph
+          emptyDir: {}
+        - name: gateway-config
+          projected:
+            defaultMode: 420
+            sources:
+              - configMap:
+                  items:
+                    - key: config
+                      mode: 292
+                      path: ceph-nvmeof.conf
+                  name: ceph-nvmeof-config

--- a/e2e/nvmeof/scc.yaml
+++ b/e2e/nvmeof/scc.yaml
@@ -1,0 +1,39 @@
+---
+# ssc based on the Ceph-CSI ssc
+# the "users:" contains a reference to the "default" namespace
+#
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: "ceph-nvmeof"
+# To allow running privilegedContainers
+allowPrivilegedContainer: true
+# CSI daemonset pod needs hostnetworking
+allowHostNetwork: true
+priority:
+# SYS_ADMIN is needed for rbd to execute rbd map command
+allowedCapabilities:
+  - "SYS_ADMIN"
+# Needed as we run liveness container on daemonset pods
+allowHostPorts: true
+# Set to false as we write to RootFilesystem inside container
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+# The type of volumes which are mounted to csi pods
+volumes:
+  - configMap
+  - projected
+  - emptyDir
+  - secret
+users:
+  # A user needs to be added for each service account.
+  - "system:serviceaccount:rook-ceph:ceph-nvmeof-gateway"

--- a/e2e/nvmeof/serviceaccount.yaml
+++ b/e2e/nvmeof/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ceph-nvmeof-gateway

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -82,12 +82,14 @@ var (
 	deployCephFS       bool
 	deployRBD          bool
 	deployNFS          bool
+	deployNVMeoF       bool
 	testCephFS         bool
 	testCephFSFscrypt  bool
 	testRBD            bool
 	testRBDFSCrypt     bool
 	testNBD            bool
 	testNFS            bool
+	testNVMeoF         bool
 	helmTest           bool
 	upgradeTesting     bool
 	upgradeVersion     string


### PR DESCRIPTION

Rook is not yet able to deploy the NVMe-oF gateway, so it needs to be
done manually.

When the gateway starts, it uses a pool for fetching/storing some
metadata. If the pool does not exist, the gateway fails to start.
Before the gateway is deployed the `nvmeofpool` is created (and deleted
after testing).

The deployment is currently disabled by default, as the NVMe-oF components
withing Ceph-CSI are not completely merged yet. When the NVMe-oF components are
hooked into the main executable, the tests should get enabled by default too.

This has been manually tested by building the `e2e.test` executable and running
it against a cluster that has a full Rook deployment (with Toolbox pod)
available:

```
$ make containerized-build TARGET=e2e.test
$ cd e2e
$ export KUBECONFIG=/path/to/kubeconfig
$ ../e2e.test -test-cephfs=false -test-nfs=false -test-rbd=false -test-nbd=false -test-nvmeof=true -rook-namespace=openshift-storage -ginkgo.v=true
  I1001 18:16:01.678209 117358 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
timeout for deploytimeout  10
Running Suite: E2e Suite - /home/ndevos/go/src/github.com/ceph/ceph-csi/e2e
===========================================================================
Random Seed: 1759335361

Will run 1 of 1 specs
------------------------------
nvmeof Test NVMe CSI Test NVMe-oF CSI
/go/src/github.com/ceph/ceph-csi/e2e/nvmeof.go:58
  STEP: Creating a kubernetes client @ 10/01/25 18:16:01.678
  I1001 18:16:01.678563 117358 util.go:453] >>> kubeConfig: /tmp/kubeconfig
  STEP: Building a namespace api object, basename nvmeof @ 10/01/25 18:16:01.679
  STEP: Waiting for a default service account to be provisioned in namespace @ 10/01/25 18:16:02.734
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 10/01/25 18:16:03.141
  I1001 18:16:03.390536 117358 nvmeof-gateway.go:67] going to create pool "nvmeofpool" with help from the Rook Toolbox
  I1001 18:16:03.549601 117358 exec_util.go:63] ExecWithOptions {Command:[/bin/sh -c ceph osd pool create nvmeofpool 128 --yes-i-really-mean-it] Namespace:openshift-storage PodName:rook-ceph-tools-54f58d7d49-zj7xs ContainerName:rook-ceph-tools Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:true Quiet:false}
  I1001 18:16:03.549677 117358 exec_util.go:68] ExecWithOptions: Clientset creation
  I1001 18:16:03.549774 117358 exec_util.go:84] ExecWithOptions: execute(https://api.ndevos-nvmegw.ocs.syseng.devcluster.openshift.com:6443/api/v1/namespaces/openshift-storage/pods/rook-ceph-tools-54f58d7d49-zj7xs/exec?command=%2Fbin%2Fsh&command=-c&command=ceph+osd+pool+create+nvmeofpool+128+--yes-i-really-mean-it&container=rook-ceph-tools&stderr=true&stdout=true)
  I1001 18:16:03.991262 117358 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I1001 18:16:06.196767 117358 pod.go:314] stdErr occurred: pool 'nvmeofpool' created

  I1001 18:16:06.325343 117358 exec_util.go:63] ExecWithOptions {Command:[/bin/sh -c ceph osd pool set nvmeofpool size 1 --yes-i-really-mean-it] Namespace:openshift-storage PodName:rook-ceph-tools-54f58d7d49-zj7xs ContainerName:rook-ceph-tools Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:true Quiet:false}
  I1001 18:16:06.325411 117358 exec_util.go:68] ExecWithOptions: Clientset creation
  I1001 18:16:06.325494 117358 exec_util.go:84] ExecWithOptions: execute(https://api.ndevos-nvmegw.ocs.syseng.devcluster.openshift.com:6443/api/v1/namespaces/openshift-storage/pods/rook-ceph-tools-54f58d7d49-zj7xs/exec?command=%2Fbin%2Fsh&command=-c&command=ceph+osd+pool+set+nvmeofpool+size+1+--yes-i-really-mean-it&container=rook-ceph-tools&stderr=true&stdout=true)
  I1001 18:16:06.734534 117358 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I1001 18:16:09.152377 117358 pod.go:314] stdErr occurred: set pool 21 size to 1

  I1001 18:16:09.152598 117358 utils.go:1748] waiting for kubectl (create -f args []) to finish
  I1001 18:16:09.152989 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=default create -f -'
  I1001 18:16:10.069965 117358 builder.go:146] stderr: ""
  I1001 18:16:10.070000 117358 builder.go:147] stdout: "securitycontextconstraints.security.openshift.io/ceph-nvmeof created\n"
  I1001 18:16:10.070070 117358 utils.go:1748] waiting for kubectl (create -f args []) to finish
  I1001 18:16:10.070097 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=openshift-storage create -f -'
  I1001 18:16:10.946602 117358 builder.go:146] stderr: ""
  I1001 18:16:10.946687 117358 builder.go:147] stdout: "serviceaccount/ceph-nvmeof-gateway created\n"
  I1001 18:16:10.946864 117358 utils.go:1748] waiting for kubectl (create -f args []) to finish
  I1001 18:16:10.946944 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=openshift-storage create -f -'
  I1001 18:16:11.828342 117358 builder.go:146] stderr: ""
  I1001 18:16:11.828419 117358 builder.go:147] stdout: "configmap/ceph-nvmeof-config created\n"
  I1001 18:16:11.829009 117358 utils.go:1748] waiting for kubectl (create -f args []) to finish
  I1001 18:16:11.829086 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=openshift-storage create -f -'
  I1001 18:16:12.583652 117358 builder.go:146] stderr: ""
  I1001 18:16:12.583731 117358 builder.go:147] stdout: "deployment.apps/ceph-nvmeof-gateway created\n"
  I1001 18:16:12.583767 117358 deployment.go:121] Waiting up to "ceph-nvmeof-gateway" to be in Available state
  I1001 18:16:12.946078 117358 pod.go:367] Waiting up to ceph-nvmeof-gateway-5db655d6d9-ch9p7 to be in Running state
  [SKIPPED] in [It] - /go/src/github.com/ceph/ceph-csi/e2e/nvmeof.go:59 @ 10/01/25 18:16:17.125
  I1001 18:16:17.125496 117358 utils.go:1748] waiting for kubectl (delete -f args []) to finish
  I1001 18:16:17.125619 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=default delete -f -'
  I1001 18:16:17.948906 117358 builder.go:146] stderr: "Warning: deleting cluster-scoped resources, not scoped to the provided namespace\n"
  I1001 18:16:17.948976 117358 builder.go:147] stdout: "securitycontextconstraints.security.openshift.io \"ceph-nvmeof\" deleted\n"
  I1001 18:16:17.949100 117358 utils.go:1748] waiting for kubectl (delete -f args []) to finish
  I1001 18:16:17.949162 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=openshift-storage delete -f -'
  I1001 18:16:18.819026 117358 builder.go:146] stderr: ""
  I1001 18:16:18.819126 117358 builder.go:147] stdout: "serviceaccount \"ceph-nvmeof-gateway\" deleted\n"
  I1001 18:16:18.819268 117358 utils.go:1748] waiting for kubectl (delete -f args []) to finish
  I1001 18:16:18.819346 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=openshift-storage delete -f -'
  I1001 18:16:19.509418 117358 builder.go:146] stderr: ""
  I1001 18:16:19.509497 117358 builder.go:147] stdout: "configmap \"ceph-nvmeof-config\" deleted\n"
  I1001 18:16:19.510393 117358 utils.go:1748] waiting for kubectl (delete -f args []) to finish
  I1001 18:16:19.510500 117358 builder.go:121] Running '/home/ndevos/bin/kubectl --kubeconfig=/tmp/kubeconfig --namespace=openshift-storage delete -f -'
  I1001 18:16:20.113059 117358 builder.go:146] stderr: ""
  I1001 18:16:20.113113 117358 builder.go:147] stdout: "deployment.apps \"ceph-nvmeof-gateway\" deleted\n"
  I1001 18:16:20.259287 117358 exec_util.go:63] ExecWithOptions {Command:[/bin/sh -c ceph osd pool delete nvmeofpool nvmeofpool --yes-i-really-really-mean-it] Namespace:openshift-storage PodName:rook-ceph-tools-54f58d7d49-zj7xs ContainerName:rook-ceph-tools Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:true Quiet:false}
  I1001 18:16:20.259345 117358 exec_util.go:68] ExecWithOptions: Clientset creation
  I1001 18:16:20.259423 117358 exec_util.go:84] ExecWithOptions: execute(https://api.ndevos-nvmegw.ocs.syseng.devcluster.openshift.com:6443/api/v1/namespaces/openshift-storage/pods/rook-ceph-tools-54f58d7d49-zj7xs/exec?command=%2Fbin%2Fsh&command=-c&command=ceph+osd+pool+delete+nvmeofpool+nvmeofpool+--yes-i-really-really-mean-it&container=rook-ceph-tools&stderr=true&stdout=true)
  I1001 18:16:20.657955 117358 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I1001 18:16:22.550800 117358 pod.go:314] stdErr occurred: pool 'nvmeofpool' removed

  STEP: Destroying namespace "nvmeof-7908" for this suite. @ 10/01/25 18:16:22.551
S [SKIPPED] [21.077 seconds]
nvmeof Test NVMe CSI [It] Test NVMe-oF CSI
/go/src/github.com/ceph/ceph-csi/e2e/nvmeof.go:58

  [SKIPPED] no NVMe-oF test cases yet
  In [It] at: /go/src/github.com/ceph/ceph-csi/e2e/nvmeof.go:59 @ 10/01/25 18:16:17.125
------------------------------

Ran 0 of 1 Specs in 21.077 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 1 Skipped
PASS
```

Updates: #5370