### PR TITLE
ci: add weekly e2e job against ceph main branch

### DIFF
--- a/.github/workflows/e2e-ceph-main-weekly.yaml
+++ b/.github/workflows/e2e-ceph-main-weekly.yaml
@@ -1,0 +1,28 @@
+name: Weekly E2E (Ceph main)
+
+on:
+  schedule:
+    # Run once a week (Sunday 00:00 UTC)
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  e2e-ceph-main:
+    name: E2E tests against Ceph main
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout ceph-csi
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run E2E tests (Ceph main)
+        env:
+          CEPH_VERSION: main
+        run: |
+          make e2e


### PR DESCRIPTION
**Describe what this PR does**

1. This PR adds a standalone GitHub Actions workflow that runs ceph-csi E2E tests weekly against the Ceph main branch.
2. The workflow reuses the existing E2E test runner and is configured as non-blocking, ensuring it does not impact PR
    or release CI while helping detect regressions from upstream Ceph changes early.

**Is there anything that requires special attention**
- No special attention required.
- The workflow is isolated and marked as non-blocking (continue-on-error: true).

**Provide any external context for the change, if any.**

This follows the goal of catching compatibility issues early when Ceph main
introduces changes that may affect ceph-csi behavior, without impacting
day-to-day development workflows.

**Future concerns**

If the job proves stable and valuable, it could later be promoted to a more
frequent schedule or integrated with additional reporting/alerting.

**Checklist:**

- [x] Commit Message Formatting: Commit titles and messages follow guidelines in the developer guide.
- [x] Reviewed the developer guide on Submitting a Pull Request
- [ ] Pending release notes updated with breaking and/or notable changes (not required for CI-only change).
- [ ] Documentation has been updated, if necessary (not required).
- [ ] Unit tests have been added, if necessary (not applicable).
- [ ] Integration tests have been added, if necessary (existing E2E reused).

> Fixes: #5855