### PR TITLE
ci: add nvmeof test-type support for triggering CI jobs

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -16,8 +16,9 @@
           only_run_on_request: true
     test_type:
       - 'cephfs'
-      - 'rbd'
       - 'nfs'
+      - 'nvmeof'
+      - 'rbd'
     jobs:
       - 'mini-e2e_k8s-{k8s_version}'
       - 'mini-e2e-helm_k8s-{k8s_version}'
@@ -44,7 +45,7 @@
       - string:
           name: test_type
           default: ''
-          description: Mentions whether tests run for rbd/cephfs/nfs.
+          description: Mentions whether tests run for rbd/cephfs/nfs/nvmeof.
     pipeline-scm:
       scm:
         - git:
@@ -89,7 +90,7 @@
       - string:
           name: test_type
           default: ''
-          description: Mentions whether tests run for rbd/cephfs/nfs.
+          description: Mentions whether tests run for rbd/cephfs/nfs/nvmeof.
 
     pipeline-scm:
       scm:
@@ -136,7 +137,7 @@
       - string:
           name: test_type
           default: ''
-          description: Mentions whether tests run for rbd/cephfs/nfs.
+          description: Mentions whether tests run for rbd/cephfs/nfs/nvmeof.
 
     pipeline-scm:
       scm:

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -60,7 +60,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}(/test_type-{test_type})?)?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}(/{test_type})?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
@@ -106,7 +106,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version}(/test_type-{test_type})?)?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version}(/{test_type})?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
@@ -153,7 +153,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-operator/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e-operator(/k8s-{k8s_version}(/test_type-{test_type})?)?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e-operator(/k8s-{k8s_version}(/{test_type})?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -198,15 +198,15 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 150, unit: 'MINUTES') {
-				def t_type = ""
+				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
 					t_type = '--test-cephfs=true --test-rbd=false --test-nfs=false'
 				} else if ("${test_type}" == "rbd"){
 					t_type = '--test-rbd=true --test-cephfs=false --test-nfs=false'
 				} else if ("${test_type}" == "nfs"){
 					t_type = '--test-nfs=true --test-cephfs=false --test-rbd=false'
-				} else {
-					t_type = '--test-rbd=true --test-cephfs=true --test-nfs=true'
+				} else if ("${test_type}" == "nvmeof"){
+					t_type = '--test-nvmeof=true --test-nfs=false --test-cephfs=false --test-rbd=false'
 				}
 				def e2e_args = "--delete-namespace-on-failure=false --deploy-cephfs=false --deploy-rbd=false --helm-test=true ${t_type}"
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e NAMESPACE='${namespace}' E2E_ARGS='${e2e_args}'"

--- a/mini-e2e-operator.groovy
+++ b/mini-e2e-operator.groovy
@@ -198,15 +198,15 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 120, unit: 'MINUTES') {
-				def t_type = ""
+				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
 					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"
 				} else if ("${test_type}" == "rbd"){
 					t_type = "--test-rbd=true --test-cephfs=false --test-nfs=false"
 				} else if ("${test_type}" == "nfs"){
 					t_type = "--test-nfs=true --test-cephfs=false --test-rbd=false"
-				} else {
-					t_type = "--test-rbd=true --test-cephfs=true --test-nfs=true"
+				} else if ("${test_type}" == "nvmeof"){
+					t_type = '--test-nvmeof=true --test-nfs=false --test-cephfs=false --test-rbd=false'
 				}
 				deploy_param = "--deploy-cephfs=false --deploy-rbd=false --deploy-nfs=false --operator-deployment=true"
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS=\"--delete-namespace-on-failure=false ${t_type} ${deploy_param}\""

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -185,15 +185,15 @@ node('cico-workspace') {
 		}
 		stage('run e2e') {
 			timeout(time: 150, unit: 'MINUTES') {
-				def t_type = ""
+				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
 					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"
 				} else if ("${test_type}" == "rbd"){
 					t_type = "--test-rbd=true --test-cephfs=false --test-nfs=false"
 				} else if ("${test_type}" == "nfs"){
 					t_type = "--test-nfs=true --test-cephfs=false --test-rbd=false"
-				} else {
-					t_type = "--test-rbd=true --test-cephfs=true --test-nfs=true"
+				} else if ("${test_type}" == "nvmeof"){
+					t_type = '--test-nvmeof=true --test-nfs=false --test-cephfs=false --test-rbd=false'
 				}
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS=\"--delete-namespace-on-failure=false ${t_type}\""
 			}


### PR DESCRIPTION
- **ci: add test_type=nvmeof for running only the NVMe-oF tests**
- **ci: drop unneeded `test_type-` prefix from trigger phrase**

Relates-to: #5641