### PR TITLE
nvmeof: fix bug in cleanup NVMe-oF resources 

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -149,12 +149,7 @@ func (cs *Server) CreateVolume(
 
 	// Step 2: Setup NVMe-oF resources
 	var nvmeofData *nvmeof.NVMeoFVolumeData
-	nvmeofData, err = cs.createNVMeoFResources(ctx, req, rbdPoolName, rbdRadosNameSpace, rbdImageName)
-	if err != nil {
-		log.ErrorLog(ctx, "NVMe-oF resource setup failed for volumeID %s: %v", volumeID, err)
-
-		return nil, status.Errorf(codes.Internal, "NVMe-oF setup failed: %v", err)
-	}
+	// Defer: Cleanup NVMe-oF on any error (BEFORE the call!)
 	defer func() {
 		// Cleanup NVMe-oF resources on subsequent errors.
 		// only if there was an error and nvmeofData is not nil, it means resources were created.
@@ -167,6 +162,12 @@ func (cs *Server) CreateVolume(
 		}
 	}()
 
+	nvmeofData, err = cs.createNVMeoFResources(ctx, req, rbdPoolName, rbdRadosNameSpace, rbdImageName)
+	if err != nil {
+		log.ErrorLog(ctx, "NVMe-oF resource setup failed for volumeID %s: %v", volumeID, err)
+
+		return nil, status.Errorf(codes.Internal, "NVMe-oF setup failed: %v", err)
+	}
 	// step 3: Populate volume context for NodeServer
 	err = populateVolumeContext(backend, nvmeofData)
 	if err != nil {

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -589,14 +589,14 @@ func ensureSubsystem(
 	if err != nil {
 		return err
 	}
-	if exists {
-		return nil
+	if !exists {
+		// Create if it doesn't exist (controller decision)
+		err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask)
+		if err != nil {
+			return err
+		}
 	}
-	// Create if doesn't exist (controller decision)
-	err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask)
-	if err != nil {
-		return err
-	}
+	// if the subsystem exists, we need to ensure the listeners are created. (if exists, it is OK)
 
 	// if networkMask is not provided, listeners are not created automatically by gateway,
 	// should create them manually one by one.

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -648,7 +648,9 @@ func cleanupEmptySubsystem(
 	// subsystem is empty delete listener first
 	for i, listener := range listeners {
 		if err := gateway.DeleteListener(ctx, subsystemNQN, listener); err != nil {
-			return fmt.Errorf("failed to delete listener %d (%s) for subsystem %s: %w",
+			// Log and continue deleting other listeners. maybe on failure in creation some listeners were not created.
+			// anyway we want to delete the empty subsystem. deleting the subsystem will delete all listeners anyway.
+			log.WarningLog(ctx, "Failed to delete listener %d (%s) for subsystem %s: %v",
 				i, listener.String(), subsystemNQN, err)
 		}
 	}

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -148,31 +148,34 @@ func (cs *Server) CreateVolume(
 	rbdRadosNameSpace := res.GetVolume().GetVolumeContext()["radosNamespace"]
 
 	// Step 2: Setup NVMe-oF resources
-	nvmeofData, err := cs.createNVMeoFResources(ctx, req, rbdPoolName, rbdRadosNameSpace, rbdImageName)
+	var nvmeofData *nvmeof.NVMeoFVolumeData
+	nvmeofData, err = cs.createNVMeoFResources(ctx, req, rbdPoolName, rbdRadosNameSpace, rbdImageName)
 	if err != nil {
 		log.ErrorLog(ctx, "NVMe-oF resource setup failed for volumeID %s: %v", volumeID, err)
 
 		return nil, status.Errorf(codes.Internal, "NVMe-oF setup failed: %v", err)
 	}
 	defer func() {
-		// skip cleanup if there was no error
-		if err == nil {
-			return
-		}
-
-		cleanupErr := cs.cleanupNVMeoFResources(ctx, nvmeofData)
-		if cleanupErr != nil {
-			log.ErrorLog(ctx, "failed to cleanup NVMe-oF resources for volume  %q: %v", volumeID, cleanupErr)
+		// Cleanup NVMe-oF resources on subsequent errors.
+		// only if there was an error and nvmeofData is not nil, it means resources were created.
+		if err != nil && nvmeofData != nil {
+			log.DebugLog(ctx, "Cleaning up NVMe-oF resources for volume %q due to error: %v", volumeID, err)
+			cleanupErr := cs.cleanupNVMeoFResources(ctx, nvmeofData)
+			if cleanupErr != nil {
+				log.ErrorLog(ctx, "failed to cleanup NVMe-oF resources for volume  %q: %v", volumeID, cleanupErr)
+			}
 		}
 	}()
 
 	// step 3: Populate volume context for NodeServer
-	if err := populateVolumeContext(backend, nvmeofData); err != nil {
+	err = populateVolumeContext(backend, nvmeofData)
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to populate volume context: %v", err)
 	}
 
 	// Step 4: Store NVMe-oF metadata in the volume context
-	if err := cs.storeNVMeoFMetadata(ctx, req, volumeID, nvmeofData); err != nil {
+	err = cs.storeNVMeoFMetadata(ctx, req, volumeID, nvmeofData)
+	if err != nil {
 		return nil, err // Error already formatted with proper status code
 	}
 
@@ -728,7 +731,7 @@ func (cs *Server) createNVMeoFResources(
 
 	// Step 3: Ensure subsystem exists (and listener)
 	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, networkMask, nvmeofData.ListenerInfo); err != nil {
-		return nil, fmt.Errorf("subsystem setup failed: %w", err)
+		return nvmeofData, fmt.Errorf("subsystem setup failed: %w", err)
 	}
 
 	log.DebugLog(ctx, "subsystem %s and Listener %s for the subsystem were created", nvmeofData.SubsystemNQN,
@@ -737,7 +740,7 @@ func (cs *Server) createNVMeoFResources(
 	// Step 4: Create namespace and set its uuid
 	nsid, err := gateway.CreateNamespace(ctx, nvmeofData.SubsystemNQN, rbdPoolName, rbdRadosNameSpace, rbdImageName)
 	if err != nil {
-		return nil, fmt.Errorf("namespace creation failed: %w", err)
+		return nvmeofData, fmt.Errorf("namespace creation failed: %w", err)
 	}
 	log.DebugLog(ctx, "Namespace created: %s/%s with NSID: %d", rbdPoolName, rbdImageName, nsid)
 	nvmeofData.NamespaceID = nsid
@@ -747,7 +750,7 @@ func (cs *Server) createNVMeoFResources(
 		log.DebugLog(ctx, "Setting QoS limits: %s", nvmeofQoS)
 		if err := gateway.SetQoSLimitsForNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID,
 			*nvmeofQoS); err != nil {
-			return nil, fmt.Errorf("setting QoS limits failed: %w", err)
+			return nvmeofData, fmt.Errorf("setting QoS limits failed: %w", err)
 		}
 	}
 
@@ -755,7 +758,7 @@ func (cs *Server) createNVMeoFResources(
 	if networkMask != "" {
 		autoListeners, err := gateway.ListListeners(ctx, nvmeofData.SubsystemNQN)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list auto-created listeners: %w", err)
+			return nvmeofData, fmt.Errorf("failed to list auto-created listeners: %w", err)
 		}
 		nvmeofData.ListenerInfo = nvmeof.ConvertListenersFromProto(autoListeners.GetListeners())
 		log.DebugLog(ctx, "Retrieved %d auto-created listeners", len(nvmeofData.ListenerInfo))
@@ -763,15 +766,16 @@ func (cs *Server) createNVMeoFResources(
 
 	uuid, err := gateway.GetUUIDBySubsystemAndNameSpaceID(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID)
 	if err != nil {
-		return nil, fmt.Errorf("get namespace uuid failed: %w", err)
+		return nvmeofData, fmt.Errorf("get namespace uuid failed: %w", err)
 	}
 	nvmeofData.NamespaceUUID = uuid
 
 	return nvmeofData, nil
 }
 
-// cleanupNVMeoFResources cleans up NVMe-oF resources associated with the volume.
-// This includes removing the host, listener, namespace, and potentially the subsystem.
+// cleanupEmptySubsystem removes the subsystem if it exists and has no namespaces.
+// This function is idempotent and safe to call even if the subsystem doesn't exist
+// or has active namespaces.
 func (cs *Server) cleanupNVMeoFResources(
 	ctx context.Context,
 	nvmeofData *nvmeof.NVMeoFVolumeData,
@@ -790,11 +794,6 @@ func (cs *Server) cleanupNVMeoFResources(
 		}
 	}()
 
-	// TODO: maybe just check before if the subsystem exists, if not ,
-	// there is no relevant to continue , will make it simple ?
-	// instead of check in the std error if "not found"..
-
-	// TODO: replace util.VolumeOperationAlreadyExistsFmt
 	if acquired := cs.subsystemLocks.TryAcquire(nvmeofData.SubsystemNQN); !acquired {
 		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
 
@@ -803,11 +802,18 @@ func (cs *Server) cleanupNVMeoFResources(
 	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
 
 	// Step 2: Delete namespace
-	if err := gateway.DeleteNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID); err != nil {
-		return fmt.Errorf("failed to delete namespace %d for subsystem %s: %w",
-			nvmeofData.NamespaceID, nvmeofData.SubsystemNQN, err)
+	// just in case namespace was created. NsID=0 means it was never created.
+	// it is not possible to have a namespace with ID 0.
+	if nvmeofData.NamespaceID > 0 {
+		log.DebugLog(ctx, "Deleting namespace %d for subsystem %s", nvmeofData.NamespaceID, nvmeofData.SubsystemNQN)
+		if err := gateway.DeleteNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID); err != nil {
+			return fmt.Errorf("failed to delete namespace %d for subsystem %s: %w",
+				nvmeofData.NamespaceID, nvmeofData.SubsystemNQN, err)
+		}
+		log.DebugLog(ctx, "Namespace %d deleted for subsystem %s", nvmeofData.NamespaceID, nvmeofData.SubsystemNQN)
+	} else {
+		log.DebugLog(ctx, "No namespace ID found in NVMe-oF metadata, skipping namespace deletion")
 	}
-	log.DebugLog(ctx, "Namespace %d deleted for subsystem %s", nvmeofData.NamespaceID, nvmeofData.SubsystemNQN)
 
 	// Step 3: Cleanup empty subsystem
 	if err := cleanupEmptySubsystem(ctx, gateway, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo); err != nil {

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -158,19 +158,26 @@ func (gw *GatewayRpcClient) DeleteNamespace(ctx context.Context, subsystemNQN st
 	if err != nil {
 		return fmt.Errorf("failed to delete namespace %d: %w", namespaceID, err)
 	}
-	if status.GetStatus() == 0 {
+	switch {
+	case status.GetStatus() == 0:
 		log.DebugLog(ctx, "Namespace deleted successfully: %d", namespaceID)
 
 		return nil
-	}
-	if status.GetStatus() == int32(syscall.ENOENT) { // ENOENT
-		log.DebugLog(ctx, "Namespace %d already deleted (not found)", namespaceID)
 
-		return nil // Namespace already deleted, no error
-	}
+	case status.GetStatus() == int32(syscall.ENOENT):
+		log.DebugLog(ctx, "The subsystem %s that contains namespace %d already deleted (not found)",
+			subsystemNQN, namespaceID)
 
-	return fmt.Errorf("gateway NamespaceDelete returned error (status=%d): %s",
-		status.GetStatus(), status.GetErrorMessage())
+		return nil // Subsystem (and Namespace) are already deleted, no error
+	case status.GetStatus() == int32(syscall.ENODEV):
+		log.DebugLog(ctx, "The namespace %d already deleted (not found)",
+			subsystemNQN, namespaceID)
+
+		return nil // Namespace is already deleted, no error
+	default:
+		return fmt.Errorf("gateway NamespaceDelete returned error (status=%d): %s",
+			status.GetStatus(), status.GetErrorMessage())
+	}
 }
 
 // SetQoSLimitsForNamespace sets QoS limits on a namespace.
@@ -271,6 +278,8 @@ func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN, n
 		return fmt.Errorf("failed to create subsystem %s: %w", subsystemNQN, err)
 	case status.GetStatus() == int32(syscall.EEXIST):
 		// subsystem was already created
+		log.DebugLog(ctx, "Subsystem %s already exists", subsystemNQN)
+
 		return nil
 	case status.GetStatus() != 0:
 		return fmt.Errorf("gateway CreateSubsystem returned error: %s", status.GetErrorMessage())


### PR DESCRIPTION

# Describe what this PR does #

## Problem
1. When `CreateVolume` fails during NVMe-oF resource setup, the cleanup defer does not execute properly, leaving orphaned subsystems (instead of removing it) on the gateway that cause subsequent volume creation attempts to success (but should not success).

### Root Cause

The issue occurred in the following sequence:

1. `CreateVolume` creates an RBD volume successfully
2. `createNVMeoFResources()` is called to set up NVMe-oF resources:
   - Creates subsystem successfully
   - Attempts to create listener - **FAILS** (e.g., "Invalid parameters")
3. `createNVMeoFResources()` returns `nil, error` <-- **Bug**
4. Deferred cleanup in `CreateVolume` was not called at all! <-- **Another Bug**
5. **Cleanup never executes** - subsystem remains on gateway
6. Retry attempt sees existing subsystem and assumes it's ready, but it's actually incomplete (missing listeners) <-- **Another Bug**
7. Volume creation succeeds on retry but with incorrect configuration (missing the listeners..)


**Example from logs:**
```
I0114 14:09:57.263554       1 utils.go:350] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 GRPC call: /csi.v1.Controller/CreateVolume
I0114 14:09:57.466641       1 nvmeof.go:248] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Creating NVMe subsystem: nqn.2016-06.io.spdk:cnode1.rook-ceph on gateway rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:5500
I0114 14:09:57.490502       1 nvmeof.go:277] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Subsystem created successfully: nqn.2016-06.io.spdk:cnode1.rook-ceph
I0114 14:09:57.490521       1 controllerserver.go:569] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Creating listener 0: rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:4420 (rook-ceph-nvmeof-nvmeof-0)
I0114 14:09:57.490525       1 nvmeof.go:367] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Adding listener rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc to subsystem nqn.2016-06.io.spdk:cnode1.rook-ceph
E0114 14:09:57.509716       1 controllerserver.go:152] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 NVMe-oF resource setup failed for volumeID 0001-0009-rook-ceph-0000000000000002-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505: subsystem setup failed: failed to create listener 0 (rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:4420 (rook-ceph-nvmeof-nvmeof-0)): gateway AddListener returned error (status=32602): Failure adding nqn.2016-06.io.spdk:cnode1.rook-ceph listener at rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:4420: Invalid parameters
I0114 14:09:57.512304       1 omap.go:89] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 got omap values: (pool="nvmeofpool", namespace="", name="csi.volume.6a7447ca-ce4b-4fcf-a123-4ce22d9d5505"): map[csi.imageid:12971c079d96 csi.imagename:csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505 csi.volname:pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 csi.volume.owner:default]
I0114 14:09:57.533878       1 rbd_util.go:1548] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 rbd: snap rm nvmeofpool/csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505-temp@csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505 using mon 
I0114 14:09:57.536827       1 rbd_util.go:682] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 rbd: delete csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505-temp using mon 10.101.55.5:6789, pool nvmeofpool
I0114 14:09:57.538643       1 controllerserver.go:1106] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 deleting image csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505
I0114 14:09:57.538719       1 rbd_util.go:682] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 rbd: delete csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505 using mon 10.101.55.5:6789, pool nvmeofpool
I0114 14:09:57.557466       1 rbd_util.go:728] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 rbd: adding task to remove image "nvmeofpool/csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505" with id "12971c079d96" from trash
I0114 14:09:57.565129       1 rbd_util.go:756] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 rbd: successfully added task to move image "nvmeofpool/csi-vol-6a7447ca-ce4b-4fcf-a123-4ce22d9d5505" with id "12971c079d96" to trash
I0114 14:09:57.569464       1 omap.go:126] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 removed omap keys (pool="nvmeofpool", namespace="", name="csi.volumes.default"): [csi.volume.pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4]
E0114 14:09:57.569599       1 utils.go:355] ID: 15 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 GRPC error: rpc error: code = Internal desc = NVMe-oF setup failed: subsystem setup failed: failed to create listener 0 (rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:4420 (rook-ceph-nvmeof-nvmeof-0)): gateway AddListener returned error (status=32602): Failure adding nqn.2016-06.io.spdk:cnode1.rook-ceph listener at rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:4420: Invalid parameters
I0114 14:09:58.077290       1 utils.go:350] ID: 16 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 GRPC call: /csi.v1.Controller/CreateVolume
...
...
I0114 14:09:58.126102       1 controllerserver.go:1115] ID: 16 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Connected to the gateway rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:5500
I0114 14:09:58.126154       1 nvmeof.go:307] ID: 16 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Checking if subsystem nqn.2016-06.io.spdk:cnode1.rook-ceph exists on gateway rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:5500
I0114 14:09:58.133641       1 nvmeof.go:323] ID: 16 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Subsystem nqn.2016-06.io.spdk:cnode1.rook-ceph exists
I0114 14:09:58.133669       1 controllerserver.go:699] ID: 16 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 subsystem nqn.2016-06.io.spdk:cnode1.rook-ceph and Listener [rook-ceph-nvmeof-nvmeof-0.rook-ceph.svc:4420 (rook-ceph-nvmeof-nvmeof-0)] for the subsystem were created
I0114 14:09:58.133686       1 nvmeof.go:112] ID: 16 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Creating namespace for RBD nvmeofpool/csi-vol-df56be2d-81ee-45a9-97d1-f66152770812 in subsystem nqn.2016-06.io.spdk:cnode1.rook-ceph
I0114 14:09:58.801472       1 nvmeof.go:143] ID: 16 Req-ID: pvc-ba4f407d-fda1-4a11-afd1-d944eb4971c4 Namespace created with NSID: 1
```
**you can see from the log that in the second try (by CSI mechanism)  it passed and subsystem existed already, but it should not!!** 


## Solution

### 1. Return nvmeofData on Error (Main Fix)
Modified `createNVMeoFResources()` to return `nvmeofData` instead of `nil` when errors occur after the struct is initialized:
```go
// Before
if err := ensureSubsystem(...); err != nil {
    return nil, fmt.Errorf("subsystem setup failed: %w", err)  // ❌ Returns nil
}

// After
if err := ensureSubsystem(...); err != nil {
    return nvmeofData, fmt.Errorf("subsystem setup failed: %w", err)  // ✅ Returns nvmeofData
}
```

**Why this fixes it:** The cleanup defer now receives valid `nvmeofData` containing gateway connection info and subsystem details, allowing it to properly clean up the orphaned subsystem.

### 2. Add NamespaceID Guard
Added check in `cleanupNVMeoFResources()` to skip namespace deletion when it was never created:
```go
if nvmeofData.NamespaceID > 0 {
    // Delete namespace
} else {
    log.DebugLog(ctx, "No namespace to delete (NamespaceID=0)")
}
```

**Why this is needed:** Since we now return `nvmeofData` even when namespace creation fails, `NamespaceID` may still be 0 (the default value). Attempting to delete namespace 0 would fail.

### 3. Fix ensureSubsystem to Create Listeners Even if Subsystem Exists
Modified `ensureSubsystem()` to attempt listener creation even when the subsystem already exists:
```go
// Before
if !exists {
    err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask)
    if err != nil {
        return err
    }
    
    // Only create listeners if we just created the subsystem
    if networkMask == "" {
        for i, listener := range listeners { ... }
    }
}

// After
if !exists {
    err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask)
    if err != nil {
        return err
    }
}

// Create listeners regardless of whether subsystem was just created
// (handles retry scenarios and multiple PVCs with different listeners on same subsystem)
if networkMask == "" {
    for i, listener := range listeners { ... }
}
```
### 4. The defer was declared AFTER the call that could fail

```go
// ❌ WRONG - defer declared after the call
nvmeofData, err = cs.createNVMeoFResources(...)
if err != nil {
    return nil, status.Errorf(...)  // Returns here, defer below never registered!
}
defer func() {  // ← This line never reached on error!
    if err == nil {
        return
    }
    cleanupErr := cs.cleanupNVMeoFResources(ctx, nvmeofData)
}()
```
Moved the cleanup defer to be declared **BEFORE** the call to `createNVMeoFResources()`:
```go
// ✅ CORRECT - defer declared before the call
var nvmeofData *nvmeof.NVMeoFVolumeData

defer func() {
    if err != nil && nvmeofData != nil {  // Added nil check
        cleanupErr := cs.cleanupNVMeoFResources(ctx, nvmeofData)
        if cleanupErr != nil {
            log.ErrorLog(ctx, "failed to cleanup NVMe-oF resources: %v", cleanupErr)
        }
    }
}()

nvmeofData, err = cs.createNVMeoFResources(...)
if err != nil {
    return nil, status.Errorf(...)  // Defer IS registered and will execute
}
```
**Note:** The RBD cleanup defer remains in its current position (after `CreateVolume`) because:
- If RBD creation fails, nothing was created → no cleanup needed
- If RBD creation succeeds, we need `volumeID` from the response for cleanup
- NVMe-oF is different because partial resources (subsystem) can exist even on failure


**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
