### PR TITLE
ci: improve debuggability of Ceph and Rook failures

### DIFF
--- a/build.env
+++ b/build.env
@@ -62,6 +62,8 @@ CHANGE_MINIKUBE_NONE_USER=true
 ROOK_VERSION=v1.18.4
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v20
+# Enable extra Ceph debugging in scripts/rook.sh when set to a non-empty value
+#CEPH_DEBUG=1
 
 # CSI sidecar version
 K8S_IMAGE_REPO=registry.k8s.io/sig-storage

--- a/build.env
+++ b/build.env
@@ -61,7 +61,7 @@ CHANGE_MINIKUBE_NONE_USER=true
 # Rook options
 ROOK_VERSION=v1.18.4
 # Provide ceph image path
-ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v19.2.2
+ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v20
 
 # CSI sidecar version
 K8S_IMAGE_REPO=registry.k8s.io/sig-storage

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -810,7 +810,10 @@ func checkDataPersist(pvcPath, appPath string, f *framework.Framework) error {
 	// write data to PVC
 	filePath := app.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
 
-	_, stdErr, err := execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, filePath), app.Namespace, &opt)
+	_, stdErr, err := execCommandInPod(f,
+		fmt.Sprintf("echo -n '%s' > %s ; sync %s", data, filePath, filePath),
+		app.Namespace,
+		&opt)
 	if err != nil {
 		return fmt.Errorf("failed to exec command in pod: %w", err)
 	}
@@ -834,8 +837,9 @@ func checkDataPersist(pvcPath, appPath string, f *framework.Framework) error {
 	if stdErr != "" {
 		return fmt.Errorf("failed to get file content %v", stdErr)
 	}
-	if !strings.Contains(persistData, data) {
-		return fmt.Errorf("data not persistent expected data %s received data %s  ", data, persistData)
+	if persistData != data {
+		return fmt.Errorf("data not persistent (expected data: %v, received data: %v)",
+			[]byte(data), []byte(persistData))
 	}
 
 	err = deletePVCAndApp("", f, pvc, app)

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -41,6 +41,9 @@ function deploy_rook() {
 	sed -i 's|ROOK_CSI_ENABLE_RBD: "true"|ROOK_CSI_ENABLE_RBD: "false"|g' "${TEMP_DIR}/operator.yaml"
 	sed -i 's|ROOK_USE_CSI_OPERATOR: "true"|ROOK_USE_CSI_OPERATOR: "false"|g' "${TEMP_DIR}/operator.yaml"
 
+	# enable more verbose logging
+	sed -i 's|ROOK_LOG_LEVEL: "INFO"|ROOK_LOG_LEVEL: "DEBUG"|g' "${TEMP_DIR}/operator.yaml"
+
 	kubectl_retry create -f "${TEMP_DIR}/operator.yaml"
 	# Override the ceph version which rook installs by default.
 	if [ -z "${ROOK_CEPH_CLUSTER_IMAGE}" ]; then

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -186,7 +186,11 @@ function check_ceph_mgr() {
 
 function check_mds_stat() {
 	for ((retry = 0; retry <= ROOK_DEPLOY_TIMEOUT; retry = retry + 5)); do
-		echo "Configuring MDS and OSD logging to 20/20... ${retry}s"
+		if [ -n "${CEPH_DEBUG}" ]; then
+			echo "Configuring MDS and OSD logging to 20/20... ${retry}s"
+		else
+			echo "Checking MDS stats... ${retry}s"
+		fi
 
 		TOOLBOX_POD=$(kubectl_retry -n rook-ceph get pods -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
 		TOOLBOX_POD_STATUS=$(kubectl_retry -n rook-ceph get pod "$TOOLBOX_POD" -ojsonpath='{.status.phase}')
@@ -197,20 +201,22 @@ function check_mds_stat() {
 				continue
 			}
 
-		if kubectl_retry exec -n rook-ceph "$TOOLBOX_POD" -it -- ceph config set mds debug_mds 20/20 &>/dev/null; then
-			echo "Ceph MDS loglevel successfully configured..."
-		else
-			echo "Failed to configure Ceph MDS loglevel..."
-			sleep 5
-			continue
-		fi
+		if [ -n "${CEPH_DEBUG}" ]; then
+			if kubectl_retry exec -n rook-ceph "$TOOLBOX_POD" -it -- ceph config set mds debug_mds 20/20 &>/dev/null; then
+				echo "Ceph MDS loglevel successfully configured..."
+			else
+				echo "Failed to configure Ceph MDS loglevel..."
+				sleep 5
+				continue
+			fi
 
-		if kubectl_retry exec -n rook-ceph "$TOOLBOX_POD" -it -- ceph config set osd debug_osd 20/20 &>/dev/null; then
-			echo "Ceph OSD loglevel successfully configured..."
-		else
-			echo "Failed to configure Ceph OSD loglevel..."
-			sleep 5
-			continue
+			if kubectl_retry exec -n rook-ceph "$TOOLBOX_POD" -it -- ceph config set osd debug_osd 20/20 &>/dev/null; then
+				echo "Ceph OSD loglevel successfully configured..."
+			else
+				echo "Failed to configure Ceph OSD loglevel..."
+				sleep 5
+				continue
+			fi
 		fi
 
 		FS_NAME=$(kubectl_retry -n rook-ceph get cephfilesystems.ceph.rook.io -ojsonpath='{.items[0].metadata.name}')

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -22,6 +22,7 @@ function log_errors() {
 	kubectl -n rook-ceph get events
 	kubectl -n rook-ceph describe pods
 	kubectl -n rook-ceph logs -l app=rook-ceph-operator --tail=-1
+	kubectl -n rook-ceph logs -l app=rook-ceph-osd-prepare
 	kubectl -n rook-ceph get CephClusters -oyaml
 	kubectl -n rook-ceph get CephFilesystems -oyaml
 	kubectl -n rook-ceph get CephBlockPools -oyaml

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -186,7 +186,7 @@ function check_ceph_mgr() {
 
 function check_mds_stat() {
 	for ((retry = 0; retry <= ROOK_DEPLOY_TIMEOUT; retry = retry + 5)); do
-		echo "Configuring MDS logging to 20/20... ${retry}s"
+		echo "Configuring MDS and OSD logging to 20/20... ${retry}s"
 
 		TOOLBOX_POD=$(kubectl_retry -n rook-ceph get pods -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
 		TOOLBOX_POD_STATUS=$(kubectl_retry -n rook-ceph get pod "$TOOLBOX_POD" -ojsonpath='{.status.phase}')
@@ -201,6 +201,14 @@ function check_mds_stat() {
 			echo "Ceph MDS loglevel successfully configured..."
 		else
 			echo "Failed to configure Ceph MDS loglevel..."
+			sleep 5
+			continue
+		fi
+
+		if kubectl_retry exec -n rook-ceph "$TOOLBOX_POD" -it -- ceph config set osd debug_osd 20/20 &>/dev/null; then
+			echo "Ceph OSD loglevel successfully configured..."
+		else
+			echo "Failed to configure Ceph OSD loglevel..."
 			sleep 5
 			continue
 		fi

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -186,6 +186,25 @@ function check_ceph_mgr() {
 
 function check_mds_stat() {
 	for ((retry = 0; retry <= ROOK_DEPLOY_TIMEOUT; retry = retry + 5)); do
+		echo "Configuring MDS logging to 20/20... ${retry}s"
+
+		TOOLBOX_POD=$(kubectl_retry -n rook-ceph get pods -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
+		TOOLBOX_POD_STATUS=$(kubectl_retry -n rook-ceph get pod "$TOOLBOX_POD" -ojsonpath='{.status.phase}')
+		[[ "$TOOLBOX_POD_STATUS" != "Running" ]] &&
+			{
+				echo "Toolbox POD ($TOOLBOX_POD) status: [$TOOLBOX_POD_STATUS]"
+				sleep 5
+				continue
+			}
+
+		if kubectl_retry exec -n rook-ceph "$TOOLBOX_POD" -it -- ceph config set mds debug_mds 20/20 &>/dev/null; then
+			echo "Ceph MDS loglevel successfully configured..."
+		else
+			echo "Failed to configure Ceph MDS loglevel..."
+			sleep 5
+			continue
+		fi
+
 		FS_NAME=$(kubectl_retry -n rook-ceph get cephfilesystems.ceph.rook.io -ojsonpath='{.items[0].metadata.name}')
 		echo "Checking MDS ($FS_NAME) stats... ${retry}s" && sleep 5
 


### PR DESCRIPTION
The CephFS test `check data persist after recreating pod` has been disabled when Ceph-CSI is deployed with Helm. This PR is used for troubleshooting the issue and re-enabling the test.

Because enabling debugging information in Ceph and Rook isn't trivial while running the e2e suite, `CEPH_DEBUG` has been introduced so that future debugging sessions should become easier.

See-also: https://tracker.ceph.com/issues/73997
Depends-on: #5672

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
