### PR TITLE
CI: Use gci in the golangci-lint

### DIFF
--- a/api/deploy/kubernetes/cephfs/csi-config-map.go
+++ b/api/deploy/kubernetes/cephfs/csi-config-map.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 //go:embed csi-config-map.yaml

--- a/api/deploy/kubernetes/cephfs/csidriver.yaml
+++ b/api/deploy/kubernetes/cephfs/csidriver.yaml
@@ -4,7 +4,7 @@ kind: CSIDriver
 metadata:
   name: "{{ .Name }}"
 spec:
-  attachRequired: false
+  attachRequired: true
   podInfoOnMount: false
   fsGroupPolicy: File
   seLinuxMount: true

--- a/api/deploy/kubernetes/nfs/csi-config-map.go
+++ b/api/deploy/kubernetes/nfs/csi-config-map.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 //go:embed csi-config-map.yaml

--- a/api/deploy/kubernetes/nfs/csi-provisioner-rbac.go
+++ b/api/deploy/kubernetes/nfs/csi-provisioner-rbac.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"text/template"
 	"strings"
+	"text/template"
 
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
@@ -123,7 +123,6 @@ func NewCSIProvisionerRBACYAML(values kubernetes.CSIProvisionerRBACValues) (stri
 
 	return strings.Join(docs, "\n"), nil
 }
-
 
 func newYAML(name, data string, values kubernetes.CSIProvisionerRBACValues) (string, error) {
 	var buf bytes.Buffer

--- a/api/deploy/kubernetes/rbd/csi-config-map.go
+++ b/api/deploy/kubernetes/rbd/csi-config-map.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 //go:embed csi-config-map.yaml

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -23,7 +23,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
+	"go.uber.org/automaxprocs/maxprocs"
+	"k8s.io/klog/v2"
+	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/ceph/ceph-csi/internal/cephfs"
 	"github.com/ceph/ceph-csi/internal/controller"
@@ -35,10 +37,7 @@ import (
 	rbddriver "github.com/ceph/ceph-csi/internal/rbd/driver"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"go.uber.org/automaxprocs/maxprocs"
-	"k8s.io/klog/v2"
-	ctrlLog "sigs.k8s.io/controller-runtime/pkg/log"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 const (

--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -21,13 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	cephcsi "github.com/ceph/ceph-csi/api/deploy/kubernetes"
-
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	cephcsi "github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 func deleteConfigMap(pluginPath string) error {

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -408,7 +408,7 @@ func checkPVSelectorValuesForPVC(f *framework.Framework, pvc *v1.PersistentVolum
 }
 
 func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t int) error {
-	if (k8sBrokenMetrics(f.ClientSet)) {
+	if k8sBrokenMetrics(f.ClientSet) {
 		return nil
 	}
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -23,10 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ceph/ceph-csi/pkg/util/crypto"
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
 	"github.com/google/uuid"
-
 	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,6 +35,9 @@ import (
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/pod-security-admission/api"
+
+	"github.com/ceph/ceph-csi/pkg/util/crypto"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 var (

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -26,9 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util/cryptsetup"
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
-
 	"github.com/google/uuid"
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	v1 "k8s.io/api/core/v1"
@@ -37,6 +34,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/ceph/ceph-csi/internal/util/cryptsetup"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 //nolint:mnd // numbers specify Kernel versions.

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -23,6 +23,12 @@ import (
 	"fmt"
 	"syscall"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/ceph/ceph-csi/internal/cephfs/core"
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
@@ -33,13 +39,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 	rterrors "github.com/ceph/ceph-csi/internal/util/reftracker/errors"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // ControllerServer struct of CEPH CSI driver with supported methods of CSI

--- a/internal/cephfs/core/clone.go
+++ b/internal/cephfs/core/clone.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ceph/go-ceph/cephfs/admin"
+
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/ceph/go-ceph/cephfs/admin"
 )
 
 // cephFSCloneState describes the status of the clone.

--- a/internal/cephfs/core/clone_test.go
+++ b/internal/cephfs/core/clone_test.go
@@ -19,10 +19,10 @@ package core
 import (
 	"testing"
 
-	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
-
 	fsa "github.com/ceph/go-ceph/cephfs/admin"
 	"github.com/stretchr/testify/require"
+
+	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 )
 
 func TestCloneStateToError(t *testing.T) {

--- a/internal/cephfs/core/quiesce.go
+++ b/internal/cephfs/core/quiesce.go
@@ -19,10 +19,10 @@ package core
 import (
 	"context"
 
+	"github.com/ceph/go-ceph/cephfs/admin"
+
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/ceph/go-ceph/cephfs/admin"
 )
 
 type QuiesceState string

--- a/internal/cephfs/core/snapshot.go
+++ b/internal/cephfs/core/snapshot.go
@@ -21,13 +21,13 @@ import (
 	"errors"
 	"time"
 
-	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/ceph/go-ceph/cephfs/admin"
 	"github.com/ceph/go-ceph/rados"
 	"github.com/golang/protobuf/ptypes/timestamp"
+
+	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // SnapshotClient is the interface that holds the signature of snapshot methods

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -24,13 +24,13 @@ import (
 	"strings"
 	"sync"
 
+	fsAdmin "github.com/ceph/go-ceph/cephfs/admin"
+	"github.com/ceph/go-ceph/rados"
+
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	fsAdmin "github.com/ceph/go-ceph/cephfs/admin"
-	"github.com/ceph/go-ceph/rados"
 )
 
 var (

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -19,6 +19,8 @@ package cephfs
 import (
 	"fmt"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
 	"github.com/ceph/ceph-csi/internal/cephfs/mounter"
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
 	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
@@ -31,8 +33,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 // cephfsDriver contains the default identity,node and controller struct.

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -24,18 +24,18 @@ import (
 	"sort"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/cephfs/core"
-	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
-	"github.com/ceph/ceph-csi/internal/cephfs/store"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/ceph/go-ceph/cephfs/admin"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/ceph/ceph-csi/internal/cephfs/core"
+	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
+	"github.com/ceph/ceph-csi/internal/cephfs/store"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // validateCreateVolumeGroupSnapshotRequest validates the request for creating

--- a/internal/cephfs/groupcontrollerserver_test.go
+++ b/internal/cephfs/groupcontrollerserver_test.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"testing"
 
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 )
 
 func TestControllerServer_validateCreateVolumeGroupSnapshotRequest(t *testing.T) {

--- a/internal/cephfs/identityserver.go
+++ b/internal/cephfs/identityserver.go
@@ -19,9 +19,9 @@ package cephfs
 import (
 	"context"
 
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 )
 
 // IdentityServer struct of ceph CSI driver with supported methods of CSI

--- a/internal/cephfs/mounter/volumemounter.go
+++ b/internal/cephfs/mounter/volumemounter.go
@@ -23,11 +23,10 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
-
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 var (

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -26,6 +26,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/ceph/ceph-csi/internal/cephfs/core"
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 	"github.com/ceph/ceph-csi/internal/cephfs/mounter"
@@ -37,10 +41,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/fscrypt"
 	iolock "github.com/ceph/ceph-csi/internal/util/lock"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // NodeServer struct of ceph CSI driver with supported methods of CSI

--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -21,16 +21,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/ceph/ceph-csi/internal/cephfs/core"
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/ceph/ceph-csi/pkg/util/crypto"
-
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (

--- a/internal/cephfs/store/volumegroup.go
+++ b/internal/cephfs/store/volumegroup.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
 	"github.com/ceph/ceph-csi/internal/cephfs/core"
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 type VolumeGroupOptions struct {

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
-	"github.com/ceph/ceph-csi/pkg/util/crypto"
-
 	cephcsi "github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	"github.com/ceph/ceph-csi/internal/cephfs/core"
 	cerrors "github.com/ceph/ceph-csi/internal/cephfs/errors"
@@ -37,6 +35,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/pkg/util/crypto"
 )
 
 const (

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -19,11 +19,11 @@ package cephfs
 import (
 	"fmt"
 
-	"github.com/ceph/ceph-csi/internal/util"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // validateCreateVolumeRequest validates the Controller CreateVolume request.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -18,8 +18,6 @@ package controller
 import (
 	"fmt"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // Manager is the interface that will wrap Add function.

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -20,11 +20,6 @@ import (
 	"errors"
 	"fmt"
 
-	ctrl "github.com/ceph/ceph-csi/internal/controller"
-	"github.com/ceph/ceph-csi/internal/rbd"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +32,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ctrl "github.com/ceph/ceph-csi/internal/controller"
+	"github.com/ceph/ceph-csi/internal/rbd"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // ReconcilePersistentVolume reconciles a PersistentVolume object.

--- a/internal/csi-addons/cephfs/network_fence.go
+++ b/internal/csi-addons/cephfs/network_fence.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"errors"
 
-	nf "github.com/ceph/ceph-csi/internal/csi-addons/networkfence"
-	"github.com/ceph/ceph-csi/internal/util"
-
 	"github.com/csi-addons/spec/lib/go/fence"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	nf "github.com/ceph/ceph-csi/internal/csi-addons/networkfence"
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // FenceControllerServer struct of cephFS CSI driver with supported methods

--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/csi-addons/spec/lib/go/fence"
+
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/csi-addons/spec/lib/go/fence"
 )
 
 const (

--- a/internal/csi-addons/rbd/encryptionkeyrotation.go
+++ b/internal/csi-addons/rbd/encryptionkeyrotation.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ceph/ceph-csi/internal/rbd"
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	ekr "github.com/csi-addons/spec/lib/go/encryptionkeyrotation"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/ceph/ceph-csi/internal/rbd"
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 type EncryptionKeyRotationServer struct {

--- a/internal/csi-addons/rbd/network_fence.go
+++ b/internal/csi-addons/rbd/network_fence.go
@@ -17,13 +17,13 @@ import (
 	"context"
 	"errors"
 
-	nf "github.com/ceph/ceph-csi/internal/csi-addons/networkfence"
-	"github.com/ceph/ceph-csi/internal/util"
-
 	"github.com/csi-addons/spec/lib/go/fence"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	nf "github.com/ceph/ceph-csi/internal/csi-addons/networkfence"
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // FenceControllerServer struct of rbd CSI driver with supported methods

--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -21,17 +21,17 @@ import (
 	"errors"
 	"fmt"
 
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	rs "github.com/csi-addons/spec/lib/go/reclaimspace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // ReclaimSpaceControllerServer struct of rbd CSI driver with supported methods

--- a/internal/csi-addons/rbd/reclaimspace_test.go
+++ b/internal/csi-addons/rbd/reclaimspace_test.go
@@ -19,10 +19,10 @@ package rbd
 import (
 	"testing"
 
-	"github.com/ceph/ceph-csi/internal/util"
-
 	rs "github.com/csi-addons/spec/lib/go/reclaimspace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // TestControllerReclaimSpace is a minimal test for the

--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -25,14 +25,6 @@ import (
 	"strings"
 	"time"
 
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-	"github.com/ceph/ceph-csi/internal/rbd"
-	corerbd "github.com/ceph/ceph-csi/internal/rbd"
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/rbd/types"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
 	"github.com/csi-addons/spec/lib/go/replication"
@@ -41,6 +33,14 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/rbd"
+	corerbd "github.com/ceph/ceph-csi/internal/rbd"
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // imageMirroringMode is used to indicate the mirroring mode for an RBD image.

--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -23,17 +23,17 @@ import (
 	"testing"
 	"time"
 
-	corerbd "github.com/ceph/ceph-csi/internal/rbd"
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/rbd/types"
-	"github.com/ceph/ceph-csi/internal/util"
-
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
 	"github.com/csi-addons/spec/lib/go/replication"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	corerbd "github.com/ceph/ceph-csi/internal/rbd"
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 func TestValidateSchedulingInterval(t *testing.T) {

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -22,15 +22,15 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/ceph/ceph-csi/internal/rbd"
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/rbd/types"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/csi-addons/spec/lib/go/volumegroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/ceph/ceph-csi/internal/rbd"
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // VolumeGroupServer struct of rbd CSI driver with supported methods of

--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -19,11 +19,11 @@ package csicommon
 import (
 	"context"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // DefaultControllerServer points to default driver.

--- a/internal/csi-common/driver.go
+++ b/internal/csi-common/driver.go
@@ -17,12 +17,12 @@ limitations under the License.
 package csicommon
 
 import (
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // CSIDriver stores driver information.

--- a/internal/csi-common/identityserver-default.go
+++ b/internal/csi-common/identityserver-default.go
@@ -19,11 +19,11 @@ package csicommon
 import (
 	"context"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // DefaultIdentityServer stores driver object.

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -19,10 +19,10 @@ package csicommon
 import (
 	"context"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	mount "k8s.io/mount-utils"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // DefaultNodeServer stores driver object.

--- a/internal/csi-common/server.go
+++ b/internal/csi-common/server.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"sync"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // NonBlockingGRPCServer defines Non blocking GRPC server interfaces.

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -25,8 +25,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/csi-addons/spec/lib/go/replication"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
@@ -38,6 +36,8 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 	mount "k8s.io/mount-utils"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 func parseEndpoint(ep string) (string, string, error) {

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ceph/go-ceph/rados"
+
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/ceph/go-ceph/rados"
 )
 
 // chunkSize is the number of key-value pairs that will be fetched in

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -24,12 +24,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ceph/ceph-csi/pkg/util/crypto"
+	"github.com/google/uuid"
 
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/google/uuid"
+	"github.com/ceph/ceph-csi/pkg/util/crypto"
 )
 
 // Length of string representation of uuid, xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx is 36 bytes.

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/google/uuid"
 )
 
 const (

--- a/internal/kms/aws_metadata.go
+++ b/internal/kms/aws_metadata.go
@@ -22,12 +22,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	"github.com/aws/aws-sdk-go/aws"
 	awsCreds "github.com/aws/aws-sdk-go/aws/credentials"
 	awsSession "github.com/aws/aws-sdk-go/aws/session"
 	awsKMS "github.com/aws/aws-sdk-go/service/kms"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/aws_sts_metadata.go
+++ b/internal/kms/aws_sts_metadata.go
@@ -23,13 +23,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	awsSTS "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go/aws"
 	awsCreds "github.com/aws/aws-sdk-go/aws/credentials"
 	awsSession "github.com/aws/aws-sdk-go/aws/session"
 	awsKMS "github.com/aws/aws-sdk-go/service/kms"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/azure_vault.go
+++ b/internal/kms/azure_vault.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/keyprotect.go
+++ b/internal/kms/keyprotect.go
@@ -22,9 +22,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	kp "github.com/IBM/keyprotect-go-client"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -28,12 +28,12 @@ import (
 	"io"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	kmip "github.com/gemalto/kmip-go"
 	"github.com/gemalto/kmip-go/kmip14"
 	"github.com/gemalto/kmip-go/ttlv"
 	"github.com/google/uuid"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -26,9 +26,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	"golang.org/x/crypto/scrypt"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -22,13 +22,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	"github.com/libopenstorage/secrets/vault"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/kms/vault_tokens.go
+++ b/internal/kms/vault_tokens.go
@@ -24,14 +24,14 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/ceph/ceph-csi/internal/util/file"
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	"github.com/hashicorp/vault/api"
 	loss "github.com/libopenstorage/secrets"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/ceph/ceph-csi/internal/util/file"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (

--- a/internal/liveness/liveness.go
+++ b/internal/liveness/liveness.go
@@ -20,14 +20,14 @@ import (
 	"context"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	connlib "github.com/kubernetes-csi/csi-lib-utils/connection"
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	"github.com/kubernetes-csi/csi-lib-utils/rpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 var liveness = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"errors"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/ceph/ceph-csi/internal/cephfs"
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
 	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
@@ -27,10 +31,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/journal"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Server struct of CEPH CSI driver with supported methods of CSI controller

--- a/internal/nfs/controller/volume.go
+++ b/internal/nfs/controller/volume.go
@@ -22,13 +22,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ceph/go-ceph/common/admin/nfs"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
 	fscore "github.com/ceph/ceph-csi/internal/cephfs/core"
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
 	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
 	"github.com/ceph/ceph-csi/internal/util"
-
-	"github.com/ceph/go-ceph/common/admin/nfs"
-	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 const (

--- a/internal/nfs/driver/driver.go
+++ b/internal/nfs/driver/driver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driver
 
 import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/driver"
 	"github.com/ceph/ceph-csi/internal/nfs/controller"
@@ -24,8 +26,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/nfs/nodeserver"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 // nfsDriver contains the default identity and controller struct.

--- a/internal/nfs/identity/identityserver.go
+++ b/internal/nfs/identity/identityserver.go
@@ -19,9 +19,9 @@ package identity
 import (
 	"context"
 
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 )
 
 // Server struct of ceph CSI driver with supported methods of CSI identity

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -22,16 +22,16 @@ import (
 	"os"
 	"strings"
 
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	mount "k8s.io/mount-utils"
 	netutil "k8s.io/utils/net"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (

--- a/internal/nvmeof/driver/driver.go
+++ b/internal/nvmeof/driver/driver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driver
 
 import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/driver"
 	"github.com/ceph/ceph-csi/internal/nvmeof/controller"
@@ -25,8 +27,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 // nvmeofDriver provides the entry point for the NVMe-oF CSI driver.

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -23,11 +23,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/avast/retry-go/v4"
+
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/kmod"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/avast/retry-go/v4"
 )
 
 const (

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -22,13 +22,13 @@ import (
 	"fmt"
 	"strings"
 
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	librbd "github.com/ceph/go-ceph/rbd"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // checkCloneImage check the cloned image exists, if the cloned image is not

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -23,17 +23,17 @@ import (
 	"fmt"
 	"strconv"
 
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
 	casrbd "github.com/ceph/ceph-csi/internal/csi-addons/rbd"
 	csiaddons "github.com/ceph/ceph-csi/internal/csi-addons/server"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
@@ -30,8 +32,6 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 // driver contains the default identity,node and controller struct.

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -24,15 +24,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ceph/ceph-csi/pkg/util/crypto"
+	librbd "github.com/ceph/go-ceph/rbd"
 
 	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/cryptsetup"
 	"github.com/ceph/ceph-csi/internal/util/lock"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/ceph/ceph-csi/pkg/util/crypto"
 )
 
 // rbdEncryptionState describes the status of the process where the image is

--- a/internal/rbd/group/util_test.go
+++ b/internal/rbd/group/util_test.go
@@ -20,10 +20,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ceph/go-ceph/rados"
+
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/util"
-
-	"github.com/ceph/go-ceph/rados"
 )
 
 func Test_shouldRetryVolumeGroupGeneration(t *testing.T) {

--- a/internal/rbd/identityserver.go
+++ b/internal/rbd/identityserver.go
@@ -19,11 +19,11 @@ package rbd
 import (
 	"context"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/rbd/features"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 // IdentityServer struct of rbd CSI driver with supported methods of CSI

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 	"time"
 
+	librbd "github.com/ceph/go-ceph/rbd"
+
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	librbd "github.com/ceph/go-ceph/rbd"
 )
 
 // HandleParentImageExistence checks the image's parent.

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -25,15 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
-
-	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/file"
-	"github.com/ceph/ceph-csi/internal/util/fscrypt"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -41,6 +32,14 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	mount "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
+
+	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/file"
+	"github.com/ceph/ceph-csi/internal/util/fscrypt"
+	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 // NodeServer struct of ceph rbd driver with supported methods of CSI

--- a/internal/rbd/nodeserver_test.go
+++ b/internal/rbd/nodeserver_test.go
@@ -21,12 +21,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/require"
+
 	cephcsi "github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/util"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetStagingPath(t *testing.T) {

--- a/internal/rbd/qos.go
+++ b/internal/rbd/qos.go
@@ -21,9 +21,9 @@ import (
 	"errors"
 	"strconv"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	librbd "github.com/ceph/go-ceph/rbd"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -23,14 +23,13 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
+	"github.com/avast/retry-go/v4"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/kmod"
 	"github.com/ceph/ceph-csi/internal/util/log"
-
-	"github.com/avast/retry-go/v4"
-	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 const (

--- a/internal/rbd/rbd_healer.go
+++ b/internal/rbd/rbd_healer.go
@@ -24,15 +24,15 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/ceph/ceph-csi/internal/util"
-	kubeclient "github.com/ceph/ceph-csi/internal/util/k8s"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/ceph/ceph-csi/internal/util"
+	kubeclient "github.com/ceph/ceph-csi/internal/util/k8s"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -21,13 +21,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ceph/ceph-csi/pkg/util/crypto"
-
 	"github.com/ceph/ceph-csi/internal/journal"
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/pkg/util/crypto"
 )
 
 func validateNonEmptyField(field, fieldName, structName string) error {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -29,15 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ceph/ceph-csi/pkg/util/crypto"
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
-
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/rbd/types"
-	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/kmod"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
@@ -45,6 +36,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cloud-provider/volume/helpers"
 	mount "k8s.io/mount-utils"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/kmod"
+	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/pkg/util/crypto"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 const (

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"testing"
 
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/util"
-
 	"github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/stretchr/testify/require"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 func TestHasSnapshotFeature(t *testing.T) {

--- a/internal/rbd/replication.go
+++ b/internal/rbd/replication.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	librbd "github.com/ceph/go-ceph/rbd"
+
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
-
-	librbd "github.com/ceph/go-ceph/rbd"
 )
 
 // repairResyncedImageID updates the existing image ID with new one.

--- a/internal/rbd/sms_controllerserver.go
+++ b/internal/rbd/sms_controllerserver.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"errors"
 
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/rbd/features"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/features"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (

--- a/internal/rbd/snap_diff.go
+++ b/internal/rbd/snap_diff.go
@@ -21,13 +21,13 @@ import (
 	"errors"
 	"fmt"
 
-	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
-	"github.com/ceph/ceph-csi/internal/rbd/types"
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // ProcessMetadata streams the block metadata for a snapshot.

--- a/internal/rbd/types/mirror.go
+++ b/internal/rbd/types/mirror.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util"
-
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
+
+	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // FlattenMode is used to indicate the flatten mode for an RBD image.

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -25,10 +25,10 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/ceph/go-ceph/rados"
+
 	"github.com/ceph/ceph-csi/internal/util/log"
 	"github.com/ceph/ceph-csi/internal/util/stripsecrets"
-
-	"github.com/ceph/go-ceph/rados"
 )
 
 const (

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -26,11 +26,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ceph/ceph-csi/pkg/util/crypto"
-
 	"github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util/cryptsetup"
 	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/pkg/util/crypto"
 )
 
 const (

--- a/internal/util/crypto_test.go
+++ b/internal/util/crypto_test.go
@@ -20,10 +20,10 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/pkg/util/crypto"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateNewEncryptionPassphrase(t *testing.T) {

--- a/internal/util/cryptsetup/cryptsetup.go
+++ b/internal/util/cryptsetup/cryptsetup.go
@@ -27,11 +27,11 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/cloud-provider/volume/helpers"
+
 	"github.com/ceph/ceph-csi/internal/util/file"
 	"github.com/ceph/ceph-csi/internal/util/log"
 	"github.com/ceph/ceph-csi/internal/util/stripsecrets"
-
-	"k8s.io/cloud-provider/volume/helpers"
 )
 
 const (

--- a/internal/util/csiconfig_test.go
+++ b/internal/util/csiconfig_test.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"testing"
 
-	cephcsi "github.com/ceph/ceph-csi/api/deploy/kubernetes"
-
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+
+	cephcsi "github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 var (

--- a/internal/util/fscrypt/fscrypt.go
+++ b/internal/util/fscrypt/fscrypt.go
@@ -35,11 +35,10 @@ import (
 	"github.com/pkg/xattr"
 	"golang.org/x/sys/unix"
 
-	"github.com/ceph/ceph-csi/pkg/util/kernel"
-
 	"github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
+	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
 
 const (

--- a/internal/util/getsecret_test.go
+++ b/internal/util/getsecret_test.go
@@ -17,9 +17,9 @@ import (
 	"errors"
 	"testing"
 
-	kmsapi "github.com/ceph/ceph-csi/internal/kms"
-
 	"github.com/stretchr/testify/require"
+
+	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 )
 
 func TestGetPassphraseFromKMS(t *testing.T) {

--- a/internal/util/httpserver.go
+++ b/internal/util/httpserver.go
@@ -8,9 +8,9 @@ import (
 	runtime_pprof "runtime/pprof"
 	"strconv"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // ValidateURL validates the url.

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 const (

--- a/internal/util/k8s/secrets.go
+++ b/internal/util/k8s/secrets.go
@@ -28,12 +28,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util/log"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // cachedSecret is a string representation of a Kubernetes

--- a/internal/util/reftracker/reftracker.go
+++ b/internal/util/reftracker/reftracker.go
@@ -20,13 +20,13 @@ import (
 	goerrors "errors"
 	"fmt"
 
+	"github.com/ceph/go-ceph/rados"
+
 	"github.com/ceph/ceph-csi/internal/util/reftracker/errors"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/reftype"
 	v1 "github.com/ceph/ceph-csi/internal/util/reftracker/v1"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/version"
-
-	"github.com/ceph/go-ceph/rados"
 )
 
 // reftracker is key-based implementation of a reference counter.

--- a/internal/util/reftracker/reftracker_test.go
+++ b/internal/util/reftracker/reftracker_test.go
@@ -19,10 +19,10 @@ package reftracker
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/reftype"
-
-	"github.com/stretchr/testify/require"
 )
 
 const rtName = "hello-rt"

--- a/internal/util/reftracker/v1/v1.go
+++ b/internal/util/reftracker/v1/v1.go
@@ -20,12 +20,12 @@ import (
 	goerrors "errors"
 	"fmt"
 
+	"github.com/ceph/go-ceph/rados"
+
 	"github.com/ceph/ceph-csi/internal/util/reftracker/errors"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/reftype"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/version"
-
-	"github.com/ceph/go-ceph/rados"
 )
 
 /*

--- a/internal/util/reftracker/v1/v1_test.go
+++ b/internal/util/reftracker/v1/v1_test.go
@@ -19,11 +19,11 @@ package v1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ceph/ceph-csi/internal/util/reftracker/errors"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
 	"github.com/ceph/ceph-csi/internal/util/reftracker/reftype"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestV1Read(t *testing.T) {

--- a/internal/util/reftracker/version/version_test.go
+++ b/internal/util/reftracker/version/version_test.go
@@ -19,9 +19,9 @@ package version
 import (
 	"testing"
 
-	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/ceph-csi/internal/util/reftracker/radoswrapper"
 )
 
 var (

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -29,11 +29,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ceph/ceph-csi/internal/util/k8s"
-
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cloud-provider/volume/helpers"
 	mount "k8s.io/mount-utils"
+
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 // Driver types to identify type of driver running.

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -141,12 +141,18 @@ formatters:
     - gofmt
     - gofumpt
     - goimports
+    - gci
   settings:
     gofmt:
       simplify: true
     goimports:
       local-prefixes:
         - github.com/ceph/ceph-csi
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
   exclusions:
     generated: lax
     paths:

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs/csi-config-map.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs/csi-config-map.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 //go:embed csi-config-map.yaml

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs/csidriver.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs/csidriver.yaml
@@ -4,7 +4,7 @@ kind: CSIDriver
 metadata:
   name: "{{ .Name }}"
 spec:
-  attachRequired: false
+  attachRequired: true
   podInfoOnMount: false
   fsGroupPolicy: File
   seLinuxMount: true

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csi-config-map.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csi-config-map.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 //go:embed csi-config-map.yaml

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csi-provisioner-rbac.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csi-provisioner-rbac.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"text/template"
 	"strings"
+	"text/template"
 
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
@@ -123,7 +123,6 @@ func NewCSIProvisionerRBACYAML(values kubernetes.CSIProvisionerRBACValues) (stri
 
 	return strings.Join(docs, "\n"), nil
 }
-
 
 func newYAML(name, data string, values kubernetes.CSIProvisionerRBACValues) (string, error) {
 	var buf bytes.Buffer

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd/csi-config-map.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd/csi-config-map.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/ceph/ceph-csi/api/deploy/kubernetes"
 )
 
 //go:embed csi-config-map.yaml


### PR DESCRIPTION
adding one more formater to check the import order as per the cephcsi documented way https://github.com/ceph/ceph-csi/blob/devel/docs/coding.md#imports  so that we dont get into this problem again.

https://golangci-lint.run/docs/formatters/configuration/#gci contains more details