### PR TITLE
ci: start testing the devel branch with Kubernetes 1.35

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -19,8 +19,14 @@ jobs:
     strategy:
       matrix:
         branch: [release-v3.15, release-v3.16, devel]
-        k8s: ["1.31", "1.32", "1.33", "1.34"]
+        k8s: ["1.31", "1.32", "1.33", "1.34", "1.35"]
         exclude:
+          - k8s: "1.35"
+            branch: "release-v3.15"
+
+          - k8s: "1.35"
+            branch: "release-v3.16"
+
           - k8s: "1.34"
             branch: "release-v3.15"
 
@@ -28,6 +34,9 @@ jobs:
             branch: "release-v3.16"
 
           - k8s: "1.31"
+            branch: "devel"
+
+          - k8s: "1.32"
             branch: "devel"
 
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -72,15 +72,15 @@ queue_rules:
               - or:
                   - label=ci/skip/e2e
                   - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
+                      - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
+                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
                       - "status-success=ci/centos/mini-e2e/k8s-1.33"
                       - "status-success=ci/centos/mini-e2e/k8s-1.34"
+                      - "status-success=ci/centos/mini-e2e/k8s-1.35"
                       - "status-success=ci/centos/upgrade-tests-cephfs"
                       - "status-success=ci/centos/upgrade-tests-rbd"
           - and:
@@ -149,15 +149,15 @@ pull_request_rules:
       - or:
           - label=ci/skip/e2e
           - and:
-              - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
               - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
               - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-              - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
               - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
               - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-              - "status-success=ci/centos/mini-e2e/k8s-1.32"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
               - "status-success=ci/centos/mini-e2e/k8s-1.33"
               - "status-success=ci/centos/mini-e2e/k8s-1.34"
+              - "status-success=ci/centos/mini-e2e/k8s-1.35"
               - "status-success=ci/centos/upgrade-tests-cephfs"
               - "status-success=ci/centos/upgrade-tests-rbd"
     actions:
@@ -253,15 +253,15 @@ pull_request_rules:
               - or:
                   - label=ci/skip/e2e
                   - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
                       - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
+                      - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
                       - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
+                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
                       - "status-success=ci/centos/mini-e2e/k8s-1.33"
                       - "status-success=ci/centos/mini-e2e/k8s-1.34"
+                      - "status-success=ci/centos/mini-e2e/k8s-1.35"
                       - "status-success=ci/centos/upgrade-tests-cephfs"
                       - "status-success=ci/centos/upgrade-tests-rbd"
     actions:

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Status: **GA**
 Ceph CSI drivers are currently developed and tested **exclusively** in Kubernetes
 environments.
 
-| Ceph CSI Version | Container Orchestrator Name | Version Tested     |
-| -----------------| --------------------------- | -------------------|
-| v3.16.0          | Kubernetes                  | v1.32, v1.33, v1.34|
-| v3.15.0          | Kubernetes                  | v1.31, v1.32, v1.33|
+| Ceph CSI Version | Container Orchestrator Name | Version Tested      |
+| -----------------| --------------------------- | ------------------- |
+| devel (v3.17.0)  | Kubernetes                  | v1.33, v1.34, v1.35 |
+| v3.16.0          | Kubernetes                  | v1.32, v1.33, v1.34 |
+| v3.15.0          | Kubernetes                  | v1.31, v1.32, v1.33 |
 
 There is work in progress to make this CO-independent and thus
 support other orchestration environments (Nomad, Mesos..etc).


### PR DESCRIPTION
There is no need to test the devel branch with Kubernetes 1.32 anymore.
Current release branches will not change their tested Kubernetes
versions.

The `ok-to-test` label still comments with the previous version of the
workflow. It uses the one that is available in the `devel` branch.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
