### PR TITLE
ci: prevent Mergify from triggering CI jobs twice

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -100,6 +100,7 @@ pull_request_rules:
       - base~=^(devel)|(release-.+)$
       - label!=conflicts
       - label!=ci/skip/e2e
+      - label!=queued
       - not:
           check-pending~=^ci/centos
       - not:


### PR DESCRIPTION
When a PR is queued for merging, Mergify creates a new draft PR to run
the CI jobs against. This is relatively new behavior, and confuses the
triggering (old behavior) of CI jobs.

In order to prevent Mergify from triggering CI jobs on the original PR
as well as on the new draft PR, let Mergify not add the `ok-to-test`
label if there is a `queued` label already.
