### PR TITLE
rbd: remove forcePromote function

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -447,13 +447,7 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 
 	// promote secondary to primary
 	if !info.IsPrimary() {
-		if req.GetForce() {
-			// workaround for https://github.com/ceph/ceph-csi/issues/2736
-			// TODO: remove this workaround when the issue is fixed
-			err = mirror.ForcePromote(ctx, cr)
-		} else {
-			err = mirror.Promote(ctx, req.GetForce())
-		}
+		err = mirror.Promote(ctx, req.GetForce())
 		if err != nil {
 			log.ErrorLog(ctx, err.Error())
 			// In case of the DR the image on the primary site cannot be

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -27,7 +27,6 @@ import (
 
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
-	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
@@ -187,39 +186,7 @@ func (rm *rbdMirror) Promote(ctx context.Context, force bool) error {
 		return fmt.Errorf("failed to promote image %q with error: %w", rm, err)
 	}
 
-	log.DebugLog(ctx, "image %q has been promoted", rm)
-
-	return nil
-}
-
-// ForcePromote promotes image to primary with force option with 2 minutes
-// timeout. If there is no response within 2 minutes,the rbd CLI process will be
-// killed and an error is returned.
-func (rm *rbdMirror) ForcePromote(ctx context.Context, cr *util.Credentials) error {
-	promoteArgs := []string{
-		"mirror", "image", "promote",
-		rm.String(),
-		"--force",
-		"--id", cr.ID,
-		"-m", rm.Monitors,
-		"--keyfile=" + cr.KeyFile,
-	}
-	_, stderr, err := util.ExecCommandWithTimeout(
-		ctx,
-		// 2 minutes timeout as the Replication RPC timeout is 2.5 minutes.
-		2*time.Minute,
-		"rbd",
-		promoteArgs...,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to promote image %q with error: %w", rm, err)
-	}
-
-	if stderr != "" {
-		return fmt.Errorf("failed to promote image %q with stderror: %s", rm, stderr)
-	}
-
-	log.DebugLog(ctx, "image %q has been force promoted", rm)
+	log.DebugLog(ctx, "image has been promoted with force=%v", rm, force)
 
 	return nil
 }

--- a/internal/rbd/types/mirror.go
+++ b/internal/rbd/types/mirror.go
@@ -22,8 +22,6 @@ import (
 
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/ceph/go-ceph/rbd/admin"
-
-	"github.com/ceph/ceph-csi/internal/util"
 )
 
 // FlattenMode is used to indicate the flatten mode for an RBD image.
@@ -44,8 +42,6 @@ type Mirror interface {
 	DisableMirroring(ctx context.Context, force bool) error
 	// Promote promotes the resource to primary status with the option to force the operation
 	Promote(ctx context.Context, force bool) error
-	// ForcePromote promotes the resource to primary status with a timeout
-	ForcePromote(ctx context.Context, cr *util.Credentials) error
 	// Demote demotes the resource to secondary status
 	Demote(ctx context.Context) error
 	// Resync resynchronizes the resource


### PR DESCRIPTION
# Describe what this PR does #

Remove `ForcePromote` function as we don't need a timeout for force promote to work anymore. The issue has been fixed in rbd and force promote is supposed to work without the timeout.

Fixes: #5349 