### PR TITLE
build: update CSI_UPGRADE_VERSION to v3.16.1

### DIFF
--- a/build.env
+++ b/build.env
@@ -12,7 +12,7 @@
 CSI_IMAGE_VERSION=canary
 
 # cephcsi upgrade version
-CSI_UPGRADE_VERSION=v3.16.0
+CSI_UPGRADE_VERSION=v3.16.1
 
 # ceph-csi-operator version used for e2e test
 # TODO: use release tag which includes the bug fixes


### PR DESCRIPTION
```
Update the upgrade testing version to v3.16.1 to align with the
latest release version for end-to-end upgrade testing.
```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
