### PR TITLE
cephfs: pass fsName when mounting from monitor list

### DIFF
--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -684,6 +684,10 @@ func NewVolumeOptionsFromMonitorList(
 		return nil, nil, err
 	}
 
+	if err = extractOptionalOption(&opts.FsName, "fsName", options); err != nil {
+		return nil, nil, err
+	}
+
 	opts.Owner = k8s.GetOwner(options)
 	if err = opts.InitKMS(context.TODO(), options, secrets); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Fixes failing to mount shares with an alternate filesystem when mounting by monitor list.

backport of #5643 