### PR TITLE
nvmeof: add qos ability

### DIFF
--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -209,6 +209,9 @@ func getReqID(req interface{}) string {
 	case *csi.ControllerExpandVolumeRequest:
 		reqID = r.GetVolumeId()
 
+	case *csi.ControllerModifyVolumeRequest:
+		reqID = r.GetVolumeId()
+
 	case *csi.ControllerPublishVolumeRequest:
 		reqID = r.GetVolumeId()
 	case *csi.ControllerUnpublishVolumeRequest:

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -312,6 +312,22 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	if err != nil {
 		return fmt.Errorf("invalid listeners parameter: %w", err)
 	}
+	// Validate QoS parameters - cannot mix RBD and NVMe-oF QoS
+	mutableParams := req.GetMutableParameters()
+
+	// check for RBD QoS parameters in both params and mutableParams
+	if hasRBDQoS := rbd.HasQoSParams(params); hasRBDQoS {
+		return errors.New("setting RBD QoS parameters on NVMe-oF volumes is not supported")
+	}
+	if hasRBDQoS := rbd.HasQoSParams(mutableParams); hasRBDQoS {
+		return errors.New("setting RBD QoS parameters on NVMe-oF volumes is not supported")
+	}
+
+	// It take the mutableParams value from the volumeAttributesClassName in the PersistentVolumeClaim yaml.
+	_, err = parseQoSParameters(mutableParams)
+	if err != nil {
+		return fmt.Errorf("invalid NVMe-oF QoS parameters: %w", err)
+	}
 
 	return nil
 }
@@ -349,6 +365,44 @@ func parseListeners(listenersJSON string) ([]nvmeof.ListenerDetails, error) {
 	}
 
 	return listeners, nil
+}
+
+// parseQoSParameters extracts and parses QoS parameters from the given map.
+func parseQoSParameters(params map[string]string) (*nvmeof.NVMeoFQosVolume, error) {
+	qos := &nvmeof.NVMeoFQosVolume{}
+	hasAnyQoS := false
+
+	parseParam := func(key, name string, dest **uint64) error {
+		if val, exists := params[key]; exists && val != "" {
+			parsed, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid %s: %w", name, err)
+			}
+			*dest = &parsed
+			hasAnyQoS = true
+		}
+
+		return nil
+	}
+
+	if err := parseParam(nvmeof.RwIosPerSecond, nvmeof.RwIosPerSecond, &qos.RwIosPerSecond); err != nil {
+		return nil, err
+	}
+	if err := parseParam(nvmeof.RwMbytesPerSecond, nvmeof.RwMbytesPerSecond, &qos.RwMbytesPerSecond); err != nil {
+		return nil, err
+	}
+	if err := parseParam(nvmeof.RMbytesPerSecond, nvmeof.RMbytesPerSecond, &qos.RMbytesPerSecond); err != nil {
+		return nil, err
+	}
+	if err := parseParam(nvmeof.WMbytesPerSecond, nvmeof.WMbytesPerSecond, &qos.WMbytesPerSecond); err != nil {
+		return nil, err
+	}
+
+	if !hasAnyQoS {
+		return nil, nil
+	}
+
+	return qos, nil
 }
 
 // ensureSubsystem checks if the subsystem exists, and creates it if not.
@@ -434,7 +488,6 @@ func cleanupEmptySubsystem(
 }
 
 // createNVMeoFResources sets up the NVMe-oF resources for the given RBD volume.
-// TODO - need to support multiple listeners.
 func (cs *Server) createNVMeoFResources(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
@@ -464,6 +517,16 @@ func (cs *Server) createNVMeoFResources(
 			Address: params["nvmeofGatewayAddress"],
 			Port:    uint32(nvmeofGatewayPort),
 		},
+	}
+	// extract Qos parameters if any
+	mutableParams := req.GetMutableParameters()
+	// It take the mutableParams value from the volumeAttributesClassName in the PersistentVolumeClaim yaml.
+	// We already verified in the validateCreateVolumeRequest that there is no RBD QoS
+	nvmeofQoS, err := parseQoSParameters(mutableParams)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to parse NVMe-oF QoS parameters: %v", err)
+
+		return nil, fmt.Errorf("failed to parse QoS parameters: %w", err)
 	}
 
 	// Step 2: Connect to gateway
@@ -504,6 +567,15 @@ func (cs *Server) createNVMeoFResources(
 	}
 	log.DebugLog(ctx, "Namespace created: %s/%s with NSID: %d", rbdPoolName, rbdImageName, nsid)
 	nvmeofData.NamespaceID = nsid
+
+	// Step 5: Set QoS limits if any
+	if nvmeofQoS != nil {
+		log.DebugLog(ctx, "Setting QoS limits: %s", nvmeofQoS)
+		if err := gateway.SetQoSLimitsForNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID,
+			*nvmeofQoS); err != nil {
+			return nil, fmt.Errorf("setting QoS limits failed: %w", err)
+		}
+	}
 
 	uuid, err := gateway.GetUUIDBySubsystemAndNameSpaceID(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID)
 	if err != nil {

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -29,6 +29,7 @@ import (
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/nvmeof"
+	nvmeoferrors "github.com/ceph/ceph-csi/internal/nvmeof/errors"
 	"github.com/ceph/ceph-csi/internal/rbd"
 	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
 	rbddriver "github.com/ceph/ceph-csi/internal/rbd/driver"
@@ -293,6 +294,42 @@ func (cs *Server) ControllerUnpublishVolume(
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
+// ControllerModifyVolume modifies the volume's QoS parameters.
+func (cs *Server) ControllerModifyVolume(
+	ctx context.Context,
+	req *csi.ControllerModifyVolumeRequest,
+) (*csi.ControllerModifyVolumeResponse, error) {
+	volumeID := req.GetVolumeId()
+	params := req.GetMutableParameters()
+
+	// Step 1: Acquire volume lock
+	if acquired := cs.volumeLocks.TryAcquire(volumeID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer cs.volumeLocks.Release(volumeID)
+
+	// Step 2: Parse QoS parameters from mutable_parameters
+	hasRBDQoS := rbd.HasQoSParams(params)
+	if hasRBDQoS {
+		log.ErrorLog(ctx, "Cannot set RBD QoS parameters on NVMe-oF volumes")
+
+		return nil, status.Error(codes.InvalidArgument, "cannot set RBD QoS parameters on NVMe-oF volumes")
+	}
+	nvmeofQoS, err := parseQoSParameters(params)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to parse NVMe-oF QoS parameters: %v", err)
+
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse QoS parameters: %v", err)
+	}
+	if nvmeofQoS != nil {
+		return cs.modifyNVMeoFQoS(ctx, req, nvmeofQoS)
+	}
+
+	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
 // validateCreateVolumeRequest validates the incoming request for nvmeof.
 // the rest of the parameters are validated by RBD.
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
@@ -403,6 +440,85 @@ func parseQoSParameters(params map[string]string) (*nvmeof.NVMeoFQosVolume, erro
 	}
 
 	return qos, nil
+}
+
+// modifyNVMeoFQoS handles NVMe-oF gateway QoS modification.
+func (cs *Server) modifyNVMeoFQoS(
+	ctx context.Context,
+	req *csi.ControllerModifyVolumeRequest,
+	qos *nvmeof.NVMeoFQosVolume,
+) (*csi.ControllerModifyVolumeResponse, error) {
+	volumeID := req.GetVolumeId()
+
+	// Step 1: Get secrets
+
+	// Since ControllerModifyVolume doesn't receive volume context and dont have option to take secrets
+	// because there is no "csi.storage.k8s.io/controller-modify-secret-name" field in the SC !,
+	// the full solution for it is to use GetControllerExpandSecretRef but there is no such function yet.
+	// TODO: change the call to GetControllerExpandSecretRef once it is implemented.
+	secrets := req.GetSecrets()
+	if secrets == nil {
+		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeID, util.RBDType)
+		if err != nil {
+			log.ErrorLog(ctx, "Failed to get secret reference: %v", err)
+
+			return nil, status.Errorf(codes.Internal, "failed to get secret reference: %v", err)
+		}
+
+		secrets, err = k8s.GetSecret(secretName, secretNamespace)
+		if err != nil {
+			log.ErrorLog(ctx, "Failed to get secret from k8s: %v", err)
+
+			return nil, status.Errorf(codes.Internal, "failed to get secret: %v", err)
+		}
+	}
+
+	// Step 2: Get NVMe-oF metadata
+	nvmeofData, err := cs.getNVMeoFMetadata(ctx, secrets, volumeID)
+	if err != nil {
+		log.ErrorLog(ctx, "Failed to get NVMe-oF metadata: %v", err)
+
+		return nil, nvmeoferrors.ToGRPCError(err)
+	}
+
+	// Step 3: Connect to gateway
+	config := &nvmeof.GatewayConfig{
+		Address: nvmeofData.GatewayManagementInfo.Address,
+		Port:    nvmeofData.GatewayManagementInfo.Port,
+	}
+	gateway, err := connectGateway(ctx, config)
+	if err != nil {
+		log.ErrorLog(ctx, "Gateway connection failed: %v", err)
+
+		return nil, status.Errorf(codes.Unavailable, "gateway connection failed: %v", err)
+	}
+	defer func() {
+		if closeErr := gateway.Destroy(); closeErr != nil {
+			log.ErrorLog(ctx, "Failed to close gateway connection: %v", closeErr)
+		}
+	}()
+
+	// Step 4: Apply NVMe-oF QoS via gateway
+	log.DebugLog(ctx, "Setting QoS for subsystem=%s, nsid=%d", nvmeofData.SubsystemNQN, nvmeofData.NamespaceID)
+
+	err = gateway.SetQoSLimitsForNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID, *qos)
+	if err != nil {
+		// Check if error is EEXIST (RBD QoS already set)
+		if errors.Is(err, nvmeoferrors.ErrRbdQoSExists) {
+			log.ErrorLog(ctx, "RBD QoS already configured on volume")
+
+			return nil, status.Error(codes.InvalidArgument,
+				"RBD QoS already configured on this volume, cannot set NVMe-oF gateway QoS")
+		}
+
+		log.ErrorLog(ctx, "Failed to set QoS limits: %v", err)
+
+		return nil, status.Errorf(codes.Internal, "failed to set QoS limits: %v", err)
+	}
+
+	log.DebugLog(ctx, "Successfully modified NVMe-oF QoS for volume %s", volumeID)
+
+	return &csi.ControllerModifyVolumeResponse{}, nil
 }
 
 // ensureSubsystem checks if the subsystem exists, and creates it if not.

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -282,7 +282,7 @@ func (cs *Server) ControllerUnpublishVolume(
 	if err != nil {
 		log.ErrorLog(ctx, "failed to get NVMe-oF metadata for volumeID %s: %v", volumeID, err)
 
-		return nil, status.Errorf(codes.Internal, "failed to get NVMe-oF metadata: %v", err)
+		return nil, nvmeoferrors.ToGRPCError(err)
 	}
 
 	// Unpublish NVMe-oF resources
@@ -799,7 +799,8 @@ func (cs *Server) getNVMeoFMetadata(
 	// Get RBD volume
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find volume with ID %q: %w", volumeID, err)
+		return nil, fmt.Errorf("%w: failed to find volume with ID %q: %w",
+			nvmeoferrors.ErrMetadataNotFound, volumeID, err)
 	}
 	defer rbdVol.Destroy(ctx)
 
@@ -820,10 +821,12 @@ func (cs *Server) getNVMeoFMetadata(
 	for _, key := range requiredKeys {
 		value, err := rbdVol.GetMetadata(key)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get %s: %w", key, err)
+			return nil, fmt.Errorf("%w: failed to get %s: %w",
+				nvmeoferrors.ErrMetadataNotFound, key, err)
 		}
 		if value == "" {
-			return nil, fmt.Errorf("metadata %s is empty", key)
+			return nil, fmt.Errorf("%w: metadata %s is empty",
+				nvmeoferrors.ErrMetadataNotFound, key)
 		}
 		metadata[key] = value
 	}
@@ -831,18 +834,21 @@ func (cs *Server) getNVMeoFMetadata(
 	// Parse namespace ID
 	nsid, err := strconv.ParseUint(metadata[toRBDMetadataKey(vcNamespaceID)], 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("invalid namespace ID: %w", err)
+		return nil, fmt.Errorf("%w: invalid namespace ID: %w",
+			nvmeoferrors.ErrMetadataCorrupted, err)
 	}
 
 	gatewayPort, err := strconv.ParseUint(metadata[toRBDMetadataKey(vcGatewayPort)], 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("invalid gateway port: %w", err)
+		return nil, fmt.Errorf("%w: invalid gateway port: %w",
+			nvmeoferrors.ErrMetadataCorrupted, err)
 	}
 
 	// Parse listeners from JSON
 	var listeners []nvmeof.ListenerDetails
 	if err := json.Unmarshal([]byte(metadata[toRBDMetadataKey(vcListeners)]), &listeners); err != nil {
-		return nil, fmt.Errorf("failed to parse listeners JSON: %w", err)
+		return nil, fmt.Errorf("%w: failed to parse listeners JSON: %w",
+			nvmeoferrors.ErrMetadataCorrupted, err)
 	}
 
 	// Construct NVMe-oF volume data

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -330,6 +330,18 @@ func (cs *Server) ControllerModifyVolume(
 	return &csi.ControllerModifyVolumeResponse{}, nil
 }
 
+// ControllerExpandVolume handles volume expansion requests.
+// For now it only updates the capacity in the response as NVMe-oF
+// this must be added because ControllerModifyVolume requires the sidecar csi-resizer. and
+// csi-resizer searches for the capacity ControllerServiceCapability_RPC_EXPAND_VOLUME.
+// In the future, if NVMe-oF gateway supports volume expansion, the logic must be added here.
+func (cs *Server) ControllerExpandVolume(
+	ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest,
+) (*csi.ControllerExpandVolumeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "ControllerExpandVolume is not implemented for NVMe-oF volumes")
+}
+
 // validateCreateVolumeRequest validates the incoming request for nvmeof.
 // the rest of the parameters are validated by RBD.
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {

--- a/internal/nvmeof/controller/qos_test.go
+++ b/internal/nvmeof/controller/qos_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/ceph-csi/internal/nvmeof"
+)
+
+func TestParseQoSParameters(t *testing.T) {
+	t.Parallel()
+
+	uint64Ptr := func(v uint64) *uint64 { return &v }
+
+	tests := []struct {
+		name        string
+		params      map[string]string
+		expected    *nvmeof.NVMeoFQosVolume
+		expectError bool
+	}{
+		{
+			name:     "empty parameters",
+			params:   map[string]string{},
+			expected: nil,
+		},
+		{
+			name: "all QoS parameters",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond:    "10000",
+				nvmeof.RwMbytesPerSecond: "100",
+				nvmeof.RMbytesPerSecond:  "50",
+				nvmeof.WMbytesPerSecond:  "50",
+			},
+			expected: &nvmeof.NVMeoFQosVolume{
+				RwIosPerSecond:    uint64Ptr(10000),
+				RwMbytesPerSecond: uint64Ptr(100),
+				RMbytesPerSecond:  uint64Ptr(50),
+				WMbytesPerSecond:  uint64Ptr(50),
+			},
+		},
+		{
+			name: "single QoS parameter",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond: "5000",
+			},
+			expected: &nvmeof.NVMeoFQosVolume{
+				RwIosPerSecond: uint64Ptr(5000),
+			},
+		},
+		{
+			name: "zero value (unlimited)",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond:    "0",
+				nvmeof.RwMbytesPerSecond: "100",
+			},
+			expected: &nvmeof.NVMeoFQosVolume{
+				RwIosPerSecond:    uint64Ptr(0),
+				RwMbytesPerSecond: uint64Ptr(100),
+			},
+		},
+		{
+			name: "partial QoS parameters",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond:   "10000",
+				nvmeof.RMbytesPerSecond: "50",
+			},
+			expected: &nvmeof.NVMeoFQosVolume{
+				RwIosPerSecond:   uint64Ptr(10000),
+				RMbytesPerSecond: uint64Ptr(50),
+			},
+		},
+		{
+			name: "empty string values ignored",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond:    "",
+				nvmeof.RwMbytesPerSecond: "100",
+			},
+			expected: &nvmeof.NVMeoFQosVolume{
+				RwMbytesPerSecond: uint64Ptr(100),
+			},
+		},
+		{
+			name: "invalid number format",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond: "invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "negative number",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond: "-100",
+			},
+			expectError: true,
+		},
+		{
+			name: "number too large",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond: "18446744073709551616", // uint64 max + 1
+			},
+			expectError: true,
+		},
+		{
+			name: "floating point number",
+			params: map[string]string{
+				nvmeof.RwMbytesPerSecond: "100.5",
+			},
+			expectError: true,
+		},
+		{
+			name: "mixed valid and invalid",
+			params: map[string]string{
+				nvmeof.RwIosPerSecond:    "10000",
+				nvmeof.RwMbytesPerSecond: "invalid",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseQoSParameters(tt.params)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/nvmeof/driver/driver.go
+++ b/internal/nvmeof/driver/driver.go
@@ -64,6 +64,7 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 			csi.ControllerServiceCapability_RPC_MODIFY_VOLUME,
+			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		})
 
 		cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{

--- a/internal/nvmeof/driver/driver.go
+++ b/internal/nvmeof/driver/driver.go
@@ -63,6 +63,7 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 		cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+			csi.ControllerServiceCapability_RPC_MODIFY_VOLUME,
 		})
 
 		cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{

--- a/internal/nvmeof/errors/errors.go
+++ b/internal/nvmeof/errors/errors.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvmeoferrors
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TODO: next PR - look at nvmeof package and see if any errors can be moved here.
+var (
+	// ErrRbdQoSExists is returned when the user tries to set a QoS for namespace, and that namespace
+	// already has a RBD QoS associated with it.
+	ErrRbdQoSExists = errors.New("QoS limits already configured (RBD QoS exists)")
+	// ErrMetadataNotFound is returned when NVMe-oF volume metadata is not found.
+	ErrMetadataNotFound = errors.New("metadata not found")
+	// ErrMetadataCorrupted is returned when NVMe-oF volume metadata(=rbd metadata) is corrupted or invalid.
+	ErrMetadataCorrupted = errors.New("metadata corrupted or invalid")
+)
+
+// errorToGRPCCode maps custom errors to gRPC status codes.
+var errorToGRPCCode = map[error]codes.Code{
+	ErrMetadataNotFound:  codes.NotFound,
+	ErrMetadataCorrupted: codes.Internal,
+	ErrRbdQoSExists:      codes.InvalidArgument,
+}
+
+// ToGRPCError converts a custom error to a gRPC status error.
+// If the error is not recognized, it returns codes.Internal.
+func ToGRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check if it's one of our custom errors
+	for customErr, code := range errorToGRPCCode {
+		if errors.Is(err, customErr) {
+			return status.Error(code, err.Error())
+		}
+	}
+
+	// Unknown error - return Internal
+	return status.Errorf(codes.Internal, "internal error: %v", err)
+}

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 
+	nvmeoferrors "github.com/ceph/ceph-csi/internal/nvmeof/errors"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
@@ -164,6 +165,43 @@ func (gw *GatewayRpcClient) DeleteNamespace(ctx context.Context, subsystemNQN st
 	}
 
 	return fmt.Errorf("gateway NamespaceDelete returned error (status=%d): %s",
+		status.GetStatus(), status.GetErrorMessage())
+}
+
+// SetQoSLimitsForNamespace sets QoS limits on a namespace.
+func (gw *GatewayRpcClient) SetQoSLimitsForNamespace(
+	ctx context.Context,
+	subsystemNQN string,
+	namespaceID uint32,
+	qos NVMeoFQosVolume,
+) error {
+	log.DebugLog(ctx, "Setting QoS limits on namespace %d in subsystem %s", namespaceID, subsystemNQN)
+
+	req := &pb.NamespaceSetQosReq{
+		SubsystemNqn:      subsystemNQN,
+		Nsid:              namespaceID,
+		RwIosPerSecond:    qos.RwIosPerSecond,
+		RwMbytesPerSecond: qos.RwMbytesPerSecond,
+		RMbytesPerSecond:  qos.RMbytesPerSecond,
+		WMbytesPerSecond:  qos.WMbytesPerSecond,
+	}
+
+	status, err := gw.client.NamespaceSetQosLimits(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to set QoS limits on namespace %d: %w", namespaceID, err)
+	}
+
+	if status.GetStatus() == 0 {
+		log.DebugLog(ctx, "QoS limits set successfully on namespace %d", namespaceID)
+
+		return nil
+	}
+
+	if status.GetStatus() == int32(syscall.EEXIST) { // EEXIST
+		return fmt.Errorf("%w: %s", nvmeoferrors.ErrRbdQoSExists, status.GetErrorMessage())
+	}
+
+	return fmt.Errorf("gateway SetNamespaceQos returned error (status=%d): %s",
 		status.GetStatus(), status.GetErrorMessage())
 }
 

--- a/internal/nvmeof/qos.go
+++ b/internal/nvmeof/qos.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nvmeof
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NVMeoFQosVolume holds the QoS parameters for an NVMe-oF volume.
+type NVMeoFQosVolume struct {
+	RwIosPerSecond    *uint64 // R/W IOs per second limit, 0 means unlimited.
+	RwMbytesPerSecond *uint64 // R/W megabytes per second limit, 0 means unlimited.
+	RMbytesPerSecond  *uint64 // Read megabytes per second limit, 0 means unlimited.
+	WMbytesPerSecond  *uint64 // Write megabytes per second limit, 0 means unlimited.
+}
+
+// QoS parameter keys that user can set.
+// these parameters are used to configure the QoS limits for NVMe-oF volumes.
+// They correspond to the fields in NVMeoFQosVolume struct.
+const (
+	RwIosPerSecond    = "rwIosPerSecond"
+	RwMbytesPerSecond = "rwMbytesPerSecond"
+	RMbytesPerSecond  = "rMbytesPerSecond"
+	WMbytesPerSecond  = "wMbytesPerSecond"
+)
+
+// String returns a string representation of the NVMeoFQosVolume.
+func (q *NVMeoFQosVolume) String() string {
+	if q == nil {
+		return "nil"
+	}
+
+	parts := []string{}
+	if q.RwIosPerSecond != nil {
+		parts = append(parts, fmt.Sprintf("RwIops=%d", *q.RwIosPerSecond))
+	}
+	if q.RwMbytesPerSecond != nil {
+		parts = append(parts, fmt.Sprintf("RwMB/s=%d", *q.RwMbytesPerSecond))
+	}
+	if q.RMbytesPerSecond != nil {
+		parts = append(parts, fmt.Sprintf("RMB/s=%d", *q.RMbytesPerSecond))
+	}
+	if q.WMbytesPerSecond != nil {
+		parts = append(parts, fmt.Sprintf("WMB/s=%d", *q.WMbytesPerSecond))
+	}
+
+	if len(parts) == 0 {
+		return "no QoS limits"
+	}
+
+	return strings.Join(parts, ", ")
+}

--- a/internal/rbd/qos.go
+++ b/internal/rbd/qos.go
@@ -89,6 +89,18 @@ type qosSpec struct {
 	present         bool
 }
 
+// HasQoSParams checks if any RBD QoS parameters are present.
+func HasQoSParams(params map[string]string) bool {
+	rbdQosParams := parseQosParams(params)
+	for _, qos := range rbdQosParams {
+		if qos.present {
+			return true
+		}
+	}
+
+	return false
+}
+
 func parseQosParams(
 	scParams map[string]string,
 ) map[string]*qosSpec {


### PR DESCRIPTION
# Describe what this PR does #

Adds QoS (Quality of Service) support for NVMe-oF CSI driver, allowing users to set IOPS and bandwidth limits on volumes at creation time and modify them dynamically at runtime.


## Is there anything that requires special attention ##

**New StorageClass parameters:**
- `rwIosPerSecond` - Read/Write IOPS limit
- `rwMbytesPerSecond` - Read/Write bandwidth limit (MB/s)
- `rMbytesPerSecond` - Read bandwidth limit (MB/s)
- `wMbytesPerSecond` - Write bandwidth limit (MB/s)

**Key decisions:**
- Uses NVMe-oF-specific parameter names (not RBD QoS keys) because the architectures are different: details [here](https://github.com/ceph/ceph-csi/issues/5694
)
- Implements `ControllerModifyVolume()` RPC for runtime QoS changes via VolumeAttributesClass (GA at K8s 1.34+ 
you can read more about it here: [volume-attributes-classes)](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/)
- Adds stub `ControllerExpandVolume()` with `EXPAND_VOLUME` capability to satisfy csi-resizer requirements (csi-resizer needs this capability to start, even when only using it for modify operations)
- Uses `GetControllerPublishSecretRef()` for credential retrieval in `ControllerModifyVolume()` as a temporary solution (TODO: implement `GetControllerExpandSecretRef()` with proper NVMeoF support in ceph-csi-config)

**Credential handling note:**
Since CSI spec doesn't define `csi.storage.k8s.io/controller-modify-secret-name` parameter and csi-resizer doesn't pass secrets to `ControllerModifyVolume()` according to [storageclass-secrets,](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#storageclass-secrets) . The implementation retrieves credentials from ceph-csi-config ConfigMap using the existing `controllerPublishSecretRef` field. This follows the same pattern as other CSI operations.


**Example workflow:**

1. Create StorageClass with:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: csi-nvmeof-qos
provisioner: nvmeof.csi.ceph.com
parameters:
  clusterID: "cluster-1"
  pool: "mypool"
  # ... other params
```

2. Create default QoS

```yaml 
apiVersion: storage.k8s.io/v1
kind: VolumeAttributesClass
metadata:
  name: default
driverName: nvmeof.csi.ceph.com
parameters:
  rwIopsPerSecond: "5000"
```

3. Create PVC (gets 10000 IOPS, 100 MB/s):
```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: my-pvc
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  storageClassName: csi-nvmeof-qos
  volumeAttributesClassName: default  # ← Start with default (5000 IOPS)
```

4. Later, define VolumeAttributesClass for runtime modification:
```yaml
apiVersion: storage.k8s.io/v1alpha1
kind: VolumeAttributesClass
metadata:
  name: high-performance
driverName: nvmeof.csi.ceph.com
parameters:
  nvmeof_rw_ios_per_second: "50000"
  nvmeof_rw_mbytes_per_second: "500"
```


5. Modify existing PVC (triggers ControllerModifyVolume):
```bash
kubectl patch pvc my-pvc -p '{"spec":{"volumeAttributesClassName":"high-performance"}}'
```

Result: Volume QoS updated to 50000 IOPS, 500 MB/s without recreation or downtime.

NOTE: 
- Adds csi-resizer sidecar to controller deployment according to this: [resizer](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/#resizer)

## Related issues ##

https://github.com/ceph/ceph-csi/issues/5694

## Future concerns ##
- Add proper NVMeoF struct to ceph-csi-config-map ClusterInfo with dedicated `controllerExpandSecretRef` field **OR** Add `controllerExpandSecretRef` for the existing `RBD` struct. (because NVMeoF is just a wrapper to RBD). 
- Implement `GetControllerExpandSecretRef()` to replace temporary use of `GetControllerPublishSecretRef()`

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
