### PR TITLE
nvmeof: expansion volume feature

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -76,6 +76,12 @@ func (cs *Server) ControllerGetCapabilities(
 	return cs.backendServer.ControllerGetCapabilities(ctx, req)
 }
 
+// ValidateControllerServiceRequest uses the RBD backendServer driver field.
+// It checks whether the controller service request is valid.
+func (cs *Server) ValidateControllerServiceRequest(capability csi.ControllerServiceCapability_RPC_Type) error {
+	return cs.backendServer.Driver.ValidateControllerServiceRequest(capability)
+}
+
 // ValidateVolumeCapabilities checks whether the volume capabilities requested
 // are supported.
 func (cs *Server) ValidateVolumeCapabilities(
@@ -330,16 +336,18 @@ func (cs *Server) ControllerModifyVolume(
 	return &csi.ControllerModifyVolumeResponse{}, nil
 }
 
-// ControllerExpandVolume handles volume expansion requests.
-// For now it only updates the capacity in the response as NVMe-oF
-// this must be added because ControllerModifyVolume requires the sidecar csi-resizer. and
-// csi-resizer searches for the capacity ControllerServiceCapability_RPC_EXPAND_VOLUME.
-// In the future, if NVMe-oF gateway supports volume expansion, the logic must be added here.
 func (cs *Server) ControllerExpandVolume(
 	ctx context.Context,
 	req *csi.ControllerExpandVolumeRequest,
 ) (*csi.ControllerExpandVolumeResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "ControllerExpandVolume is not implemented for NVMe-oF volumes")
+	err := cs.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_EXPAND_VOLUME)
+	if err != nil {
+		log.ErrorLog(ctx, "invalid expand volume req: %v", err)
+
+		return nil, err
+	}
+	// expand volume is handled by rbd backend server
+	return cs.backendServer.ControllerExpandVolume(ctx, req)
 }
 
 // validateCreateVolumeRequest validates the incoming request for nvmeof.

--- a/internal/nvmeof/identity/identityserver.go
+++ b/internal/nvmeof/identity/identityserver.go
@@ -51,6 +51,13 @@ func (is *Server) GetPluginCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -121,6 +121,13 @@ func (ns *NodeServer) NodeGetCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+					},
+				},
+			},
 		},
 	}, nil
 }
@@ -335,6 +342,60 @@ func (ns *NodeServer) NodeUnstageVolume(
 	log.DebugLog(ctx, "successfully removed staging path (%s)", stagingTargetPath)
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
+}
+
+// NodeExpandVolume resizes nvmeof volumes (namespace).
+func (ns *NodeServer) NodeExpandVolume(
+	ctx context.Context,
+	req *csi.NodeExpandVolumeRequest,
+) (*csi.NodeExpandVolumeResponse, error) {
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume ID must be provided")
+	}
+
+	// Block mode - nothing to do
+	if req.GetVolumeCapability() != nil && req.GetVolumeCapability().GetBlock() != nil {
+		log.DebugLog(ctx, "nvmeof: block mode volume, no filesystem resize needed for %s", volumeID)
+
+		return &csi.NodeExpandVolumeResponse{}, nil
+	}
+
+	// Get staging path
+	volumePath := req.GetStagingTargetPath()
+	if volumePath == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume path must be provided")
+	}
+
+	if acquired := ns.volumeLocks.TryAcquire(volumeID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	}
+	defer ns.volumeLocks.Release(volumeID)
+
+	mountPath := volumePath + "/" + volumeID
+
+	// Find device from mount (no metadata needed!)
+	devicePath, err := ns.getDeviceFromMount(ctx, mountPath)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to find device for mount %s: %v", mountPath, err)
+
+		return nil, status.Errorf(codes.Internal, "failed to find device: %v", err)
+	}
+
+	log.DebugLog(ctx, "nvmeof: resizing filesystem on device %s at mount path %s", devicePath, mountPath)
+
+	resizer := mount.NewResizeFs(utilexec.New())
+	var ok bool
+	ok, err = resizer.Resize(devicePath, mountPath)
+	if !ok {
+		return nil, status.Errorf(codes.Internal,
+			"nvmeof: resize failed on path %s, error: %v", req.GetVolumePath(), err)
+	}
+	log.DebugLog(ctx, "nvmeof: successfully resized filesystem for volume %s", volumeID)
+
+	return &csi.NodeExpandVolumeResponse{}, nil
 }
 
 func (ns *NodeServer) mountVolume(ctx context.Context, stagingPath string, req *csi.NodePublishVolumeRequest) error {
@@ -652,4 +713,22 @@ func getStagingTargetPath(req interface{}) string {
 	}
 
 	return ""
+}
+
+// getDeviceFromMount finds the device path for a given mount path.
+func (ns *NodeServer) getDeviceFromMount(ctx context.Context, mountPath string) (string, error) {
+	mountPoints, err := ns.Mounter.List()
+	if err != nil {
+		return "", fmt.Errorf("failed to list mounts: %w", err)
+	}
+
+	for _, mp := range mountPoints {
+		if mp.Path == mountPath {
+			log.DebugLog(ctx, "found device %s for mount path %s", mp.Device, mountPath)
+
+			return mp.Device, nil
+		}
+	}
+
+	return "", fmt.Errorf("no mount found for path %s", mountPath)
 }


### PR DESCRIPTION
# Describe what this PR does

Implements CSI `ControllerExpandVolume` and `NodeExpandVolume` for NVMe-oF volumes to support online volume expansion.

## Is there anything that requires special attention

**ControllerExpandVolume:**
- Calls directly to rbd `ControllerExpandVolume()` . 

**NodeExpandVolume:**
- Search for the by the current staging path the device path the pod is mounted to . 
- Resizes filesystem using `mount.NewResizeFs()` (supports ext4, xfs, btrfs)
- Skips filesystem resize for block mode volumes


FYI:
1. The NVMe-oF gateway supports namespace resizing via the ResizeNamespace GRPC call, which internally calls SPDK's `bdev_rbd_resize` to resize both the RBD image and the NVMeoF namespace. - BUT best practice is to resize directly the rbd itself. 

TODO:
 - add some unit tests 

## Related issues ##

https://github.com/ceph/ceph-csi/issues/5757


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
