### PR TITLE
ci: correct regular expression for triggering jobs with test-type

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -60,7 +60,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}(/{test_type})?)?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}(/(cephfs|nfs|nvmeof|rbd))?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
@@ -106,7 +106,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-helm/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version}(/{test_type})?)?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e-helm(/k8s-{k8s_version}(/(cephfs|nfs|nvmeof|rbd))?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true
@@ -153,7 +153,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e-operator/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e-operator(/k8s-{k8s_version}(/{test_type})?)?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e-operator(/k8s-{k8s_version}(/(cephfs|nfs|nvmeof|rbd))?)?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true


### PR DESCRIPTION
The `{test_type}` in the trigger phrase expanded to an array notation
like `['cephfs', 'nfs', 'nvmeof', 'rbd']`. This isn't a valid regular
expression, so passing the test-type on the trigger phrase could not
work.

By explicitly constructing the regular expression with all the available
test-types, this should now work (again?).
