### PR TITLE
nvmeof: fix bug "already connected"

### DIFF
--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -38,6 +38,11 @@ const (
 	listSubsysTimeout = 60 * time.Second
 )
 
+// nvmeCtrlLossTmo is the controller loss timeout passed to nvme connect -l flag.
+// This defines how long (in seconds) the kernel will retry reconnecting to a
+// failed controller before giving up.
+const nvmeCtrlLossTmo = "1800"
+
 // NVMeInitiator handles NVMe-oF initiator operations.
 type NVMeInitiator interface {
 	// LoadKernelModules ensures required kernel modules are loaded
@@ -136,12 +141,36 @@ func (ni *nvmeInitiator) LoadKernelModules(ctx context.Context) error {
 
 // ConnectSubsystem connects to an NVMe-oF subsystem.
 func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectRequest) (bool, error) {
+	// Get existing subsystem connections once to avoid repeated nvme list-subsys calls
+	var existingConnections nvmeHostConnections
+	if req.HostNQN != "" {
+		connections, err := listSubsystems(ctx)
+		if err != nil {
+			log.WarningLog(ctx, "Failed to list existing subsystems: %v (continuing anyway)", err)
+		} else {
+			existingConnections = connections
+		}
+	}
 	// Try connecting to each address until one succeeds
 	var success bool
 	for _, listener := range req.Listeners {
-		log.DebugLog(ctx, "Connecting to NVMe-oF subsystem %s at %v:%v",
-			req.SubsystemNQN, listener.Address, listener.Port)
 		portStr := strconv.FormatUint(uint64(listener.Port), 10)
+
+		// Check if already connected to this specific gateway
+		if req.HostNQN != "" && existingConnections != nil {
+			if existingConnections.hasLivePathToGateway(
+				req.SubsystemNQN, req.HostNQN, listener.Address, portStr) {
+				log.DebugLog(ctx, "Already connected to subsystem %s via %s:%s with HostNQN %s",
+					req.SubsystemNQN, listener.Address, portStr, req.HostNQN)
+				success = true
+
+				continue
+			}
+		}
+
+		log.DebugLog(ctx, "Connecting to NVMe-oF subsystem %s at %v:%s",
+			req.SubsystemNQN, listener.Address, portStr)
+
 		// Build nvme connect command for this address
 		args := []string{
 			"connect",
@@ -149,7 +178,7 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 			"-n", req.SubsystemNQN,
 			"-a", listener.Address,
 			"-s", portStr,
-			"-l", "1800", // TODO - known value for connection timeout.move to be const.
+			"-l", nvmeCtrlLossTmo,
 		}
 
 		// Add HostNQN only if specified

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -18,9 +18,11 @@ package nvmeof
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -33,7 +35,7 @@ import (
 const (
 	// Command timeouts.
 	connectTimeout    = 30 * time.Second
-	disconnectTimeout = 15 * time.Second
+	listSubsysTimeout = 60 * time.Second
 )
 
 // NVMeInitiator handles NVMe-oF initiator operations.
@@ -58,6 +60,54 @@ type ConnectRequest struct {
 
 // nvmeInitiator implements NVMeInitiator interface.
 type nvmeInitiator struct{}
+
+// nvmePathAddress represents a parsed NVMe path address string.
+type nvmePathAddress struct {
+	Traddr  string
+	Trsvcid string
+	SrcAddr string
+}
+
+// nvmeHost represents the structure from nvme list-subsys output.
+type nvmeHost struct {
+	HostNQN    string `json:"HostNQN"`
+	Subsystems []struct {
+		NQN   string `json:"NQN"`
+		Paths []struct {
+			Address nvmePathAddress `json:"Address"`
+			State   string          `json:"State"`
+		} `json:"Paths"`
+	} `json:"Subsystems"`
+}
+
+// nvmeHostConnections represents a collection of NVMe host connections.
+type nvmeHostConnections []nvmeHost
+
+// UnmarshalJSON implements custom JSON unmarshaling for nvmePathAddress.
+func (na *nvmePathAddress) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Parse: "traddr=10.242.64.32,trsvcid=4420,src_addr=10.242.64.33"
+	for part := range strings.SplitSeq(raw, ",") {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "traddr":
+			na.Traddr = kv[1]
+		case "trsvcid":
+			na.Trsvcid = kv[1]
+		case "src_addr":
+			na.SrcAddr = kv[1]
+		}
+	}
+
+	return nil
+}
 
 // NewNVMeInitiator creates a new NVMe-oF initiator.
 func NewNVMeInitiator() NVMeInitiator {
@@ -151,4 +201,46 @@ func (ni *nvmeInitiator) GetNamespaceDeviceByUUID(ctx context.Context, uuid stri
 		// BackOffDelay is the default, starts at 100ms
 		retry.Attempts(4), // defaults to 10 delays, too many
 	)
+}
+
+// listSubsystems retrieves current NVMe subsystem connections.
+func listSubsystems(ctx context.Context) (nvmeHostConnections, error) {
+	stdout, _, err := util.ExecCommandWithTimeout(ctx, listSubsysTimeout, "nvme", "list-subsys", "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	var hosts nvmeHostConnections
+	if err := json.Unmarshal([]byte(stdout), &hosts); err != nil {
+		return nil, err
+	}
+
+	return hosts, nil
+}
+
+// hasLivePathToGateway checks if a live path exists to the specified gateway.
+func (nhc nvmeHostConnections) hasLivePathToGateway(subsystemNQN, hostNQN,
+	gatewayIP, gatewayPort string,
+) bool {
+	for _, host := range nhc {
+		if host.HostNQN != hostNQN {
+			continue
+		}
+
+		for _, subsys := range host.Subsystems {
+			if subsys.NQN != subsystemNQN {
+				continue
+			}
+
+			for _, path := range subsys.Paths {
+				if path.Address.Traddr == gatewayIP &&
+					path.Address.Trsvcid == gatewayPort &&
+					path.State == "live" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/nvmeof/nvmeof_test.go
+++ b/internal/nvmeof/nvmeof_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nvmeof
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -56,4 +57,314 @@ func TestGatewayRpcClient_generateSerialNumber(t *testing.T) {
 	serial, err := client.generateSerialNumber()
 	require.NoError(t, err)
 	require.Equal(t, "Ceph2", serial)
+}
+
+func TestListSubsystems(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		jsonInput string
+		wantErr   bool
+		wantHosts int
+		validate  func(t *testing.T, hosts nvmeHostConnections)
+	}{
+		{
+			name: "valid single host with single subsystem and single path",
+			jsonInput: `[
+				{
+					"HostNQN": "nqn.2014-08.org.nvmexpress:uuid:12345678",
+					"Subsystems": [
+						{
+							"NQN": "nqn.2016-06.io.ceph:subsystem.test",
+							"Paths": [
+								{
+									"Address": "traddr=10.242.64.32,trsvcid=4420,src_addr=10.242.64.33",
+									"State": "live"
+								}
+							]
+						}
+					]
+				}
+			]`,
+			wantErr:   false,
+			wantHosts: 1,
+			validate: func(t *testing.T, hosts nvmeHostConnections) {
+				t.Helper()
+				require.Len(t, hosts, 1)
+				require.Equal(t, "nqn.2014-08.org.nvmexpress:uuid:12345678", hosts[0].HostNQN)
+				require.Len(t, hosts[0].Subsystems, 1)
+				require.Equal(t, "nqn.2016-06.io.ceph:subsystem.test", hosts[0].Subsystems[0].NQN)
+				require.Len(t, hosts[0].Subsystems[0].Paths, 1)
+
+				// Validate parsed address fields
+				path := hosts[0].Subsystems[0].Paths[0]
+				require.Equal(t, "10.242.64.32", path.Address.Traddr)
+				require.Equal(t, "4420", path.Address.Trsvcid)
+				require.Equal(t, "10.242.64.33", path.Address.SrcAddr)
+				require.Equal(t, "live", path.State)
+			},
+		},
+		{
+			name: "valid host with multipath (multiple paths)",
+			jsonInput: `[
+				{
+					"HostNQN": "nqn.2014-08.org.nvmexpress:uuid:abcdef",
+					"Subsystems": [
+						{
+							"NQN": "nqn.2016-06.io.ceph:subsystem.multipath",
+							"Paths": [
+								{
+									"Address": "traddr=10.128.2.70,trsvcid=4420,src_addr=10.242.64.33",
+									"State": "live"
+								},
+								{
+									"Address": "traddr=10.129.2.45,trsvcid=4420,src_addr=10.242.64.33",
+									"State": "live"
+								}
+							]
+						}
+					]
+				}
+			]`,
+			wantErr:   false,
+			wantHosts: 1,
+			validate: func(t *testing.T, hosts nvmeHostConnections) {
+				t.Helper()
+				require.Len(t, hosts[0].Subsystems[0].Paths, 2)
+
+				// Check first path
+				path1 := hosts[0].Subsystems[0].Paths[0]
+				require.Equal(t, "10.128.2.70", path1.Address.Traddr)
+				require.Equal(t, "4420", path1.Address.Trsvcid)
+				require.Equal(t, "live", path1.State)
+
+				// Check second path
+				path2 := hosts[0].Subsystems[0].Paths[1]
+				require.Equal(t, "10.129.2.45", path2.Address.Traddr)
+				require.Equal(t, "4420", path2.Address.Trsvcid)
+				require.Equal(t, "live", path2.State)
+			},
+		},
+		{
+			name: "path with non-live state",
+			jsonInput: `[
+				{
+					"HostNQN": "nqn.2014-08.org.nvmexpress:uuid:test",
+					"Subsystems": [
+						{
+							"NQN": "nqn.2016-06.io.ceph:subsystem.test",
+							"Paths": [
+								{
+									"Address": "traddr=192.168.1.10,trsvcid=5500,",
+									"State": "connecting"
+								}
+							]
+						}
+					]
+				}
+			]`,
+			wantErr:   false,
+			wantHosts: 1,
+			validate: func(t *testing.T, hosts nvmeHostConnections) {
+				t.Helper()
+				path := hosts[0].Subsystems[0].Paths[0]
+				require.Equal(t, "connecting", path.State)
+			},
+		},
+		{
+			name: "multiple hosts",
+			jsonInput: `[
+				{
+					"HostNQN": "nqn.2014-08.org.nvmexpress:uuid:host1",
+					"Subsystems": [
+						{
+							"NQN": "nqn.2016-06.io.ceph:subsystem.one",
+							"Paths": [
+								{
+									"Address": "traddr=10.0.0.1,trsvcid=4420,src_addr=10.0.0.2",
+									"State": "live"
+								}
+							]
+						}
+					]
+				},
+				{
+					"HostNQN": "nqn.2014-08.org.nvmexpress:uuid:host2",
+					"Subsystems": [
+						{
+							"NQN": "nqn.2016-06.io.ceph:subsystem.two",
+							"Paths": [
+								{
+									"Address": "traddr=10.0.1.1,trsvcid=4420,src_addr=10.0.1.2",
+									"State": "live"
+								}
+							]
+						}
+					]
+				}
+			]`,
+			wantErr:   false,
+			wantHosts: 2,
+			validate: func(t *testing.T, hosts nvmeHostConnections) {
+				t.Helper()
+				require.Len(t, hosts, 2)
+				require.Equal(t, "nqn.2014-08.org.nvmexpress:uuid:host1", hosts[0].HostNQN)
+				require.Equal(t, "nqn.2014-08.org.nvmexpress:uuid:host2", hosts[1].HostNQN)
+			},
+		},
+		{
+			name:      "invalid json",
+			jsonInput: `{invalid json}`,
+			wantErr:   true,
+		},
+		{
+			name:      "empty array",
+			jsonInput: `[]`,
+			wantErr:   false,
+			wantHosts: 0,
+			validate: func(t *testing.T, hosts nvmeHostConnections) {
+				t.Helper()
+				require.Empty(t, hosts)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hosts nvmeHostConnections
+			err := json.Unmarshal([]byte(tt.jsonInput), &hosts)
+
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, hosts, tt.wantHosts)
+
+			if tt.validate != nil {
+				tt.validate(t, hosts)
+			}
+		})
+	}
+}
+
+func TestHasLivePathToGateway(t *testing.T) {
+	t.Parallel()
+
+	// Setup test data
+	connections := nvmeHostConnections{
+		{
+			HostNQN: "nqn.2014-08.org.nvmexpress:uuid:test-host",
+			Subsystems: []struct {
+				NQN   string `json:"NQN"`
+				Paths []struct {
+					Address nvmePathAddress `json:"Address"`
+					State   string          `json:"State"`
+				} `json:"Paths"`
+			}{
+				{
+					NQN: "nqn.2016-06.io.ceph:subsystem.test",
+					Paths: []struct {
+						Address nvmePathAddress `json:"Address"`
+						State   string          `json:"State"`
+					}{
+						{
+							Address: nvmePathAddress{
+								Traddr:  "10.128.2.70",
+								Trsvcid: "4420",
+								SrcAddr: "10.242.64.33",
+							},
+							State: "live",
+						},
+						{
+							Address: nvmePathAddress{
+								Traddr:  "10.129.2.45",
+								Trsvcid: "4420",
+								SrcAddr: "10.242.64.33",
+							},
+							State: "connecting",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		subsystemNQN string
+		hostNQN      string
+		gatewayIP    string
+		gatewayPort  string
+		want         bool
+	}{
+		{
+			name:         "matching live path",
+			subsystemNQN: "nqn.2016-06.io.ceph:subsystem.test",
+			hostNQN:      "nqn.2014-08.org.nvmexpress:uuid:test-host",
+			gatewayIP:    "10.128.2.70",
+			gatewayPort:  "4420",
+			want:         true,
+		},
+		{
+			name:         "path exists but not live",
+			subsystemNQN: "nqn.2016-06.io.ceph:subsystem.test",
+			hostNQN:      "nqn.2014-08.org.nvmexpress:uuid:test-host",
+			gatewayIP:    "10.129.2.45",
+			gatewayPort:  "4420",
+			want:         false,
+		},
+		{
+			name:         "wrong gateway IP",
+			subsystemNQN: "nqn.2016-06.io.ceph:subsystem.test",
+			hostNQN:      "nqn.2014-08.org.nvmexpress:uuid:test-host",
+			gatewayIP:    "10.130.0.1",
+			gatewayPort:  "4420",
+			want:         false,
+		},
+		{
+			name:         "wrong port",
+			subsystemNQN: "nqn.2016-06.io.ceph:subsystem.test",
+			hostNQN:      "nqn.2014-08.org.nvmexpress:uuid:test-host",
+			gatewayIP:    "10.128.2.70",
+			gatewayPort:  "5500",
+			want:         false,
+		},
+		{
+			name:         "wrong subsystem NQN",
+			subsystemNQN: "nqn.2016-06.io.ceph:subsystem.wrong",
+			hostNQN:      "nqn.2014-08.org.nvmexpress:uuid:test-host",
+			gatewayIP:    "10.128.2.70",
+			gatewayPort:  "4420",
+			want:         false,
+		},
+		{
+			name:         "wrong host NQN",
+			subsystemNQN: "nqn.2016-06.io.ceph:subsystem.test",
+			hostNQN:      "nqn.2014-08.org.nvmexpress:uuid:wrong-host",
+			gatewayIP:    "10.128.2.70",
+			gatewayPort:  "4420",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := connections.hasLivePathToGateway(
+				tt.subsystemNQN,
+				tt.hostNQN,
+				tt.gatewayIP,
+				tt.gatewayPort,
+			)
+
+			require.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
# Describe what this PR does #

This PR fixes the NVMe-oF CSI node plugin's handling of already-connected subsystems. Previously, when `NodeStageVolume` was called for a volume, whose subsystem was already connected, the `nvme connect` command would return "already connected" error, causing the staging operation to fail.

The fix introduces a pre-connection check that calls `nvme list-subsys -o json` once before attempting connections. For each gateway listener, the driver checks if a live path already exists from the specific HostNQN to that gateway IP:port. If found, the connection attempt is skipped, and the driver proceeds directly to device path resolution and staging.

## Is there anything that requires special attention ##

**Backward Compatibility**: This change is fully backward compatible. The behavior only changes in the error case (already connected), converting it to a success case.


**Key behavioral changes**:
- The driver now calls `nvme list-subsys -o json` once per `ConnectSubsystem` call to retrieve existing connections
- Connection attempts are skipped (and marks `success = true` for the `ConnectSubsystem()` ) only when a live path exists to the specific gateway IP:port



## Related issues ##
example of the bug:

```bash 
E1126 12:07:47.541273  179952 cephcmds.go:156] ID: 58 Req-ID: 0001-0011-openshift-storage-0000000000000002-c7a2646a-c39e-44b7-8c2a-287c8c79c1c5 an error (exit status 1) and stderror (already connected
) occurred while running nvme args: [connect -t tcp -n nqn.2016-06.io.ceph:subsystem.test-integration -a d.c.b.a -s 4420 -l 1800 --hostnqn nqn.2014-08.org.nvmexpress:gdidi-9dqf2-worker-1-5f48x]
W1126 12:07:47.541316  179952 nvmeof_initiator.go:113] ID: 58 Req-ID: 0001-0011-openshift-storage-0000000000000002-c7a2646a-c39e-44b7-8c2a-287c8c79c1c5 Failed to connect to d.c.b.a:4420 - stdout: , stderr: already connected
I1126 12:07:47.541338  179952 nvmeof_initiator.go:92] ID: 58 Req-ID: 0001-0011-openshift-storage-0000000000000002-c7a2646a-c39e-44b7-8c2a-287c8c79c1c5 Connecting to NVMe-oF subsystem nqn.2016-06.io.ceph:subsystem.test-integration at a.b.c.d:4420
E1126 12:07:47.547762  179952 cephcmds.go:156] ID: 58 Req-ID: 0001-0011-openshift-storage-0000000000000002-c7a2646a-c39e-44b7-8c2a-287c8c79c1c5 an error (exit status 1) and stderror (already connected
) occurred while running nvme args: [connect -t tcp -n nqn.2016-06.io.ceph:subsystem.test-integration -a a.b.c.d -s 4420 -l 1800 --hostnqn nqn.2014-08.org.nvmexpress:gdidi-9dqf2-worker-1-5f48x]
W1126 12:07:47.547797  179952 nvmeof_initiator.go:113] ID: 58 Req-ID: 0001-0011-openshift-storage-0000000000000002-c7a2646a-c39e-44b7-8c2a-287c8c79c1c5 Failed to connect to a.b.c.d:4420 - stdout: , stderr: already connected
E1126 12:07:47.547939  179952 utils.go:355] ID: 58 Req-ID: 0001-0011-openshift-storage-0000000000000002-c7a2646a-c39e-44b7-8c2a-287c8c79c1c5 GRPC error: rpc error: code = Internal desc = failed to connect to subsystem: failed to connect to any gateway address for subsystem nqn.2016-06.io.ceph:subsystem.test-integration

```


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
