### PR TITLE
cleanup: introduce a Driver interface for Run() function

### DIFF
--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -25,6 +25,7 @@ import (
 	casceph "github.com/ceph/ceph-csi/internal/csi-addons/cephfs"
 	csiaddons "github.com/ceph/ceph-csi/internal/csi-addons/server"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/driver"
 	hc "github.com/ceph/ceph-csi/internal/health-checker"
 	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -34,8 +35,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
-// Driver contains the default identity,node and controller struct.
-type Driver struct {
+// cephfsDriver contains the default identity,node and controller struct.
+type cephfsDriver struct {
 	cd *csicommon.CSIDriver
 
 	is *IdentityServer
@@ -45,9 +46,12 @@ type Driver struct {
 	cas *csiaddons.CSIAddonsServer
 }
 
+// assert that cephfsDriver implements the Driver interface.
+var _ driver.Driver = &cephfsDriver{}
+
 // NewDriver returns new ceph driver.
-func NewDriver() *Driver {
-	return &Driver{}
+func NewDriver() driver.Driver {
+	return &cephfsDriver{}
 }
 
 // NewIdentityServer initialize a identity server for ceph CSI driver.
@@ -90,7 +94,7 @@ func NewNodeServer(
 
 // Run start a non-blocking grpc controller,node and identityserver for
 // ceph CSI driver which can serve multiple parallel requests.
-func (fs *Driver) Run(conf *util.Config) {
+func (fs *cephfsDriver) Run(conf *util.Config) {
 	var (
 		err                                    error
 		nodeLabels, topology, crushLocationMap map[string]string
@@ -216,7 +220,7 @@ func (fs *Driver) Run(conf *util.Config) {
 // setupCSIAddonsServer creates a new CSI-Addons Server on the given (URL)
 // endpoint. The supported CSI-Addons operations get registered as their own
 // services.
-func (fs *Driver) setupCSIAddonsServer(conf *util.Config) error {
+func (fs *cephfsDriver) setupCSIAddonsServer(conf *util.Config) error {
 	var err error
 
 	fs.cas, err = csiaddons.NewCSIAddonsServer(conf.CSIAddonsEndpoint)

--- a/internal/cephfs/driver_test.go
+++ b/internal/cephfs/driver_test.go
@@ -36,7 +36,7 @@ func TestSetupCSIAddonsServer(t *testing.T) {
 		CSIAddonsEndpoint: endpoint,
 	}
 
-	drv := &Driver{}
+	drv := &cephfsDriver{}
 	err := drv.setupCSIAddonsServer(config)
 	require.NoError(t, err)
 	require.NotNil(t, drv.cas)

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import "github.com/ceph/ceph-csi/internal/util"
+
+// Driver is the interface that all driver types should implement.
+type Driver interface {
+	// Run is called to start the driver, this function is not expected
+	// to return.
+	Run(conf *util.Config)
+}

--- a/internal/nfs/driver/driver.go
+++ b/internal/nfs/driver/driver.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/driver"
 	"github.com/ceph/ceph-csi/internal/nfs/controller"
 	"github.com/ceph/ceph-csi/internal/nfs/identity"
 	"github.com/ceph/ceph-csi/internal/nfs/nodeserver"
@@ -27,17 +28,20 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
-// Driver contains the default identity and controller struct.
-type Driver struct{}
+// nfsDriver contains the default identity and controller struct.
+type nfsDriver struct{}
 
 // NewDriver returns new ceph driver.
-func NewDriver() *Driver {
-	return &Driver{}
+func NewDriver() driver.Driver {
+	return &nfsDriver{}
 }
+
+// assert that nfsDriver implements the Driver interface.
+var _ driver.Driver = &nfsDriver{}
 
 // Run start a non-blocking grpc controller,node and identityserver for
 // ceph CSI driver which can serve multiple parallel requests.
-func (fs *Driver) Run(conf *util.Config) {
+func (fs *nfsDriver) Run(conf *util.Config) {
 	// Initialize default library driver
 	cd := csicommon.NewCSIDriver(conf.DriverName, util.DriverVersion, conf.NodeID, conf.InstanceID,
 		conf.EnableFencing)

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -24,6 +24,7 @@ import (
 	casrbd "github.com/ceph/ceph-csi/internal/csi-addons/rbd"
 	csiaddons "github.com/ceph/ceph-csi/internal/csi-addons/server"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/driver"
 	"github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/rbd/features"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -33,8 +34,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
-// Driver contains the default identity,node and controller struct.
-type Driver struct {
+// driver contains the default identity,node and controller struct.
+type rbdDriver struct {
 	cd  *csicommon.CSIDriver
 	ids *rbd.IdentityServer
 	ns  *rbd.NodeServer
@@ -44,9 +45,12 @@ type Driver struct {
 	cas *csiaddons.CSIAddonsServer
 }
 
+// assert that rbdDriver implements the Driver interface.
+var _ driver.Driver = &rbdDriver{}
+
 // NewDriver returns new rbd driver.
-func NewDriver() *Driver {
-	return &Driver{}
+func NewDriver() driver.Driver {
+	return &rbdDriver{}
 }
 
 // NewIdentityServer initialize a identity server for rbd CSI driver.
@@ -87,7 +91,7 @@ func NewNodeServer(
 //
 // This also configures and starts a new CSI-Addons service, by calling
 // setupCSIAddonsServer().
-func (r *Driver) Run(conf *util.Config) {
+func (r *rbdDriver) Run(conf *util.Config) {
 	var (
 		err                                    error
 		nodeLabels, topology, crushLocationMap map[string]string
@@ -220,7 +224,7 @@ func (r *Driver) Run(conf *util.Config) {
 // setupCSIAddonsServer creates a new CSI-Addons Server on the given (URL)
 // endpoint. The supported CSI-Addons operations get registered as their own
 // services.
-func (r *Driver) setupCSIAddonsServer(conf *util.Config) error {
+func (r *rbdDriver) setupCSIAddonsServer(conf *util.Config) error {
 	var err error
 
 	r.cas, err = csiaddons.NewCSIAddonsServer(conf.CSIAddonsEndpoint)
@@ -268,7 +272,7 @@ func (r *Driver) setupCSIAddonsServer(conf *util.Config) error {
 
 // startProfiling checks which profiling options are enabled in the config and
 // starts the required profiling services.
-func (r *Driver) startProfiling(conf *util.Config) {
+func (r *rbdDriver) startProfiling(conf *util.Config) {
 	if conf.EnableProfiling {
 		go util.StartMetricsServer(conf)
 		log.DebugLogMsg("Registering profiling handler")

--- a/internal/rbd/driver/driver_test.go
+++ b/internal/rbd/driver/driver_test.go
@@ -36,7 +36,7 @@ func TestSetupCSIAddonsServer(t *testing.T) {
 		CSIAddonsEndpoint: endpoint,
 	}
 
-	drv := &Driver{}
+	drv := &rbdDriver{}
 	err := drv.setupCSIAddonsServer(config)
 	require.NoError(t, err)
 	require.NotNil(t, drv.cas)


### PR DESCRIPTION
There are three driver implementations (CephFS, RBD, NFS), and all provide their own struct with a `Run()` function. Providing an interface for this, makes it possible to keep the implementation of the driver internal to their own package.