### PR TITLE
nvmeof: add retry mechanism for listenerList

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -796,12 +796,12 @@ func (cs *Server) createNVMeoFResources(
 
 	// Step 6: If using auto-listeners, query them back for storing in metadata
 	if networkMask != "" {
-		autoListeners, err := gateway.ListListeners(ctx, nvmeofData.SubsystemNQN)
+		listenersDetailsList, err := gateway.GetListeners(ctx, nvmeofData.SubsystemNQN)
 		if err != nil {
-			return nvmeofData, fmt.Errorf("failed to list auto-created listeners: %w", err)
+			return nvmeofData, fmt.Errorf("failed to retrieve auto-created listeners after retries: %w", err)
 		}
-		nvmeofData.ListenerInfo = nvmeof.ConvertListenersFromProto(autoListeners.GetListeners())
-		log.DebugLog(ctx, "Retrieved %d auto-created listeners", len(nvmeofData.ListenerInfo))
+		log.DebugLog(ctx, "Retrieved %d auto-created listeners", len(listenersDetailsList))
+		nvmeofData.ListenerInfo = listenersDetailsList
 	}
 
 	uuid, err := gateway.GetUUIDBySubsystemAndNameSpaceID(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID)

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"syscall"
 
+	"github.com/avast/retry-go/v4"
 	pb "github.com/ceph/ceph-nvmeof/lib/go/nvmeof"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -534,6 +535,30 @@ func ConvertListenersFromProto(protoListeners []*pb.ListenerInfo) []ListenerDeta
 	}
 
 	return listeners
+}
+
+// GetListeners retrieves listeners for a subsystem with retry logic.
+// Auto-listeners feature may takes time to sync to OMAP state, so this retries with
+// exponential backoff.
+func (gw *GatewayRpcClient) GetListeners(
+	ctx context.Context,
+	subsystemNQN string,
+) ([]ListenerDetails, error) {
+	return retry.DoWithData(
+		func() ([]ListenerDetails, error) {
+			autoListeners, err := gw.ListListeners(ctx, subsystemNQN)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list auto-created listeners: %w", err)
+			}
+
+			if len(autoListeners.GetListeners()) == 0 {
+				return nil, fmt.Errorf("no auto-listeners found for subsystem %s", subsystemNQN)
+			}
+
+			return ConvertListenersFromProto(autoListeners.GetListeners()), nil
+		},
+		retry.Attempts(6), // ~100ms, 200ms, 400ms, 800ms, 1.6s, 3.2s = ~6.3s total
+	)
 }
 
 // Connect to Gateway gRPC server.


### PR DESCRIPTION
# Describe what this PR does #

adding retry mechanism for listenerList grpc call
because there is unknown (under investigation) issue in the nvmeof gw, when user creates subsystem with autoListener option (it creates the listener automatically) but then, when the controller wants to retrieve the listeners list, it gets empty list. there is some
delay in the GW.
FYI- the listeners list comes from the ceph mon command `nvme-gw listeners`  . 

## Related issues ##

fixed: 
https://github.com/ceph/ceph-csi/issues/6037

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
