### PR TITLE
ci: use minikube v1.38.0

### DIFF
--- a/build.env
+++ b/build.env
@@ -51,7 +51,7 @@ HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 HELM_VERSION=v3.19.0
 
 # minikube settings
-MINIKUBE_VERSION=v1.37.0
+MINIKUBE_VERSION=v1.38.0
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 


### PR DESCRIPTION
Minikube 1.38.0 has been released, let's use that from now on.

See-also: https://github.com/kubernetes/minikube/releases/tag/v1.38.0

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
