### PR TITLE
util: add explicit nil check before errors.Is(err) check

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -335,7 +335,7 @@ func GetControllerPublishSecretRef(volumeId, driverType string) (string, string,
 	}
 
 	secretName, secretNamespace, err = getControllerPublishSecretRef(vi.ClusterID, driverType)
-	if !errors.Is(err, ErrConfigNotFound) {
+	if err != nil && !errors.Is(err, ErrConfigNotFound) {
 		return secretName, secretNamespace,
 			fmt.Errorf("failed to get controller publish secret details from csi config file: %w", err)
 	}
@@ -358,7 +358,7 @@ func GetControllerPublishSecretRef(volumeId, driverType string) (string, string,
 				}
 
 				secretName, secretNamespace, err := getControllerPublishSecretRef(mappedClusterID, driverType)
-				if !errors.Is(err, ErrConfigNotFound) {
+				if err != nil && !errors.Is(err, ErrConfigNotFound) {
 					return secretName, secretNamespace,
 						fmt.Errorf("failed to get controller publish secret details from csi config file: %w", err)
 				}


### PR DESCRIPTION
# Describe what this PR does #

part of https://github.com/ceph/ceph-csi/pull/5677

```
When error is nil, `!errors.Is(err, ErrConfigNotFound)` evaluates true and
`GetControllerPublishSecretRef` function returns error which should not be the case.
```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
<hr>This is an automatic backport of pull request #5692 done by [Mergify](https://mergify.com).