### PR TITLE
ci: create and use testing namespace for operator deployment

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -188,7 +188,8 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh quay.io/cephcsi/ceph-csi-operator:${operator_version}"
 
 			timeout(time: 30, unit: 'MINUTES') {
-				ssh 'cd /opt/build/go/src/github.com/ceph/ceph-csi && ./scripts/deploy-ceph-csi-operator.sh deploy'
+				ssh "kubectl create namespace '${namespace}'"
+				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && OPERATOR_NAMESPACE='${namespace}' ./scripts/deploy-ceph-csi-operator.sh deploy"
 			}
 		}
 		stage("create ConfigMap & StorageClasses") {


### PR DESCRIPTION
By default the ceph-csi-operator deploys everything in the "ceph-csi-operator-system" namespace. The Kubernetes storage tests expect a temporary namespace that.

Related-to: #5867

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
