### PR TITLE
fix: retry controllerpublish secret fetch on missing clusterId

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -326,15 +326,65 @@ func ParseClientIP(addr string) (string, error) {
 // for a given clusterID. Fetches the secret from Kubernetes, and returns it as a map of key-value pairs.
 func GetControllerPublishSecretRef(volumeId, driverType string) (string, string, error) {
 	var (
-		vi               CSIIdentifier
-		secretName       string
-		secretNamespace  string
-		getSecretRefFunc func(string, string) (string, string, error)
+		vi              CSIIdentifier
+		secretName      string
+		secretNamespace string
 	)
 	err := vi.DecomposeCSIID(volumeId)
 	if err != nil {
 		return secretName, secretNamespace, fmt.Errorf("failed to decode volume ID (%s): %w", volumeId, err)
 	}
+
+	secretName, secretNamespace, err = getControllerPublishSecretRef(vi.ClusterID, driverType)
+	if !errors.Is(err, ErrConfigNotFound) {
+		return secretName, secretNamespace,
+			fmt.Errorf("failed to get controller publish secret details from csi config file: %w", err)
+	}
+
+	if secretName != "" && secretNamespace != "" {
+		return secretName, secretNamespace, nil
+	}
+
+	// Check clusterID mapping exists
+	mapping, mErr := GetClusterMappingInfo(vi.ClusterID)
+	if mErr != nil {
+		return secretName, secretNamespace, mErr
+	}
+	if mapping != nil {
+		for _, cm := range *mapping {
+			for key, val := range cm.ClusterIDMapping {
+				mappedClusterID := GetMappedID(key, val, vi.ClusterID)
+				if mappedClusterID == "" {
+					continue
+				}
+
+				secretName, secretNamespace, err := getControllerPublishSecretRef(mappedClusterID, driverType)
+				if !errors.Is(err, ErrConfigNotFound) {
+					return secretName, secretNamespace,
+						fmt.Errorf("failed to get controller publish secret details from csi config file: %w", err)
+				}
+				if secretName != "" && secretNamespace != "" {
+					return secretName, secretNamespace, nil
+				}
+			}
+		}
+	}
+
+	if secretName == "" || secretNamespace == "" {
+		return secretName, secretNamespace, fmt.Errorf("controller publish secret name or namespace is empty"+
+			" in csi config file for cluster %s", vi.ClusterID)
+	}
+
+	return secretName, secretNamespace, nil
+}
+
+func getControllerPublishSecretRef(clusterId, driverType string) (string, string, error) {
+	var (
+		err              error
+		secretName       string
+		secretNamespace  string
+		getSecretRefFunc func(string, string) (string, string, error)
+	)
 
 	switch driverType {
 	case RBDType:
@@ -345,16 +395,7 @@ func GetControllerPublishSecretRef(volumeId, driverType string) (string, string,
 		return secretName, secretNamespace, fmt.Errorf("unsupported driver type: %s", driverType)
 	}
 
-	secretName, secretNamespace, err = getSecretRefFunc(CsiConfigFile, vi.ClusterID)
-	if err != nil {
-		return secretName, secretNamespace,
-			fmt.Errorf("failed to get controller publish secret details from csi config file: %w", err)
-	}
+	secretName, secretNamespace, err = getSecretRefFunc(CsiConfigFile, clusterId)
 
-	if secretName == "" || secretNamespace == "" {
-		return secretName, secretNamespace, fmt.Errorf("controller publish secret name or namespace is empty"+
-			" in csi config file for cluster %s", vi.ClusterID)
-	}
-
-	return secretName, secretNamespace, nil
+	return secretName, secretNamespace, err
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Problem: When the CSI clusterId differs between mirroring clusters, the PVC
restore on the secondary cluster fails at the Controller[Un]PublishVolume call.
This happens because it cannot fetch secrets from the CSI ConfigMap using the
mismatched clusterId.

Solution: While fetching ControllerPublishSecrets from the CSI ConfigMap, if the
error returned is ErrConfigNotFound, retry the operation using the mapped
clusterId from the clusterMapping configuration.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
