### PR TITLE
util: include stderr in cryptsetup errors

### DIFF
--- a/internal/util/cryptsetup/cryptsetup.go
+++ b/internal/util/cryptsetup/cryptsetup.go
@@ -275,14 +275,18 @@ func (l *luksWrapper) execCryptsetupCommand(stdin *string, args ...string) (stri
 	stdout := stdoutBuf.String()
 	stderr := stderrBuf.String()
 
-	if errors.Is(l.ctx.Err(), context.DeadlineExceeded) {
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(l.ctx.Err(), context.DeadlineExceeded) {
 		return stdout, stderr, fmt.Errorf("timeout occurred while running %s args: %v", program, sanitizedArgs)
 	}
 
 	if err != nil {
-		return stdout, stderr, fmt.Errorf("an error (%v)"+
-			" occurred while running %s args: %v", err, program, sanitizedArgs)
+		if e := strings.TrimSpace(stderr); e != "" {
+			return stdout, stderr, fmt.Errorf("error running %s args: %v: %w; stderr: %s", program, sanitizedArgs, err, e)
+		}
+
+		return stdout, stderr, fmt.Errorf("error running %s args: %v: %w", program, sanitizedArgs, err)
 	}
 
-	return stdout, stderr, err
+	return stdout, stderr, nil
 }

--- a/internal/util/file/file.go
+++ b/internal/util/file/file.go
@@ -22,8 +22,8 @@ import (
 )
 
 // CreateTempFile create a temporary file with the given string
-// content and returns the reference to the file.
-// The caller is responsible for disposing the file.
+// content and returns the reference to the file. The file is automatically
+// closed; the caller is responsible for removing the file when done.
 func CreateTempFile(prefix, contents string) (*os.File, error) {
 	// Create a temp file
 	file, err := os.CreateTemp("", prefix)
@@ -31,8 +31,10 @@ func CreateTempFile(prefix, contents string) (*os.File, error) {
 		return nil, fmt.Errorf("failed to create temporary file: %w", err)
 	}
 
-	// In case of error, remove the file if it was created
+	// Always close the file and remove it on error
 	defer func() {
+		//nolint:errcheck // close error is less important than sync error
+		_ = file.Close()
 		if err != nil {
 			//nolint:errcheck // temporary file failed to remove, shrug
 			_ = os.Remove(file.Name())
@@ -46,9 +48,9 @@ func CreateTempFile(prefix, contents string) (*os.File, error) {
 		return nil, fmt.Errorf("failed to write temporary file: %w", err)
 	}
 
-	// Close the handle
-	if err = file.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close temporary file: %w", err)
+	// Flush the contents to ensure they're written to disk
+	if err = file.Sync(); err != nil {
+		return nil, fmt.Errorf("failed to sync temporary file: %w", err)
 	}
 
 	return file, nil


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This patch includes the stderr when an error is encountered in cryptsetup.

This patch additionally fixes a potential memory leak which could occur if `WriteString` fails inside `file` package.