### PR TITLE
rbd: fetch the volumeIds from VGRContent's status for omap data

### DIFF
--- a/internal/controller/volumegroup/volumegroupreplicationcontent.go
+++ b/internal/controller/volumegroup/volumegroupreplicationcontent.go
@@ -207,7 +207,16 @@ func (r *ReconcileVGRContent) reconcileVGRContent(ctx context.Context, obj runti
 
 	reqName := vgrc.Name
 	groupHandle := vgrc.Spec.VolumeGroupReplicationHandle
-	volumeIds := vgrc.Spec.Source.VolumeHandles
+	volumeRefs := vgrc.Status.PersistentVolumeRefList
+	volumeIds := make([]string, len(volumeRefs))
+	for i := range volumeRefs {
+		pv := &corev1.PersistentVolume{}
+		err := r.client.Get(ctx, types.NamespacedName{Name: volumeRefs[i].Name}, pv)
+		if err != nil {
+			return fmt.Errorf("failed to get persistentvolume %s: %w", volumeRefs[i].Name, err)
+		}
+		volumeIds[i] = pv.Spec.CSI.VolumeHandle
+	}
 
 	if groupHandle == "" {
 		return errors.New("volume group replication handle is empty")


### PR DESCRIPTION
# Describe what this PR does #

Currently, we fetch the volumeId's from VGRContent.Spec.Source which has all the volumes that should be part of the group. But, it might happen that the initial modify call might fail due to some reason like network/config issue. In that case, the volumegroup omap will already be updated with the volumeIds and subsequent ModifyVolumeGroup call will fail as the volumes before and after Modify operation is same.
Therefore, we should fetch the volumeIds from the VGRContent status, which only gets updated post a succesfull modification.
