### PR TITLE
nvmeof: add rados ns ability

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -122,7 +122,7 @@ func (cs *Server) CreateVolume(
 
 	backend := res.GetVolume()
 	volumeID := backend.GetVolumeId()
-
+	volumeContext := backend.GetVolumeContext()
 	defer func() {
 		// skip cleanup if there was no error
 		if err == nil {
@@ -141,11 +141,13 @@ func (cs *Server) CreateVolume(
 		}
 	}()
 
-	rbdImageName := res.GetVolume().GetVolumeContext()["imageName"]
-	rbdPoolName := res.GetVolume().GetVolumeContext()["pool"]
+	rbdImageName := volumeContext["imageName"]
+	rbdPoolName := volumeContext["pool"]
+	// can be empty. if it was defined in config-map the rbd csi driver would have set it already
+	rbdRadosNameSpace := res.GetVolume().GetVolumeContext()["radosNamespace"]
 
 	// Step 2: Setup NVMe-oF resources
-	nvmeofData, err := cs.createNVMeoFResources(ctx, req, rbdPoolName, rbdImageName)
+	nvmeofData, err := cs.createNVMeoFResources(ctx, req, rbdPoolName, rbdRadosNameSpace, rbdImageName)
 	if err != nil {
 		log.ErrorLog(ctx, "NVMe-oF resource setup failed for volumeID %s: %v", volumeID, err)
 
@@ -628,6 +630,7 @@ func (cs *Server) createNVMeoFResources(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
 	rbdPoolName,
+	rbdRadosNameSpace,
 	rbdImageName string,
 ) (*nvmeof.NVMeoFVolumeData, error) {
 	// Step 1: Extract parameters (already validated)
@@ -697,7 +700,7 @@ func (cs *Server) createNVMeoFResources(
 		nvmeofData.ListenerInfo)
 
 	// Step 4: Create namespace and set its uuid
-	nsid, err := gateway.CreateNamespace(ctx, nvmeofData.SubsystemNQN, rbdPoolName, rbdImageName)
+	nsid, err := gateway.CreateNamespace(ctx, nvmeofData.SubsystemNQN, rbdPoolName, rbdRadosNameSpace, rbdImageName)
 	if err != nil {
 		return nil, fmt.Errorf("namespace creation failed: %w", err)
 	}

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -104,7 +104,10 @@ func (c *GatewayRpcClient) Destroy() error {
 }
 
 // CreateNamespace creates a namespace in a subsystem.
-func (gw *GatewayRpcClient) CreateNamespace(ctx context.Context, subsystemNQN, poolName, imageName string,
+func (gw *GatewayRpcClient) CreateNamespace(
+	ctx context.Context,
+	subsystemNQN string,
+	poolName, radosNamespace, imageName string,
 ) (uint32, error) {
 	log.DebugLog(ctx, "Creating namespace for RBD %s/%s in subsystem %s",
 		poolName, imageName, subsystemNQN)
@@ -125,7 +128,9 @@ func (gw *GatewayRpcClient) CreateNamespace(ctx context.Context, subsystemNQN, p
 		// DisableAutoResize: nil,
 		// ReadOnly:          nil,
 	}
-
+	if radosNamespace != "" {
+		req.RadosNamespaceName = &radosNamespace
+	}
 	resp, err := gw.client.NamespaceAdd(ctx, req)
 	switch {
 	case err != nil:

--- a/internal/nvmeof/tests/nvmeof_test.go
+++ b/internal/nvmeof/tests/nvmeof_test.go
@@ -148,7 +148,7 @@ func TestRealGateway(t *testing.T) {
 	// Test create namespace
 	// poolName := "mypool"
 	// imageName := "test-image"
-	// nsID, err := client.CreateNamespace(ctx, testNQN, poolName, imageName)
+	// nsID, err := client.CreateNamespace(ctx, testNQN, poolName, radosNS, imageName)
 	// require.NoError(t, err)
 	// require.Greater(t, nsID, uint32(0), "Namespace ID should be greater than 0")
 


### PR DESCRIPTION

# Add RADOS namespace ability to nvmeof csi driver. #

RADOS namespace support was added to nvmeof GW project.
RADOS namespace option in create volume step is added. 

## Is there anything that requires special attention ##
It is known the ceph-csi instance (deployment) is working with only 1 RADOS namespace.  And can be more than 1 deployment on same Ceph cluster. Each of deployment has different rados ns. 

RADOS namespace value is defined in **rbd config-map**, in that way, the nvmeof controller fetch the value from the rbd response,
  
 ```Go
rbdRadosNameSpace := res.GetVolume().GetVolumeContext()["radosNamespace"]
```
and then calls to create nvmeof namespace later. 






**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
