### PR TITLE
ci: do not run main ci/centos/mini-e2e job when test-type is passed

### DIFF
--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -63,7 +63,7 @@
           status-url: $RUN_DISPLAY_URL
           status-context: 'ci/centos/mini-e2e/k8s-{k8s_version}'
           # yamllint disable-line rule:line-length
-          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version}(/(cephfs|nfs|nvmeof|rbd))?)?'
+          trigger-phrase: '/(re)?test ci/centos/mini-e2e(/k8s-{k8s_version})?'
           only-trigger-phrase: '{only_run_on_request}'
           permit-all: true
           github-hooks: true


### PR DESCRIPTION
The trigger-phrase for the ci/centos/mini-e2e job did still include the
optional test-type regular expression part. Because there are now
dedicated jobs for the test-type arguments, the main ci/centos/mini-e2e
job should not have the test-type checking and should not run when the
test-type is passed.

Other jobs were modified correctly already.