### PR TITLE
util: add support for GKLM KMS over KMIP

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,5 +5,6 @@
 ## Features
 
 - nfs: allow changing NFS-server through ControllerModifyVolume [PR](https://github.com/ceph/ceph-csi/pull/5829)
+- util: add support for GKLM KMS over KMIP [PR](https://github.com/ceph/ceph-csi/pull/6048)
 
 ## NOTE

--- a/docs/design/proposals/encryption-with-gklm.md
+++ b/docs/design/proposals/encryption-with-gklm.md
@@ -1,0 +1,155 @@
+# Encrypted volumes with IBM GKLM
+
+IBM Guardium Key Lifecycle Manager (GKLM) is a centralized key management system
+that helps manage encryption keys and certificates across the enterprise. GKLM
+supports the Key Management Interoperability Protocol (KMIP), an industry-standard
+protocol for communication with key management systems. To support this KMS
+integration in Ceph-CSI and enable GKLM users to perform volume encryption
+operations, the following details are provided.
+
+## Connection to IBM GKLM service
+
+GKLM uses the KMIP protocol for communication. The following parameters/values
+can be used to establish the connection to the GKLM service from the CSI driver
+and to perform encryption operations:
+
+```text
+* KMS_PROVIDER
+Must be set to "kmip" to use the KMIP protocol.
+
+* USE_CRYPTO_RPC
+Indicates whether cryptographic operations should be handled by the KMS server.
+The KMS provider must support the Encrypt and Decrypt RPC methods defined
+in the KMIP specification.
+For GKLM, this setting MUST be `false`.
+
+* KMIP_ENDPOINT
+The GKLM server endpoint address (e.g., "gklm-server:5696").
+
+* KMIP_SECRET_NAME
+Name of the Kubernetes Secret containing the credentials for
+communicating with the GKLM server. Defaults to "ceph-csi-kmip-credentials".
+
+* KMS_SERVICE_NAME (optional)
+A unique name for the key management service within the project.
+
+* TLS_SERVER_NAME (optional)
+The endpoint server name. Useful when the GKLM endpoint does not have
+a DNS entry. This SAN on the returned certificate must match this.
+
+* READ_TIMEOUT (optional)
+Network read timeout, in seconds. The default value is 10.
+
+* WRITE_TIMEOUT (optional)
+Network write timeout, in seconds. The default value is 10.
+```
+
+### Values provided in the connection Secret
+
+The Secret contains TLS certificates for secure communication with the GKLM
+server and the unique identifier of the encryption key:
+
+```text
+* CA_CERT
+The GKLM server's certificate that is marked as key serving certificate.
+
+* CLIENT_CERT
+Client certificate that will be used to connect to the GKLM server.
+
+* CLIENT_KEY
+Client key that will be used to connect to the GKLM server.
+
+* UNIQUE_IDENTIFIER
+UUID of the symmetric key pair in GKLM to use for encryption/decryption.
+```
+
+The Ceph-CSI KMS plugin interface for GKLM will read the Secret name from the
+KMS ConfigMap and fetch these values.
+
+### Values provided in the ConfigMap
+
+The KMS configuration is stored in a ConfigMap (typically named
+`ceph-csi-encryption-kms-config`) with the following structure:
+
+```json
+{
+  "gklm-test": {
+    "KMS_PROVIDER": "kmip",
+    "KMS_SERVICE_NAME": "gklm",
+    "USE_CRYPTO_RPC": "false",
+    "KMIP_ENDPOINT": "sklmapp.sklm.svc.cluster.local:5696",
+    "KMIP_SECRET_NAME": "ceph-csi-kmip-credentials",
+    "TLS_SERVER_NAME": "sklmapp.sklm.svc.cluster.local",
+    "READ_TIMEOUT": 10,
+    "WRITE_TIMEOUT": 10
+  }
+}
+```
+
+### Storage class configuration
+
+As with other KMS integrations, the StorageClass must be configured for
+encryption with the `encryptionKMSID` parameter matching the key in the KMS ConfigMap:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-rbd-sc-gklm
+parameters:
+  encrypted: "true"
+  encryptionKMSID: "gklm-test" # This matches the JSON key for GKLM config above
+  # ... other parameters
+```
+
+## Prerequisites
+
+Before using GKLM for volume encryption, you must:
+
+1. Create a symmetric key pair (256-bit) in the GKLM server
+1. Obtain the UUID of this key
+1. Provide this UUID as the `UNIQUE_IDENTIFIER` in the Kubernetes Secret
+1. Ensure `USE_CRYPTO_RPC` is set to `"false"` in the KMS ConfigMap
+
+## Volume Encrypt and Decrypt Operations
+
+GKLM integration differs from traditional KMIP implementations in how it handles
+encryption and decryption:
+
+This approach uses GKLM's `Get` RPC operations instead of the
+`Encrypt/Decrypt` operations used by other KMIP servers. The actual
+encryption/decryption of the DEK happens locally using the key
+fetched from GKLM by its UUID.
+
+**Note:** The above will only apply if `USE_CRYPTO_RPC` is set to false in
+the KMS ConfigMap.
+
+### Encryption Process
+
+1. The CSI driver connects to the GKLM server using KMIP protocol and TLS
+   certificates
+1. It fetches the encryption key from GKLM using the `Get` operation with the
+   provided `UNIQUE_IDENTIFIER`
+1. A Data Encryption Key (DEK) is generated locally for LUKS encryption
+1. The DEK is encrypted locally using AES-256-GCM with the fetched encryption key
+1. The encrypted DEK and nonce are stored in the RBD image metadata (similar to
+   other KMS integrations)
+
+### Decryption Process
+
+1. The encrypted DEK and nonce are retrieved from the RBD image metadata
+1. The encryption key is fetched from GKLM using the `Get` operation
+1. The DEK is decrypted locally using AES-256-GCM with the fetched key and nonce
+1. The decrypted DEK is used for LUKS volume decryption
+
+## Integration Protocol
+
+GKLM integration uses the [KMIP protocol](https://en.wikipedia.org/wiki/Key_Management_Interoperability_Protocol)
+for communication. The [KMIP Go library](https://github.com/gemalto/kmip-go)
+provides the client SDK to interact with the KMIP server and perform key
+management operations.
+
+## Additional References
+
+- [IBM Guardium Key Lifecycle Manager Documentation](https://www.ibm.com/docs/en/gklm)
+- [KMIP Specification](https://docs.oasis-open.org/kmip/spec/v1.4/kmip-spec-v1.4.html)

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -514,6 +514,10 @@ file](../../examples/kms/vault/kms-config.yaml):
 
 1. `KMS_PROVIDER`: should be set to `kmip`.
 1. `KMIP_ENDPOINT` KMIP endpoint address.
+1. `USE_CRYPTO_RPC`(optional): Indicates whether to use the KMIP Encrypt and
+    Decrypt RPC operations. Defaults to `true`. Set to `false` if the KMS does not
+    support these RPCs, in which case encryption is performed locally using a
+    cipher derived from the key referenced by `UNIQUE_IDENTIFIER` in the secret.
 1. `KMIP_SECRET_NAME`(optional): name of the Kubernetes Secret which contains
    the credentials for communicating with KMIP server, defaults to
    `ceph-csi-kmip-credentials`.

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -20,6 +20,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -73,6 +75,14 @@ const (
 	kmipCLientCert       = "CLIENT_CERT"
 	kmipClientKey        = "CLIENT_KEY"
 	kmipUniqueIdentifier = "UNIQUE_IDENTIFIER"
+
+	// A config boolean stating the RPCs to use for encrypt
+	// and decrypt operations.
+	//
+	// When set to true: ENCRYPT and DECRYPT RPCs are used.
+	// Otherwise: GET RPC is used to fetch the key referenced
+	// by `UNIQUE_IDENTIFIER` and crypto is performed locally.
+	kmipUseCryptoRPC = "USE_CRYPTO_RPC"
 )
 
 var _ = RegisterProvider(Provider{
@@ -91,6 +101,7 @@ type kmipKMS struct {
 	uniqueIdentifier string
 	readTimeout      uint8
 	writeTimeout     uint8
+	useCryptoRPC     bool
 }
 
 func initKMIPKMS(args ProviderInitArgs) (EncryptionKMS, error) {
@@ -108,6 +119,13 @@ func initKMIPKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 
 	err = setConfigString(&kms.endpoint, args.Config, kmipEndpoint)
 	if err != nil {
+		return nil, err
+	}
+
+	// optional
+	kms.useCryptoRPC = true
+	err = setConfigBoolean(&kms.useCryptoRPC, args.Config, kmipUseCryptoRPC)
+	if errors.Is(err, errConfigOptionInvalid) {
 		return nil, err
 	}
 
@@ -178,8 +196,46 @@ func initKMIPKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 	return kms, nil
 }
 
-// EncryptDEK uses the KMIP encrypt operation to encrypt the DEK.
-func (kms *kmipKMS) EncryptDEK(ctx context.Context, _, plainDEK string) (string, error) {
+// EncryptDEK calls either GET or ENCRYPT operation on the KMIP kms to encrypt the DEK.
+// The operation to call depends upon the config value `USE_CRYPTO_RPC`.
+//
+// If USE_CRYPTO_RPC == false : GET operation is used.
+// If USE_CRYPTO_RPC == true : ENCRYPT operation is used.
+func (kms *kmipKMS) EncryptDEK(ctx context.Context, volumeID, plainDEK string) (string, error) {
+	if kms.useCryptoRPC {
+		return kms.encryptDEKUsingEncryptRPC(ctx, volumeID, plainDEK)
+	}
+
+	return kms.encryptDEKUsingRemoteKey(ctx, volumeID, plainDEK)
+}
+
+// DecryptDEK calls either GET or DECRYPT operation on the KMIP kms to decrypt the DEK.
+// The operation to call depends upon the config value `USE_CRYPTO_RPC`.
+//
+// If USE_CRYPTO_RPC == false : GET operation is used.
+// If USE_CRYPTO_RPC == true : DECRYPT operation is used.
+func (kms *kmipKMS) DecryptDEK(ctx context.Context, volumeID, encryptedDEK string) (string, error) {
+	if kms.useCryptoRPC {
+		return kms.decryptDEKUsingDecryptRPC(ctx, volumeID, encryptedDEK)
+	}
+
+	return kms.decryptDEKUsingRemoteKey(ctx, volumeID, encryptedDEK)
+}
+
+func (kms *kmipKMS) Destroy() {
+	// Nothing to do.
+}
+
+func (kms *kmipKMS) RequiresDEKStore() DEKStoreType {
+	return DEKStoreMetadata
+}
+
+func (kms *kmipKMS) GetSecret(ctx context.Context, volumeID string) (string, error) {
+	return "", ErrGetSecretUnsupported
+}
+
+// encryptDEKUsingEncryptRPC uses the KMIP encrypt operation to encrypt the DEK.
+func (kms *kmipKMS) encryptDEKUsingEncryptRPC(_ context.Context, _, plainDEK string) (string, error) {
 	conn, err := kms.connect()
 	if err != nil {
 		return "", err
@@ -234,8 +290,55 @@ func (kms *kmipKMS) EncryptDEK(ctx context.Context, _, plainDEK string) (string,
 	return string(emdData), nil
 }
 
-// DecryptDEK uses the KMIP decrypt operation  to decrypt the DEK.
-func (kms *kmipKMS) DecryptDEK(ctx context.Context, _, encryptedDEK string) (string, error) {
+// encryptDEKUsingRemoteKey uses the KMIP get operation to fetch the key and encrypts DEK using GCM.
+func (kms *kmipKMS) encryptDEKUsingRemoteKey(_ context.Context, _, plainDEK string) (string, error) {
+	// Fetch the key from the KMS
+	key, err := kms.getKey(kms.uniqueIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	// Seal the passphrase using GCM
+	emd, err := symmetricEncrypt(plainDEK, key)
+	if err != nil {
+		return "", err
+	}
+
+	// Return encrypted passphrase with nonce
+	emdData, err := json.Marshal(emd)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert encryptedMetadataDEK to JSON: %w", err)
+	}
+
+	return string(emdData), nil
+}
+
+// decryptDEKUsingRemoteKey uses the KMIP get operation to fetch the key and decrypts the DEK using GCM.
+func (kms *kmipKMS) decryptDEKUsingRemoteKey(_ context.Context, _, encryptedDEK string) (string, error) {
+	emd := encryptedMetadataDEK{}
+	err := json.Unmarshal([]byte(encryptedDEK), &emd)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal encrypted DEK: %w", err)
+	}
+
+	// Fetch the key
+	key, err := kms.getKey(kms.uniqueIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	// Decrypt locally
+	plainDEK, err := symmetricDecrypt(&emd, key)
+	if err != nil {
+		return "", err
+	}
+
+	// Just return the plain text
+	return plainDEK, nil
+}
+
+// decryptDEKUsingDecryptRPC uses the KMIP decrypt operation to decrypt the DEK.
+func (kms *kmipKMS) decryptDEKUsingDecryptRPC(_ context.Context, _, encryptedDEK string) (string, error) {
 	conn, err := kms.connect()
 	if err != nil {
 		return "", err
@@ -282,18 +385,6 @@ func (kms *kmipKMS) DecryptDEK(ctx context.Context, _, encryptedDEK string) (str
 	}
 
 	return string(decryptRespPayload.Data), nil
-}
-
-func (kms *kmipKMS) Destroy() {
-	// Nothing to do.
-}
-
-func (kms *kmipKMS) RequiresDEKStore() DEKStoreType {
-	return DEKStoreMetadata
-}
-
-func (kms *kmipKMS) GetSecret(ctx context.Context, volumeID string) (string, error) {
-	return "", ErrGetSecretUnsupported
 }
 
 // getSecrets returns required options from the Kubernetes Secret.
@@ -493,6 +584,107 @@ func (kms *kmipKMS) verifyResponse(
 	}
 
 	return &batchItem, nil
+}
+
+// symmetricEncrypt seals the plainText DEK using the given key and returns
+// `encryptedMetadataDEK` with nonce.
+func symmetricEncrypt(plainDEK string, key []byte) (*encryptedMetadataDEK, error) {
+	plainText := []byte(plainDEK)
+
+	// Create GCM cipher, simpler, does not require padding
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a cipher from the given key: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	// Generate a nonce
+	nonce, err := generateNonce(gcm.NonceSize())
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate a nonce for DEK encryption: %w", err)
+	}
+
+	cipherText := gcm.Seal(nil, nonce, plainText, nil)
+
+	return &encryptedMetadataDEK{
+		Nonce: nonce,
+		DEK:   cipherText,
+	}, nil
+}
+
+// symmetricDecrypt decrypts an encrypted DEK using the given key.
+func symmetricDecrypt(emd *encryptedMetadataDEK, key []byte) (string, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create a cipher from the given key: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	decrypted, err := gcm.Open(nil, emd.Nonce, emd.DEK, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt the DEK using the provided key: %w", err)
+	}
+
+	return string(decrypted), nil
+}
+
+// getKey fetches the symmetric key with given UUID from the KMS.
+func (kms *kmipKMS) getKey(keyUID string) ([]byte, error) {
+	conn, err := kms.connect()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close() //nolint:errcheck // more important errors are returned
+
+	payload := &kmip.GetRequestPayload{
+		UniqueIdentifier: keyUID,
+	}
+
+	resp, decoder, uid, err := kms.send(conn, kmip14.OperationGet, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	batchItem, err := kms.verifyResponse(resp, kmip14.OperationGet, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	ttlvPayload, ok := batchItem.ResponsePayload.(ttlv.TTLV)
+	if !ok {
+		return nil, errors.New("failed to cast payload to TTLV")
+	}
+
+	var getRespPayload kmip.GetResponsePayload
+	err = decoder.DecodeValue(&getRespPayload, ttlvPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reject other objects.
+	if getRespPayload.ObjectType != kmip14.ObjectTypeSymmetricKey {
+		return nil, fmt.Errorf("received object is of unknown type: %s", getRespPayload.ObjectType)
+	}
+
+	// Ensure the key has a value and also prevent nil derefs.
+	if getRespPayload.SymmetricKey == nil || getRespPayload.SymmetricKey.KeyBlock.KeyValue == nil {
+		return nil, errors.New("retrieved symmetric key has no value")
+	}
+
+	// return the raw bytes.
+	if keyMaterial, ok := getRespPayload.SymmetricKey.KeyBlock.KeyValue.KeyMaterial.([]byte); ok {
+		return keyMaterial, nil
+	}
+
+	return nil, errors.New("failed to convert the key material to bytes")
 }
 
 // TODO: use the following structs from https://github.com/gemalto/kmip-go

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -18,8 +18,6 @@ package kms
 
 import (
 	"context"
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/rand"
 	"encoding/json"
 	"errors"
@@ -184,17 +182,15 @@ func (kms secretsMetadataKMS) EncryptDEK(ctx context.Context, volumeID, plainDEK
 		return "", fmt.Errorf("failed to get passphrase: %w", err)
 	}
 
-	aead, err := generateCipher(passphrase, volumeID)
+	key, err := generateKeyFromPassphrase(passphrase, volumeID)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate cipher: %w", err)
+		return "", fmt.Errorf("failed to generate key for cipher: %w", err)
 	}
 
-	emd := encryptedMetadataDEK{}
-	emd.Nonce, err = generateNonce(aead.NonceSize())
+	emd, err := symmetricEncrypt(plainDEK, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to generated nonce: %w", err)
+		return "", fmt.Errorf("failed to encrypt the plainDEK: %w", err)
 	}
-	emd.DEK = aead.Seal(nil, emd.Nonce, []byte(plainDEK), nil)
 
 	emdData, err := json.Marshal(&emd)
 	if err != nil {
@@ -214,9 +210,9 @@ func (kms secretsMetadataKMS) DecryptDEK(ctx context.Context, volumeID, encrypte
 		return "", fmt.Errorf("failed to get passphrase: %w", err)
 	}
 
-	aead, err := generateCipher(passphrase, volumeID)
+	key, err := generateKeyFromPassphrase(passphrase, volumeID)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate cipher: %w", err)
+		return "", fmt.Errorf("failed to generate key for cipher: %w", err)
 	}
 
 	emd := encryptedMetadataDEK{}
@@ -226,12 +222,12 @@ func (kms secretsMetadataKMS) DecryptDEK(ctx context.Context, volumeID, encrypte
 			"encryptedMetadataDEK: %w", err)
 	}
 
-	dek, err := aead.Open(nil, emd.Nonce, emd.DEK, nil)
+	val, err := symmetricDecrypt(&emd, key)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt DEK: %w", err)
 	}
 
-	return string(dek), nil
+	return val, nil
 }
 
 func (kms secretsMetadataKMS) GetSecret(ctx context.Context, volumeID string) (string, error) {
@@ -278,23 +274,15 @@ func (kms secretsMetadataKMS) fetchEncryptionPassphrase(
 	return passphraseValue, nil
 }
 
-// generateCipher returns a AEAD cipher based on a passphrase and salt
-// (volumeID). The cipher can then be used to encrypt/decrypt the DEK.
-func generateCipher(passphrase, salt string) (cipher.AEAD, error) {
+// generateKeyFromPassphrase generates a 256bit key to be used for
+// crypto operations from the provided passphrase and salt.
+func generateKeyFromPassphrase(passphrase, salt string) ([]byte, error) {
 	key, err := scrypt.Key([]byte(passphrase), []byte(salt), 32768, 8, 1, 32)
 	if err != nil {
 		return nil, err
 	}
-	blockCipher, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	aead, err := cipher.NewGCM(blockCipher)
-	if err != nil {
-		return nil, err
-	}
 
-	return aead, nil
+	return key, nil
 }
 
 // generateNonce returns a byte slice with random contents.

--- a/internal/kms/secretskms_test.go
+++ b/internal/kms/secretskms_test.go
@@ -50,15 +50,88 @@ func TestGenerateNonce(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGenerateCipher(t *testing.T) {
+func TestGenerateKeyFromPassphrase(t *testing.T) {
 	t.Parallel()
-	//nolint:gosec // this passphrase is intentionally hardcoded
-	passphrase := "my-cool-luks-passphrase"
-	salt := "unique-id-for-the-volume"
 
-	aead, err := generateCipher(passphrase, salt)
-	require.NoError(t, err)
-	require.NotNil(t, aead)
+	tests := []struct {
+		name       string
+		passphrase string
+		salt       string
+		wantErr    bool
+	}{
+		{
+			name:       "basic valid inputs",
+			passphrase: "my-super-secret-passphrase",
+			salt:       "some-random-generated-salt",
+			wantErr:    false,
+		},
+		{
+			name:       "realistic volume ID as salt",
+			passphrase: "kubernetes-secret-passphrase",
+			salt:       "csi-vol-1b00f5f8-b1c1-11e9-8421-9243c1f659f0",
+			wantErr:    false,
+		},
+		{
+			name:       "empty passphrase",
+			passphrase: "",
+			salt:       "some-salt",
+			wantErr:    false,
+		},
+		{
+			name:       "empty salt",
+			passphrase: "some-passphrase",
+			salt:       "",
+			wantErr:    false,
+		},
+		{
+			name:       "both empty",
+			passphrase: "",
+			salt:       "",
+			wantErr:    false,
+		},
+		{
+			name:       "special characters in passphrase",
+			passphrase: "p@ssw0rd!#$%^&*()",
+			salt:       "salt",
+			wantErr:    false,
+		},
+		{
+			name:       "very long passphrase",
+			passphrase: "this-is-a-very-long-passphrase-that-goes-on-and-on-and-on-with-many-characters",
+			salt:       "short",
+			wantErr:    false,
+		},
+		{
+			name:       "very long salt",
+			passphrase: "short",
+			salt:       "this-is-a-very-long-salt-that-goes-on-and-on-and-on-with-many-characters",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := generateKeyFromPassphrase(tt.passphrase, tt.salt)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, key)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, key)
+			require.Len(t, key, 32, "key should be of 256 bits")
+
+			// We should get the same output for same input.
+			key2, err2 := generateKeyFromPassphrase(tt.passphrase, tt.salt)
+			require.NoError(t, err2)
+			require.Equal(t, key, key2, "same inputs should produce identical keys")
+		})
+	}
 }
 
 func TestInitSecretsMetadataKMS(t *testing.T) {

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -122,6 +122,36 @@ func setConfigString(option *string, config map[string]interface{}, key string) 
 	return nil
 }
 
+// setConfigBoolean fetches a value from a configuration map and converts it to
+// a boolean.
+//
+// If the value is not available, *option is not adjusted and
+// errConfigOptionMissing is returned.
+// In case the value is available, but can not be parsed to a boolean,
+// errConfigOptionInvalid is returned.
+func setConfigBoolean(option *bool, config map[string]any, key string) error {
+	value, ok := config[key]
+	if !ok {
+		return fmt.Errorf("%w: %s", errConfigOptionMissing, key)
+	}
+
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("%w: expected string for %q, but got %T",
+			errConfigOptionInvalid, key, value)
+	}
+
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return fmt.Errorf("%w: expected a valid boolean value for %q, but got %T",
+			errConfigOptionInvalid, key, value)
+	}
+
+	*option = b
+
+	return nil
+}
+
 // Destroy frees allocated resources. For a vaultConnection that means removing
 // the created temporary files.
 func (vc *vaultConnection) Destroy() {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This patch adds support for GKLM KMS using the KMIP protocol.

Details specific to GKLM:
- Get RPC to encrypt and decrypt the KEK for LUKS.
- KMS' `USE_CRYPTO_RPC` is used to distinguish between which RPC to
  call.
  - If `USE_CRYPTO_RPC` is true, `Encrypt/Decrypt` RPCs are called.
  - If `USE_CRYPTO_RPC` is false, `Get` RPC is called to fetch the key
    by its UUID and encryption/decryption is done locally.
