### PR TITLE
rbd: add block volume stats support

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -7,5 +7,6 @@
 - set nodeId:userId mapping in metadata [PR](https://github.com/ceph/ceph-csi/pull/5445)
    - refer design doc for more details - [here](https://github.com/ceph/ceph-csi/blob/devel/docs/design/proposals/userID-mapping.md)
 - cephfs-csi: fix mounting alternate filesystem when mounting by monitor lists [PR](https://github.com/ceph/ceph-csi/pull/5643)
+- rbd: add block volume stats support [PR](https://github.com/ceph/ceph-csi/pull/5799)
 
 ## NOTE

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/file"
 	"github.com/ceph/ceph-csi/internal/util/fscrypt"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 	"github.com/ceph/ceph-csi/pkg/util/kernel"
 )
@@ -1486,6 +1487,13 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	req *csi.NodeGetVolumeStatsRequest,
 ) (*csi.NodeGetVolumeStatsResponse, error) {
 	var err error
+	volumeId := req.GetVolumeId()
+	if volumeId == "" {
+		err = fmt.Errorf("volumeID %v is empty", volumeId)
+
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	targetPath := req.GetVolumePath()
 	if targetPath == "" {
 		err = fmt.Errorf("targetpath %v is empty", targetPath)
@@ -1512,19 +1520,98 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	if stat.Mode().IsDir() {
 		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, true)
 	} else if (stat.Mode() & os.ModeDevice) == os.ModeDevice {
-		return blockNodeGetVolumeStats(ctx, targetPath)
+		return ns.blockNodeGetVolumeStats(ctx, targetPath, volumeId)
 	}
 
 	return nil, fmt.Errorf("targetpath %q is not a block device", targetPath)
 }
 
 // blockNodeGetVolumeStats gets the metrics for a `volumeMode: Block` type of
-// volume. At the moment, only the size of the block-device can be returned, as
-// there are no secrets in the NodeGetVolumeStats request that enables us to
-// connect to the Ceph cluster.
+// volume. At the moment,
+// - if the volume is dynamically provisioned and secretRef is present in the
+// configmap, both size and used metrics are returned by performing a
+// DiffIterate on the rbd image.
+// - else only the size of the block-device can be returned, as there are no
+// secrets in the NodeGetVolumeStats request that enables us to connect to the
+// Ceph cluster.
 //
 // TODO: https://github.com/container-storage-interface/spec/issues/371#issuecomment-756834471
-func blockNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.NodeGetVolumeStatsResponse, error) {
+func (ns *NodeServer) blockNodeGetVolumeStats(
+	ctx context.Context,
+	targetPath,
+	volumeId string,
+) (*csi.NodeGetVolumeStatsResponse, error) {
+	var (
+		err error
+		vi  util.CSIIdentifier
+	)
+	isDiffPossible := true
+
+	err = vi.DecomposeCSIID(volumeId)
+	if err != nil {
+		// treat it as a static volume if decomposition fails.
+		// Static volumes do not support diff iterate to measure usage.
+		isDiffPossible = false
+	}
+
+	secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeId, util.RBDType)
+	if errors.Is(err, util.ErrConfigNotFound) {
+		// diff iterate to measure usage is not possible without secrets.
+		isDiffPossible = false
+	} else if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	// If diff iterate is not possible, return only the size of the block device.
+	if !isDiffPossible {
+		return getBlockMetrics(ctx, targetPath)
+	}
+
+	secrets, err := k8s.GetSecret(secretName, secretNamespace)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get secret from k8s: %v", err)
+	}
+
+	credentials, err := util.NewAdminCredentials(secrets)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create credentials from secrets: %v", err)
+	}
+	defer credentials.DeleteCredentials()
+
+	rv, err := GenVolFromVolID(ctx, volumeId, credentials, secrets)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to generate volume from volume ID %s: %v",
+			volumeId, err)
+	}
+	defer rv.Destroy(ctx)
+
+	usedBytes, err := rv.getUsedBytes(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get used bytes for volume %s: %v",
+			rv, err)
+	}
+
+	return &csi.NodeGetVolumeStatsResponse{
+		Usage: []*csi.VolumeUsage{
+			{
+				Total:     rv.VolSize,
+				Used:      int64(usedBytes),
+				Available: rv.VolSize - int64(usedBytes),
+				Unit:      csi.VolumeUsage_BYTES,
+			},
+		},
+		VolumeCondition: &csi.VolumeCondition{
+			Abnormal: false,
+			Message:  "volume is in a healthy condition",
+		},
+	}, nil
+}
+
+// getBlockMetrics gets the size of the block device at the given target path.
+func getBlockMetrics(
+	ctx context.Context,
+	targetPath string,
+) (*csi.NodeGetVolumeStatsResponse, error) {
 	mp := volume.NewMetricsBlock(targetPath)
 	m, err := mp.GetMetrics()
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2338,3 +2338,39 @@ func (rv *rbdVolume) PrepareVolumeForSnapshot(ctx context.Context, cr *util.Cred
 
 	return nil
 }
+
+// getUsedBytes returns the logical used bytes of the rbd image by iterating over
+// the image using DiffIterate API.
+func (rv *rbdVolume) getUsedBytes(ctx context.Context) (uint64, error) {
+	img, err := rv.open()
+	if err != nil {
+		return 0, err
+	}
+	defer img.Close() //nolint:errcheck // not a critical failure
+
+	log.DebugLog(ctx, "rbd: running DiffIterate over image %s of size %d bytes", rv, rv.VolSize)
+
+	var usedBytes uint64
+	start := time.Now()
+	err = img.DiffIterate(
+		librbd.DiffIterateConfig{
+			Offset:        0,
+			Length:        uint64(rv.VolSize),
+			IncludeParent: librbd.IncludeParent,
+			WholeObject:   librbd.EnableWholeObject,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				usedBytes += l
+
+				return 0
+			},
+		})
+	if err != nil {
+		return 0, fmt.Errorf("failed to iterate over rbd image %s: %w", rv, err)
+	}
+
+	end := time.Now()
+	log.DebugLog(ctx, "DiffIterate on image %s of size %d bytes took %v seconds",
+		rv, rv.VolSize, end.Sub(start).Seconds())
+
+	return usedBytes, nil
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -372,7 +372,7 @@ func GetControllerPublishSecretRef(volumeId, driverType string) (string, string,
 
 	if secretName == "" || secretNamespace == "" {
 		return secretName, secretNamespace, fmt.Errorf("controller publish secret name or namespace is empty"+
-			" in csi config file for cluster %s", vi.ClusterID)
+			" in csi config file for cluster %s: %w", vi.ClusterID, ErrConfigNotFound)
 	}
 
 	return secretName, secretNamespace, nil


### PR DESCRIPTION
This commit adds support for providing rbd
block mode volume stats for NodeGetVolumeStats
call using DiffIterate API.
To compensate for lack of secrets in NodeGetVolumeStats call. The newly introduced ControllerPublishSecretRef is used to get credentials to connect to ceph
cluster.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
