### PR TITLE
nvmeof: Add support for snapshots in the NVMe-oF driver

### DIFF
--- a/examples/nvmeof/pvc-restore.yaml
+++ b/examples/nvmeof/pvc-restore.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nvme-pvc-restore
+spec:
+  storageClassName: csi-nvmeof-sc
+  dataSource:
+    name: nvme-pvc-snapshot
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/nvmeof/snapshot.yaml
+++ b/examples/nvmeof/snapshot.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: nvme-pvc-snapshot
+spec:
+  volumeSnapshotClassName: csi-nvmeplugin-snapclass
+  source:
+    persistentVolumeClaimName: nvmeof-pvc

--- a/examples/nvmeof/snapshotclass.yaml
+++ b/examples/nvmeof/snapshotclass.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-nvmeplugin-snapclass
+driver: nvmeof.csi.ceph.com
+deletionPolicy: Delete
+parameters:
+  # String representing a Ceph cluster to provision storage snapshot from.
+  # Should be unique across all Ceph clusters in use for provisioning,
+  # cannot be greater than 36 bytes in length, and should remain immutable for
+  # the lifetime of the StorageClass in use.
+  # Ensure to create an entry in the configmap named ceph-csi-config, based on
+  # csi-config-map-sample.yaml, to accompany the string chosen to
+  # represent the Ceph cluster in clusterID below
+  clusterID: <cluster-id>
+
+  # Prefix to use for naming RBD snapshots (NVMe volumes are RBD-images).
+  # If omitted, defaults to "csi-snap-".
+  # snapshotNamePrefix: "foo-bar-"
+
+  csi.storage.k8s.io/snapshotter-list-secret-name: csi-nvme-secret
+  csi.storage.k8s.io/snapshotter-list-secret-namespace: default
+  csi.storage.k8s.io/snapshotter-secret-name: csi-nvme-secret
+  csi.storage.k8s.io/snapshotter-secret-namespace: default

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -357,6 +357,40 @@ func (cs *Server) ControllerExpandVolume(
 	return cs.backendServer.ControllerExpandVolume(ctx, req)
 }
 
+// CreateSnapshot forwards the snapshot creation to the backend RBD driver. Because Snapshots do not need to
+// be available in the NVMe-oF gateway, there are no further actions needed.
+func (cs *Server) CreateSnapshot(
+	ctx context.Context,
+	req *csi.CreateSnapshotRequest,
+) (*csi.CreateSnapshotResponse, error) {
+	err := cs.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT)
+	if err != nil {
+		log.ErrorLog(ctx, "invalid create snapshot req: %v", err)
+
+		return nil, err
+	}
+
+	// create snapshot is handled by rbd backend server
+	return cs.backendServer.CreateSnapshot(ctx, req)
+}
+
+// DeleteSnapshot forwards the snapshot deletion to the backend RBD driver. Because Snapshots are not
+// available in the NVMe-oF gateway, there are no further actions needed.
+func (cs *Server) DeleteSnapshot(
+	ctx context.Context,
+	req *csi.DeleteSnapshotRequest,
+) (*csi.DeleteSnapshotResponse, error) {
+	err := cs.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT)
+	if err != nil {
+		log.ErrorLog(ctx, "invalid delete snapshot req: %v", err)
+
+		return nil, err
+	}
+
+	// delete snapshot is handled by rbd backend server
+	return cs.backendServer.DeleteSnapshot(ctx, req)
+}
+
 // validateCreateVolumeRequest validates the incoming request for nvmeof.
 // the rest of the parameters are validated by RBD.
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {

--- a/internal/nvmeof/driver/driver.go
+++ b/internal/nvmeof/driver/driver.go
@@ -65,6 +65,7 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 			csi.ControllerServiceCapability_RPC_MODIFY_VOLUME,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
 		})
 
 		cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{


### PR DESCRIPTION
Add support for snapshots in the NVMe-oF driver

* [x] forward `CreateSnapshot` and `DeleteSnapshot` CSI procedures to the RBD driver
* [x] add a `VolumeSnapshotClass`

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
