### PR TITLE
ci: add Jenkins jobs for Kubernetes 1.35

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -14,6 +14,8 @@
           only_run_on_request: true
       - '1.34':
           only_run_on_request: true
+      - '1.35':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -14,6 +14,8 @@
           only_run_on_request: true
       - '1.34':
           only_run_on_request: true
+      - '1.35':
+          only_run_on_request: true
     test_type:
       - 'cephfs'
       - 'nfs'


### PR DESCRIPTION
Kubernetes 1.35 has been release a while ago, and we really should start testing Ceph-CSI with that.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
