### PR TITLE
ci: increase the timeout for e2e with operator to 150 minutes

### DIFF
--- a/mini-e2e-operator.groovy
+++ b/mini-e2e-operator.groovy
@@ -197,7 +197,7 @@ node('cico-workspace') {
 			}
 		}
 		stage('run e2e') {
-			timeout(time: 120, unit: 'MINUTES') {
+			timeout(time: 150, unit: 'MINUTES') {
 				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
 					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"


### PR DESCRIPTION
The other two (Helm and simple yaml) deployments already have a timeout
of 150 minutes. Just the operator tests time-out at the moment.

See-also: #5672
