### PR TITLE
deploy: add list and watch permissions for secrets

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-clusterrole.yaml
@@ -22,6 +22,6 @@ rules:
   # allow to read the encryption key used with the metadata KMS
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
 {{- end -}}
 {{- end -}}

--- a/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
@@ -13,7 +13,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]

--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -17,7 +17,7 @@ rules:
   # allow to read Vault Token and connection options from the Tenants namespace
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-rbac.yaml
@@ -15,7 +15,7 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -17,7 +17,7 @@ rules:
   # allow to read Vault Token and connection options from the Tenants namespace
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]


### PR DESCRIPTION
# Describe what this PR does #

This patch adds list and watch RBACs to CephFS and RBD nodeplugin/provisioner cluster roles.

This is required to ensure the watcher actually starts.

