### PR TITLE
nvmeof: add dhchap feature into nvmeof csi driver 

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -54,6 +54,9 @@ type Server struct {
 	// anymore" subsystem (and listeners).
 	subsystemLocks *util.IDLocker
 
+	// securityKeys manages DH-CHAP and PSK\TLS keys
+	securityKeys nvmeof.SecurityKeyManager
+
 	// backendServer handles the RBD requests
 	backendServer *rbd.ControllerServer
 }
@@ -65,6 +68,7 @@ func NewControllerServer(d *csicommon.CSIDriver) (*Server, error) {
 		hostLocks:      util.NewIDLocker(),
 		subsystemLocks: util.NewIDLocker(),
 		backendServer:  rbddriver.NewControllerServer(d),
+		securityKeys:   nil, // Initialize lazily when needed
 	}, nil
 }
 

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -245,7 +245,7 @@ func (cs *Server) ControllerPublishVolume(
 	defer cs.hostLocks.Release(nodeID)
 
 	// Publish NVMe-oF resources
-	hostNqn, err := publishResources(ctx, req)
+	hostNqn, err := cs.publishResources(ctx, req)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to publish resources: %v", err)
 	}
@@ -304,7 +304,7 @@ func (cs *Server) ControllerUnpublishVolume(
 	}
 
 	// Unpublish NVMe-oF resources
-	if err := unpublishResources(ctx, nvmeofData, nodeID); err != nil {
+	if err := cs.unpublishResources(ctx, secrets, nvmeofData, nodeID, req.GetVolumeId()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to unpublish resources: %v", err)
 	}
 
@@ -893,7 +893,7 @@ func (cs *Server) cleanupNVMeoFResources(
 }
 
 // publishResources publishes the HostNQN to be allowed to see the Volume.
-func publishResources(ctx context.Context,
+func (cs *Server) publishResources(ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest,
 ) (string, error) {
 	nodeID := req.GetNodeId()
@@ -927,8 +927,16 @@ func publishResources(ctx context.Context,
 		}
 	}()
 
+	// Get DH-CHAP configuration from volume context
+	dhchapMode := volumeContext[vcDHCHAPMode] // "none", "unidirectional", "bidirectional", or empty
+	var dhchapKeys nvmeof.DHCHAPKeys
+	dhchapKeys, err = cs.setupDHCHAPKeys(ctx, req, nodeID, subsystemNQN, hostNQN, dhchapMode)
+	if err != nil {
+		return "", err
+	}
+
 	// Add host to subsystem
-	if err := gateway.AddHost(ctx, subsystemNQN, hostNQN); err != nil {
+	if err := gateway.AddHost(ctx, subsystemNQN, hostNQN, dhchapKeys); err != nil {
 		return "", fmt.Errorf("failed to add host %s: %w", hostNQN, err)
 	}
 
@@ -938,7 +946,9 @@ func publishResources(ctx context.Context,
 }
 
 // unpublishResources removes the host from the NVMe-oF subsystem.
-func unpublishResources(ctx context.Context, data *nvmeof.NVMeoFVolumeData, nodeID string) error {
+func (cs *Server) unpublishResources(ctx context.Context,
+	secrets map[string]string, data *nvmeof.NVMeoFVolumeData, nodeID, volumeID string,
+) error {
 	// Extract host NQN from nodeID
 	hostNQN, err := getHostNQNFromNodeID(nodeID)
 	if err != nil {
@@ -983,6 +993,16 @@ func unpublishResources(ctx context.Context, data *nvmeof.NVMeoFVolumeData, node
 			hostNQN, subsystemNQN, err)
 	}
 	log.DebugLog(ctx, "Host %s removed from subsystem %s", hostNQN, subsystemNQN)
+
+	// Cleanup DH-CHAP keys if any
+	if data.Security.DhchapMode == nvmeof.DHCHAPModeUniDirectional ||
+		data.Security.DhchapMode == nvmeof.DHCHAPModeBiDirectional {
+		err = cs.cleanupDHCHAPKeys(ctx, secrets, nodeID, volumeID, subsystemNQN,
+			data.Security.DhchapMode, data.Security.AuthenticationKMSID)
+		if err != nil {
+			return fmt.Errorf("failed to cleanup DH-CHAP keys for host %s: %w", hostNQN, err)
+		}
+	}
 
 	return nil
 }

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -745,7 +745,21 @@ func (cs *Server) createNVMeoFResources(
 			Address: params["nvmeofGatewayAddress"],
 			Port:    uint32(nvmeofGatewayPort),
 		},
+		Security: nvmeof.NVMeoFSecurityConfig{
+			DhchapMode:          params["dhchapMode"],
+			AuthenticationKMSID: params["authenticationKMSID"],
+		},
 	}
+
+	// If dhchapMode was explicitly provided and is not "none", and authenticationKMSID is empty,
+	// use a default KMS ID - RBD metadata KMS.
+	// In production, users should always provide a KMS ID when using DH-CHAP.
+	if nvmeofData.Security.DhchapMode != nvmeof.DHCHAPEmpty &&
+		nvmeofData.Security.DhchapMode != nvmeof.DHCHAPModeNone &&
+		nvmeofData.Security.AuthenticationKMSID == "" {
+		nvmeofData.Security.AuthenticationKMSID = "metadata"
+	}
+
 	// extract Qos parameters if any
 	mutableParams := req.GetMutableParameters()
 	// It take the mutableParams value from the volumeAttributesClassName in the PersistentVolumeClaim yaml.
@@ -1087,6 +1101,10 @@ func (cs *Server) storeNVMeoFMetadata(
 		// Gateway management info
 		toRBDMetadataKey(vcGatewayAddress): nvmeofData.GatewayManagementInfo.Address,
 		toRBDMetadataKey(vcGatewayPort):    gatewayManagementInfoPortStr,
+
+		// DH-CHAP mode
+		toRBDMetadataKey(vcDHCHAPMode):          nvmeofData.Security.DhchapMode,
+		toRBDMetadataKey(vcAuthenticationKMSID): nvmeofData.Security.AuthenticationKMSID,
 	}
 
 	// Store all metadata entries
@@ -1138,6 +1156,8 @@ func (cs *Server) getNVMeoFMetadata(
 		toRBDMetadataKey(vcListeners),
 		toRBDMetadataKey(vcGatewayAddress),
 		toRBDMetadataKey(vcGatewayPort),
+		toRBDMetadataKey(vcDHCHAPMode),
+		toRBDMetadataKey(vcAuthenticationKMSID),
 	}
 
 	// Retrieve all metadata values
@@ -1184,6 +1204,10 @@ func (cs *Server) getNVMeoFMetadata(
 		GatewayManagementInfo: nvmeof.GatewayConfig{
 			Address: metadata[toRBDMetadataKey(vcGatewayAddress)],
 			Port:    uint32(gatewayPort),
+		},
+		Security: nvmeof.NVMeoFSecurityConfig{
+			DhchapMode:          metadata[toRBDMetadataKey(vcDHCHAPMode)],
+			AuthenticationKMSID: metadata[toRBDMetadataKey(vcAuthenticationKMSID)],
 		},
 	}
 

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -391,6 +391,16 @@ func (cs *Server) DeleteSnapshot(
 	return cs.backendServer.DeleteSnapshot(ctx, req)
 }
 
+// validateDHCHAPParameter helper function to validates the DH-CHAP parameters.
+func validateDHCHAPParameter(dhchapMode string) error {
+	if dhchapMode != nvmeof.DHCHAPEmpty && dhchapMode != nvmeof.DHCHAPModeNone &&
+		dhchapMode != nvmeof.DHCHAPModeUniDirectional && dhchapMode != nvmeof.DHCHAPModeBiDirectional {
+		return fmt.Errorf("invalid dhchapMode: %s", dhchapMode)
+	}
+
+	return nil
+}
+
 // validateCreateVolumeRequest validates the incoming request for nvmeof.
 // the rest of the parameters are validated by RBD.
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
@@ -437,6 +447,10 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	_, err = parseQoSParameters(mutableParams)
 	if err != nil {
 		return fmt.Errorf("invalid NVMe-oF QoS parameters: %w", err)
+	}
+	err = validateDHCHAPParameter(params["dhchapMode"])
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -983,6 +997,12 @@ const (
 	// Gateway management info.
 	vcGatewayAddress = "GatewayAddress"
 	vcGatewayPort    = "GatewayPort"
+
+	// Additional KMS ID for authentication if needed.
+	vcAuthenticationKMSID = "authenticationKMSID"
+
+	// DH-CHAP mode for authentication.
+	vcDHCHAPMode = "dhchapMode"
 )
 
 // toRBDMetadataKey converts clean volume context key to prefixed RBD metadata key.
@@ -1009,6 +1029,10 @@ func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) er
 		return fmt.Errorf("failed to marshal listener info: %w", err)
 	}
 	volume.VolumeContext[vcListeners] = string(listenersJSON)
+
+	// Store Security info
+	volume.VolumeContext[vcAuthenticationKMSID] = data.Security.AuthenticationKMSID
+	volume.VolumeContext[vcDHCHAPMode] = data.Security.DhchapMode
 
 	return nil
 }

--- a/internal/nvmeof/controller/controllerserver_test.go
+++ b/internal/nvmeof/controller/controllerserver_test.go
@@ -89,6 +89,9 @@ func TestPolulateVolumeContext(t *testing.T) {
 			Address: "127.0.0.2",
 			Port:    5500,
 		},
+		Security: nvmeof.NVMeoFSecurityConfig{
+			DhchapMode: "none",
+		},
 	}
 
 	err := populateVolumeContext(volume, config)

--- a/internal/nvmeof/controller/security.go
+++ b/internal/nvmeof/controller/security.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ceph/ceph-csi/internal/nvmeof"
+)
+
+func (cs *Server) getOrInitSecurityKeys(
+	ctx context.Context,
+	kmsID string,
+	credentials map[string]string,
+) (nvmeof.SecurityKeyManager, error) {
+	if cs.securityKeys != nil {
+		return cs.securityKeys, nil
+	}
+
+	var err error
+	securityKeys, err := nvmeof.InitSecurityKeyManager(ctx, kmsID, credentials)
+
+	// Only cache if it doesn't need external DEKStore (like Vault)
+	// (RBD Metadata KMS needs fresh RBD volume each call)
+	if !errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		cs.securityKeys = securityKeys
+	}
+
+	return securityKeys, err
+}

--- a/internal/nvmeof/controller/security.go
+++ b/internal/nvmeof/controller/security.go
@@ -19,8 +19,13 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
 
 	"github.com/ceph/ceph-csi/internal/nvmeof"
+	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 func (cs *Server) getOrInitSecurityKeys(
@@ -42,4 +47,132 @@ func (cs *Server) getOrInitSecurityKeys(
 	}
 
 	return securityKeys, err
+}
+
+// setupDHCHAPKeys configures DH-CHAP authentication and returns the host key.
+// Returns empty string if DH-CHAP is disabled.
+func (cs *Server) setupDHCHAPKeys(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+	nodeID,
+	subsystemNQN,
+	hostNQN,
+	dhchapMode string,
+) (nvmeof.DHCHAPKeys, error) {
+	dhchapKeys := nvmeof.DHCHAPKeys{}
+	// Return empty key if DH-CHAP is disabled
+	if dhchapMode == nvmeof.DHCHAPEmpty || dhchapMode == nvmeof.DHCHAPModeNone {
+		return dhchapKeys, nil
+	}
+
+	log.DebugLog(ctx, "DH-CHAP mode: %s - setting up authentication for node %s", dhchapMode, nodeID)
+	// Get authentication KMS ID from volume context
+	volumeContext := req.GetVolumeContext()
+	authKMSID := volumeContext[vcAuthenticationKMSID]
+	secrets := req.GetSecrets()
+
+	// Initialize security key manager
+	securityKeysManager, err := cs.getOrInitSecurityKeys(ctx, authKMSID, secrets)
+
+	// Setup DEK store if needed (for metadata KMS)
+	// (just for test, not for production!! for production, use external KMS like Vault)
+	if errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		volumeID := req.GetVolumeId()
+		mgr := rbdutil.NewManager(cs.backendServer.Driver.GetInstanceID(), nil, secrets)
+		defer mgr.Destroy(ctx)
+
+		rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+		if err != nil {
+			return dhchapKeys, fmt.Errorf("failed to find volume with ID %q: %w", volumeID, err)
+		}
+		defer rbdVol.Destroy(ctx)
+
+		dekStore := nvmeof.NewRBDVolumeDEKStore(rbdVol)
+		securityKeysManager.SetDEKStore(dekStore)
+	} else if err != nil {
+		return dhchapKeys, fmt.Errorf("failed to initialize security key manager: %w", err)
+	}
+
+	// Get or create DH-CHAP host key
+	hostDhchapKey, err := nvmeof.GetOrCreateDHCHAPHostKey(ctx, securityKeysManager, nodeID, subsystemNQN, hostNQN)
+	if err != nil {
+		return dhchapKeys, fmt.Errorf("failed to get/create DH-CHAP host key: %w", err)
+	}
+
+	log.DebugLog(ctx, "DH-CHAP host key retrieved for node %s, subsystem %s", nodeID, subsystemNQN)
+
+	// If bidirectional, get or create subsystem key
+	if dhchapMode == nvmeof.DHCHAPModeBiDirectional {
+		subsystemKey, err := nvmeof.GetOrCreateDHCHAPSubsystemKey(ctx, securityKeysManager, nodeID, subsystemNQN, hostNQN)
+		if err != nil {
+			return dhchapKeys, fmt.Errorf("failed to get/create DH-CHAP subsystem key: %w", err)
+		}
+		log.DebugLog(ctx, "DH-CHAP subsystem key retrieved for node %s, subsystem %s", nodeID, subsystemNQN)
+		dhchapKeys = nvmeof.DHCHAPKeys{
+			SubsystemKey: subsystemKey,
+		}
+	}
+	dhchapKeys.HostKey = hostDhchapKey
+
+	return dhchapKeys, nil
+}
+
+// cleanupDHCHAPKeys removes DH-CHAP keys for the unpublished host.
+func (cs *Server) cleanupDHCHAPKeys(
+	ctx context.Context,
+	secrets map[string]string,
+	nodeID,
+	volumeID,
+	subsystemNQN,
+	dhchapMode,
+	authKMSID string,
+) error {
+	// Return empty key if DH-CHAP is disabled
+	if dhchapMode == nvmeof.DHCHAPEmpty || dhchapMode == nvmeof.DHCHAPModeNone {
+		return nil
+	}
+	log.DebugLog(ctx, "Cleaning up DH-CHAP keys for node %s, subsystem %s", nodeID, subsystemNQN)
+
+	log.DebugLog(ctx, "DH-CHAP mode: %s - setting up authentication for node %s", dhchapMode, nodeID)
+	// Get authentication KMS ID from volume context
+
+	// Initialize security key manager
+	securityKeysManager, err := cs.getOrInitSecurityKeys(ctx, authKMSID, secrets)
+
+	// Setup DEK store if needed (for metadata KMS)
+	// (just for test, not for production!! for production, use external KMS like Vault)
+	if errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		mgr := rbdutil.NewManager(cs.backendServer.Driver.GetInstanceID(), nil, secrets)
+		defer mgr.Destroy(ctx)
+
+		rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+		if err != nil {
+			return fmt.Errorf("failed to find volume with ID %q: %w", volumeID, err)
+		}
+		defer rbdVol.Destroy(ctx)
+
+		dekStore := nvmeof.NewRBDVolumeDEKStore(rbdVol)
+		securityKeysManager.SetDEKStore(dekStore)
+	} else if err != nil {
+		return fmt.Errorf("failed to initialize security key manager: %w", err)
+	}
+
+	// Remove host key
+	if err := nvmeof.RemoveDHCHAPHostKey(ctx, securityKeysManager, nodeID, subsystemNQN); err != nil {
+		log.ErrorLog(ctx, "Failed to remove DH-CHAP host key: %v", err)
+		// Don't return error - continue to try subsystem key
+	} else {
+		log.DebugLog(ctx, "DH-CHAP host key removed for node %s", nodeID)
+	}
+
+	// Remove subsystem key if bidirectional
+	if dhchapMode == nvmeof.DHCHAPModeBiDirectional {
+		if err := nvmeof.RemoveDHCHAPSubsystemKey(ctx, securityKeysManager, nodeID, subsystemNQN); err != nil {
+			log.ErrorLog(ctx, "Failed to remove DH-CHAP subsystem key: %v", err)
+		} else {
+			log.DebugLog(ctx, "DH-CHAP subsystem key removed for node %s", nodeID)
+		}
+	}
+
+	return nil
 }

--- a/internal/nvmeof/crypto.go
+++ b/internal/nvmeof/crypto.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nvmeof
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ceph/ceph-csi/internal/kms"
+)
+
+var (
+	// ErrDEKStoreNotSet is returned when attempting to use StoreKey/GetKey/RemoveKey
+	// before configuring a DEKStore via SetDEKStore(). This indicates a programming
+	// error - the caller must set the DEKStore before performing key operations.
+	ErrDEKStoreNotSet = errors.New("DEKStore not found for security keys")
+
+	// ErrDEKStoreNeeded is returned by InitSecurityKeyManager when the KMS backend
+	// requires external storage (like metadata KMS). The caller must configure a
+	// DEKStore by calling SetDEKStore() before using StoreKey/GetKey/RemoveKey.
+	// This is expected behavior for certain KMS types and not an error condition.
+	ErrDEKStoreNeeded = errors.New("DEKStore required, use SetDEKStore()")
+
+	// ErrKeyNotFound is returned when a requested key is not found in the DEKStore.
+	ErrKeyNotFound = errors.New("key not found in DEKStore")
+)
+
+const (
+	// NVMeOFSecurityOwner is the identifier used when requesting KMS instances
+	// for NVMe-oF authentication key management.
+	NVMeOFSecurityOwner = "nvmeof-system"
+)
+
+// SecurityKeyManager defines the interface for managing NVMe-oF security keys.
+// It provides encrypted storage and retrieval of authentication keys (like DH-CHAP keys)
+// using a KMS (Key Management System) for encryption and a DEKStore for persistence.
+type SecurityKeyManager interface {
+	// StoreKey encrypts and stores a plaintext key.
+	StoreKey(ctx context.Context, keyID string, plainKey string) error
+	// GetKey retrieves and decrypts a stored key.
+	GetKey(ctx context.Context, keyID string) (string, error)
+	// RemoveKey deletes a stored key.
+	RemoveKey(ctx context.Context, keyID string) error
+	// SetDEKStore sets the storage backend for encrypted keys.
+	// Required for KMS implementations that don't have integrated storage (like metadata KMS).
+	SetDEKStore(dekStore kms.DEKStore)
+	// GetID returns the KMS identifier.
+	GetID() string
+	// Destroy releases resources held by the manager.
+	Destroy()
+}
+
+// SecurityKeyManager manages NVMe-oF authentication keys
+// Similar to VolumeEncryption, but for authentication instead of disk encryption.
+type securityKeyManager struct {
+	// KMS instance for key operations
+	kms kms.EncryptionKMS
+
+	// Where to store encrypted keys (if KMS doesn't store internally)
+	dekStore kms.DEKStore
+
+	// KMS identifier
+	id string
+}
+
+// InitSecurityKeyManager creates a new SecurityKeyManager instance.
+// If kmsID is empty, defaults to "metadata" KMS which stores keys in RBD image metadata.
+// Returns ErrDEKStoreNeeded if the KMS requires external storage (caller must call SetDEKStore).
+func InitSecurityKeyManager(
+	ctx context.Context,
+	kmsID string, // From volume context
+	credentials map[string]string, // From K8s Secret
+) (SecurityKeyManager, error) {
+	if kmsID == "" {
+		// Use metadata KMS for testing (stores in RBD metadata)
+		kmsID = "metadata"
+	}
+	kmsInstance, err := kms.GetKMS(NVMeOFSecurityOwner, kmsID, credentials)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get KMS: %w", err)
+	}
+
+	securityKeys, err := newSecurityKeyManager(kmsID, kmsInstance)
+	if errors.Is(err, ErrDEKStoreNeeded) {
+		return securityKeys, err
+	} else if err != nil {
+		return nil, err
+	}
+
+	return securityKeys, nil
+}
+
+// newSecurityKeyManager creates a new securityKeyManager instance.
+// If KMS has integrated storage (like Vault), it's configured automatically.
+// Otherwise, returns ErrDEKStoreNeeded and caller must provide DEKStore via SetDEKStore.
+func newSecurityKeyManager(
+	kmsID string,
+	ekms kms.EncryptionKMS,
+) (SecurityKeyManager, error) {
+	skm := &securityKeyManager{
+		id:  kmsID,
+		kms: ekms,
+	}
+
+	// Check if KMS stores keys internally (like Vault)
+	if ekms.RequiresDEKStore() == kms.DEKStoreIntegrated {
+		// KMS implements DEKStore, use it
+		dekStore, ok := ekms.(kms.DEKStore)
+		if !ok {
+			return nil, fmt.Errorf("KMS %T does not implement DEKStore", ekms)
+		}
+		skm.dekStore = dekStore
+
+		return skm, nil
+	}
+
+	// KMS needs external storage (metadata KMS)
+	return skm, ErrDEKStoreNeeded
+}
+
+func (skm *securityKeyManager) SetDEKStore(dekStore kms.DEKStore) {
+	skm.dekStore = dekStore
+}
+
+func (skm *securityKeyManager) GetID() string {
+	return skm.id
+}
+
+// Destroy frees any resources that the SecurityKeyManager instance allocated.
+func (skm *securityKeyManager) Destroy() {
+	skm.kms.Destroy()
+}
+
+// StoreKey encrypts the plaintext key using KMS and stores it in the DEKStore.
+func (skm *securityKeyManager) StoreKey(
+	ctx context.Context,
+	keyID string,
+	plainKey string,
+) error {
+	if skm.dekStore == nil {
+		return ErrDEKStoreNotSet
+	}
+	// Step 1: Encrypt key with KMS
+	encryptedKey, err := skm.kms.EncryptDEK(ctx, keyID, plainKey)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt key for %s: %w", keyID, err)
+	}
+
+	// Step 2: Store encrypted key in DEKStore
+	err = skm.dekStore.StoreDEK(ctx, keyID, encryptedKey)
+	if err != nil {
+		return fmt.Errorf("failed to save key for %s: %w", keyID, err)
+	}
+
+	return nil
+}
+
+// GetKey retrieves the encrypted key from DEKStore and decrypts it using KMS.
+func (skm *securityKeyManager) GetKey(
+	ctx context.Context,
+	keyID string,
+) (string, error) {
+	if skm.dekStore == nil {
+		return "", ErrDEKStoreNotSet
+	}
+	// Step 1: Fetch encrypted key from DEKStore
+	encryptedKey, err := skm.dekStore.FetchDEK(ctx, keyID)
+
+	if errors.Is(err, ErrKeyNotFound) {
+		return "", fmt.Errorf("%w: %s", ErrKeyNotFound, keyID)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch key %s: %w", keyID, err)
+	}
+
+	// Step 2: Decrypt key with KMS
+	plainKey, err := skm.kms.DecryptDEK(ctx, keyID, encryptedKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt key %s: %w", keyID, err)
+	}
+
+	return plainKey, nil
+}
+
+// RemoveKey deletes the key from the DEKStore.
+func (skm *securityKeyManager) RemoveKey(
+	ctx context.Context,
+	keyID string,
+) error {
+	if skm.dekStore == nil {
+		return ErrDEKStoreNotSet
+	}
+
+	return skm.dekStore.RemoveDEK(ctx, keyID)
+}

--- a/internal/nvmeof/dhchap.go
+++ b/internal/nvmeof/dhchap.go
@@ -1,0 +1,351 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nvmeof
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+// DH-CHAP Key Storage Architecture
+//
+// DH-CHAP keys are stored in a DEKStore (Data Encryption Key Store) using a structured key ID format.
+// The DEKStore can be backed by different storage systems:
+//   - RBD metadata (for testing) - stored as RBD image metadata key-value pairs
+//   - External KMS like Vault (for production) - stored in the KMS system
+//
+// Key ID Format:
+//   <prefix>-<nodeID>-<subsystemHash>
+//
+// Components:
+//   prefix:         Either "nvmeof-dhchap-host" or "nvmeof-dhchap-subsystem"
+//   nodeID:         Kubernetes node name (e.g., "worker-node-1")
+//   subsystemHash:  First 16 characters of SHA-256 hash of subsystem NQN
+//
+// Examples:
+//   Host key:       nvmeof-dhchap-host-worker-node-1-a1b2c3d4e5f6g7h8
+//   Subsystem key:  nvmeof-dhchap-subsystem-worker-node-1-a1b2c3d4e5f6g7h8
+//
+// Key Value Format:
+//   The value stored is the DH-CHAP key in nvme-cli format:
+//   DHHC-1:<hash_type>:<base64_encoded_key_with_crc32>:
+//
+//   Example: DHHC-1:01:tY6/W/5reir8GG6AYcHmRjhEj3l4UMt4GgG9nq+plT0NsIEu:
+//
+// Storage Flow:
+//   1. Generate key using nvme gen-dhchap-key
+//   2. Encrypt key using KMS (EncryptDEK)
+//   3. Store encrypted key in DEKStore with key ID
+//
+// Retrieval Flow:
+//   1. Fetch encrypted key from DEKStore using key ID
+//   2. Decrypt key using KMS (DecryptDEK)
+//   3. Return plaintext DH-CHAP key for nvme connect
+//
+
+// DH-CHAP modes.
+const (
+	DHCHAPEmpty              = ""               // when no DH-CHAP is provided
+	DHCHAPModeNone           = "none"           // when the provided DH-CHAP is explicitly 'none'
+	DHCHAPModeUniDirectional = "unidirectional" // when only host has DH-CHAP
+	DHCHAPModeBiDirectional  = "bidirectional"  // when both host and subsystem have DH-CHAP
+)
+
+// DH-CHAP specific constants.
+// The DH-CHAP key format is:
+//
+//	DHHC-1:<hash_type>:<base64_encoded_key_with_crc32>:
+const (
+	DHCHAPHashNone   = 0
+	DHCHAPHashSHA256 = 1
+	DHCHAPHashSHA384 = 2
+	DHCHAPHashSHA512 = 3
+
+	defaultDHCHAPKeySize = 32
+	defaultDHCHAPHash    = DHCHAPHashSHA256
+
+	// Key prefixes for DEKStore key IDs.
+	keyPrefixDHCHAPHost      = "nvmeof-dhchap-host"
+	keyPrefixDHCHAPSubsystem = "nvmeof-dhchap-subsystem"
+
+	// subsystemHashLength is the number of hex characters to use from the SHA-256 hash
+	// of the subsystem NQN when building key IDs. 16 chars = 64 bits = sufficient uniqueness.
+	subsystemHashLength = 16
+)
+
+// DHCHAPKeys holds the DH-CHAP keys for host and subsystem.
+type DHCHAPKeys struct {
+	HostKey      string // DH-CHAP host key
+	SubsystemKey string // DH-CHAP subsystem key
+}
+
+// GetOrCreateDHCHAPHostKey retrieves existing key or creates new one if not found.
+func GetOrCreateDHCHAPHostKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID,
+	subsystemNQN,
+	hostNQN string,
+) (string, error) {
+	// Try to get existing key
+	hostKey, err := getDHCHAPHostKey(ctx, skm, nodeID, subsystemNQN)
+	if err == nil {
+		// Key exists, return it
+		return hostKey, nil
+	}
+
+	// TODO - when another KMS implementation is added, we should check what kind of error it returns
+	// when key is not found and check for that here instead of ErrKeyNotFound.!!!
+	// for now , since we have only RBD DEKStore, we can check for ErrKeyNotFound which
+	// is returned by RBD DEKStore when key is not found.
+
+	// Only create if truly not found - not on any other error.
+	if !errors.Is(err, ErrKeyNotFound) {
+		// Real error (KMS down, network issue etc) - don't generate new key
+		return "", fmt.Errorf("failed to check existing host key: %w", err)
+	}
+
+	// Key doesn't exist, generate new one
+	dhchapKey, err := generateAndStoreDHCHAPKey(ctx, skm, keyPrefixDHCHAPHost, nodeID, subsystemNQN, hostNQN)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate host key: %w", err)
+	}
+
+	// Retrieve the newly generated key
+	return dhchapKey, nil
+}
+
+// GetOrCreateDHCHAPSubsystemKey retrieves existing key or creates new one if not found.
+func GetOrCreateDHCHAPSubsystemKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID string,
+	subsystemNQN string,
+	hostNQN string,
+) (string, error) {
+	// Try to get existing key
+	subsystemKey, err := getDHCHAPSubsystemKey(ctx, skm, nodeID, subsystemNQN)
+	if err == nil {
+		// Key exists, return it
+		return subsystemKey, nil
+	}
+
+	// TODO - when another KMS implementation is added, we should check what kind of error it returns
+	// when key is not found and check for that here instead of ErrKeyNotFound.!!!
+	// for now , since we have only RBD DEKStore, we can check for ErrKeyNotFound which
+	// is returned by RBD DEKStore when key is not found.
+
+	// Only create if truly not found - not on any other error.
+	if !errors.Is(err, ErrKeyNotFound) {
+		// Real error (KMS down, network issue etc) - don't generate new key
+		return "", fmt.Errorf("failed to check existing subsystem key: %w", err)
+	}
+
+	// Key doesn't exist, generate new one
+	dhchapKey, err := generateAndStoreDHCHAPKey(ctx, skm, keyPrefixDHCHAPSubsystem, nodeID, subsystemNQN, hostNQN)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate subsystem key: %w", err)
+	}
+
+	return dhchapKey, nil
+}
+
+// RemoveDHCHAPHostKey removes the DH-CHAP host key for the given node and subsystem connection.
+func RemoveDHCHAPHostKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID string,
+	subsystemNQN string,
+) error {
+	keyID := buildDHCHAPKeyID(keyPrefixDHCHAPHost, nodeID, subsystemNQN)
+
+	return skm.RemoveKey(ctx, keyID)
+}
+
+// RemoveDHCHAPSubsystemKey removes the DH-CHAP subsystem key for the given node and subsystem connection.
+func RemoveDHCHAPSubsystemKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID string,
+	subsystemNQN string,
+) error {
+	keyID := buildDHCHAPKeyID(keyPrefixDHCHAPSubsystem, nodeID, subsystemNQN)
+
+	return skm.RemoveKey(ctx, keyID)
+}
+
+// hashSubsystemNQN creates a short hash of the subsystem NQN for use in key IDs.
+// Returns the first 16 characters (64 bits) of the SHA-256 hash as hex string.
+//
+// Example:
+//
+//	Input:  nqn.2016-06.io.spdk:cnode1
+//	Output: a1b2c3d4e5f6g7h8
+func hashSubsystemNQN(subsystemNQN string) string {
+	h := sha256.Sum256([]byte(subsystemNQN))
+
+	return hex.EncodeToString(h[:])[:subsystemHashLength]
+}
+
+// generateAndStoreDHCHAPKey generates a new DH-CHAP key and stores it in the DEKStore.
+//
+// Key generation and storage flow:
+//  1. Build key ID: <prefix>-<nodeID>-<subsystemHash>
+//  2. Generate DH-CHAP key using nvme gen-dhchap-key command
+//  3. Encrypt key using KMS
+//  4. Store encrypted key in DEKStore with key ID
+//
+// Example key ID: nvmeof-dhchap-host-worker-node-1-a1b2c3d4e5f6g7h8.
+func generateAndStoreDHCHAPKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	prefix,
+	nodeID,
+	subsystemNQN,
+	hostNQN string,
+) (string, error) {
+	keyID := buildDHCHAPKeyID(prefix, nodeID, subsystemNQN)
+	dhchapKey, err := generateDHCHAPKey(ctx, defaultDHCHAPKeySize, defaultDHCHAPHash, hostNQN)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate DH-CHAP key for %s: %w", keyID, err)
+	}
+	err = skm.StoreKey(ctx, keyID, dhchapKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to store DH-CHAP key for %s: %w", keyID, err)
+	}
+
+	return dhchapKey, nil
+}
+
+// generateDHCHAPKey generates a DH-CHAP key using the nvme-cli gen-dhchap-key command.
+// This generates a DH-CHAP key in the format: DHHC-1:<hash_type>:<base64_encoded_key_with_crc32>:
+// According to NVMe-oF spec: NVM Express® Base Specification, Revision 2.3.
+//
+// The key format includes:
+//   - DHHC-1: Protocol identifier
+//   - hash_type: 01 (SHA-256), 02 (SHA-384), or 03 (SHA-512)
+//   - base64_encoded_key_with_crc32: Base64 of (key_bytes + crc32_checksum)
+//
+// Example output: DHHC-1:01:tY6/W/5reir8GG6AYcHmRjhEj3l4UMt4GgG9nq+plT0NsIEu: .
+func generateDHCHAPKey(ctx context.Context, keyLength, hashAlgorithm int, hostNQN string) (string, error) {
+	// Validate
+	if hashAlgorithm < DHCHAPHashNone || hashAlgorithm > DHCHAPHashSHA512 {
+		return "", fmt.Errorf("invalid hash algorithm: %d", hashAlgorithm)
+	}
+
+	// Validate key length for specific hash
+	switch hashAlgorithm {
+	case DHCHAPHashSHA256:
+		if keyLength != 32 {
+			return "", fmt.Errorf("SHA-256 requires 32 byte key, got %d", keyLength)
+		}
+	case DHCHAPHashSHA384:
+		if keyLength != 48 {
+			return "", fmt.Errorf("SHA-384 requires 48 byte key, got %d", keyLength)
+		}
+	case DHCHAPHashSHA512:
+		if keyLength != 64 {
+			return "", fmt.Errorf("SHA-512 requires 64 byte key, got %d", keyLength)
+		}
+	}
+
+	// Generate random key bytes
+	keyBytes := make([]byte, keyLength)
+	_, err := rand.Read(keyBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+
+	// Build nvme gen-dhchap-key command
+	args := []string{
+		"gen-dhchap-key",
+		"-n", hostNQN,
+		"-l", strconv.Itoa(keyLength),
+		"-m", strconv.Itoa(hashAlgorithm),
+	}
+
+	stdout, stderr, err := util.ExecCommandWithTimeout(ctx, connectTimeout, "nvme", args...)
+	// Execute connection
+	if err != nil {
+		log.ErrorLog(ctx, "failed to generate DH-CHAP key: %s: %s", err.Error(), stderr)
+
+		return "", fmt.Errorf("nvme gen-dhchap-key command failed: %w", err)
+	}
+
+	// Parse output - nvme gen-dhchap-key outputs the key in format:
+	// DHHC-1:01:base64key:
+	key := strings.TrimSpace(stdout)
+	if key == "" {
+		return "", errors.New("generated DH-CHAP key is empty")
+	}
+
+	return key, nil
+}
+
+// buildDHCHAPKeyID constructs a unique key ID for DEKStore storage.
+//
+// Format: <prefix>-<nodeID>-<subsystemHash>
+//
+// Components:
+//   - prefix: "nvmeof-dhchap-host" or "nvmeof-dhchap-subsystem"
+//   - nodeID: Kubernetes node name
+//   - subsystemHash: First 16 chars of SHA-256 hash of subsystem NQN
+//
+// Examples:
+//
+//	buildDHCHAPKeyID("nvmeof-dhchap-host", "worker-1", "nqn.2016-06.io.spdk:cnode1")
+//	 "nvmeof-dhchap-host-worker-1-a1b2c3d4e5f6g7h8"
+func buildDHCHAPKeyID(
+	prefix string,
+	nodeID string,
+	subsystemNQN string,
+) string {
+	subsystemHash := hashSubsystemNQN(subsystemNQN)
+
+	return fmt.Sprintf("%s-%s-%s", prefix, nodeID, subsystemHash)
+}
+
+func getDHCHAPHostKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID string,
+	subsystemNQN string,
+) (string, error) {
+	keyID := buildDHCHAPKeyID(keyPrefixDHCHAPHost, nodeID, subsystemNQN)
+	// Returns DH-CHAP formatted string: "DHHC-1:01:..."
+
+	return skm.GetKey(ctx, keyID)
+}
+
+func getDHCHAPSubsystemKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID string,
+	subsystemNQN string,
+) (string, error) {
+	keyID := buildDHCHAPKeyID(keyPrefixDHCHAPSubsystem, nodeID, subsystemNQN)
+
+	return skm.GetKey(ctx, keyID)
+}

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -45,6 +45,12 @@ type NodeServer struct {
 	volumeLocks *util.IDLocker
 
 	initiator nvmeof.NVMeInitiator
+
+	// securityKeys manages DH-CHAP and PSK\TLS keys
+	securityKeys nvmeof.SecurityKeyManager
+
+	// node ID of this node server
+	nodeID string
 }
 
 // ConnectionInfo holds NVMe-oF connection details.
@@ -55,6 +61,7 @@ type NvmeConnectionInfo struct {
 	Listeners     []nvmeof.GatewayAddress `json:"listeners"`
 	HostNQN       string                  `json:"hostNQN,omitempty"`
 	Transport     string                  `json:"transport"`
+	DhchapMode    string                  `json:"dhchapMode,omitempty"`
 }
 
 // stageTransaction struct represents the state a transaction was when it either completed
@@ -76,6 +83,8 @@ const (
 	nvmeofListeners     = "listeners"
 	nvmeofHostNQN       = "HostNQN"
 	defaultTransport    = "tcp"
+	nvmeofdhchapMode    = "dhchapMode"
+	authenticationKMSID = "authenticationKMSID"
 )
 
 // NewNodeServer initialize a node server for ceph CSI driver.
@@ -90,6 +99,8 @@ func NewNodeServer(
 		DefaultNodeServer: *csicommon.NewDefaultNodeServer(d, t, "", map[string]string{}, map[string]string{}),
 		initiator:         nvmeInitiator,
 		volumeLocks:       util.NewIDLocker(),
+		securityKeys:      nil, // Initialize lazily when needed
+		nodeID:            nodeID,
 	}
 
 	// Load nvme kernel modules
@@ -141,13 +152,7 @@ func (ns *NodeServer) NodeStageVolume(
 	if err = util.ValidateNodeStageVolumeRequest(req); err != nil {
 		return nil, err
 	}
-
 	volumeID := req.GetVolumeId()
-	cr, err := util.NewUserCredentialsWithMigration(req.GetSecrets())
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-	defer cr.DeleteCredentials()
 	if acquired := ns.volumeLocks.TryAcquire(volumeID); !acquired {
 		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
 
@@ -173,10 +178,13 @@ func (ns *NodeServer) NodeStageVolume(
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume context: %v", err)
 	}
+	// Get authentication KMS ID from volume context.
+	// can be empty! it will take default KMS in that case
+	authKMSID := volumeContext[authenticationKMSID]
 
 	// perform the actual staging and if this fails, have undoStagingTransaction
 	// cleans up for us
-	txn, err := ns.stageTransaction(ctx, req, connectionInfo)
+	txn, err := ns.stageTransaction(ctx, req, connectionInfo, authKMSID)
 	defer func() {
 		if err != nil {
 			ns.undoStagingTransaction(ctx, req, txn)
@@ -426,16 +434,18 @@ func (ns *NodeServer) stageTransaction(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest,
 	connectionInfo *NvmeConnectionInfo,
+	authKMSID string,
 ) (*stageTransaction, error) {
 	transaction := &stageTransaction{}
 
 	var err error
 
 	// perform the actual staging
-	devicePath, err := ns.connectToSubsystem(ctx, connectionInfo)
+	devicePath, err := ns.connectToSubsystem(ctx, req.GetVolumeId(), connectionInfo, req.GetSecrets(), authKMSID)
 	if err != nil {
 		return transaction, err
 	}
+
 	transaction.devicePath = devicePath
 
 	stagingTargetPath := getStagingTargetPath(req)
@@ -579,6 +589,10 @@ func (ns *NodeServer) getNvmeConnection(volumeContext, publishContext map[string
 	if !ok || hostNQN == "" {
 		return nil, errors.New("missing host NQN in publish context")
 	}
+	dhchapMode, ok := volumeContext[nvmeofdhchapMode]
+	if !ok || dhchapMode == "" || dhchapMode == "none" {
+		dhchapMode = ""
+	}
 
 	return &NvmeConnectionInfo{
 		SubsystemNQN:  subsystemNQN,
@@ -587,17 +601,31 @@ func (ns *NodeServer) getNvmeConnection(volumeContext, publishContext map[string
 		Listeners:     listeners,
 		HostNQN:       hostNQN,
 		Transport:     defaultTransport,
+		DhchapMode:    dhchapMode,
 	}, nil
 }
 
 // connectToSubsystem connects to the NVMe-oF subsystem and returns device path.
-func (ns *NodeServer) connectToSubsystem(ctx context.Context, info *NvmeConnectionInfo) (string, error) {
+func (ns *NodeServer) connectToSubsystem(
+	ctx context.Context,
+	volumeID string,
+	info *NvmeConnectionInfo,
+	secrets map[string]string,
+	authKMSID string,
+) (string, error) {
 	// Create connect request
 	connectReq := &nvmeof.ConnectRequest{
 		SubsystemNQN: info.SubsystemNQN,
 		Listeners:    info.Listeners,
 		Transport:    info.Transport,
 		HostNQN:      info.HostNQN,
+	}
+
+	// Setup DH-CHAP authentication if required
+	if info.DhchapMode != nvmeof.DHCHAPEmpty && info.DhchapMode != nvmeof.DHCHAPModeNone {
+		if err := ns.setupDHCHAPAuth(ctx, volumeID, info, secrets, authKMSID, connectReq); err != nil {
+			return "", err
+		}
 	}
 
 	// Connect to subsystem

--- a/internal/nvmeof/nodeserver/security.go
+++ b/internal/nvmeof/nodeserver/security.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ceph/ceph-csi/internal/nvmeof"
+	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
+	"github.com/ceph/ceph-csi/internal/util"
+)
+
+// getOrInitSecurityKeys initializes or retrieves cached security keys manager.
+func (cs *NodeServer) getOrInitSecurityKeys(
+	ctx context.Context,
+	kmsID string,
+	secrets map[string]string,
+) (nvmeof.SecurityKeyManager, error) {
+	if cs.securityKeys != nil {
+		return cs.securityKeys, nil
+	}
+
+	var err error
+	securityKeys, err := nvmeof.InitSecurityKeyManager(ctx, kmsID, secrets)
+
+	// Only cache if it doesn't need external DEKStore (like Vault)
+	// (RBD Metadata KMS needs fresh RBD volume each call)
+	if !errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		cs.securityKeys = securityKeys
+	}
+
+	return securityKeys, err
+}
+
+// setupDHCHAPAuth configures DH-CHAP authentication for the connection.
+func (ns *NodeServer) setupDHCHAPAuth(
+	ctx context.Context,
+	volumeID string,
+	info *NvmeConnectionInfo,
+	secrets map[string]string,
+	authKMSID string,
+	connectReq *nvmeof.ConnectRequest,
+) error {
+	// Initialize security key manager
+	securityKeys, err := ns.getOrInitSecurityKeys(ctx, authKMSID, secrets)
+
+	// Setup DEK store if needed (for metadata KMS)
+	if errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		cr, err := util.NewUserCredentialsWithMigration(secrets)
+		if err != nil {
+			return fmt.Errorf("failed to get user credentials: %w", err)
+		}
+		defer cr.DeleteCredentials()
+
+		rbdVol, err := rbdutil.GenVolFromVolID(ctx, volumeID, cr, secrets)
+		if err != nil {
+			return fmt.Errorf("failed to get volume: %w", err)
+		}
+		defer rbdVol.Destroy(ctx)
+
+		dekStore := nvmeof.NewRBDVolumeDEKStore(rbdVol)
+		securityKeys.SetDEKStore(dekStore)
+	} else if err != nil {
+		return fmt.Errorf("failed to initialize security key manager: %w", err)
+	}
+
+	// Get host key
+	hostKey, err := nvmeof.GetOrCreateDHCHAPHostKey(ctx, securityKeys, ns.nodeID, info.SubsystemNQN, connectReq.HostNQN)
+	if err != nil {
+		return fmt.Errorf("failed to get DHCHAP host key: %w", err)
+	}
+	connectReq.HostDhchapKey = hostKey
+
+	// Get subsystem key for bidirectional mode
+	if info.DhchapMode == nvmeof.DHCHAPModeBiDirectional {
+		subsystemKey, err := nvmeof.GetOrCreateDHCHAPSubsystemKey(ctx, securityKeys, ns.nodeID,
+			info.SubsystemNQN, connectReq.HostNQN)
+		if err != nil {
+			return fmt.Errorf("failed to get DH-CHAP subsystem key: %w", err)
+		}
+		connectReq.SubsystemDhchapKey = subsystemKey
+	}
+
+	return nil
+}

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -347,10 +347,12 @@ func (gw *GatewayRpcClient) SubsystemExists(ctx context.Context, subsystemNQN st
 }
 
 // AddHost adds a host to a subsystem (allows access).
-func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN string) error {
+func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN string, dhchapKeys DHCHAPKeys) error {
 	log.DebugLog(ctx, "Adding host %s to subsystem %s on gateway %s",
 		hostNQN, subsystemNQN, gw.config)
 
+	// TODO: if GW deployed with encryption=True it means KeyEncrypted and CtrlrKeyEncrypted
+	// should be set to true as well.
 	req := &pb.AddHostReq{
 		SubsystemNqn: subsystemNQN,
 		HostNqn:      hostNQN,
@@ -358,8 +360,17 @@ func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN s
 		// DhchapKey: nil,    // No DH-CHAP authentication
 		// PskEncrypted: nil, // No PSK encryption
 		// KeyEncrypted: nil, // No key encryption
+		// CtrlrKeyEncrypted: nil, // No controller key encryption
 	}
 
+	// Add DH-CHAP key if provided
+	if dhchapKeys.HostKey != "" {
+		req.DhchapKey = &dhchapKeys.HostKey
+	}
+
+	if dhchapKeys.SubsystemKey != "" {
+		req.DhchapCtrlrKey = &dhchapKeys.SubsystemKey
+	}
 	resp, err := gw.client.AddHost(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to add host %s to subsystem %s: %w", hostNQN, subsystemNQN, err)

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -61,6 +61,10 @@ type ConnectRequest struct {
 	Listeners    []GatewayAddress
 	Transport    string // "tcp"
 	HostNQN      string // Optional - empty means use system default
+	// Optional - In-band authentication controller secret for bi-directional authentication.
+	SubsystemDhchapKey string
+	// Optional - In-band authentication secret for uni-directional authentication
+	HostDhchapKey string
 }
 
 // nvmeInitiator implements NVMeInitiator interface.
@@ -185,7 +189,14 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 		if req.HostNQN != "" {
 			args = append(args, "--hostnqn", req.HostNQN)
 		}
-
+		// if Host DH-CHAP key is provided, add it to the command
+		if req.HostDhchapKey != "" {
+			args = append(args, "--dhchap-secret", req.HostDhchapKey)
+		}
+		// if Subsystem DH-CHAP key is provided, add it to the command (for bi-directional auth)
+		if req.SubsystemDhchapKey != "" {
+			args = append(args, "--dhchap-ctrl-secret", req.SubsystemDhchapKey)
+		}
 		stdout, stderr, err := util.ExecCommandWithTimeout(ctx, connectTimeout, "nvme", args...)
 		// Execute connection
 		if err != nil {

--- a/internal/nvmeof/rbd_dekstore.go
+++ b/internal/nvmeof/rbd_dekstore.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvmeof
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	librbd "github.com/ceph/go-ceph/rbd"
+
+	"github.com/ceph/ceph-csi/internal/kms"
+	rbdutil "github.com/ceph/ceph-csi/internal/rbd/types"
+)
+
+// rbdVolumeDEKStore implements kms.DEKStore using RBD image metadata
+// It stores DH-CHAP keys as metadata entries in the RBD image.
+type rbdVolumeDEKStore struct {
+	rbdVol rbdutil.Volume
+}
+
+// Ensure rbdVolumeDEKStore implements kms.DEKStore.
+var _ kms.DEKStore = &rbdVolumeDEKStore{}
+
+// NewRBDVolumeDEKStore creates a new RBD metadata-based DEKStore.
+func NewRBDVolumeDEKStore(rbdVol rbdutil.Volume) kms.DEKStore {
+	return &rbdVolumeDEKStore{
+		rbdVol: rbdVol,
+	}
+}
+
+// StoreDEK stores the encrypted DEK in RBD image metadata.
+func (r *rbdVolumeDEKStore) StoreDEK(ctx context.Context, keyID, encryptedDEK string) error {
+	// Prefix to distinguish DH-CHAP keys from other metadata
+	metadataKey := "nvmeof.csi.ceph.com/" + keyID
+
+	err := r.rbdVol.SetMetadata(metadataKey, encryptedDEK)
+	if err != nil {
+		return fmt.Errorf("failed to store DH-CHAP key %s in RBD metadata: %w", keyID, err)
+	}
+
+	return nil
+}
+
+// FetchDEK retrieves the encrypted DEK from RBD image metadata.
+func (r *rbdVolumeDEKStore) FetchDEK(ctx context.Context, keyID string) (string, error) {
+	metadataKey := "nvmeof.csi.ceph.com/" + keyID
+
+	encryptedDEK, err := r.rbdVol.GetMetadata(metadataKey)
+	if errors.Is(err, librbd.ErrNotFound) {
+		return "", fmt.Errorf("%w: %s", ErrKeyNotFound, keyID)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch DH-CHAP key %s from RBD metadata: %w", keyID, err)
+	}
+
+	return encryptedDEK, nil
+}
+
+// RemoveDEK deletes the encrypted DEK from RBD image metadata.
+func (r *rbdVolumeDEKStore) RemoveDEK(ctx context.Context, keyID string) error {
+	// For now, we don't remove keys from metadata
+	// They'll be cleaned up when the volume is deleted
+	// If you want to implement removal, you'll need to add a RemoveMetadata method to rbdutil.Volume
+	return nil
+}

--- a/internal/nvmeof/tests/nvmeof_test.go
+++ b/internal/nvmeof/tests/nvmeof_test.go
@@ -88,6 +88,9 @@ func TestRealGateway(t *testing.T) {
 			},
 		},
 		GatewayManagementInfo: *config,
+		Security: nvmeof.NVMeoFSecurityConfig{
+			DhchapMode: "none",
+		},
 	}
 
 	t.Cleanup(func() {
@@ -121,7 +124,8 @@ func TestRealGateway(t *testing.T) {
 	t.Logf("✓ Subsystem created: %s", nvmeofData.SubsystemNQN)
 
 	// Test add host
-	err = client.AddHost(ctx, nvmeofData.SubsystemNQN, hostNQN)
+	noneDhchapKeys := nvmeof.DHCHAPKeys{} // No DH-CHAP authentication
+	err = client.AddHost(ctx, nvmeofData.SubsystemNQN, hostNQN, noneDhchapKeys)
 	require.NoError(t, err)
 	t.Logf("✓ Host added: %s to subsystem %s", hostNQN, nvmeofData.SubsystemNQN)
 

--- a/internal/nvmeof/volume.go
+++ b/internal/nvmeof/volume.go
@@ -23,4 +23,10 @@ type NVMeoFVolumeData struct {
 	NamespaceUUID         string
 	ListenerInfo          []ListenerDetails
 	GatewayManagementInfo GatewayConfig
+	Security              NVMeoFSecurityConfig
+}
+
+type NVMeoFSecurityConfig struct {
+	DhchapMode          string
+	AuthenticationKMSID string
 }


### PR DESCRIPTION
# Describe what this PR does

Adds DH-CHAP (Diffie-Hellman Challenge Handshake Authentication Protocol) 
authentication support for NVMe-oF connections with pluggable KMS backend 
for secure key management.

**Key components:**
- `SecurityKeyNVMEOFManager`: Manages authentication keys using KMS encryption 
  (similar to volume encryption pattern)
- `dhchapMode` parameter: `none` (default), `unidirectional`, 
  `bidirectional`
- RBD metadata DEKStore: Stores encrypted keys in RBD image metadata (testing)
- Controller: Generates and stores keys during ControllerPublishVolume
- Node: Retrieves keys during NodeStageVolume and passes to nvme-cli

**Authentication flow:**
1. Controller generates unique DH-CHAP key per node-subsystem pair
2. Key encrypted with KEK from Secret and stored via DEKStore
3. Node retrieves and decrypts key during connection setup
4. nvme-cli performs in-band authentication with gateway

## Is there anything that requires special attention

**Testing limitations:**
- RBD metadata DEKStore is for **POC/testing only** - stores encrypted keys 
  in volume metadata
- Not tested with Vault KMS (recommended for production)
- For production, use Vault with integrated DEK storage.

**Implementation notes:**
- Backward compatible: omitting `dhchapMode` defaults to `none` (no auth)
- Keys persist per node-subsystem pair, not per volume
- Supports RWX volumes (multiple nodes mounting same namespace)

## Related issues ##
More details here:
https://github.com/ceph/ceph-csi/issues/5723


## Testing ##
1. Create kms-config.yml (with rbd metadata kms type) for nvmeof csi driver:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: csi-kms-connection-details
  namespace: openshift-storage
data:
  metadata: |
    {
      "encryptionKMSType": "metadata"
    }
```
2. Create PVC 
```yaml
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: cephcsi-nvmeof-pvc
spec:
  volumeAttributesClassName: default
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 64Mi
  storageClassName: ocs-storagecluster-ceph-nvmeof
```
logs:
 ```bash
I0122 12:38:24.049751       1 utils.go:350] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 GRPC call: /csi.v1.Controller/CreateVolume
I0122 12:38:24.049860       1 utils.go:351] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 GRPC request: {"capacity_range":{"required_bytes":67108864},"mutable_parameters":{"rwIosPerSecond":"5000"},"name":"pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0","parameters":{"clusterID":"openshift-storage","csi.storage.k8s.io/pv/name":"pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0","csi.storage.k8s.io/pvc/name":"cephcsi-nvmeof-pvc","csi.storage.k8s.io/pvc/namespace":"default","dhchapMode":"bidirectional","imageFeatures":"layering","listeners":"[\n  {\n    \"address\": \"10.131.0.130\",\n    \"port\": 4420,\n    \"hostname\": \"ceph-nvmeof-gateway-67468f76d7-49v8c\"\n  },\n  {\n    \"address\": \"10.128.2.52\",\n    \"port\": 4420,\n    \"hostname\": \"ceph-nvmeof-gateway-67468f76d7-hkv98\"\n  }\n]\n","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"},"secrets":"***stripped***","volume_capabilities":[{"access_mode":{"mode":"SINGLE_NODE_WRITER"},"mount":{"fs_type":"ext4"}}]}
I0122 12:38:24.050271       1 rbd_util.go:1424] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 setting disableInUseChecks: false image features: [layering] mounter: rbd
I0122 12:38:24.084068       1 omap.go:89] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volumes.default"): map[]
I0122 12:38:24.110441       1 omap.go:159] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volumes.default"): map[csi.volume.pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0:a617ce6d-9918-4451-98e9-a2096c57a456])
I0122 12:38:24.115872       1 omap.go:159] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a617ce6d-9918-4451-98e9-a2096c57a456"): map[csi.imagename:csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 csi.volname:pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 csi.volume.owner:default])
I0122 12:38:24.115902       1 rbd_journal.go:521] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 generated Volume ID (0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456) and image name (csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456) for request name (pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0)
I0122 12:38:24.115980       1 rbd_util.go:462] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 rbd: create ocs-storagecluster-cephblockpool/csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 size 64M (features: [layering]) using mon 172.30.188.242:3300,172.30.64.86:3300,172.30.84.79:3300
I0122 12:38:24.116036       1 rbd_util.go:1688] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 setting image options on ocs-storagecluster-cephblockpool/csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456
I0122 12:38:24.141228       1 controllerserver.go:809] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 created image ocs-storagecluster-cephblockpool/csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 backed for request name pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0
I0122 12:38:24.165260       1 omap.go:159] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 set omap keys (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a617ce6d-9918-4451-98e9-a2096c57a456"): map[csi.imageid:9b12e674b06a])
I0122 12:38:24.165521       1 controllerserver.go:1232] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Connected to the gateway 172.30.192.133:5500
I0122 12:38:24.165575       1 nvmeof.go:323] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Checking if subsystem nqn.2016-06.io.ceph:subsystem.test-integration exists on gateway 172.30.192.133:5500
I0122 12:38:24.176463       1 nvmeof.go:344] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Subsystem nqn.2016-06.io.ceph:subsystem.test-integration does not exist
I0122 12:38:24.176503       1 nvmeof.go:255] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Creating NVMe subsystem: nqn.2016-06.io.ceph:subsystem.test-integration on gateway 172.30.192.133:5500
I0122 12:38:24.209949       1 nvmeof.go:293] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Subsystem created successfully: nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:24.209978       1 controllerserver.go:616] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Creating listener 0: 10.131.0.130:4420 (ceph-nvmeof-gateway-67468f76d7-49v8c)
I0122 12:38:24.209985       1 nvmeof.go:394] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Adding listener 10.131.0.130 to subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:24.254837       1 nvmeof.go:425] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Listener added successfully: 10.131.0.130 to subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:24.254866       1 controllerserver.go:616] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Creating listener 1: 10.128.2.52:4420 (ceph-nvmeof-gateway-67468f76d7-hkv98)
I0122 12:38:24.254871       1 nvmeof.go:394] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Adding listener 10.128.2.52 to subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:24.281339       1 nvmeof.go:416] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Listener 10.128.2.52 stashed for subsystem nqn.2016-06.io.ceph:subsystem.test-integration (will be active when ceph-nvmeof-gateway-67468f76d7-hkv98 gateway comes up)
I0122 12:38:24.281393       1 controllerserver.go:763] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 subsystem nqn.2016-06.io.ceph:subsystem.test-integration and Listener [10.131.0.130:4420 (ceph-nvmeof-gateway-67468f76d7-49v8c) 10.128.2.52:4420 (ceph-nvmeof-gateway-67468f76d7-hkv98)] for the subsystem were created
I0122 12:38:24.281405       1 nvmeof.go:112] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Creating namespace for RBD ocs-storagecluster-cephblockpool/csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 in subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:25.210734       1 nvmeof.go:143] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Namespace created with NSID: 1
I0122 12:38:25.210765       1 controllerserver.go:771] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Namespace created: ocs-storagecluster-cephblockpool/csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 with NSID: 1
I0122 12:38:25.210790       1 controllerserver.go:776] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Setting QoS limits: RwIops=5000
I0122 12:38:25.210800       1 nvmeof.go:190] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 Setting QoS limits on namespace 1 in subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:25.312336       1 nvmeof.go:207] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 QoS limits set successfully on namespace 1
I0122 12:38:25.393869       1 omap.go:89] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a617ce6d-9918-4451-98e9-a2096c57a456"): map[csi.imageid:9b12e674b06a csi.imagename:csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 csi.volname:pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 csi.volume.owner:default]
I0122 12:38:25.636432       1 controllerserver.go:1106] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 All NVMe-oF metadata stored successfully for volume: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456
I0122 12:38:25.636731       1 utils.go:357] ID: 15 Req-ID: pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 GRPC response: {"volume":{"capacity_bytes":67108864,"volume_context":{"GatewayAddress":"172.30.192.133","GatewayPort":"5500","NamespaceID":"1","NamespaceUUID":"c33919e8-d6ba-49e3-8670-8e3346b9318d","SubsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration","authenticationKMSID":"metadata","clusterID":"openshift-storage","dhchapMode":"bidirectional","imageFeatures":"layering","imageName":"csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456","journalPool":"ocs-storagecluster-cephblockpool","listeners":"[{\"address\":\"10.131.0.130\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-49v8c\"},{\"address\":\"10.128.2.52\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-hkv98\"}]","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"},"volume_id":"0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456"}}
[root@cephnvme-devel-server-gadi nvmeof]#
```
3. Create test-pod
```yaml 
apiVersion: v1
kind: Pod
metadata:
  name: nvmeof-test-pod
spec:
  containers:
  - name: test-container
    image: busybox
    command: ["/bin/sh"]
    args: ["-c", "while true; do echo 'Testing NVMe-oF mount'; df -h /mnt/nvmeof; sleep 45; done"]
    volumeMounts:
    - name: nvmeof-volume
      mountPath: /mnt/nvmeof
  volumes:
  - name: nvmeof-volume
    persistentVolumeClaim:
      claimName: cephcsi-nvmeof-pvc
  restartPolicy: Never
```
logs from provisione:
```bash
I0122 12:38:56.204437       1 utils.go:350] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC call: /csi.v1.Controller/ControllerPublishVolume
I0122 12:38:56.204660       1 utils.go:351] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC request: {"node_id":"gdidi-gwfsm-worker-3-ngbpx","secrets":"***stripped***","volume_capability":{"access_mode":{"mode":"SINGLE_NODE_WRITER"},"mount":{"fs_type":"ext4"}},"volume_context":{"GatewayAddress":"172.30.192.133","GatewayPort":"5500","NamespaceID":"1","NamespaceUUID":"c33919e8-d6ba-49e3-8670-8e3346b9318d","SubsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration","authenticationKMSID":"metadata","clusterID":"openshift-storage","dhchapMode":"bidirectional","imageFeatures":"layering","imageName":"csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456","journalPool":"ocs-storagecluster-cephblockpool","listeners":"[{\"address\":\"10.131.0.130\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-49v8c\"},{\"address\":\"10.128.2.52\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-hkv98\"}]","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","storage.kubernetes.io/csiProvisionerIdentity":"1769085470831-2724-nvmeof.csi.ceph.com","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"},"volume_id":"0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456"}
I0122 12:38:56.204822       1 controllerserver.go:1232] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Connected to the gateway 172.30.192.133:5500
I0122 12:38:56.204838       1 controllerserver.go:1273] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 DH-CHAP mode: bidirectional - setting up authentication for node gdidi-gwfsm-worker-3-ngbpx
I0122 12:38:56.230277       1 omap.go:89] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a617ce6d-9918-4451-98e9-a2096c57a456"): map[csi.imageid:9b12e674b06a csi.imagename:csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 csi.volname:pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 csi.volume.owner:default]
I0122 12:38:56.406653       1 controllerserver.go:1307] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 DH-CHAP host key retrieved for node gdidi-gwfsm-worker-3-ngbpx, subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:56.568944       1 controllerserver.go:1315] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 DH-CHAP subsystem key retrieved for node gdidi-gwfsm-worker-3-ngbpx, subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:56.569042       1 nvmeof.go:351] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Adding host nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx to subsystem nqn.2016-06.io.ceph:subsystem.test-integration on gateway 172.30.192.133:5500
I0122 12:38:56.640341       1 nvmeof.go:379] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Host added successfully: nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx to subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:56.640375       1 controllerserver.go:900] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Host nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx successfully added to subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:38:56.640846       1 utils.go:357] ID: 16 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC response: {"publish_context":{"GatewayAddress":"172.30.192.133","GatewayPort":"5500","HostNQN":"nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx","NamespaceID":"1","NamespaceUUID":"c33919e8-d6ba-49e3-8670-8e3346b9318d","SubsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration","authenticationKMSID":"metadata","clusterID":"openshift-storage","dhchapMode":"bidirectional","imageFeatures":"layering","imageName":"csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456","journalPool":"ocs-storagecluster-cephblockpool","listeners":"[{\"address\":\"10.131.0.130\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-49v8c\"},{\"address\":\"10.128.2.52\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-hkv98\"}]","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","storage.kubernetes.io/csiProvisionerIdentity":"1769085470831-2724-nvmeof.csi.ceph.com","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"}}
[root@cephnvme-devel-server-gadi nvmeof]#
``` 
logs from nodeserer:

```bash 
I0122 12:39:01.823458  105266 utils.go:350] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC call: /csi.v1.Node/NodeStageVolume
I0122 12:39:01.823658  105266 utils.go:351] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC request: {"publish_context":{"GatewayAddress":"172.30.192.133","GatewayPort":"5500","HostNQN":"nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx","NamespaceID":"1","NamespaceUUID":"c33919e8-d6ba-49e3-8670-8e3346b9318d","SubsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration","authenticationKMSID":"metadata","clusterID":"openshift-storage","dhchapMode":"bidirectional","imageFeatures":"layering","imageName":"csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456","journalPool":"ocs-storagecluster-cephblockpool","listeners":"[{\"address\":\"10.131.0.130\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-49v8c\"},{\"address\":\"10.128.2.52\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-hkv98\"}]","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","storage.kubernetes.io/csiProvisionerIdentity":"1769085470831-2724-nvmeof.csi.ceph.com","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"},"secrets":"***stripped***","staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount","volume_capability":{"access_mode":{"mode":"SINGLE_NODE_MULTI_WRITER"},"mount":{"fs_type":"ext4"}},"volume_context":{"GatewayAddress":"172.30.192.133","GatewayPort":"5500","NamespaceID":"1","NamespaceUUID":"c33919e8-d6ba-49e3-8670-8e3346b9318d","SubsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration","authenticationKMSID":"metadata","clusterID":"openshift-storage","dhchapMode":"bidirectional","imageFeatures":"layering","imageName":"csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456","journalPool":"ocs-storagecluster-cephblockpool","listeners":"[{\"address\":\"10.131.0.130\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-49v8c\"},{\"address\":\"10.128.2.52\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-hkv98\"}]","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","storage.kubernetes.io/csiProvisionerIdentity":"1769085470831-2724-nvmeof.csi.ceph.com","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"},"volume_id":"0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456"}
I0122 12:39:01.839793  105266 omap.go:89] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a617ce6d-9918-4451-98e9-a2096c57a456"): map[csi.imageid:9b12e674b06a csi.imagename:csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 csi.volname:pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 csi.volume.owner:default]
I0122 12:39:02.099316  105266 cephcmds.go:164] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 command succeeded: nvme [list-subsys -o json]
I0122 12:39:02.099386  105266 nvmeof_initiator.go:175] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Connecting to NVMe-oF subsystem nqn.2016-06.io.ceph:subsystem.test-integration at 10.131.0.130:4420
I0122 12:39:03.274222  105266 cephcmds.go:164] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 command succeeded: nvme [connect -t tcp -n nqn.2016-06.io.ceph:subsystem.test-integration -a 10.131.0.130 -s 4420 -l 1800 --hostnqn nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx --dhchap-secret DHHC-1:01:WcZe7dl7Rf+kr2jL8Yw1oR5M0Sb0mtl/8o45JJzWgGhaKarA: --dhchap-ctrl-secret DHHC-1:01:v9V4Ig5zLlI8+y1r4P/11czWD/OfcEwdZnCy0wHhpY6tw1a4:]
I0122 12:39:03.274291  105266 nvmeof_initiator.go:208] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Successfully connected to subsystem nqn.2016-06.io.ceph:subsystem.test-integration via 10.131.0.130:4420
I0122 12:39:03.274303  105266 nvmeof_initiator.go:175] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Connecting to NVMe-oF subsystem nqn.2016-06.io.ceph:subsystem.test-integration at 10.128.2.52:4420
E0122 12:39:03.281079  105266 cephcmds.go:157] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 an error (exit status 1) and stderror (already connected
) occurred while running nvme args: [connect -t tcp -n nqn.2016-06.io.ceph:subsystem.test-integration -a 10.128.2.52 -s 4420 -l 1800 --hostnqn nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx --dhchap-secret DHHC-1:01:WcZe7dl7Rf+kr2jL8Yw1oR5M0Sb0mtl/8o45JJzWgGhaKarA: --dhchap-ctrl-secret DHHC-1:01:v9V4Ig5zLlI8+y1r4P/11czWD/OfcEwdZnCy0wHhpY6tw1a4:]
W0122 12:39:03.281121  105266 nvmeof_initiator.go:203] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Failed to connect to 10.128.2.52:4420 - stdout: , stderr: already connected
I0122 12:39:03.404608  105266 nodeserver.go:727] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 nvmeof: mounting device /dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d to /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 with fsType ext4
I0122 12:39:03.404638  105266 mount_linux.go:670] Attempting to determine if disk "/dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d])
I0122 12:39:03.477409  105266 mount_linux.go:673] Output: ""
I0122 12:39:03.477450  105266 mount_linux.go:608] Disk "/dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d" appears to be unformatted, attempting to format as type: "ext4" with options: [-F -m0 /dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d]
I0122 12:39:03.524091  105266 mount_linux.go:619] Disk successfully formatted (mkfs): ext4 - /dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456
I0122 12:39:03.524131  105266 mount_linux.go:637] Attempting to mount disk /dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d in ext4 format at /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456
I0122 12:39:03.524158  105266 mount_linux.go:260] Mounting cmd (mount) with arguments (-t ext4 -o _netdev,defaults /dev/disk/by-id/nvme-uuid.c33919e8-d6ba-49e3-8670-8e3346b9318d /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456)
I0122 12:39:03.536261  105266 nodeserver.go:204] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 nvmeof: successfully staged volume 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 to stagingTargetPath /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456
I0122 12:39:03.536410  105266 utils.go:357] ID: 33 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC response: {}
I0122 12:39:03.538050  105266 utils.go:350] ID: 34 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0122 12:39:03.538072  105266 utils.go:351] ID: 34 GRPC request: {}
I0122 12:39:03.538144  105266 utils.go:357] ID: 34 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"EXPAND_VOLUME"}}]}
I0122 12:39:03.551101  105266 utils.go:350] ID: 35 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0122 12:39:03.551121  105266 utils.go:351] ID: 35 GRPC request: {}
I0122 12:39:03.551178  105266 utils.go:357] ID: 35 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"EXPAND_VOLUME"}}]}
I0122 12:39:03.552245  105266 utils.go:350] ID: 36 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0122 12:39:03.552265  105266 utils.go:351] ID: 36 GRPC request: {}
I0122 12:39:03.552323  105266 utils.go:357] ID: 36 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"EXPAND_VOLUME"}}]}
I0122 12:39:03.553324  105266 utils.go:350] ID: 37 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC call: /csi.v1.Node/NodePublishVolume
I0122 12:39:03.553435  105266 utils.go:351] ID: 37 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC request: {"publish_context":{"GatewayAddress":"172.30.192.133","GatewayPort":"5500","HostNQN":"nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx","NamespaceID":"1","NamespaceUUID":"c33919e8-d6ba-49e3-8670-8e3346b9318d","SubsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration","authenticationKMSID":"metadata","clusterID":"openshift-storage","dhchapMode":"bidirectional","imageFeatures":"layering","imageName":"csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456","journalPool":"ocs-storagecluster-cephblockpool","listeners":"[{\"address\":\"10.131.0.130\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-49v8c\"},{\"address\":\"10.128.2.52\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-hkv98\"}]","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","storage.kubernetes.io/csiProvisionerIdentity":"1769085470831-2724-nvmeof.csi.ceph.com","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"},"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount","target_path":"/var/lib/kubelet/pods/c25d681a-9ad9-42aa-8977-14d7a40054be/volumes/kubernetes.io~csi/pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0/mount","volume_capability":{"access_mode":{"mode":"SINGLE_NODE_MULTI_WRITER"},"mount":{"fs_type":"ext4"}},"volume_context":{"GatewayAddress":"172.30.192.133","GatewayPort":"5500","NamespaceID":"1","NamespaceUUID":"c33919e8-d6ba-49e3-8670-8e3346b9318d","SubsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration","authenticationKMSID":"metadata","clusterID":"openshift-storage","dhchapMode":"bidirectional","imageFeatures":"layering","imageName":"csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456","journalPool":"ocs-storagecluster-cephblockpool","listeners":"[{\"address\":\"10.131.0.130\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-49v8c\"},{\"address\":\"10.128.2.52\",\"port\":4420,\"hostname\":\"ceph-nvmeof-gateway-67468f76d7-hkv98\"}]","nvmeofGatewayAddress":"172.30.192.133","nvmeofGatewayPort":"5500","pool":"ocs-storagecluster-cephblockpool","storage.kubernetes.io/csiProvisionerIdentity":"1769085470831-2724-nvmeof.csi.ceph.com","subsystemNQN":"nqn.2016-06.io.ceph:subsystem.test-integration"},"volume_id":"0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456"}
I0122 12:39:03.553647  105266 nodeserver.go:426] ID: 37 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 target /var/lib/kubelet/pods/c25d681a-9ad9-42aa-8977-14d7a40054be/volumes/kubernetes.io~csi/pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0/mount
isBlock false
fstype ext4
stagingPath /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456
readonly false
mountflags [bind]
I0122 12:39:03.553675  105266 mount_linux.go:260] Mounting cmd (mount) with arguments (-t ext4 -o bind /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 /var/lib/kubelet/pods/c25d681a-9ad9-42aa-8977-14d7a40054be/volumes/kubernetes.io~csi/pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0/mount)
I0122 12:39:03.555523  105266 mount_linux.go:260] Mounting cmd (mount) with arguments (-t ext4 -o bind,remount /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 /var/lib/kubelet/pods/c25d681a-9ad9-42aa-8977-14d7a40054be/volumes/kubernetes.io~csi/pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0/mount)
I0122 12:39:03.557109  105266 nodeserver.go:252] ID: 37 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 nvmeof: successfully mounted stagingPath /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/bf75892c9c560a63f15aa55cfd4701da521cf3feb7135fd6bf4276e1da92be88/globalmount/0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 to targetPath /var/lib/kubelet/pods/c25d681a-9ad9-42aa-8977-14d7a40054be/volumes/kubernetes.io~csi/pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0/mount
I0122 12:39:03.557166  105266 utils.go:357] ID: 37 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC response: {}



# test pod event description 

Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Normal   Scheduled               56s                default-scheduler        Successfully assigned default/nvmeof-test-pod to gdidi-gwfsm-worker-3-ngbpx
  Normal   SuccessfulAttachVolume  56s                attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0"
  Warning  FailedMount             53s (x3 over 55s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0" : rpc error: code = Internal desc = failed to connect to subsystem: failed to connect to any gateway address for subsystem nqn.2016-06.io.ceph:subsystem.test-integration
  Normal   AddedInterface          49s                multus                   Add eth0 [10.131.0.145/23] from ovn-kubernetes
  Normal   Pulling                 49s                kubelet                  Pulling image "busybox"
  Normal   Pulled                  48s                kubelet                  Successfully pulled image "busybox" in 639ms (639ms including waiting). Image size: 4670414 bytes.
  Normal   Created                 48s                kubelet                  Created container: test-container
  Normal   Started                 48s                kubelet                  Started container test-container

```
verift with nvmeof GW:
```bash
[root@cephnvme-devel-server-gadi nvmeof]# kubectl -n openshift-storage exec -it nvmeof-cli -- /tmp/nvmeof-cli host list -n nqn.2016-06.io.ceph:subsystem.test-integration
Hosts allowed to access nqn.2016-06.io.ceph:subsystem.test-integration:
╒═══════════════════════════════════════════════════════╤════════════╤═══════════════╕
│                       Host NQN                        │  Uses PSK  │  Uses DHCHAP  │
╞═══════════════════════════════════════════════════════╪════════════╪═══════════════╡
│ nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx │     No     │      Yes      │
╘═══════════════════════════════════════════════════════╧════════════╧═══════════════╛
[root@cephnvme-devel-server-gadi nvmeof]#
[root@cephnvme-devel-server-gadi nvmeof]# kubectl -n openshift-storage exec -it nvmeof-cli -- /tmp/nvmeof-cli ns list -n nqn.2016-06.io.ceph:subsystem.test-integration
Namespaces in subsystem nqn.2016-06.io.ceph:subsystem.test-integration:
╒════════════════════════════════════════════════╤════════╤════════════════════════╤═══════════════════════════════════════════════════════════════════════════════╤════════════╤═════════╤═════════╤═════════════════════╤═════════════╤════════════╤══════════════╤═══════════╤═════════════════╕
│ NQN                                            │   NSID │ Bdev                   │ RBD                                                                           │ Mode       │ Image   │ Block   │ UUID                │        Load │ Location   │ Visibility   │   IOs per │ R/W, R, W MBs   │
│                                                │        │ Name                   │ Image                                                                         │            │ Size    │ Size    │                     │   Balancing │            │              │    second │ per second      │
│                                                │        │                        │                                                                               │            │         │         │                     │       Group │            │              │           │                 │
╞════════════════════════════════════════════════╪════════╪════════════════════════╪═══════════════════════════════════════════════════════════════════════════════╪════════════╪═════════╪═════════╪═════════════════════╪═════════════╪════════════╪══════════════╪═══════════╪═════════════════╡
│ nqn.2016-06.io.ceph:subsystem.test-integration │      1 │ bdev_c33919e8-d6ba-    │ ocs-storagecluster-cephblockpool/csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 │ Read-Write │ 64 MiB  │ 4 KiB   │ c33919e8-d6ba-49e3- │           2 │ <N/A>      │ All Hosts    │      5000 │ unset           │
│                                                │        │ 49e3-8670-8e3346b9318d │                                                                               │            │         │         │ 8670-8e3346b9318d   │             │            │              │           │ unset           │
│                                                │        │                        │                                                                               │            │         │         │                     │             │            │              │           │ unset           │
╘════════════════════════════════════════════════╧════════╧════════════════════════╧═══════════════════════════════════════════════════════════════════════════════╧════════════╧═════════╧═════════╧═════════════════════╧═════════════╧════════════╧══════════════╧═══════════╧═════════════════╛
[root@cephnvme-devel-server-gadi nvmeof]#

```

Delete test-pod:
```bash
I0122 12:41:10.905952       1 utils.go:350] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC call: /csi.v1.Controller/ControllerUnpublishVolume
I0122 12:41:10.906039       1 utils.go:351] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC request: {"node_id":"gdidi-gwfsm-worker-3-ngbpx","secrets":"***stripped***","volume_id":"0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456"}
I0122 12:41:10.913464       1 omap.go:89] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a617ce6d-9918-4451-98e9-a2096c57a456"): map[csi.imageid:9b12e674b06a csi.imagename:csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 csi.volname:pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 csi.volume.owner:default]
I0122 12:41:11.065162       1 controllerserver.go:1232] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Connected to the gateway 172.30.192.133:5500
I0122 12:41:11.065191       1 nvmeof.go:494] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Listing namespaces in subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:41:11.182261       1 nvmeof.go:508] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Listed namespaces in subsystem nqn.2016-06.io.ceph:subsystem.test-integration successfully
I0122 12:41:11.182292       1 nvmeof.go:467] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Removing host nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx from subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:41:11.280930       1 nvmeof.go:479] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Host nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx removed successfully from subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:41:11.280959       1 controllerserver.go:952] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Host nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx removed from subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:41:11.280969       1 controllerserver.go:1339] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 Cleaning up DH-CHAP keys for node gdidi-gwfsm-worker-3-ngbpx, subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0122 12:41:11.280974       1 controllerserver.go:1341] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 DH-CHAP mode: bidirectional - setting up authentication for node gdidi-gwfsm-worker-3-ngbpx
I0122 12:41:11.302981       1 omap.go:89] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 got omap values: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.a617ce6d-9918-4451-98e9-a2096c57a456"): map[csi.imageid:9b12e674b06a csi.imagename:csi-vol-a617ce6d-9918-4451-98e9-a2096c57a456 csi.volname:pvc-aed85ef3-9023-4587-aa71-05ef188f8ce0 csi.volume.owner:default]
I0122 12:41:11.320743       1 controllerserver.go:1370] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 DH-CHAP host key removed for node gdidi-gwfsm-worker-3-ngbpx
I0122 12:41:11.320771       1 controllerserver.go:1378] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 DH-CHAP subsystem key removed for node gdidi-gwfsm-worker-3-ngbpx
I0122 12:41:11.321152       1 utils.go:357] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-a617ce6d-9918-4451-98e9-a2096c57a456 GRPC response: {}
```

You can see

```
nvme connect -t tcp -n nqn.2016-06.io.ceph:subsystem.test-integration -a 10.128.2.52 -s 4420 -l 1800 --hostnqn nqn.2014-08.org.nvmexpress:gdidi-gwfsm-worker-3-ngbpx --dhchap-secret DHHC-1:01:WcZe7dl7Rf+kr2jL8Yw1oR5M0Sb0mtl/8o45JJzWgGhaKarA: --dhchap-ctrl-secret DHHC-1:01:v9V4Ig5zLlI8+y1r4P/11czWD/OfcEwdZnCy0wHhpY6tw1a4:]
```


## Future concerns ##
- **Vault integration testing**: Validate with production Vault KMS
- **Key rotation**: Add support for periodic key rotation

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
