### PR TITLE
Revert "rbd: fetch the volumeIds from VGRContent's status for omap data"

### DIFF
--- a/internal/controller/volumegroup/volumegroupreplicationcontent.go
+++ b/internal/controller/volumegroup/volumegroupreplicationcontent.go
@@ -207,16 +207,7 @@ func (r *ReconcileVGRContent) reconcileVGRContent(ctx context.Context, obj runti
 
 	reqName := vgrc.Name
 	groupHandle := vgrc.Spec.VolumeGroupReplicationHandle
-	volumeRefs := vgrc.Status.PersistentVolumeRefList
-	volumeIds := make([]string, len(volumeRefs))
-	for i := range volumeRefs {
-		pv := &corev1.PersistentVolume{}
-		err := r.client.Get(ctx, types.NamespacedName{Name: volumeRefs[i].Name}, pv)
-		if err != nil {
-			return fmt.Errorf("failed to get persistentvolume %s: %w", volumeRefs[i].Name, err)
-		}
-		volumeIds[i] = pv.Spec.CSI.VolumeHandle
-	}
+	volumeIds := vgrc.Spec.Source.VolumeHandles
 
 	if groupHandle == "" {
 		return errors.New("volume group replication handle is empty")


### PR DESCRIPTION
This PR reverts commit e62e08332f9294167e3e4e929386dc942c78157d.

The commit needs to be reverted as on further testing it was found that fetching the omap data from status could mean that we would trigger a modify operation during promotion of a group which could lead to inconsistency.

A safer option to check the sanity of groups before modifying is added in the d/s PR: https://github.com/red-hat-storage/ceph-csi/pull/687 before attempting to modify the group.