### PR TITLE
ci: add labeled, unlabled pull_request event types

### DIFF
--- a/.github/workflows/build-multi-stage.yaml
+++ b/.github/workflows/build-multi-stage.yaml
@@ -3,6 +3,7 @@ name: multi-arch-build
 # yamllint disable-line rule:truthy
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - '*'
 permissions:


### PR DESCRIPTION
# Describe what this PR does #

Add `labeled`, `unlabled` pull_request event types to multi-arch-build github action such that the event is triggered when the "skip/ci-multi-arch-build" label is added/removed.

The default type includes opened, synchronize, reopened. Hence, included them too when sepcifying the type specifically.
