### PR TITLE
ci: use Rook 1.19.3 and Ceph Tentacle

### DIFF
--- a/build.env
+++ b/build.env
@@ -59,7 +59,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.18.4
+ROOK_VERSION=v1.19.3
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v19.2.2
 

--- a/build.env
+++ b/build.env
@@ -61,7 +61,7 @@ CHANGE_MINIKUBE_NONE_USER=true
 # Rook options
 ROOK_VERSION=v1.19.3
 # Provide ceph image path
-ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v19.2.2
+ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v20
 
 # CSI sidecar version
 K8S_IMAGE_REPO=registry.k8s.io/sig-storage

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -248,6 +248,11 @@ var _ = Describe(cephfsType, func() {
 			logAndFail("failed to set cluster name: %v", err)
 		}
 
+		err = cephFSDeployment.setEnableFencing(true)
+		if err != nil {
+			logAndFail("failed to enable fencing: %v", err)
+		}
+
 		err = createSubvolumegroup(f, fileSystemName, subvolumegroup)
 		if err != nil {
 			logAndFail("failed to create subvolumegroup %s: %v", subvolumegroup, err)

--- a/e2e/operator.go
+++ b/e2e/operator.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -58,7 +59,7 @@ func (r *OperatorDeployment) getPodSelector() string {
 		r.deploymentName, r.daemonsetName)
 }
 
-func (OperatorDeployment) setEnableMetadata(value bool) error {
+func (r *OperatorDeployment) setEnableMetadata(value bool) error {
 	command := []string{
 		"operatorconfigs.csi.ceph.io",
 		OperatorConfigName,
@@ -73,7 +74,21 @@ func (OperatorDeployment) setEnableMetadata(value bool) error {
 		return err
 	}
 
-	// FIXME: wait for the change to be propagated to the pods (see e2e/rbd.go)
+	// restart the pods so that the new configuration is activated
+	framework.Logf("enableMetadata has been set to %t, restarting Ceph-CSI pods", value)
+	podLabels := r.getPodSelector()
+	err = deletePodWithLabel(podLabels, cephCSINamespace, false)
+	if err != nil {
+		return fmt.Errorf("failed to delete pods with labels (%s): %w", podLabels, err)
+	}
+	err = waitForDaemonSets(r.daemonsetName, cephCSINamespace, r.clientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("timeout waiting for daemonset pods: %w", err)
+	}
+	err = waitForDeploymentComplete(r.clientSet, r.deploymentName, cephCSINamespace, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("timeout waiting for deployment to be in running state: %w", err)
+	}
 
 	return nil
 }

--- a/e2e/operator.go
+++ b/e2e/operator.go
@@ -73,6 +73,8 @@ func (OperatorDeployment) setEnableMetadata(value bool) error {
 		return err
 	}
 
+	// FIXME: wait for the change to be propagated to the pods (see e2e/rbd.go)
+
 	return nil
 }
 

--- a/e2e/operator.go
+++ b/e2e/operator.go
@@ -76,6 +76,24 @@ func (OperatorDeployment) setEnableMetadata(value bool) error {
 	return nil
 }
 
+func (OperatorDeployment) setEnableFencing(value bool) error {
+	command := []string{
+		"operatorconfigs.csi.ceph.io",
+		OperatorConfigName,
+		"--type=merge",
+		"-p",
+		fmt.Sprintf(`{"spec": {"driverSpecDefaults": {"enableFencing": %t}}}`, value),
+	}
+
+	// Patch the operator config
+	err := retryKubectlArgs(cephCSINamespace, kubectlPatch, deployTimeout, command...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (OperatorDeployment) setClusterName(value string) error {
 	command := []string{
 		"operatorconfigs.csi.ceph.io",

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -6252,6 +6252,12 @@ var _ = Describe("RBD", func() {
 					cephCSINamespace, rbdDeployment.getDeploymentName(), err)
 			}
 
+			// FIXME: OperatorDeployment.setEnableMetadata() should wait
+			if operatorDeployment {
+				// give ceph-csi-operator time to apply the change
+				time.Sleep(1 * time.Minute)
+			}
+
 			pvcSmartClone, err := loadPVC(pvcSmartClonePath)
 			if err != nil {
 				logAndFail("failed to load PVC: %v", err)

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -446,6 +446,11 @@ var _ = Describe("RBD", func() {
 			logAndFail("failed to set domain labels: %v", err)
 		}
 
+		err = rbdDeployment.setEnableFencing(true)
+		if err != nil {
+			logAndFail("failed to enable fencing: %v", err)
+		}
+
 		err = rbdDeployment.setClusterName(defaultClusterName)
 		if err != nil {
 			logAndFail("failed to set cluster name: %v", err)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -817,7 +817,12 @@ func checkDataPersist(pvcPath, appPath string, f *framework.Framework) error {
 	// write data to PVC
 	filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
 
-	_, stdErr, err := execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, filePath), app.Namespace, &opt)
+	_, stdErr, err := execCommandInPod(
+		f,
+		fmt.Sprintf("echo -n '%s' | dd of=%s status=none conv=fsync", data, filePath),
+		app.Namespace,
+		&opt,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to exec command in pod: %w", err)
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -112,6 +112,7 @@ type DeploymentMethod interface {
 	getDaemonsetName() string
 	getPodSelector() string
 	setClusterName(clusterName string) error
+	setEnableFencing(enable bool) error
 }
 type RBDDeploymentMethod interface {
 	DeploymentMethod
@@ -155,6 +156,12 @@ func (d *DriverInfo) setClusterName(clusterName string) error {
 		return fmt.Errorf("timeout waiting for clustername arg update %s/%s: %v", cephCSINamespace, d.deploymentName, err)
 	}
 
+	return nil
+}
+
+func (d *DriverInfo) setEnableFencing(enable bool) error {
+	// No-op as fencing is enabled in the yaml files by default, disabling is not needed.
+	// Required implementation in OperatorDeployment.
 	return nil
 }
 

--- a/internal/nfs/types/volume.go
+++ b/internal/nfs/types/volume.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
 	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (
@@ -173,6 +174,10 @@ func (nv *NFSVolume) CreateExport(backend *csi.Volume) error {
 	case strings.Contains(err.Error(), "Export already exists"):
 		return nil
 	case strings.Contains(err.Error(), "rados: ret=-2"): // try with the old command
+		log.ErrorLogMsg("going to fallback to cli, "+
+			"go-ceph failed to create export %q in NFS-cluster %q: %v",
+			nv, nfsCluster, err)
+
 		break
 	default: // any other error
 		return fmt.Errorf("exporting %q on NFS-cluster %q failed: %w",


### PR DESCRIPTION
Recent versions of Rook use Ceph-CSI Operator by default. There is no need to have Ceph-CSI deployed by Rook, as our CI deploys it from the PR that is being tested.

Rook v1.18.4 works well with Ceph Squid (v19). But for NVMe-oF testing we need a Ceph Tentacle (v20) cluster.

Closes: #5772

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
