### PR TITLE
util: disable informers on secrets

### DIFF
--- a/internal/util/k8s/secrets.go
+++ b/internal/util/k8s/secrets.go
@@ -155,6 +155,26 @@ func (sc *secretCache) updateCache(secret *corev1.Secret, force bool) map[string
 // It returns a map of key-value pairs contained in the Secret's data.
 // If the Secret does not exist or cannot be accessed, it returns an error.
 func GetSecret(secretName, secretNamespace string) (map[string]string, error) {
+	client, err := NewK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Kubernetes: %w", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret %q in namespace %q information: %w", secretName, secretNamespace, err)
+	}
+
+	secretData := make(map[string]string, len(secret.Data))
+	for k, v := range secret.Data {
+		secretData[k] = string(v)
+	}
+
+	return secretData, nil
+}
+
+// FIXME: Implement the secret cache in a manner that does not explode memory.
+func _(secretName, secretNamespace string) (map[string]string, error) {
 	// Start the watcher if not already running, only once
 	if cachedSecrets.running.CompareAndSwap(false, true) {
 		stopCh := make(chan struct{})


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
This patch disables the secret cache which relied on Informers. As the informer was cluster scoped, it led to huge memory spikes due to decoding every secret.

The cache is disabled for it to be implemented in a better manner or to be removed entirely later.
