### PR TITLE
helm: inject POD_NAMESPACE for KMIP secret lookup

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -90,6 +90,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -110,6 +110,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -88,6 +88,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -115,6 +115,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DRIVER_NAME
               value: {{ .Values.driverName }}
             - name: NODE_ID


### PR DESCRIPTION
Align the Helm deployments for both RBD and CephFS with the static manifests by wiring the downward API `POD_NAMESPACE` env into every CSI container that reads the KMS config. Without it the KMIP provider falls back to an empty namespace and fails to fetch `ceph-csi-kmip-credentials`.

Fixes: #5721

# Describe what this PR does #

- inject the downward API `POD_NAMESPACE` env into all CSI containers in the RBD and CephFS Helm charts, so the KMIP provider resolves the correct namespace
- bring the Helm charts in line with the static manifests, which already set this env var, preventing encrypted PVC provisioning failures when KMIP is enabled
- verified with `helm lint charts/ceph-csi-rbd` and `helm lint charts/ceph-csi-cephfs`

Provide some context for the reviewer

## Is there anything that requires special attention ##

No backward-compatibility concerns: the env var comes from the pod namespace and is already expected by the Ceph-CSI binaries. Helm users without KMIP see no behavioural change.

## Related issues ##

Fixes: #5721

## Future concerns ##

None.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
