### PR TITLE
fix(helm): fix invalid YAML syntax and nil pointer in values.yaml

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -66,7 +66,7 @@ spec:
             - "--csi-addons-endpoint=$(CSI_ADDONS_ENDPOINT)"
             - "--v={{ .Values.logLevel }}"
             - "--drivername=$(DRIVER_NAME)"
-{{- if .Values.topology.domainLabels }}
+{{- if and .Values.topology.domainLabels (gt (len .Values.topology.domainLabels) 0) }}
             - "--domainlabels={{ .Values.topology.domainLabels | join "," }}"
 {{- end }}
 {{- if .Values.instanceID }}


### PR DESCRIPTION
The template check for domainLabels evaluates empty arrays as truthy,
causing an invalid --domainlabels= flag to be generated. Fix by
checking that the array is both defined and non-empty before generating
the flag.

Keep domainLabels: [] in values.yaml for better user experience -
users can uncomment example values without needing to add the array
syntax back."