### PR TITLE
helm: use repository-id instead of name for artifacthub

### DIFF
--- a/charts/artifacthub-repo.yml
+++ b/charts/artifacthub-repo.yml
@@ -1,6 +1,6 @@
 ---
 # see https://artifacthub.io/docs/topics/repositories/#ownership-claim
-repositoryID: ceph-csi
+repositoryID: 5509143c-e176-40de-94d3-56c00be47aee
 owners:
   - name: Madhu Rajanna
     email: madhupr007@gmail.com


### PR DESCRIPTION
It seems that claiming the ownership does not work when the "repository-id" is set to the name of the repository. Instead, is should be its unique UUID.

Updates: #5902 (contains API call to get the UUID)

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
