### PR TITLE
nvmeof: adding of nvmeof csi driver

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/controller/volumegroup"
 	"github.com/ceph/ceph-csi/internal/liveness"
 	nfsdriver "github.com/ceph/ceph-csi/internal/nfs/driver"
+	nvmeofdriver "github.com/ceph/ceph-csi/internal/nvmeof/driver"
 	rbddriver "github.com/ceph/ceph-csi/internal/rbd/driver"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -44,6 +45,7 @@ const (
 	rbdDefaultName      = "rbd.csi.ceph.com"
 	cephFSDefaultName   = "cephfs.csi.ceph.com"
 	nfsDefaultName      = "nfs.csi.ceph.com"
+	nvmeofDefaultName   = "nvmeof.csi.ceph.com"
 	livenessDefaultName = "liveness.csi.ceph.com"
 
 	pollTime     = 60 // seconds
@@ -60,7 +62,7 @@ var conf util.Config
 
 func init() {
 	// common flags
-	flag.StringVar(&conf.Vtype, "type", "", "driver type [rbd|cephfs|nfs|liveness|controller]")
+	flag.StringVar(&conf.Vtype, "type", "", "driver type [rbd|cephfs|nfs|nvmeof|liveness|controller]")
 	flag.StringVar(&conf.Endpoint, "endpoint", "unix:///tmp/csi.sock", "CSI endpoint")
 	flag.StringVar(&conf.DriverName, "drivername", "", "name of the driver")
 	flag.StringVar(&conf.DriverNamespace, "drivernamespace", defaultNS, "namespace in which driver is deployed")
@@ -178,6 +180,8 @@ func getDriverName() string {
 		return cephFSDefaultName
 	case util.NFSType:
 		return nfsDefaultName
+	case util.NVMeoFType:
+		return nvmeofDefaultName
 	case util.LivenessType:
 		return livenessDefaultName
 	default:
@@ -258,6 +262,9 @@ func main() {
 		driver := nfsdriver.NewDriver()
 		driver.Run(&conf)
 
+	case util.NVMeoFType:
+		driver := nvmeofdriver.NewDriver()
+		driver.Run(&conf)
 	case util.LivenessType:
 		liveness.Run(&conf)
 

--- a/internal/nvmeof/driver/driver.go
+++ b/internal/nvmeof/driver/driver.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/driver"
+	"github.com/ceph/ceph-csi/internal/nvmeof/controller"
+	"github.com/ceph/ceph-csi/internal/nvmeof/identity"
+	"github.com/ceph/ceph-csi/internal/nvmeof/nodeserver"
+	"github.com/ceph/ceph-csi/internal/rbd"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+// nvmeofDriver provides the entry point for the NVMe-oF CSI driver.
+// The actual implementation is delegated to identity, controller, and node servers.
+type nvmeofDriver struct{}
+
+// NewDriver returns new NVMe-oF driver.
+func NewDriver() driver.Driver {
+	return &nvmeofDriver{}
+}
+
+// assert that nvmeofDriver implements the Driver interface.
+var _ driver.Driver = &nvmeofDriver{}
+
+// Run starts the NVMe-oF CSI driver.
+func (d *nvmeofDriver) Run(conf *util.Config) {
+	// TODO: move rbd initialization to a common function
+	// update clone soft and hard limit
+	rbd.SetGlobalInt("rbdHardMaxCloneDepth", conf.RbdHardMaxCloneDepth)
+	rbd.SetGlobalInt("rbdSoftMaxCloneDepth", conf.RbdSoftMaxCloneDepth)
+	rbd.SetGlobalBool("skipForceFlatten", conf.SkipForceFlatten)
+	rbd.SetGlobalInt("maxSnapshotsOnImage", conf.MaxSnapshotsOnImage)
+	rbd.SetGlobalInt("minSnapshotsOnImageToStartFlatten", conf.MinSnapshotsOnImage)
+	// Create instances of the volume and snapshot journal
+	rbd.InitJournals(conf.InstanceID)
+	// Initialize CSI driver
+	cd := csicommon.NewCSIDriver(conf.DriverName, util.DriverVersion, conf.NodeID, conf.InstanceID, conf.EnableFencing)
+	if cd == nil {
+		log.FatalLogMsg("failed to initialize CSI driver")
+	}
+
+	// Set capabilities
+	if conf.IsControllerServer || !conf.IsNodeServer {
+		cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
+			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+		})
+
+		cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
+		})
+	}
+
+	// Create gRPC servers
+	server := csicommon.NewNonBlockingGRPCServer()
+	srv := &csicommon.Servers{
+		IS: identity.NewIdentityServer(cd),
+	}
+
+	switch {
+	case conf.IsNodeServer:
+		ns := nodeserver.NewNodeServer(cd, conf.NodeID, conf.Vtype)
+		srv.NS = ns
+	case conf.IsControllerServer:
+		cs, err := controller.NewControllerServer(cd)
+		if err != nil {
+			log.FatalLogMsg("failed to initialize controller server: %v", err)
+		}
+		srv.CS = cs
+	default:
+		ns := nodeserver.NewNodeServer(cd, conf.NodeID, conf.Vtype)
+		srv.NS = ns
+		cs, err := controller.NewControllerServer(cd)
+		if err != nil {
+			log.FatalLogMsg("failed to initialize controller server: %v", err)
+		}
+		srv.CS = cs
+	}
+
+	server.Start(conf.Endpoint, srv, csicommon.MiddlewareServerOptionConfig{
+		LogSlowOpInterval: conf.LogSlowOpInterval,
+	})
+
+	if conf.EnableProfiling {
+		go util.StartMetricsServer(conf)
+		go util.EnableProfiling()
+	}
+
+	server.Wait()
+}

--- a/internal/nvmeof/driver/driver.go
+++ b/internal/nvmeof/driver/driver.go
@@ -81,7 +81,10 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 
 	switch {
 	case conf.IsNodeServer:
-		ns := nodeserver.NewNodeServer(cd, conf.NodeID, conf.Vtype)
+		ns, err := nodeserver.NewNodeServer(cd, conf.NodeID, conf.Vtype)
+		if err != nil {
+			log.FatalLogMsg("failed to initialize node server: %v", err)
+		}
 		srv.NS = ns
 	case conf.IsControllerServer:
 		cs, err := controller.NewControllerServer(cd)
@@ -90,7 +93,10 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 		}
 		srv.CS = cs
 	default:
-		ns := nodeserver.NewNodeServer(cd, conf.NodeID, conf.Vtype)
+		ns, err := nodeserver.NewNodeServer(cd, conf.NodeID, conf.Vtype)
+		if err != nil {
+			log.FatalLogMsg("failed to initialize node server: %v", err)
+		}
 		srv.NS = ns
 		cs, err := controller.NewControllerServer(cd)
 		if err != nil {

--- a/internal/nvmeof/identity/identityserver.go
+++ b/internal/nvmeof/identity/identityserver.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+)
+
+// Server implements the CSI Identity service for NVMe-oF driver.
+// It embeds the default identity server and overrides specific methods.
+type Server struct {
+	*csicommon.DefaultIdentityServer
+}
+
+// NewIdentityServer creates and returns a new instance of the identity server.
+func NewIdentityServer(d *csicommon.CSIDriver) *Server {
+	return &Server{
+		DefaultIdentityServer: csicommon.NewDefaultIdentityServer(d),
+	}
+}
+
+// GetPluginCapabilities returns the supported capabilities of the NVMe-oF CSI plugin.
+func (is *Server) GetPluginCapabilities(
+	ctx context.Context,
+	req *csi.GetPluginCapabilitiesRequest,
+) (*csi.GetPluginCapabilitiesResponse, error) {
+	return &csi.GetPluginCapabilitiesResponse{
+		Capabilities: []*csi.PluginCapability{
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -83,7 +83,7 @@ func NewNodeServer(
 	d *csicommon.CSIDriver,
 	nodeID,
 	t string,
-) *NodeServer {
+) (*NodeServer, error) {
 	// Create NVMe initiator
 	nvmeInitiator := nvmeof.NewNVMeInitiator()
 	ns := &NodeServer{
@@ -92,7 +92,12 @@ func NewNodeServer(
 		volumeLocks:       util.NewIDLocker(),
 	}
 
-	return ns
+	// Load nvme kernel modules
+	if err := nvmeInitiator.LoadKernelModules(context.Background()); err != nil {
+		return nil, fmt.Errorf("failed to load NVMe kernel modules: %w", err)
+	}
+
+	return ns, nil
 }
 
 // NodeGetCapabilities returns the supported capabilities of the node server.
@@ -160,12 +165,6 @@ func (ns *NodeServer) NodeStageVolume(
 	connectionInfo, err := ns.getNvmeConnection(volumeContext, req.GetPublishContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume context: %v", err)
-	}
-
-	// TODO: MOVE THE LOADING KERNEL MODULE TO DRIVE.GO!!!
-	// Load kernel modules first
-	if err := ns.initiator.LoadKernelModules(ctx); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to load kernel modules: %v", err)
 	}
 
 	// perform the actual staging and if this fails, have undoStagingTransaction

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -41,6 +41,7 @@ const (
 	RBDType        = "rbd"
 	CephFsType     = "cephfs"
 	NFSType        = "nfs"
+	NVMeoFType     = "nvmeof"
 	LivenessType   = "liveness"
 	ControllerType = "controller"
 )


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This PR adds initial NVMe-oF CSI driver support by introducing the core driver structure and identity server implementation. The driver wraps RBD functionality to provide NVMe-oF block storage capabilities.
The Implementations of node-plugin and controller-plugin are already merged.

## Is there anything that requires special attention ##


* Node server changes show kernel module loading logic being refactored from inline to a dedicated function


## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
