### PR TITLE
nvmeof: resolve listener hostname into IP-address

### DIFF
--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -49,12 +49,12 @@ type NodeServer struct {
 
 // ConnectionInfo holds NVMe-oF connection details.
 type NvmeConnectionInfo struct {
-	SubsystemNQN  string                  `json:"subsystemNQN"`
-	NamespaceID   uint32                  `json:"namespaceID"`
-	NamespaceUUID string                  `json:"namespaceUUID"`
-	Listeners     []nvmeof.GatewayAddress `json:"listeners"`
-	HostNQN       string                  `json:"hostNQN,omitempty"`
-	Transport     string                  `json:"transport"`
+	SubsystemNQN  string                   `json:"subsystemNQN"`
+	NamespaceID   uint32                   `json:"namespaceID"`
+	NamespaceUUID string                   `json:"namespaceUUID"`
+	Listeners     []nvmeof.ListenerDetails `json:"listeners"`
+	HostNQN       string                   `json:"hostNQN,omitempty"`
+	Transport     string                   `json:"transport"`
 }
 
 // stageTransaction struct represents the state a transaction was when it either completed
@@ -566,7 +566,7 @@ func (ns *NodeServer) getNvmeConnection(volumeContext, publishContext map[string
 		return nil, errors.New("missing listeners in volume context")
 	}
 
-	var listeners []nvmeof.GatewayAddress
+	var listeners []nvmeof.ListenerDetails
 	if err := json.Unmarshal([]byte(listenersJSON), &listeners); err != nil {
 		return nil, fmt.Errorf("failed to parse listeners JSON: %w", err)
 	}

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -385,7 +385,7 @@ func (gw *GatewayRpcClient) CreateListener(ctx context.Context, subsystemNQN str
 	req := &pb.CreateListenerReq{
 		Nqn:      subsystemNQN,
 		HostName: listenerInfo.Hostname,
-		Traddr:   listenerInfo.Address,
+		Traddr:   "0.0.0.0",
 		Trsvcid:  &listenerInfo.Port,
 		Adrfam:   &adrfam, // Assuming IPv4, can be configurable // TODO - make it configurable
 		// Secure  // false, // Assuming no security for now   // TODO - make it configurable?

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -58,7 +59,7 @@ type NVMeInitiator interface {
 // ConnectRequest represents a subsystem connection request.
 type ConnectRequest struct {
 	SubsystemNQN string
-	Listeners    []GatewayAddress
+	Listeners    []ListenerDetails
 	Transport    string // "tcp"
 	HostNQN      string // Optional - empty means use system default
 }
@@ -154,14 +155,29 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 	// Try connecting to each address until one succeeds
 	var success bool
 	for _, listener := range req.Listeners {
+		//  resolve the IP-address of the listener, .Address can be set to 0.0.0.0
+		addrs, err := net.LookupHost(listener.Hostname)
+		if err != nil {
+			log.WarningLog(ctx, "Failed to resolve %q: %v", listener.Hostname, err)
+
+			continue
+		}
+		if len(addrs) == 0 {
+			log.WarningLog(ctx, "Resolving %q returned 0 IP-addresses", listener.Hostname)
+
+			continue
+		}
+
+		ip := addrs[0]
+
 		portStr := strconv.FormatUint(uint64(listener.Port), 10)
 
 		// Check if already connected to this specific gateway
 		if req.HostNQN != "" && existingConnections != nil {
 			if existingConnections.hasPathToGateway(
-				req.SubsystemNQN, req.HostNQN, listener.Address, portStr) {
+				req.SubsystemNQN, req.HostNQN, ip, portStr) {
 				log.DebugLog(ctx, "Already connected to subsystem %s via %s:%s with HostNQN %s",
-					req.SubsystemNQN, listener.Address, portStr, req.HostNQN)
+					req.SubsystemNQN, ip, portStr, req.HostNQN)
 				success = true
 
 				continue
@@ -169,14 +185,14 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 		}
 
 		log.DebugLog(ctx, "Connecting to NVMe-oF subsystem %s at %v:%s",
-			req.SubsystemNQN, listener.Address, portStr)
+			req.SubsystemNQN, ip, portStr)
 
 		// Build nvme connect command for this address
 		args := []string{
 			"connect",
 			"-t", req.Transport,
 			"-n", req.SubsystemNQN,
-			"-a", listener.Address,
+			"-a", ip,
 			"-s", portStr,
 			"-l", nvmeCtrlLossTmo,
 		}


### PR DESCRIPTION
This allows a configuration in the StorageClass with listeners set to a Kubernetes Service hostname and IP-address 0.0.0.0. This means the gateway listens on the wildard IP-address, and the node-plugin can use the IP-address of the Kubernetes Service to connect to.

**Note:** This PR is for testing only. `quay.io/nixpanic/cephcsi:nvmeof` is a container buildt from this PR.

This works with the following configuration:

- gateway deployment with a fixed `hostname`
- gateway has a service (cluster-ip)
- StorageClass has these parameters
  ```
  nvmeofGatewayAddress: nvmeof-gw.openshift-storage.svc.cluster.local // service hostname
  nvmeofGatewayPort: "5500"

  # connection details for the listeners (NVMe-oF data protocol)
  listeners: |
    [{
      "address": "172.30.176.241", // cluster-ip from service
      "port": 4420,
      "hostname": "ceph-nvmeof-gateway" // hostname of the pod/deployment
    }]
  ```

The 2nd commit is a hack to have the listeners configured to listen on IP 0.0.0.0 in the gateway.

/cc @OdedViner @gadididi 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
