### PR TITLE
fix: mounting of alternate filesystem failing when mounting by monitor list

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,5 +6,6 @@
 
 - set nodeId:userId mapping in metadata [PR](https://github.com/ceph/ceph-csi/pull/5445)
    - refer design doc for more details - [here](https://github.com/ceph/ceph-csi/blob/devel/docs/design/proposals/userID-mapping.md)
+- cephfs-csi: fix mounting alternate filesystem when mounting by monitor lists [PR](https://github.com/ceph/ceph-csi/pull/5643)
 
 ## NOTE

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -684,6 +684,10 @@ func NewVolumeOptionsFromMonitorList(
 		return nil, nil, err
 	}
 
+	if err = extractOptionalOption(&opts.FsName, "fsName", options); err != nil {
+		return nil, nil, err
+	}
+
 	opts.Owner = k8s.GetOwner(options)
 	if err = opts.InitKMS(context.TODO(), options, secrets); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
# Describe what this PR does #

Passes in missing fsName from volumeContext when mounting by monitor list.

## Is there anything that requires special attention ##

Do you have any questions? No

Is the change backward compatible? Yes

Are there concerns around backward compatibility? No


## Related issues ##

* https://github.com/ceph/ceph-csi/issues/5642
* https://github.com/kubernetes/cloud-provider-openstack/issues/2992

Fixes: #5642

## Future concerns ##
None

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
