### PR TITLE
ci: fix pushing artifacts to quay.io

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Login to Quay
         # yamllint disable-line rule:line-length
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_IO_USERNAME }}


### PR DESCRIPTION
Commit fb82d701 updated docker/login-action to v3.6.0, but that version is not allowed by the Ceph organization. This prevents the project from pushing container images to quay.io.

By reverting commit fb82d701, the older version of docker/login-action is used, which is allowed by the Ceph organization.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
