### PR TITLE
helm: claim ownership of the ArtifactHub repository

### DIFF
--- a/charts/artifacthub-repo.yml
+++ b/charts/artifacthub-repo.yml
@@ -1,0 +1,10 @@
+---
+# see https://artifacthub.io/docs/topics/repositories/#ownership-claim
+repositoryID: ceph-csi
+owners:
+  - name: Madhu Rajanna
+    email: madhupr007@gmail.com
+  - name: Niels de Vos
+    email: ndevos@ibm.com
+  - name: Rakshith R
+    email: rar@redhat.com

--- a/deploy.sh
+++ b/deploy.sh
@@ -77,6 +77,7 @@ push_helm_charts() {
 	fi
 
 	mkdir -p "${CHARTDIR}/csi-charts/docs/${PACKAGE}"
+	cp ./charts/artifacthub-repo.yml "${CHARTDIR}/csi-charts/docs"
 	# Use rsync to remove files from  destination when source file is deleted.
 	rsync -avh "./charts/ceph-csi-${PACKAGE}" "${CHARTDIR}/csi-charts/docs/${PACKAGE}" --delete
 	pushd "${CHARTDIR}/csi-charts/docs/${PACKAGE}" >/dev/null

--- a/scripts/lint-extras.sh
+++ b/scripts/lint-extras.sh
@@ -56,7 +56,8 @@ function lint_yaml() {
 
 function lint_helm() {
     # Install via: https://github.com/helm/helm/blob/master/docs/install.md
-    run_check '' helm lint --namespace=test charts/*
+    # shellcheck disable=SC2046 # we want to pass multiple arguments
+    run_check '' helm lint --namespace=test $(find charts/* -maxdepth 0 -type d)
 }
 
 function lint_py() {


### PR DESCRIPTION
By placing a artifacthub-repo.yml file next to the index.yml in the Helm repository, ArtifactHub can identify the owners.

Closes: #5902

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
