### PR TITLE
e2e: auto-detect running on OpenShift

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -742,7 +742,7 @@ var _ = Describe(cephfsType, func() {
 					logAndFail("failed to list subvolumes: %v", err)
 				}
 				for _, subVol := range subvolumes {
-					fmt.Printf("Checking prefix on %s\n", subVol)
+					framework.Logf("Checking prefix on %s", subVol)
 					if strings.HasPrefix(subVol.Name, volumeNamePrefix) {
 						foundIt = true
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -58,7 +57,7 @@ func init() {
 	handleFlags()
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	fmt.Println("timeout for deploytimeout ", deployTimeout)
+	framework.Logf("timeout for deploying: %d minutes", deployTimeout)
 }
 
 func setDefaultKubeconfig() {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -48,7 +48,6 @@ func init() {
 	flag.StringVar(&upgradeVersion, "upgrade-version", "v3.5.1", "target version for upgrade testing")
 	flag.StringVar(&cephCSINamespace, "cephcsi-namespace", defaultNs, "namespace in which cephcsi deployed")
 	flag.StringVar(&rookNamespace, "rook-namespace", "rook-ceph", "namespace in which rook is deployed")
-	flag.BoolVar(&isOpenShift, "is-openshift", false, "disables certain checks on OpenShift")
 	flag.StringVar(&fileSystemName, "filesystem", "myfs", "CephFS filesystem to use")
 	flag.StringVar(&clusterID, "clusterid", "", "Ceph cluster ID to use (defaults to `ceph fsid` detection)")
 	flag.StringVar(&nfsDriverName, "nfs-driver", "nfs.csi.ceph.com", "name of the driver for NFS-volumes")
@@ -73,6 +72,13 @@ func setDefaultKubeconfig() {
 func TestE2E(t *testing.T) {
 	t.Parallel()
 	RegisterFailHandler(Fail)
+
+	ocpDetected, err := detectOpenShift()
+	if err != nil {
+		t.Errorf("failed to run OpenShift detection: %v", err)
+	}
+	isOpenShift = ocpDetected
+
 	RunSpecs(t, "E2e Suite")
 }
 

--- a/e2e/errors.go
+++ b/e2e/errors.go
@@ -169,3 +169,33 @@ func isNotFoundCLIError(err error) bool {
 
 	return true
 }
+
+// isNoSuchResourceCLIError checks for "the server doesn't have a resource type" error from kubectl CLI.
+func isNoSuchResourceCLIError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// if multiple resources already exists. each error is separated by newline
+	stdErr := getStdErr(err.Error())
+	if stdErr == "" {
+		return false
+	}
+
+	stdErrs := strings.Split(stdErr, "\n")
+	for _, s := range stdErrs {
+		// If the string is just a new line continue
+		if strings.TrimSuffix(s, "\n") == "" {
+			continue
+		}
+		// Ignore warnings
+		if strings.Contains(s, "Warning") {
+			continue
+		}
+		// Resource not found error message
+		if !strings.Contains(s, "the server doesn't have a resource type") {
+			return false
+		}
+	}
+
+	return true
+}

--- a/e2e/openshift.go
+++ b/e2e/openshift.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+)
+
+// detectOpenShift checks for the clusterversion that is provided by OpenShift.
+// If the clusterversion is not found, we're not running on an OpenShift
+// cluster.
+func detectOpenShift() (bool, error) {
+	version, err := e2ekubectl.RunKubectl("openshift",
+		"get",
+		"clusterversion.config.openshift.io/version",
+		"-ojsonpath='{.status.desired.version}'",
+	)
+
+	if err != nil {
+		if isNoSuchResourceCLIError(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	framework.Logf("running on OpenShift version %s", version)
+
+	return true, nil
+}

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -71,7 +71,7 @@ func getDaemonSetLabelSelector(f *framework.Framework, ns, daemonSetName string)
 func waitForDaemonSets(name, ns string, c kubernetes.Interface, t int) error {
 	timeout := time.Duration(t) * time.Minute
 	start := time.Now()
-	framework.Logf("Waiting up to %v for all daemonsets in namespace '%s' to start", timeout, ns)
+	framework.Logf("Waiting up to %s for all daemonsets in namespace '%s' to start", timeout, ns)
 
 	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(ctx context.Context) (bool, error) {
 		ds, err := c.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -374,7 +374,7 @@ func createAppErr(c kubernetes.Interface, app *v1.Pod, timeout int, errStrings [
 func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, expectedErrors []string) error {
 	timeout := time.Duration(t) * time.Minute
 	start := time.Now()
-	framework.Logf("Waiting up to %v to be in Running state", name)
+	framework.Logf("Waiting up to %s for %v to be in Running state", timeout, name)
 
 	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(ctx context.Context) (bool, error) {
 		pod, err := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -36,7 +36,17 @@ import (
 	frameworkPod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
-const errRWOPConflict = "node has pod using PersistentVolumeClaim with the same name and ReadWriteOncePod access mode."
+const (
+	exitOneErr = "command terminated with exit code 1"
+
+	// errRWOPConflictOld is returned by Kuberneres < 1.34
+	errRWOPConflictOld = "node has pod using PersistentVolumeClaim with the same name and ReadWriteOncePod access mode."
+	errRWOPConflict    = "unavailable due to PersistentVolumeClaim with ReadWriteOncePod access mode already in-use by another pod"
+)
+
+var (
+	noError []string = nil
+)
 
 // getDaemonSetLabelSelector returns labels of daemonset given name and namespace dynamically,
 // needed since labels are not same for helm and non-helm deployments.
@@ -352,16 +362,16 @@ func createApp(c kubernetes.Interface, app *v1.Pod, timeout int) error {
 	return waitForPodInRunningState(app.Name, app.Namespace, c, timeout, noError)
 }
 
-func createAppErr(c kubernetes.Interface, app *v1.Pod, timeout int, errString string) error {
+func createAppErr(c kubernetes.Interface, app *v1.Pod, timeout int, errStrings []string) error {
 	_, err := c.CoreV1().Pods(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
 
-	return waitForPodInRunningState(app.Name, app.Namespace, c, timeout, errString)
+	return waitForPodInRunningState(app.Name, app.Namespace, c, timeout, errStrings)
 }
 
-func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, expectedError string) error {
+func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, expectedErrors []string) error {
 	timeout := time.Duration(t) * time.Minute
 	start := time.Now()
 	framework.Logf("Waiting up to %v to be in Running state", name)
@@ -381,18 +391,22 @@ func waitForPodInRunningState(name, ns string, c kubernetes.Interface, t int, ex
 		case v1.PodFailed, v1.PodSucceeded:
 			return false, conditions.ErrPodCompleted
 		case v1.PodPending:
-			if expectedError != "" {
+			if expectedErrors != nil {
 				events, err := c.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
 					FieldSelector: "involvedObject.name=" + name,
 				})
 				if err != nil {
 					return false, err
 				}
-				if strings.Contains(events.String(), expectedError) {
-					framework.Logf("Expected Error %q found successfully", expectedError)
+				for _, expectedError := range expectedErrors {
+					if strings.Contains(events.String(), expectedError) {
+						framework.Logf("Expected Error %q found successfully", expectedError)
 
-					return true, err
+						return true, nil
+					}
 				}
+
+				framework.Logf("No failures found, events do not match expected error: %v", events)
 			}
 		case v1.PodUnknown:
 			framework.Logf(
@@ -545,7 +559,7 @@ func validateRWOPPodCreation(
 	name := fmt.Sprintf("%s-%d", uuid.NewString(), deployTimeout)
 	app.Name = name
 
-	err = createAppErr(f.ClientSet, app, deployTimeout, errRWOPConflict)
+	err = createAppErr(f.ClientSet, app, deployTimeout, []string{errRWOPConflict, errRWOPConflictOld})
 	if err != nil {
 		return fmt.Errorf("application should not go to running state due to RWOP access mode: %w", err)
 	}

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -408,6 +408,10 @@ func checkPVSelectorValuesForPVC(f *framework.Framework, pvc *v1.PersistentVolum
 }
 
 func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t int) error {
+	if (k8sBrokenMetrics(f.ClientSet)) {
+		return nil
+	}
+
 	kubelet, err := getKubeletIP(f.ClientSet)
 	if err != nil {
 		return err

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -2988,7 +2988,7 @@ var _ = Describe("RBD", func() {
 					logAndFail("failed to list rbd images: %v", err)
 				}
 				for _, imgName := range images {
-					fmt.Printf("Checking prefix on %s\n", imgName)
+					framework.Logf("Checking prefix on %s", imgName)
 					if strings.HasPrefix(imgName, volumeNamePrefix) {
 						foundIt = true
 

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -195,7 +195,7 @@ func validateRBDStaticPV(f *framework.Framework, appPath string, isBlock, checkI
 	app.Namespace = namespace
 	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcName
 	if checkImgFeat {
-		err = createAppErr(f.ClientSet, app, deployTimeout, "missing required parameter imageFeatures")
+		err = createAppErr(f.ClientSet, app, deployTimeout, []string{"missing required parameter imageFeatures"})
 	} else {
 		err = createApp(f.ClientSet, app, deployTimeout)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -1685,6 +1685,25 @@ func k8sVersionGreaterEquals(c kubernetes.Interface, major, minor int) bool {
 	return (vMajor > major) || (vMajor == major && vMinor >= minor)
 }
 
+var brokenMetrics *bool = nil
+
+// k8sBrokenMetrics detects if Kubernetes 1.34 is used, this version has broken
+// kube_volume_stats_* metrics:
+// https://github.com/kubernetes/kubernetes/issues/133847
+func k8sBrokenMetrics(c kubernetes.Interface) bool {
+	if brokenMetrics == nil {
+		broken := true
+		functional := true
+		if k8sVersionGreaterEquals(c, 1, 34) && !k8sVersionGreaterEquals(c, 1, 35) {
+			brokenMetrics = &broken
+		} else {
+			brokenMetrics = &functional
+		}
+	}
+
+	return *brokenMetrics
+}
+
 // waitForJobCompletion polls the status of the given job and waits until the
 // jobs has succeeded or until the timeout is hit.
 func waitForJobCompletion(c kubernetes.Interface, ns, job string, timeout int) error {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -68,9 +68,6 @@ const (
 	appLabel      = "write-data-in-pod"
 	appCloneLabel = "app-clone"
 
-	noError    = ""
-	exitOneErr = "command terminated with exit code 1"
-
 	// cluster Name, set by user.
 	clusterNameKey     = "csi.ceph.com/cluster/name"
 	defaultClusterName = "k8s-cluster-1"


### PR DESCRIPTION
The e2e suite can run on OpenShift, but there are a few checks that
handle certain things with a small change. OpenShift has a more struct
security policy than standard Kubernetes/Minikube, these need to be
accounted for.

There used to be a -is-openshift commandline flag. This flag is now
removed and OpenShift is auto-detected.

This PR also contains fixes for running on Kubernetes 1.34.