### PR TITLE
nvmeof: treat "connecting" state as valid in path detection

### DIFF
--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -158,7 +158,7 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 
 		// Check if already connected to this specific gateway
 		if req.HostNQN != "" && existingConnections != nil {
-			if existingConnections.hasLivePathToGateway(
+			if existingConnections.hasPathToGateway(
 				req.SubsystemNQN, req.HostNQN, listener.Address, portStr) {
 				log.DebugLog(ctx, "Already connected to subsystem %s via %s:%s with HostNQN %s",
 					req.SubsystemNQN, listener.Address, portStr, req.HostNQN)
@@ -247,8 +247,8 @@ func listSubsystems(ctx context.Context) (nvmeHostConnections, error) {
 	return hosts, nil
 }
 
-// hasLivePathToGateway checks if a live path exists to the specified gateway.
-func (nhc nvmeHostConnections) hasLivePathToGateway(subsystemNQN, hostNQN,
+// hasPathToGateway checks if a path exists to the specified gateway.
+func (nhc nvmeHostConnections) hasPathToGateway(subsystemNQN, hostNQN,
 	gatewayIP, gatewayPort string,
 ) bool {
 	for _, host := range nhc {
@@ -261,10 +261,25 @@ func (nhc nvmeHostConnections) hasLivePathToGateway(subsystemNQN, hostNQN,
 				continue
 			}
 
+			// loop through paths to find matching path
 			for _, path := range subsys.Paths {
+				// Check if the path matches the gateway IP and port
+				// and is in a usable state:
+				// - "live": connection is active and working
+				// - "connecting": kernel is actively trying to (re)connect
+				//
+				// The "connecting" state occurs when:
+				// 1. Initial connection is being established
+				// 2. Connection lost and kernel is retrying (ctrl_loss_tmo in effect)
+				// 3. Subsystem was deleted/recreated on the gateway
+				//
+				// In all cases, the kernel's retry mechanism handles reconnection
+				// for up to ctrl_loss_tmo seconds, so we should not attempt another
+				// connection which would fail with "already connected" error.
 				if path.Address.Traddr == gatewayIP &&
 					path.Address.Trsvcid == gatewayPort &&
-					path.State == "live" {
+					(path.State == "live" ||
+						path.State == "connecting") {
 					return true
 				}
 			}

--- a/internal/nvmeof/nvmeof_test.go
+++ b/internal/nvmeof/nvmeof_test.go
@@ -317,7 +317,7 @@ func TestHasLivePathToGateway(t *testing.T) {
 			hostNQN:      "nqn.2014-08.org.nvmexpress:uuid:test-host",
 			gatewayIP:    "10.129.2.45",
 			gatewayPort:  "4420",
-			want:         false,
+			want:         true,
 		},
 		{
 			name:         "wrong gateway IP",
@@ -357,7 +357,7 @@ func TestHasLivePathToGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := connections.hasLivePathToGateway(
+			got := connections.hasPathToGateway(
 				tt.subsystemNQN,
 				tt.hostNQN,
 				tt.gatewayIP,


### PR DESCRIPTION
When checking if a path to a gateway already exists, treat both "live" and "connecting" states as
valid connections that should not be re-attempted.

The "connecting" state indicates the NVMe kernel
is actively trying to establish or re-establish
a connection, which occurs in scenarios like:

- Initial connection establishment
- Gateway temporarily unavailable and kernel retrying
- Subsystem\Host deleted and recreated on the gateway

The kernel's ctrl_loss_tmo mechanism will continue retry attempts for up to 30 minutes
( by `-l 1800` param in `nvme connect` command).
Attempting nvme connect while a path is in
"connecting" state results in "already connected"
errors and can cause volume attachment failures
during create/delete cycles.

By treating "connecting" as a valid state,
we allow the kernel's retry logic to handle
reconnection automatically without interference.


## Related issues ##

Fixes: https://github.com/ceph/ceph-csi/issues/5964


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
