### PR TITLE
ci: prepare of v3.15.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ environments.
 
 | Ceph CSI Version | Container Orchestrator Name | Version Tested     |
 | -----------------| --------------------------- | -------------------|
+| v3.15.1          | Kubernetes                  | v1.31, v1.32, v1.33|
 | v3.15.0          | Kubernetes                  | v1.31, v1.32, v1.33|
 | v3.14.2          | Kubernetes                  | v1.30, v1.31, v1.32|
 | v3.14.1          | Kubernetes                  | v1.30, v1.31, v1.32|
@@ -131,6 +132,7 @@ in the Kubernetes documentation.
 | Ceph CSI Release/Branch | Container image name         | Image Tag |
 | ----------------------- | ---------------------------- | --------- |
 | devel (Branch)          | quay.io/cephcsi/cephcsi      | canary    |
+| v3.15.1 (Release)       | quay.io/cephcsi/cephcsi      | v3.15.1   |
 | v3.15.0 (Release)       | quay.io/cephcsi/cephcsi      | v3.15.0   |
 | v3.14.2 (Release)       | quay.io/cephcsi/cephcsi      | v3.14.2   |
 | v3.14.1 (Release)       | quay.io/cephcsi/cephcsi      | v3.14.1   |

--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.15-canary
+CSI_IMAGE_VERSION=v3.15.1
 
 # cephcsi upgrade version
 CSI_UPGRADE_VERSION=v3.14.2

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -138,7 +138,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.15-canary
+      tag: v3.15.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -149,7 +149,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.15-canary
+      tag: v3.15.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -193,7 +193,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -125,7 +125,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -147,7 +147,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -47,7 +47,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -209,7 +209,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--type=controller"
             - "--v=5"
@@ -230,7 +230,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -28,7 +28,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -135,7 +135,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.15-canary
+          image: quay.io/cephcsi/cephcsi:v3.15.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
There are couple of patches went in to release 3.15 branch after the initial release. It would be nice to make a patch release for the same, this commit includes the template changes for the release.

