### PR TITLE
util: validate `VolumeID` in incoming gRPC requests

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -491,7 +491,7 @@ func (cs *ControllerServer) DeleteVolume(
 	ctx context.Context,
 	req *csi.DeleteVolumeRequest,
 ) (*csi.DeleteVolumeResponse, error) {
-	if err := cs.validateDeleteVolumeRequest(); err != nil {
+	if err := cs.validateDeleteVolumeRequest(req); err != nil {
 		log.ErrorLog(ctx, "DeleteVolumeRequest validation failed: %v", err)
 
 		return nil, err
@@ -975,8 +975,8 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 	if req.GetName() == "" {
 		return status.Error(codes.NotFound, "snapshot Name cannot be empty")
 	}
-	if req.GetSourceVolumeId() == "" {
-		return status.Error(codes.NotFound, "source Volume ID cannot be empty")
+	if err := util.ValidateVolumeID(req.GetSourceVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	return nil
@@ -1152,11 +1152,11 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 
-	if req.GetVolumeId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
+	volumeId := req.GetVolumeId()
+	if err := util.ValidateVolumeID(volumeId); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	volumeId := req.GetVolumeId()
 	if acquired := cs.VolumeLocks.TryAcquire(volumeId); !acquired {
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeId)
 	}

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -975,7 +975,7 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 	if req.GetName() == "" {
 		return status.Error(codes.NotFound, "snapshot Name cannot be empty")
 	}
-	if err := util.ValidateVolumeID(req.GetSourceVolumeId()); err != nil {
+	if err := util.ValidateVolumeID(req.GetSourceVolumeId(), true); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -1153,7 +1153,7 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 	}
 
 	volumeId := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeId); err != nil {
+	if err := util.ValidateVolumeID(volumeId, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -910,8 +910,13 @@ func (ns *NodeServer) NodeGetVolumeStats(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	volumeID := req.GetVolumeId()
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	// health check first, return without stats if unhealthy
-	healthy, msg := ns.healthChecker.IsHealthy(req.GetVolumeId(), targetPath)
+	healthy, msg := ns.healthChecker.IsHealthy(volumeID, targetPath)
 
 	// If healthy and an error is returned, it means that the checker was not
 	// started. This could happen when the node-plugin was restarted and the

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -911,7 +911,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	volumeID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -72,7 +72,7 @@ func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeReq
 			if vol == nil {
 				return status.Error(codes.NotFound, "volume cannot be empty")
 			}
-			if err := util.ValidateVolumeID(vol.GetVolumeId()); err != nil {
+			if err := util.ValidateVolumeID(vol.GetVolumeId(), true); err != nil {
 				return status.Error(codes.InvalidArgument, err.Error())
 			}
 
@@ -91,7 +91,7 @@ func (cs *ControllerServer) validateDeleteVolumeRequest(req *csi.DeleteVolumeReq
 		return fmt.Errorf("invalid DeleteVolumeRequest: %w", err)
 	}
 
-	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := util.ValidateVolumeID(req.GetVolumeId(), true); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -104,7 +104,7 @@ func (cs *ControllerServer) validateExpandVolumeRequest(req *csi.ControllerExpan
 		return fmt.Errorf("invalid ExpandVolumeRequest: %w", err)
 	}
 
-	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := util.ValidateVolumeID(req.GetVolumeId(), true); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -72,8 +72,8 @@ func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeReq
 			if vol == nil {
 				return status.Error(codes.NotFound, "volume cannot be empty")
 			}
-			if vol.GetVolumeId() == "" {
-				return status.Error(codes.NotFound, "volume ID cannot be empty")
+			if err := util.ValidateVolumeID(vol.GetVolumeId()); err != nil {
+				return status.Error(codes.InvalidArgument, err.Error())
 			}
 
 		default:
@@ -85,10 +85,14 @@ func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeReq
 }
 
 // validateDeleteVolumeRequest validates the Controller DeleteVolume request.
-func (cs *ControllerServer) validateDeleteVolumeRequest() error {
+func (cs *ControllerServer) validateDeleteVolumeRequest(req *csi.DeleteVolumeRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		return fmt.Errorf("invalid DeleteVolumeRequest: %w", err)
+	}
+
+	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	return nil
@@ -100,8 +104,8 @@ func (cs *ControllerServer) validateExpandVolumeRequest(req *csi.ControllerExpan
 		return fmt.Errorf("invalid ExpandVolumeRequest: %w", err)
 	}
 
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
+	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	capRange := req.GetCapacityRange()

--- a/internal/csi-addons/rbd/encryptionkeyrotation.go
+++ b/internal/csi-addons/rbd/encryptionkeyrotation.go
@@ -54,7 +54,7 @@ func (ekrs *EncryptionKeyRotationServer) EncryptionKeyRotate(
 ) (*ekr.EncryptionKeyRotateResponse, error) {
 	// Get the volume ID from the request
 	volID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volID); err != nil {
+	if err := util.ValidateVolumeID(volID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/csi-addons/rbd/encryptionkeyrotation.go
+++ b/internal/csi-addons/rbd/encryptionkeyrotation.go
@@ -54,8 +54,8 @@ func (ekrs *EncryptionKeyRotationServer) EncryptionKeyRotate(
 ) (*ekr.EncryptionKeyRotateResponse, error) {
 	// Get the volume ID from the request
 	volID := req.GetVolumeId()
-	if volID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	if err := util.ValidateVolumeID(volID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if acquired := ekrs.volLock.TryAcquire(volID); !acquired {

--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -64,7 +64,7 @@ func (rscs *ReclaimSpaceControllerServer) ControllerReclaimSpace(
 	req *rs.ControllerReclaimSpaceRequest,
 ) (*rs.ControllerReclaimSpaceResponse, error) {
 	volumeID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -127,7 +127,7 @@ func (rsns *ReclaimSpaceNodeServer) NodeReclaimSpace(
 	// volumeID is a required attribute, it is part of the path to run the
 	// space reducing command on
 	volumeID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -64,8 +64,8 @@ func (rscs *ReclaimSpaceControllerServer) ControllerReclaimSpace(
 	req *rs.ControllerReclaimSpaceRequest,
 ) (*rs.ControllerReclaimSpaceResponse, error) {
 	volumeID := req.GetVolumeId()
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if acquired := rscs.volumeLocks.TryAcquire(volumeID); !acquired {
@@ -127,8 +127,8 @@ func (rsns *ReclaimSpaceNodeServer) NodeReclaimSpace(
 	// volumeID is a required attribute, it is part of the path to run the
 	// space reducing command on
 	volumeID := req.GetVolumeId()
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if acquired := rsns.volumeLocks.TryAcquire(volumeID); !acquired {

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -127,6 +127,11 @@ func (cs *Server) DeleteVolume(
 	ctx context.Context,
 	req *csi.DeleteVolumeRequest,
 ) (*csi.DeleteVolumeResponse, error) {
+	volumeID := req.GetVolumeId()
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	secret := req.GetSecrets()
 	cr, err := util.NewAdminCredentials(secret)
 	if err != nil {
@@ -136,7 +141,7 @@ func (cs *Server) DeleteVolume(
 	}
 	defer cr.DeleteCredentials()
 
-	nfsVolume, err := NewNFSVolume(ctx, req.GetVolumeId())
+	nfsVolume, err := NewNFSVolume(ctx, volumeID)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -250,9 +250,11 @@ func (ns *NodeServer) mountNFS(
 
 // validateNodePublishVolumeRequest validates node publish volume request.
 func validateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
+	if err := util.ValidateVolumeID(req.GetVolumeId(), util.IsStaticVol(req.GetVolumeContext())); err != nil {
+		return err
+	}
+
 	switch {
-	case req.GetVolumeId() == "":
-		return errors.New("volume ID missing in request")
 	case req.GetVolumeCapability() == nil:
 		return errors.New("volume capability missing in request")
 	case req.GetTargetPath() == "":

--- a/internal/nfs/nodeserver/nodeserver_test.go
+++ b/internal/nfs/nodeserver/nodeserver_test.go
@@ -39,6 +39,10 @@ func Test_validateNodePublishVolumeRequest(t *testing.T) {
 					VolumeId:         "123",
 					TargetPath:       "/target",
 					VolumeCapability: &csi.VolumeCapability{},
+					// staticVolume ensures format validation for volumeID is skipped.
+					VolumeContext: map[string]string{
+						"staticVolume": "true",
+					},
 				},
 			},
 			wantErr: false,

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -189,7 +189,7 @@ func (cs *Server) DeleteVolume(
 	req *csi.DeleteVolumeRequest,
 ) (*csi.DeleteVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -314,7 +314,7 @@ func (cs *Server) ControllerModifyVolume(
 ) (*csi.ControllerModifyVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	params := req.GetMutableParameters()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -189,8 +189,8 @@ func (cs *Server) DeleteVolume(
 	req *csi.DeleteVolumeRequest,
 ) (*csi.DeleteVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
-	if volumeID == "" {
-		return nil, status.Errorf(codes.InvalidArgument, "empty volume ID in request")
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	// prevent concurrent requests for the same volume
@@ -314,6 +314,9 @@ func (cs *Server) ControllerModifyVolume(
 ) (*csi.ControllerModifyVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	params := req.GetMutableParameters()
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	// Step 1: Acquire volume lock
 	if acquired := cs.volumeLocks.TryAcquire(volumeID); !acquired {

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -350,8 +350,8 @@ func (ns *NodeServer) NodeExpandVolume(
 	req *csi.NodeExpandVolumeRequest,
 ) (*csi.NodeExpandVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "volume ID must be provided")
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	// Block mode - nothing to do

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -350,7 +350,7 @@ func (ns *NodeServer) NodeExpandVolume(
 	req *csi.NodeExpandVolumeRequest,
 ) (*csi.NodeExpandVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -874,8 +874,8 @@ func checkContentSource(
 			return nil, nil, status.Error(codes.NotFound, "volume cannot be empty")
 		}
 		volID := vol.GetVolumeId()
-		if volID == "" {
-			return nil, nil, status.Errorf(codes.NotFound, "volume ID cannot be empty")
+		if err := util.ValidateVolumeID(volID); err != nil {
+			return nil, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		rbdvol, err := GenVolFromVolID(ctx, volID, cr, req.GetSecrets())
 		if err != nil {
@@ -963,8 +963,8 @@ func (cs *ControllerServer) DeleteVolume(
 
 	// For now the image get unconditionally deleted, but here retention policy can be checked
 	volumeID := req.GetVolumeId()
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	cr, err := util.NewUserCredentialsWithMigration(req.GetSecrets())
@@ -1127,8 +1127,8 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest,
 ) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	if req.GetVolumeId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if len(req.GetVolumeCapabilities()) == 0 {
@@ -1598,8 +1598,8 @@ func (cs *ControllerServer) ControllerExpandVolume(
 	}
 
 	volID := req.GetVolumeId()
-	if volID == "" {
-		return nil, status.Error(codes.InvalidArgument, "volume ID cannot be empty")
+	if err := util.ValidateVolumeID(volID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	capRange := req.GetCapacityRange()
@@ -1711,8 +1711,8 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 	if !k8s.RunsOnKubernetes() {
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
-	if req.GetVolumeId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
+	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	volumeId := req.GetVolumeId()

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -874,7 +874,7 @@ func checkContentSource(
 			return nil, nil, status.Error(codes.NotFound, "volume cannot be empty")
 		}
 		volID := vol.GetVolumeId()
-		if err := util.ValidateVolumeID(volID); err != nil {
+		if err := util.ValidateVolumeID(volID, true); err != nil {
 			return nil, nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		rbdvol, err := GenVolFromVolID(ctx, volID, cr, req.GetSecrets())
@@ -963,7 +963,7 @@ func (cs *ControllerServer) DeleteVolume(
 
 	// For now the image get unconditionally deleted, but here retention policy can be checked
 	volumeID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -1127,7 +1127,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest,
 ) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := util.ValidateVolumeID(req.GetVolumeId(), util.IsStaticVol(req.GetVolumeContext())); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -1598,7 +1598,7 @@ func (cs *ControllerServer) ControllerExpandVolume(
 	}
 
 	volID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volID); err != nil {
+	if err := util.ValidateVolumeID(volID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -1711,7 +1711,7 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 	if !k8s.RunsOnKubernetes() {
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
-	if err := util.ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := util.ValidateVolumeID(req.GetVolumeId(), true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1234,7 +1234,7 @@ func (ns *NodeServer) NodeExpandVolume(
 	req *csi.NodeExpandVolumeRequest,
 ) (*csi.NodeExpandVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeID); err != nil {
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -1496,7 +1496,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 ) (*csi.NodeGetVolumeStatsResponse, error) {
 	var err error
 	volumeId := req.GetVolumeId()
-	if err := util.ValidateVolumeID(volumeId); err != nil {
+	if err := util.ValidateVolumeID(volumeId, true); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1234,8 +1234,8 @@ func (ns *NodeServer) NodeExpandVolume(
 	req *csi.NodeExpandVolumeRequest,
 ) (*csi.NodeExpandVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "volume ID must be provided")
+	if err := util.ValidateVolumeID(volumeID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	// Get volume path
@@ -1496,9 +1496,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 ) (*csi.NodeGetVolumeStatsResponse, error) {
 	var err error
 	volumeId := req.GetVolumeId()
-	if volumeId == "" {
-		err = fmt.Errorf("volumeID %v is empty", volumeId)
-
+	if err := util.ValidateVolumeID(volumeId); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -32,7 +33,7 @@ var validator = regexp.MustCompile(`^[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[a-zA-Z0-9\-]
 
 // ValidateControllerPublishVolumeRequest validates the controller publish request.
 func ValidateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
-	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), IsStaticVol(req.GetVolumeContext())); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -48,7 +49,7 @@ func ValidateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequ
 
 // ValidateControllerUnpublishVolumeRequest validates the controller unpublish request.
 func ValidateControllerUnpublishVolumeRequest(req *csi.ControllerUnpublishVolumeRequest) error {
-	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), true); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -65,7 +66,7 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 		return status.Error(codes.InvalidArgument, "volume capability missing in request")
 	}
 
-	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), IsStaticVol(req.GetVolumeContext())); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -91,7 +92,7 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 
 // ValidateNodeUnstageVolumeRequest validates the node unstage request.
 func ValidateNodeUnstageVolumeRequest(req *csi.NodeUnstageVolumeRequest) error {
-	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), true); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -108,7 +109,7 @@ func ValidateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
 		return status.Error(codes.InvalidArgument, "volume capability missing in request")
 	}
 
-	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), IsStaticVol(req.GetVolumeContext())); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -125,7 +126,7 @@ func ValidateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
 
 // ValidateNodeUnpublishVolumeRequest validates the node unpublish request.
 func ValidateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) error {
-	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), true); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -153,10 +154,9 @@ func CheckReadOnlyManyIsSupported(req *csi.CreateVolumeRequest) error {
 
 // ValidateVolumeID checks if the specified volumeID matches
 // the expected format: 0000-0000-arbitrary-number-of-000-and-chars
-// and is void of path traversal characters.
-func ValidateVolumeID(volumeID string) error {
-	validator := regexp.MustCompile(`^\d{4}-\d{4}-[a-zA-Z0-9\-]+$`)
-
+// and is void of path traversal characters. The check for expected
+// format is not enforced when `skipFormatCheck` is true.
+func ValidateVolumeID(volumeID string, skipFormatCheck bool) error {
 	// should be non empty
 	if volumeID == "" {
 		return fmt.Errorf("the volumeID cannot be empty: %q", volumeID)
@@ -170,11 +170,28 @@ func ValidateVolumeID(volumeID string) error {
 		return fmt.Errorf("volumeID contains invalid path characters: %q", volumeID)
 	}
 
-	// Should match the expected format: 0000-0000-arbitrary-number-of-000-and-chars
-	if matches := validator.MatchString(volumeID); !matches {
+	// Should match the expected format: 0000-0000-arbitrary-number-of-000-and-chars.
+	// This is checked only when the volume is not statically provisioned.
+	if matches := validator.MatchString(volumeID); !skipFormatCheck && !matches {
 		return fmt.Errorf("the volumeID has an unexpected format: %q", volumeID)
 	}
 
-	// Is a valid volumeID
+	// Is a valid volumeID.
 	return nil
+}
+
+// IsStaticVol checks the volumeAttribute of a volume to determine
+// if it is statically provisioned.
+func IsStaticVol(volAttrs map[string]string) bool {
+	val, ok := volAttrs["staticVolume"]
+	if ok {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return false
+		}
+
+		return boolVal
+	}
+
+	return false
 }

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -17,15 +17,23 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
+// A regex to verify the expected format: 0000-0000-arbitrary-number-of-000-and-chars.
+// First two blocks are hexadecimal.
+var validator = regexp.MustCompile(`^[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[a-zA-Z0-9\-]+$`)
+
 // ValidateControllerPublishVolumeRequest validates the controller publish request.
 func ValidateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if req.GetVolumeCapability() == nil {
@@ -40,8 +48,8 @@ func ValidateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequ
 
 // ValidateControllerUnpublishVolumeRequest validates the controller unpublish request.
 func ValidateControllerUnpublishVolumeRequest(req *csi.ControllerUnpublishVolumeRequest) error {
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if req.GetNodeId() == "" {
@@ -57,8 +65,8 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 		return status.Error(codes.InvalidArgument, "volume capability missing in request")
 	}
 
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if req.GetStagingTargetPath() == "" {
@@ -83,8 +91,8 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 
 // ValidateNodeUnstageVolumeRequest validates the node unstage request.
 func ValidateNodeUnstageVolumeRequest(req *csi.NodeUnstageVolumeRequest) error {
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if req.GetStagingTargetPath() == "" {
@@ -100,8 +108,8 @@ func ValidateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
 		return status.Error(codes.InvalidArgument, "volume capability missing in request")
 	}
 
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if req.GetTargetPath() == "" {
@@ -117,8 +125,8 @@ func ValidateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
 
 // ValidateNodeUnpublishVolumeRequest validates the node unpublish request.
 func ValidateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) error {
-	if req.GetVolumeId() == "" {
-		return status.Error(codes.InvalidArgument, "volume ID missing in request")
+	if err := ValidateVolumeID(req.GetVolumeId()); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if req.GetTargetPath() == "" {
@@ -140,5 +148,33 @@ func CheckReadOnlyManyIsSupported(req *csi.CreateVolumeRequest) error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateVolumeID checks if the specified volumeID matches
+// the expected format: 0000-0000-arbitrary-number-of-000-and-chars
+// and is void of path traversal characters.
+func ValidateVolumeID(volumeID string) error {
+	validator := regexp.MustCompile(`^\d{4}-\d{4}-[a-zA-Z0-9\-]+$`)
+
+	// should be non empty
+	if volumeID == "" {
+		return fmt.Errorf("the volumeID cannot be empty: %q", volumeID)
+	}
+
+	// should not contain path traversal sequences
+	if strings.Contains(volumeID, "..") {
+		return fmt.Errorf("the volumeID contains path traversal sequences: %q", volumeID)
+	}
+	if strings.ContainsAny(volumeID, "/\\") {
+		return fmt.Errorf("volumeID contains invalid path characters: %q", volumeID)
+	}
+
+	// Should match the expected format: 0000-0000-arbitrary-number-of-000-and-chars
+	if matches := validator.MatchString(volumeID); !matches {
+		return fmt.Errorf("the volumeID has an unexpected format: %q", volumeID)
+	}
+
+	// Is a valid volumeID
 	return nil
 }

--- a/internal/util/validate_test.go
+++ b/internal/util/validate_test.go
@@ -24,9 +24,10 @@ func TestValidateVolumeID(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		volumeID string
-		wantErr  bool
+		name       string
+		volumeID   string
+		skipFormat bool
+		wantErr    bool
 	}{
 		// Dynamic volumes, must adhere to format.
 		{"valid standard", "0001-0024-rook-ceph-pool-uuid", false, false},
@@ -35,36 +36,39 @@ func TestValidateVolumeID(t *testing.T) {
 		{"valid very long", "0001-000b-clusterID-1-0000000000000001-c156bd07-e430-435f-b175-56c61a2d9297", false, false},
 		{"invalid very long", "00fg-01bg-clusterID-1-0000000000000001-c156bd07-e430-435f-b175-56c61a2d9297", false, true},
 
-		// Path traversal attempts
-		{"traversal dots", "0001-0024/../../../tmp", true},
-		{"traversal unix", "../../../etc/passwd", true},
-		{"traversal windows", "..\\..\\windows", true},
-		{"traversal embedded", "vol-id/../etc", true},
+		// Static Volumes, skip enforcing format.
+		{"valid static", "this-is-a-static-volume", true, false},
+		{"invalid static with path traversal", "this-is-a/../static-volume", true, true},
+		{"invalid static with path separator", "this-is-a\\static-volume", true, true},
 
-		// Path separator injection
-		{"forward slash", "0001-0024/etc/passwd", true},
-		{"backslash", "vol\\id", true},
-		{"mixed separators", "vol/..\\etc", true},
+		// Path traversal attempts.
+		{"traversal dots", "0001-0024/../../../tmp", false, true},
+		{"traversal unix", "../../../etc/passwd", false, true},
+		{"traversal windows", "..\\..\\windows", false, true},
+		{"traversal embedded", "vol-id/../etc", false, true},
 
-		// Format violations
-		{"missing prefix", "rook-ceph-pool", true},
-		{"wrong prefix format", "001-024-pool", true},
-		{"special chars", "0001-0024-pool$pwned", true},
-		{"spaces", "0001-0024-pool pwned", true},
-		{"null byte", "0001-0024-pool\x00etc", true},
-		{"unicode", "0001-0024-pöōl", true},
+		// Path separator injection.
+		{"forward slash", "0001-0024/etc/passwd", false, true},
+		{"backslash", "vol\\id", false, true},
+		{"mixed separators", "vol/..\\etc", false, true},
 
-		// Edge cases
-		{"empty", "", true},
-		{"only hyphens", "----", true},
-		{"only numbers", "00010024", true},
+		// Format violations.
+		{"missing prefix", "rook-ceph-pool", false, true},
+		{"wrong prefix format", "001-024-pool", false, true},
+		{"special chars", "0001-0024-pool$pwned", false, true},
+		{"spaces", "0001-0024-pool pwned", false, true},
+		{"null byte", "0001-0024-pool\x00etc", false, true},
+		{"unicode", "0001-0024-pöōl", false, true},
+
+		// Edge cases.
+		{"empty", "", false, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := ValidateVolumeID(tt.volumeID)
+			err := ValidateVolumeID(tt.volumeID, tt.skipFormat)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateVolumeID(%q) error = %v, wantErr %v", tt.volumeID, err, tt.wantErr)
 			}

--- a/internal/util/validate_test.go
+++ b/internal/util/validate_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestValidateVolumeID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		volumeID string
+		wantErr  bool
+	}{
+		// Dynamic volumes, must adhere to format.
+		{"valid standard", "0001-0024-rook-ceph-pool-uuid", false, false},
+		{"valid short", "0001-0024-pool-abc", false, false},
+		{"valid long", "0001-0024-cluster-pool-0000-0000-0000-0001", false, false},
+		{"valid very long", "0001-000b-clusterID-1-0000000000000001-c156bd07-e430-435f-b175-56c61a2d9297", false, false},
+		{"invalid very long", "00fg-01bg-clusterID-1-0000000000000001-c156bd07-e430-435f-b175-56c61a2d9297", false, true},
+
+		// Path traversal attempts
+		{"traversal dots", "0001-0024/../../../tmp", true},
+		{"traversal unix", "../../../etc/passwd", true},
+		{"traversal windows", "..\\..\\windows", true},
+		{"traversal embedded", "vol-id/../etc", true},
+
+		// Path separator injection
+		{"forward slash", "0001-0024/etc/passwd", true},
+		{"backslash", "vol\\id", true},
+		{"mixed separators", "vol/..\\etc", true},
+
+		// Format violations
+		{"missing prefix", "rook-ceph-pool", true},
+		{"wrong prefix format", "001-024-pool", true},
+		{"special chars", "0001-0024-pool$pwned", true},
+		{"spaces", "0001-0024-pool pwned", true},
+		{"null byte", "0001-0024-pool\x00etc", true},
+		{"unicode", "0001-0024-pöōl", true},
+
+		// Edge cases
+		{"empty", "", true},
+		{"only hyphens", "----", true},
+		{"only numbers", "00010024", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateVolumeID(tt.volumeID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateVolumeID(%q) error = %v, wantErr %v", tt.volumeID, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This patch includes a set of changes that validate the `VolumeID`
which is provided as an input to incoming gRPC requests.

## Open questions
- NVMe-oF uses RBD under the hood, do we need to validate VolumeIDs for it?
- I have skipped NFS under the assumption that it doesn't strictly follow the VolumeID format, is that correct?
- Will having a strict regex in place cause any future concerns around volume IDs?

Fixes: #5944