### PR TITLE
rbd: allow configuring deleted volume retention time (#5830)

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -8,5 +8,8 @@
    - refer design doc for more details - [here](https://github.com/ceph/ceph-csi/blob/devel/docs/design/proposals/userID-mapping.md)
 - cephfs-csi: fix mounting alternate filesystem when mounting by monitor lists [PR](https://github.com/ceph/ceph-csi/pull/5643)
 - rbd: add block volume stats support [PR](https://github.com/ceph/ceph-csi/pull/5799)
+- rbd: add `--rbdtrashmaxdelay` flag for configurable trash retention delay
+   - When set to a positive duration, deleted RBD volumes are moved to Ceph trash and retained for the specified period
+   - Users are responsible for purging RBD trash after the retention period using `rbd trash purge`
 
 ## NOTE

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -151,6 +151,12 @@ func init() {
 		"Minimum number of snapshots required on rbd image to start flattening")
 	flag.BoolVar(&conf.SkipForceFlatten, "skipforceflatten", false,
 		"skip image flattening if kernel support mapping of rbd images which has the deep-flatten feature")
+	flag.UintVar(
+		&conf.RbdTrashMaxDelay,
+		"rbdtrashmaxdelay",
+		0,
+		"Storage class parameter 'trashMaxDelay' value used for a delay (in seconds)"+
+			" before processing the deletion of the rbd image.")
 
 	flag.BoolVar(&conf.Version, "version", false, "Print cephcsi version information")
 	flag.BoolVar(&conf.EnableProfiling, "enableprofiling", false, "enable go profiling")

--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -151,12 +151,13 @@ func init() {
 		"Minimum number of snapshots required on rbd image to start flattening")
 	flag.BoolVar(&conf.SkipForceFlatten, "skipforceflatten", false,
 		"skip image flattening if kernel support mapping of rbd images which has the deep-flatten feature")
-	flag.UintVar(
+	flag.DurationVar(
 		&conf.RbdTrashMaxDelay,
 		"rbdtrashmaxdelay",
 		0,
-		"Storage class parameter 'trashMaxDelay' value used for a delay (in seconds)"+
-			" before processing the deletion of the rbd image.")
+		"Delay before permanently deleting RBD images from trash. When set to a positive duration, "+
+			"deleted volumes are moved to Ceph trash and retained for this period. Users are responsible "+
+			"for purging trash after the retention period.")
 
 	flag.BoolVar(&conf.Version, "version", false, "Print cephcsi version information")
 	flag.BoolVar(&conf.EnableProfiling, "enableprofiling", false, "enable go profiling")

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -62,6 +62,7 @@ spec:
             - "--rbdsoftmaxclonedepth=4"
             - "--enableprofiling=false"
             - "--setmetadata=true"
+            - "--rbdtrashmaxdelay=0"
             # - "--enable-fencing=true"
           env:
             - name: POD_IP

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -49,6 +49,7 @@ make image-cephcsi
 | `--enable-read-affinity` | `false`                       | enable read affinity                                                                                                                                                                                                                                                                 |
 | `--crush-location-labels`| _empty_                       | Kubernetes node labels that determine the CRUSH location the node belongs to, separated by ','.<br>`Note: These labels will be replaced if crush location labels are defined in the ceph-csi-config ConfigMap for the specific cluster.`                                                                                                                                                                                       |
 | `--logslowopinterval`    | `30s`                         | Log slow operations at the specified rate. Operation is considered slow if it outlives its deadline.                                                                                                                                                                                                                                                                                                                           |
+| `--rbdtrashmaxdelay`     | `0`                           | Delay before permanently deleting RBD images from trash. When set to a positive duration (e.g., `24h`, `7d`), deleted volumes are moved to Ceph trash and retained for this period. See [RBD Trash Retention](#rbd-trash-retention) for details.                                                                                                                                                                               |
 
 **Available volume parameters:**
 
@@ -560,6 +561,44 @@ kubectl edit cm ceph-config
 
 This will update the `ceph.conf` of the underlying ceph cluster to enable
 librbd logs in `csi-rbdplugin` container.
+
+## RBD Trash Retention
+
+Ceph-CSI supports configuring a retention delay for deleted RBD volumes using
+the `--rbdtrashmaxdelay` command-line flag. When this flag is set to a positive
+duration, deleted volumes are moved to the Ceph RBD trash instead of being
+immediately removed.
+
+### Configuration
+
+Set the `--rbdtrashmaxdelay` flag on the csi-rbdplugin-provisioner deployment:
+
+```yaml
+args:
+  - "--rbdtrashmaxdelay=24h"  # Retain deleted images in trash for 24 hours
+```
+
+The value accepts Go duration format (e.g., `1h`, `24h`, `7d`, `168h`).
+
+### Behavior
+
+- When `--rbdtrashmaxdelay` is set to `0` (default): Volumes are immediately
+  deleted from trash after being moved there (current behavior preserved).
+- When `--rbdtrashmaxdelay` is set to a positive duration: Volumes are moved
+  to Ceph trash and the CSI driver returns immediately. The image remains in
+  trash until Ceph's trash purge mechanism removes it.
+
+### Important Notes
+
+- **Users are responsible for purging RBD trash** after the retention period.
+  Ceph-CSI does not automatically purge images from trash.
+- To purge expired images from trash, use the Ceph CLI:
+  ```bash
+  rbd trash purge <pool-name>
+  ```
+- The configured delay applies to all volumes deleted while that configuration
+  is active. Changing the flag value only affects future deletions.
+- Images in trash still consume storage space until purged.
 
 ## Changed Block Tracking (CBT)
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -208,6 +209,14 @@ func (cs *ControllerServer) parseVolCreateRequest(
 	err = rbdVol.initKMS(ctx, req.GetParameters(), req.GetSecrets())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if delay, ok := req.GetParameters()["trashMaxDelay"]; ok {
+		d, err := time.ParseDuration(delay)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid trashMaxDelay: %v", err)
+		}
+		rbdVol.TrashMaxDelay = d
 	}
 
 	rbdVol.RequestName = req.GetName()

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -445,6 +445,9 @@ func (cs *ControllerServer) CreateVolume(
 
 	// Set Metadata on PV Create
 	metadata := k8s.GetVolumeMetadata(req.GetParameters())
+	if delay, ok := req.GetParameters()["trashMaxDelay"]; ok {
+		metadata[trashMaxDelayKey] = delay
+	}
 	err = rbdVol.setAllMetadata(metadata)
 	if err != nil {
 		if deleteErr := rbdVol.Delete(ctx); deleteErr != nil {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -209,14 +208,6 @@ func (cs *ControllerServer) parseVolCreateRequest(
 	err = rbdVol.initKMS(ctx, req.GetParameters(), req.GetSecrets())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
-	if delay, ok := req.GetParameters()["trashMaxDelay"]; ok {
-		d, err := time.ParseDuration(delay)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid trashMaxDelay: %v", err)
-		}
-		rbdVol.TrashMaxDelay = d
 	}
 
 	rbdVol.RequestName = req.GetName()
@@ -454,9 +445,6 @@ func (cs *ControllerServer) CreateVolume(
 
 	// Set Metadata on PV Create
 	metadata := k8s.GetVolumeMetadata(req.GetParameters())
-	if delay, ok := req.GetParameters()["trashMaxDelay"]; ok {
-		metadata[trashMaxDelayKey] = delay
-	}
 	err = rbdVol.setAllMetadata(metadata)
 	if err != nil {
 		if deleteErr := rbdVol.Delete(ctx); deleteErr != nil {

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -102,7 +102,7 @@ func (r *rbdDriver) Run(conf *util.Config) {
 	rbd.SetGlobalBool("skipForceFlatten", conf.SkipForceFlatten)
 	rbd.SetGlobalInt("maxSnapshotsOnImage", conf.MaxSnapshotsOnImage)
 	rbd.SetGlobalInt("minSnapshotsOnImageToStartFlatten", conf.MinSnapshotsOnImage)
-	rbd.SetGlobalInt("rbdTrashMaxDelay", conf.RbdTrashMaxDelay)
+	rbd.SetGlobalDuration("rbdTrashMaxDelay", conf.RbdTrashMaxDelay)
 	// Create instances of the volume and snapshot journal
 	rbd.InitJournals(conf.InstanceID)
 

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -102,6 +102,7 @@ func (r *rbdDriver) Run(conf *util.Config) {
 	rbd.SetGlobalBool("skipForceFlatten", conf.SkipForceFlatten)
 	rbd.SetGlobalInt("maxSnapshotsOnImage", conf.MaxSnapshotsOnImage)
 	rbd.SetGlobalInt("minSnapshotsOnImageToStartFlatten", conf.MinSnapshotsOnImage)
+	rbd.SetGlobalInt("rbdTrashMaxDelay", conf.RbdTrashMaxDelay)
 	// Create instances of the volume and snapshot journal
 	rbd.InitJournals(conf.InstanceID)
 

--- a/internal/rbd/globals.go
+++ b/internal/rbd/globals.go
@@ -18,6 +18,7 @@ package rbd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ceph/ceph-csi/internal/journal"
 )
@@ -41,7 +42,7 @@ var (
 	// krbd features supported by the loaded driver.
 	krbdFeatures uint
 
-	rbdTrashMaxDelay uint
+	rbdTrashMaxDelay time.Duration
 )
 
 // SetGlobalInt provides a way for the rbd-driver to configure global variables
@@ -62,10 +63,19 @@ func SetGlobalInt(name string, value uint) {
 		minSnapshotsOnImageToStartFlatten = value
 	case "krbdFeatures":
 		krbdFeatures = value
+	default:
+		panic(fmt.Sprintf("BUG: can not set unknown variable %q", name))
+	}
+}
+
+// SetGlobalDuration provides a way for the rbd-driver to configure global
+// duration variables in the rbd package.
+func SetGlobalDuration(name string, value time.Duration) {
+	switch name {
 	case "rbdTrashMaxDelay":
 		rbdTrashMaxDelay = value
 	default:
-		panic(fmt.Sprintf("BUG: can not set unknown variable %q", name))
+		panic(fmt.Sprintf("BUG: can not set unknown duration variable %q", name))
 	}
 }
 

--- a/internal/rbd/globals.go
+++ b/internal/rbd/globals.go
@@ -40,6 +40,8 @@ var (
 
 	// krbd features supported by the loaded driver.
 	krbdFeatures uint
+
+	rbdTrashMaxDelay uint
 )
 
 // SetGlobalInt provides a way for the rbd-driver to configure global variables
@@ -60,6 +62,8 @@ func SetGlobalInt(name string, value uint) {
 		minSnapshotsOnImageToStartFlatten = value
 	case "krbdFeatures":
 		krbdFeatures = value
+	case "rbdTrashMaxDelay":
+		rbdTrashMaxDelay = value
 	default:
 		panic(fmt.Sprintf("BUG: can not set unknown variable %q", name))
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -93,13 +93,6 @@ const (
 	// Suffix added to the temp cloned image name.
 	// This will always be (rbd image name + "-temp").
 	tempImageSuffix = "-temp"
-
-	// trashMaxDelayKey is the key used to store the trash max delay in metadata.
-	// DEPRECATED: use trashMaxDelayXattr instead.
-	trashMaxDelayKey = "csi.ceph.com/trashMaxDelay"
-
-	// trashMaxDelayXattr is the key used to store the trash max delay in xattrs.
-	trashMaxDelayXattr = "csi.ceph.com/trashMaxDelay"
 )
 
 // rbdImage contains common attributes and methods for the rbdVolume and
@@ -140,9 +133,6 @@ type rbdImage struct {
 
 	// Owner is the creator (tenant, Kubernetes Namespace) of the volume
 	Owner string
-
-	// TrashMaxDelay is the retention period for the image in trash
-	TrashMaxDelay time.Duration
 
 	// VolSize is the size of the RBD image backing this rbdImage.
 	VolSize int64
@@ -501,17 +491,6 @@ func createImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 		}
 	}
 
-	if pOpts.TrashMaxDelay > 0 {
-		err = pOpts.getImageID()
-		if err != nil {
-			return fmt.Errorf("failed to get image id for %s: %w", pOpts, err)
-		}
-		err = pOpts.setTrashMaxDelayAttribute(ctx, pOpts.TrashMaxDelay)
-		if err != nil {
-			return fmt.Errorf("failed to set trash delay attribute for %s: %w", pOpts, err)
-		}
-	}
-
 	return nil
 }
 
@@ -671,22 +650,6 @@ func isCephMgrSupported(ctx context.Context, clusterID string, err error) (bool,
 	return true, nil
 }
 
-func (ri *rbdImage) setTrashMaxDelayAttribute(ctx context.Context, delay time.Duration) error {
-	headerObject := "rbd_header." + ri.ImageID
-	return ri.ioctx.SetXattr(headerObject, trashMaxDelayXattr, []byte(delay.String()))
-}
-
-func (ri *rbdImage) getTrashMaxDelayAttribute(ctx context.Context) (time.Duration, error) {
-	headerObject := "rbd_header." + ri.ImageID
-	data := make([]byte, 64)
-	n, err := ri.ioctx.GetXattr(headerObject, trashMaxDelayXattr, data)
-	if err != nil {
-		return 0, err
-	}
-	// data[:n] contains the duration string
-	return time.ParseDuration(string(data[:n]))
-}
-
 // ensureImageCleanup finds image in trash and if found removes it
 func (ri *rbdImage) ensureImageCleanup(ctx context.Context) error {
 	err := ri.openIoctx()
@@ -744,18 +707,8 @@ func (ri *rbdImage) Delete(ctx context.Context) error {
 
 	imgHandle := librbd.GetImage(ri.ioctx, image)
 
-	// verify if the image has the trashMaxDelayXattr in the xattrs
-	// if it does, use that value, otherwise use the default delay of 0
-	trashDelay, err := ri.getTrashMaxDelayAttribute(ctx)
-	if err != nil {
-		if !errors.Is(err, rados.ErrNotFound) {
-			log.WarningLog(ctx, "failed to read trash delay xattr for %s: %v", ri, err)
-		}
-		trashDelay = 0
-	}
-
-	// rbdTrashMaxDelay is the delay in seconds to delete the image from trash
-	err = imgHandle.Trash(trashDelay)
+	// Use the globally configured trash delay from the --rbdtrashmaxdelay flag
+	err = imgHandle.Trash(rbdTrashMaxDelay)
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {
 			return fmt.Errorf("Failed as %w (internal %w)", rbderrors.ErrImageNotFound, err)
@@ -766,7 +719,11 @@ func (ri *rbdImage) Delete(ctx context.Context) error {
 		return err
 	}
 
-	if trashDelay > 0 {
+	// If rbdTrashMaxDelay > 0, the image is moved to trash and retained.
+	// Users are responsible for purging trash after the retention period.
+	if rbdTrashMaxDelay > 0 {
+		log.DebugLog(ctx, "rbd: image %s moved to trash with retention delay %v", ri, rbdTrashMaxDelay)
+
 		return nil
 	}
 
@@ -1685,17 +1642,6 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(
 
 	// Success! Do not delete the cloned image now :)
 	deleteClone = false
-
-	if rv.TrashMaxDelay > 0 {
-		err = rv.getImageID()
-		if err != nil {
-			return fmt.Errorf("failed to get image id for %s: %w", rv, err)
-		}
-		err = rv.setTrashMaxDelayAttribute(ctx, rv.TrashMaxDelay)
-		if err != nil {
-			return fmt.Errorf("failed to set trash delay attribute for %s: %w", rv, err)
-		}
-	}
 
 	return nil
 }

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -93,6 +93,9 @@ const (
 	// Suffix added to the temp cloned image name.
 	// This will always be (rbd image name + "-temp").
 	tempImageSuffix = "-temp"
+
+	// trashMaxDelayKey is the key used to store the trash max delay.
+	trashMaxDelayKey = "csi.ceph.com/trashMaxDelay"
 )
 
 // rbdImage contains common attributes and methods for the rbdVolume and
@@ -707,8 +710,25 @@ func (ri *rbdImage) Delete(ctx context.Context) error {
 	}
 
 	rbdImage := librbd.GetImage(ri.ioctx, image)
+
+	// verify if the image has the trashMaxDelayKey in the metadata
+	// if it does, use that value, otherwise use the global rbdTrashMaxDelay
+	trashDelay := rbdTrashMaxDelay
+	img, err := ri.open()
+	if err == nil {
+		val, metaErr := img.GetMetadata(trashMaxDelayKey)
+		img.Close()
+		if metaErr == nil {
+			if v, parseErr := strconv.ParseUint(val, 10, 64); parseErr == nil {
+				trashDelay = uint(v)
+			}
+		}
+	} else if !errors.Is(err, librbd.ErrNotFound) {
+		log.WarningLog(ctx, "failed to open rbd image %q to check metadata: %v", ri, err)
+	}
+
 	// rbdTrashMaxDelay is the delay in seconds to delete the image from trash
-	err = rbdImage.Trash(uint64(rbdTrashMaxDelay))
+	err = rbdImage.Trash(uint64(trashDelay))
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {
 			return fmt.Errorf("Failed as %w (internal %w)", rbderrors.ErrImageNotFound, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -707,7 +707,8 @@ func (ri *rbdImage) Delete(ctx context.Context) error {
 	}
 
 	rbdImage := librbd.GetImage(ri.ioctx, image)
-	err = rbdImage.Trash(0)
+	// rbdTrashMaxDelay is the delay in seconds to delete the image from trash
+	err = rbdImage.Trash(uint64(rbdTrashMaxDelay))
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {
 			return fmt.Errorf("Failed as %w (internal %w)", rbderrors.ErrImageNotFound, err)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -94,8 +94,12 @@ const (
 	// This will always be (rbd image name + "-temp").
 	tempImageSuffix = "-temp"
 
-	// trashMaxDelayKey is the key used to store the trash max delay.
+	// trashMaxDelayKey is the key used to store the trash max delay in metadata.
+	// DEPRECATED: use trashMaxDelayXattr instead.
 	trashMaxDelayKey = "csi.ceph.com/trashMaxDelay"
+
+	// trashMaxDelayXattr is the key used to store the trash max delay in xattrs.
+	trashMaxDelayXattr = "csi.ceph.com/trashMaxDelay"
 )
 
 // rbdImage contains common attributes and methods for the rbdVolume and
@@ -136,6 +140,9 @@ type rbdImage struct {
 
 	// Owner is the creator (tenant, Kubernetes Namespace) of the volume
 	Owner string
+
+	// TrashMaxDelay is the retention period for the image in trash
+	TrashMaxDelay time.Duration
 
 	// VolSize is the size of the RBD image backing this rbdImage.
 	VolSize int64
@@ -494,6 +501,17 @@ func createImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 		}
 	}
 
+	if pOpts.TrashMaxDelay > 0 {
+		err = pOpts.getImageID()
+		if err != nil {
+			return fmt.Errorf("failed to get image id for %s: %w", pOpts, err)
+		}
+		err = pOpts.setTrashMaxDelayAttribute(ctx, pOpts.TrashMaxDelay)
+		if err != nil {
+			return fmt.Errorf("failed to set trash delay attribute for %s: %w", pOpts, err)
+		}
+	}
+
 	return nil
 }
 
@@ -653,8 +671,23 @@ func isCephMgrSupported(ctx context.Context, clusterID string, err error) (bool,
 	return true, nil
 }
 
+func (ri *rbdImage) setTrashMaxDelayAttribute(ctx context.Context, delay time.Duration) error {
+	headerObject := "rbd_header." + ri.ImageID
+	return ri.ioctx.SetXattr(headerObject, trashMaxDelayXattr, []byte(delay.String()))
+}
+
+func (ri *rbdImage) getTrashMaxDelayAttribute(ctx context.Context) (time.Duration, error) {
+	headerObject := "rbd_header." + ri.ImageID
+	data := make([]byte, 64)
+	n, err := ri.ioctx.GetXattr(headerObject, trashMaxDelayXattr, data)
+	if err != nil {
+		return 0, err
+	}
+	// data[:n] contains the duration string
+	return time.ParseDuration(string(data[:n]))
+}
+
 // ensureImageCleanup finds image in trash and if found removes it
-// from trash.
 func (ri *rbdImage) ensureImageCleanup(ctx context.Context) error {
 	err := ri.openIoctx()
 	if err != nil {
@@ -709,26 +742,20 @@ func (ri *rbdImage) Delete(ctx context.Context) error {
 		return err
 	}
 
-	rbdImage := librbd.GetImage(ri.ioctx, image)
+	imgHandle := librbd.GetImage(ri.ioctx, image)
 
-	// verify if the image has the trashMaxDelayKey in the metadata
-	// if it does, use that value, otherwise use the global rbdTrashMaxDelay
-	trashDelay := rbdTrashMaxDelay
-	img, err := ri.open()
-	if err == nil {
-		val, metaErr := img.GetMetadata(trashMaxDelayKey)
-		img.Close()
-		if metaErr == nil {
-			if v, parseErr := strconv.ParseUint(val, 10, 64); parseErr == nil {
-				trashDelay = uint(v)
-			}
+	// verify if the image has the trashMaxDelayXattr in the xattrs
+	// if it does, use that value, otherwise use the default delay of 0
+	trashDelay, err := ri.getTrashMaxDelayAttribute(ctx)
+	if err != nil {
+		if !errors.Is(err, rados.ErrNotFound) {
+			log.WarningLog(ctx, "failed to read trash delay xattr for %s: %v", ri, err)
 		}
-	} else if !errors.Is(err, librbd.ErrNotFound) {
-		log.WarningLog(ctx, "failed to open rbd image %q to check metadata: %v", ri, err)
+		trashDelay = 0
 	}
 
 	// rbdTrashMaxDelay is the delay in seconds to delete the image from trash
-	err = rbdImage.Trash(uint64(trashDelay))
+	err = imgHandle.Trash(trashDelay)
 	if err != nil {
 		if errors.Is(err, librbd.ErrNotFound) {
 			return fmt.Errorf("Failed as %w (internal %w)", rbderrors.ErrImageNotFound, err)
@@ -737,6 +764,10 @@ func (ri *rbdImage) Delete(ctx context.Context) error {
 		log.ErrorLog(ctx, "failed to delete rbd image: %s, error: %v", ri, err)
 
 		return err
+	}
+
+	if trashDelay > 0 {
+		return nil
 	}
 
 	return ri.trashRemoveImage(ctx)
@@ -1654,6 +1685,17 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(
 
 	// Success! Do not delete the cloned image now :)
 	deleteClone = false
+
+	if rv.TrashMaxDelay > 0 {
+		err = rv.getImageID()
+		if err != nil {
+			return fmt.Errorf("failed to get image id for %s: %w", rv, err)
+		}
+		err = rv.setTrashMaxDelayAttribute(ctx, rv.TrashMaxDelay)
+		if err != nil {
+			return fmt.Errorf("failed to set trash delay attribute for %s: %w", rv, err)
+		}
+	}
 
 	return nil
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -137,9 +137,8 @@ type Config struct {
 	// reached cephcsi will start flattening the older rbd images.
 	MinSnapshotsOnImage uint
 
-	// RbdTrashMaxDelay is the maximum time in seconds to delay the deletion of a
-	// volume in the trash.
-	RbdTrashMaxDelay uint
+	// RbdTrashMaxDelay is the delay before permanently deleting RBD images from trash.
+	RbdTrashMaxDelay time.Duration
 
 	PidLimit    int           // PID limit to configure through cgroups")
 	MetricsPort int           // TCP port for liveness/grpc metrics requests

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -137,6 +137,10 @@ type Config struct {
 	// reached cephcsi will start flattening the older rbd images.
 	MinSnapshotsOnImage uint
 
+	// RbdTrashMaxDelay is the maximum time in seconds to delay the deletion of a
+	// volume in the trash.
+	RbdTrashMaxDelay uint
+
 	PidLimit    int           // PID limit to configure through cgroups")
 	MetricsPort int           // TCP port for liveness/grpc metrics requests
 	PollTime    time.Duration // time interval in seconds between each poll


### PR DESCRIPTION
# Description#

- This PR introduces a configurable option to delay the permanent deletion of RBD volumes by moving them to the RBD trash with a specified deferment time.
- 
- Previously, the CSI driver invoked `rbdImage.Trash(0)` with a hard-coded deferment value of `0`, meaning deleted volumes were immediately eligible for purge or removal depending on the backend configuration. There was no way to specify a delay from the CSI side to allow recovery of accidentally deleted volumes.
- 
- This change allows administrators to configure a safety window (for example, one hour) during which deleted volumes remain in the RBD trash and can be recovered before being permanently removed.


## Is there anything that requires special attention ##
- No special attention is required for normal usage.

Do you have any questions?
- No open questions at this time.

Is the change backward compatible?
Yes, the change is backward compatible.

Are there concerns around backward compatibility?
No. The default value of the new configuration is `0`, which preserves the existing behavior.

Provide any external context for the change, if any.
- This change aligns with Ceph RBD’s native support for trash deferment.
- It allows Ceph-CSI users to better leverage Ceph’s safety mechanisms when managing persistent volumes in Kubernetes environments.
- No CSI spec changes are required for this enhancement.

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #5830 

## Tests Performed

- Attempted local execution of RBD unit tests:
  - go test ./internal/rbd/...

  These fail locally due to missing Ceph native libraries
  (librbd, librados), required by go-ceph CGO bindings.

- Attempted CGO-disabled execution:
  - CGO_ENABLED=0 go test ./internal/rbd/features

  This fails as expected because feature detection relies on
  CGO-enabled Ceph symbols.

- Provided a detailed validation guide describing how to
  verify the behavior in a Ceph-backed Kubernetes environment.

Full verification is expected to be covered by CI.

**Checklist:**

* [✔️] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ✔️] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.


