### PR TITLE
build: use Go 1.24.6

### DIFF
--- a/build.env
+++ b/build.env
@@ -26,7 +26,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v19.2.2
 CEPH_VERSION=squid
 
 # standard Golang options
-GOLANG_VERSION=1.24.4
+GOLANG_VERSION=1.24.6
 GO111MODULE=on
 
 # commitlint version


### PR DESCRIPTION
While building Ceph-CSI the Go toolchain always downloads Go 1.24.6. It saves time (and bandwidth) when that version is installed from the start.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
