### PR TITLE
rbd: prevent panic when expanding a statically provisioned volume

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1627,6 +1627,10 @@ func (cs *ControllerServer) ControllerExpandVolume(
 		case errors.Is(err, util.ErrPoolNotFound):
 			log.ErrorLog(ctx, "failed to get backend volume for %s: %v", volID, err)
 			err = status.Error(codes.NotFound, err.Error())
+		case errors.Is(err, rbderrors.ErrInvalidVolID):
+			// likely a static provisioned volume
+			// InvalidArgument indicates that the CO has specified capabilities not supported by the volume
+			err = status.Errorf(codes.InvalidArgument, "volume ID %s does not support expansion", volID)
 		default:
 			err = status.Error(codes.Internal, err.Error())
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2229,7 +2229,7 @@ func genVolFromVolIDWithMigration(
 		return genVolFromMigVolID(ctx, pmVolID, cr)
 	}
 	rv, err := GenVolFromVolID(ctx, volID, cr, secrets)
-	if err != nil {
+	if err != nil && rv != nil {
 		rv.Destroy(ctx)
 	}
 


### PR DESCRIPTION
Expanding statically provisioned volumes is not supported. However it
seems that there is a panic when it is attempted. By returning an
appropriate error, and informing the caller, no panic should occur and
users should observe a reasonable error message.

Fixes: #5776
