### PR TITLE
nvmeof: add auto listeners feature into NVMe-oF CSI driver

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -359,17 +360,29 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	params := req.GetParameters()
 	requiredParams := []string{
 		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
-		"listeners",
 	}
 	for _, param := range requiredParams {
 		if params[param] == "" {
 			return fmt.Errorf("missing required parameter: %s", param)
 		}
 	}
-	// Validate listeners JSON
-	_, err := parseListeners(params["listeners"])
+	// Validate listeners JSON if provided
+	listeners, err := parseListeners(params["listeners"])
 	if err != nil {
 		return fmt.Errorf("invalid listeners parameter: %w", err)
+	}
+	// Validate network mask if provided
+	err = validateNetworkMask(params["networkMask"])
+	if err != nil {
+		return fmt.Errorf("invalid network mask parameter: %w", err)
+	}
+	networkMask := params["networkMask"]
+	// Must have EITHER listeners XOR networkMask
+	if len(listeners) == 0 && networkMask == "" {
+		return errors.New("must specify either 'listeners' xor 'networkMask', but got neither")
+	}
+	if len(listeners) > 0 && networkMask != "" {
+		return errors.New("must specify either 'listeners' xor 'networkMask',but got both")
 	}
 	// Validate QoS parameters - cannot mix RBD and NVMe-oF QoS
 	mutableParams := req.GetMutableParameters()
@@ -395,7 +408,7 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 func validatePublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
 	volumeContext := req.GetVolumeContext()
 	requiredParams := []string{
-		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort", "listeners",
+		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
 	}
 	for _, param := range requiredParams {
 		if volumeContext[param] == "" {
@@ -407,12 +420,15 @@ func validatePublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error
 }
 
 func parseListeners(listenersJSON string) ([]nvmeof.ListenerDetails, error) {
+	if listenersJSON == "" { // No "listeners" entry was provided
+		return []nvmeof.ListenerDetails{}, nil
+	}
 	var listeners []nvmeof.ListenerDetails
 	if err := json.Unmarshal([]byte(listenersJSON), &listeners); err != nil {
 		return nil, fmt.Errorf("failed to parse listeners JSON: %w", err)
 	}
 
-	if len(listeners) == 0 { // TODO: when auto listener will be implemented , make listeners optional
+	if len(listeners) == 0 { // At least one listener is required
 		return nil, errors.New("at least one listener must be specified")
 	}
 
@@ -424,6 +440,20 @@ func parseListeners(listenersJSON string) ([]nvmeof.ListenerDetails, error) {
 	}
 
 	return listeners, nil
+}
+
+// Validate network mask CIDR format.
+func validateNetworkMask(networkMask string) error {
+	if networkMask == "" {
+		return nil
+	}
+
+	_, _, err := net.ParseCIDR(networkMask)
+	if err != nil {
+		return fmt.Errorf("invalid network mask CIDR format: %w", err)
+	}
+
+	return nil
 }
 
 // parseQoSParameters extracts and parses QoS parameters from the given map.

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -578,7 +578,8 @@ func (cs *Server) modifyNVMeoFQoS(
 func ensureSubsystem(
 	ctx context.Context,
 	gateway *nvmeof.GatewayRpcClient,
-	subsystemNQN string,
+	subsystemNQN,
+	networkMask string,
 	listeners []nvmeof.ListenerDetails,
 ) error {
 	exists, err := gateway.SubsystemExists(ctx, subsystemNQN)
@@ -589,16 +590,20 @@ func ensureSubsystem(
 		return nil
 	}
 	// Create if doesn't exist (controller decision)
-	err = gateway.CreateSubsystem(ctx, subsystemNQN)
+	err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask)
 	if err != nil {
 		return err
 	}
 
-	// Create all listeners
-	for i, listener := range listeners {
-		log.DebugLog(ctx, "Creating listener %d: %s", i, listener.String())
-		if err := gateway.CreateListener(ctx, subsystemNQN, listener); err != nil {
-			return fmt.Errorf("failed to create listener %d (%s): %w", i, listener.String(), err)
+	// if networkMask is not provided, listeners are not created automatically by gateway,
+	// should create them manually one by one.
+	if networkMask == "" {
+		// Create all listeners
+		for i, listener := range listeners {
+			log.DebugLog(ctx, "Creating listener %d: %s", i, listener.String())
+			if err := gateway.CreateListener(ctx, subsystemNQN, listener); err != nil {
+				return fmt.Errorf("failed to create listener %d (%s): %w", i, listener.String(), err)
+			}
 		}
 	}
 
@@ -671,7 +676,7 @@ func (cs *Server) createNVMeoFResources(
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse listeners: %w", err)
 	}
-
+	networkMask := params["networkMask"]
 	nvmeofGatewayPortStr := params["nvmeofGatewayPort"]
 	nvmeofGatewayPort, err := strconv.ParseUint(nvmeofGatewayPortStr, 10, 32)
 	if err != nil {
@@ -722,7 +727,7 @@ func (cs *Server) createNVMeoFResources(
 	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
 
 	// Step 3: Ensure subsystem exists (and listener)
-	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo); err != nil {
+	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, networkMask, nvmeofData.ListenerInfo); err != nil {
 		return nil, fmt.Errorf("subsystem setup failed: %w", err)
 	}
 
@@ -744,6 +749,16 @@ func (cs *Server) createNVMeoFResources(
 			*nvmeofQoS); err != nil {
 			return nil, fmt.Errorf("setting QoS limits failed: %w", err)
 		}
+	}
+
+	// Step 6: If using auto-listeners, query them back for storing in metadata
+	if networkMask != "" {
+		autoListeners, err := gateway.ListListeners(ctx, nvmeofData.SubsystemNQN)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list auto-created listeners: %w", err)
+		}
+		nvmeofData.ListenerInfo = nvmeof.ConvertListenersFromProto(autoListeners.GetListeners())
+		log.DebugLog(ctx, "Retrieved %d auto-created listeners", len(nvmeofData.ListenerInfo))
 	}
 
 	uuid, err := gateway.GetUUIDBySubsystemAndNameSpaceID(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID)

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -483,6 +483,43 @@ func (gw *GatewayRpcClient) ListNamespaces(ctx context.Context, subsystemNQN str
 	return resp, nil
 }
 
+// List listeners in a subsystem.
+func (gw *GatewayRpcClient) ListListeners(ctx context.Context, subsystemNQN string) (*pb.ListenersInfo, error) {
+	log.DebugLog(ctx, "Listing listeners in subsystem %s", subsystemNQN)
+
+	req := &pb.ListListenersReq{
+		Subsystem: subsystemNQN,
+	}
+
+	resp, err := gw.client.ListListeners(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list listeners in subsystem %s: %w", subsystemNQN, err)
+	}
+	if resp.GetStatus() != 0 {
+		return nil, fmt.Errorf("gateway ListListeners returned error: %s", resp.GetErrorMessage())
+	}
+
+	log.DebugLog(ctx, "Listed listeners in subsystem %s successfully", subsystemNQN)
+
+	return resp, nil
+}
+
+// ConvertListenersFromProto converts protobuf ListenerInfo to internal ListenerDetails format.
+func ConvertListenersFromProto(protoListeners []*pb.ListenerInfo) []ListenerDetails {
+	listeners := make([]ListenerDetails, 0, len(protoListeners))
+	for _, l := range protoListeners {
+		listeners = append(listeners, ListenerDetails{
+			GatewayAddress: GatewayAddress{
+				Address: l.GetTraddr(),
+				Port:    l.GetTrsvcid(),
+			},
+			Hostname: l.GetHostName(),
+		})
+	}
+
+	return listeners
+}
+
 // Connect to Gateway gRPC server.
 func (c *GatewayRpcClient) connect() error {
 	// Create connection using new gRPC API

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -244,7 +244,7 @@ func (gw *GatewayRpcClient) GetUUIDBySubsystemAndNameSpaceID(
 }
 
 // CreateSubsystem creates an NVMe-oF subsystem on the gateway.
-func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN string) error {
+func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN, networkMask string) error {
 	log.DebugLog(ctx, "Creating NVMe subsystem: %s on gateway %s",
 		subsystemNQN, gw.config)
 
@@ -262,7 +262,9 @@ func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN st
 		// DhchapKey: nil,       // No authentication
 		// KeyEncrypted: nil,    // No encryption
 	}
-
+	if networkMask != "" {
+		req.NetworkMask = &networkMask
+	}
 	status, err := gw.client.CreateSubsystem(ctx, req)
 	switch {
 	case err != nil:

--- a/internal/nvmeof/tests/nvmeof_test.go
+++ b/internal/nvmeof/tests/nvmeof_test.go
@@ -115,7 +115,8 @@ func TestRealGateway(t *testing.T) {
 	})
 
 	// Test create subsystem
-	err = client.CreateSubsystem(ctx, nvmeofData.SubsystemNQN)
+	networkMask := "" // No auto-listeners
+	err = client.CreateSubsystem(ctx, nvmeofData.SubsystemNQN, networkMask)
 	require.NoError(t, err)
 	t.Logf("✓ Subsystem created: %s", nvmeofData.SubsystemNQN)
 


### PR DESCRIPTION
# Describe what this PR does #

Add new option in nvmeof storageClass "**networkMask**" . This property can replace the exists property "**listeners**".
Instead of searching and adding every GW IP and host name in SC (every redeploy), the admin just needs once edit the StorageClass file, by one searching of the subnet mask of the deployment, and add it to the SC , and that's it!
the admin can search the subnet mask by run:
`oc get network.config/cluster -o jsonpath='{.status.clusterNetwork[*].cidr}'`

the Auto listener feature was merged into nvmeof GW:
https://github.com/ceph/ceph-nvmeof/pull/1381
It means, the nvmeof creates the listeners automictically, and no need to provide the IPs in the StorageClass. It searches them by itself. 

e.g.
prev SC:

```yaml
  listeners: |
    [
      {
        "address": "10.129.2.53",
        "port": 4420,
        "hostname": "ceph-nvmeof-gateway-68645d5d89-95zc2"
      },
      {
        "address": "10.131.0.225",
        "port": 4420,
        "hostname": "ceph-nvmeof-gateway-68645d5d89-z5wvd"
      }
    ]
```
current:
```yaml
networkMask: "10.128.0.0/24"
```

## Is there anything that requires special attention ##

* This feature is added (and not replaced with the `list listener`) because the auto listeners feature is not supported in old Ceph (and nvmeof) versions. **I could not test it in ODF env.** 
* There is another field in the StorageClass called `nvmeofGatewayAddress`. This feature will not solve the need to re-edit this field (every nvmeof GW redeployment) - The next nvmeof phase ( using Ceph REST API instead of calling directly to inner nvmeof GW in Ceph cluster will solve this issue)

## Future concerns ##



**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
