### PR TITLE
ci: add weekly Jenkins mini-e2e job against ceph main

### DIFF
--- a/jobs/mini-e2e-ceph-main-weekly.yaml
+++ b/jobs/mini-e2e-ceph-main-weekly.yaml
@@ -1,10 +1,11 @@
+---
 - job:
     name: mini-e2e-ceph-main-weekly
     project-type: pipeline
     description: "Weekly mini E2E against Ceph main"
 
     triggers:
-      - timed: "H H * * 0" # weekly (Sunday)
+      - timed: "H H * * 0"      # weekly (Sunday)
 
     parameters:
       - string:

--- a/jobs/mini-e2e-ceph-main-weekly.yaml
+++ b/jobs/mini-e2e-ceph-main-weekly.yaml
@@ -1,0 +1,21 @@
+- job:
+    name: mini-e2e-ceph-main-weekly
+    project-type: pipeline
+    description: "Weekly mini E2E against Ceph main"
+
+    triggers:
+      - timed: "H H * * 0" # weekly (Sunday)
+
+    parameters:
+      - string:
+          name: CEPH_VERSION
+          default: main
+          description: "Ceph version to test against"
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-csi.git
+            branches:
+              - ci/centos
+      script-path: mini-e2e-ceph-main-weekly.groovy

--- a/mini-e2e-ceph-main-weekly.groovy
+++ b/mini-e2e-ceph-main-weekly.groovy
@@ -1,0 +1,42 @@
+pipeline {
+  agent any
+
+  parameters {
+    string(
+      name: 'CEPH_VERSION',
+      defaultValue: 'main',
+      description: 'Ceph version/branch to test against'
+    )
+  }
+
+  environment {
+    CEPH_VERSION = "${params.CEPH_VERSION}"
+  }
+
+  stages {
+    stage('Prepare environment') {
+      steps {
+        sh './prepare.sh'
+      }
+    }
+
+    stage('Run Mini E2E (Ceph main)') {
+      steps {
+        sh '''
+          echo "Running mini E2E against Ceph ${CEPH_VERSION}"
+          export CEPH_VERSION=${CEPH_VERSION}
+          make mini-e2e
+        '''
+      }
+    }
+  }
+
+  post {
+    always {
+      archiveArtifacts artifacts: '**/logs/**', allowEmptyArchive: true
+    }
+    failure {
+      echo 'Mini E2E failed'
+    }
+  }
+}


### PR DESCRIPTION
**Describe what this PR does**

1. This PR adds a weekly Jenkins-based mini E2E job that runs against the Ceph main branch.
2. The job is implemented under the ci/centos branch using existing Jenkins infrastructure and mini-e2e pipelines. It reuses current scripts and test logic, only introducing a new scheduled job and configuring it to deploy Ceph main for early regression detection.

**Provide any external context for the change, if any.**

- This follows the goal of catching compatibility issues early when upstream Ceph main introduces changes that may affect ceph-csi behavior, without impacting day-to-day development workflows.

**Related issues**

- Fixes: #5855
- 

**Future concerns**

If the job proves stable and valuable, it could later be extended to full E2E coverage or enhanced with additional reporting/alerting.

Checklist:

- [ ]  Commit Message Formatting: Commit titles and messages follow guidelines in the developer guide.
- [ ]  Reviewed the developer guide on Submitting a Pull Request
- [ ]  Pending release notes updated with breaking and/or notable changes for the next major release (not required for CI-only change).
- [ ]  Documentation has been updated, if necessary (not required).
- [ ]  Unit tests have been added, if necessary (not applicable).
- [ ]  Integration tests have been added, if necessary (existing mini E2E reused)