### PR TITLE
ci: deploy ceph-csi-operator in configurable Namespace

### DIFF
--- a/scripts/deploy-ceph-csi-operator.sh
+++ b/scripts/deploy-ceph-csi-operator.sh
@@ -17,7 +17,8 @@ OPERATOR_URL="https://raw.githubusercontent.com/ceph/ceph-csi-operator/${CEPH_CS
 # operator deployment files
 OPERATOR_INSTALL="${OPERATOR_URL}/deploy/all-in-one/install.yaml"
 
-OPERATOR_NAMESPACE="ceph-csi-operator-system"
+DEFAULT_OPERATOR_NAMESPACE="ceph-csi-operator-system"
+OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE:-"${DEFAULT_OPERATOR_NAMESPACE}"}
 IMAGESET_CONFIGMAP_NAME="ceph-csi-imageset"
 ENCRYPTION_CONFIGMAP_NAME="ceph-csi-encryption-kms-config"
 
@@ -31,6 +32,11 @@ K8S_IMAGE_REPO=${K8S_IMAGE_REPO:-"registry.k8s.io/sig-storage"}
 
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT
+
+function generate_operator_install() {
+    curl "${OPERATOR_INSTALL}" | \
+        sed "s/namespace: ${DEFAULT_OPERATOR_NAMESPACE}/namespace: ${OPERATOR_NAMESPACE}/g"
+}
 
 function generate_imageset_configmap() {
     cat <<EOF >"${TEMP_DIR}/imageset-configmap.yaml"
@@ -103,7 +109,7 @@ EOF
 }
 
 function deploy_operator() {
-    kubectl_retry create -f "${OPERATOR_INSTALL}"
+    generate_operator_install | kubectl_retry create -f -
     generate_operator_config
     generate_driver "${RBD_DRIVER_NAME}"
     generate_driver "${CEPHFS_DRIVER_NAME}"
@@ -127,7 +133,7 @@ function cleanup() {
 
     # Delete all the generated files at once
     kubectl_retry delete -f "${TEMP_DIR}"
-    kubectl_retry delete -f "${OPERATOR_INSTALL}"
+    generate_operator_install | kubectl_retry delete -f -
 }
 
 case "${1:-}" in

--- a/scripts/k8s-storage/create-configmap.sh
+++ b/scripts/k8s-storage/create-configmap.sh
@@ -23,10 +23,7 @@ TOOLBOX_POD=$(kubectl -n rook-ceph get pods -l app=rook-ceph-tools -o=jsonpath='
 FS_ID=$(kubectl -n rook-ceph exec "${TOOLBOX_POD}" -- ceph fsid)
 MONITOR=$(kubectl -n rook-ceph get services -l app=rook-ceph-mon -o=jsonpath='{.items[0].spec.clusterIP}:{.items[0].spec.ports[0].port}')
 
-# in case the ConfigMap already exists, remove it before recreating
-kubectl -n "${NAMESPACE}" delete --ignore-not-found configmap/ceph-csi-config
-
-cat << EOF | kubectl -n "${NAMESPACE}" create -f -
+cat << EOF | kubectl -n "${NAMESPACE}" replace -f -
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
The k8s-storage CI jobs expect a temporary namespace where components
are deployed. ceph-csi-operator always used its default namespace.

See-also: #5864

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
