### PR TITLE
rbd: update PV metadata

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -669,7 +669,7 @@ func RegenerateJournal(
 			}
 		}
 		// Update Metadata on reattach of the same old PV
-		parameters := k8s.PrepareVolumeMetadata(claimName, owner, "")
+		parameters := k8s.PrepareVolumeMetadata(claimName, owner, requestName)
 		err = rbdVol.setAllMetadata(parameters)
 		if err != nil {
 			return "", fmt.Errorf("failed to set volume metadata: %w", err)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
When regenerating journal pass the requestName
parameter to PrepareVolumeMetadata instead of
an empty string.
```
Am not sure why we didn't set the PV metadata during RegenerateJournal. I tried to find from git blame and PR which introduced it but couldn't find any conversation around it. May be we missed noticing it?

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>


```
[pm@dhcp53-115 cephfs]$ k get pvc
NAME                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      VOLUMEATTRIBUTESCLASS   AGE
raw-block-rbd-pvc   Bound    pvc-cd9e6b0d-a846-4b4a-91fd-734a13231527   1Gi        RWO            rook-ceph-block   <unset>                 20d

[pm@dhcp53-115 cephfs]$ k exec -it rook-direct-mount-5f695b75d8-5mzwg -- bash
[root@c1 /]# rbd image-meta ls replicapool/csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a
There are 4 metadata on this image:

Key                               Value
csi.ceph.com/cluster/name         my-cluster
csi.storage.k8s.io/pv/name        pvc-cd9e6b0d-a846-4b4a-91fd-734a13231527
csi.storage.k8s.io/pvc/name       raw-block-rbd-pvc
csi.storage.k8s.io/pvc/namespace  rook-ceph

########### Remove Metadata ###########

[root@c1 /]# rbd image-meta rm replicapool/csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a csi.storage.k8s.io/pv/name
[root@c1 /]# rbd image-meta rm replicapool/csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a csi.storage.k8s.io/pvc/name
[root@c1 /]# rbd image-meta rm replicapool/csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a csi.storage.k8s.io/pvc/namespace
[root@c1 /]# rbd image-meta ls replicapool/csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a
There is 1 metadatum on this image:

Key                        Value
csi.ceph.com/cluster/name  my-cluster
[root@c1 /]#

########### Restart the RBD controller plugin pod ###########

I0213 09:25:20.870308       1 controller.go:460] "Reconciling" controller="persistentvolume-controller" namespace="" name="pvc-cd9e6b0d-a846-4b4a-91fd-734a13231527" reconcileID="1ab42231-c294-4089-8129-e204e9a55eb6"
I0213 09:25:20.945133       1 omap.go:89] got omap values: (pool="replicapool", namespace="", name="csi.volumes.default"): map[csi.volume.pvc-cd9e6b0d-a846-4b4a-91fd-734a13231527:e9aa241a-8416-497d-a808-2ff7488de04a]
I0213 09:25:20.947276       1 omap.go:89] got omap values: (pool="replicapool", namespace="", name="csi.volume.e9aa241a-8416-497d-a808-2ff7488de04a"): map[csi.imageid:e8ec82165fb0 csi.imagename:csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a csi.volname:pvc-cd9e6b0d-a846-4b4a-91fd-734a13231527 csi.volume.owner:rook-ceph]
I0213 09:25:21.076891       1 controller.go:489] "Reconcile successful" controller="persistentvolume-controller" namespace="" name="pvc-cd9e6b0d-a846-4b4a-91fd-734a13231527" reconcileID="1ab42231-c294-4089-8129-e204e9a55eb6


########### Check image Metadata ###########

[pm@dhcp53-115 cephfs]$ k exec -it rook-direct-mount-5f695b75d8-5mzwg -- bash
[root@c1 /]# rbd image-meta ls replicapool/csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a
There are 3 metadata on this image:

Key                               Value
csi.ceph.com/cluster/name         my-cluster
csi.storage.k8s.io/pvc/name       raw-block-rbd-pvc
csi.storage.k8s.io/pvc/namespace  rook-ceph


^^^ pv/name metadata is missing ^^^

########### With this PR fix ###########

[root@c1 /]# rbd image-meta ls replicapool/csi-vol-e9aa241a-8416-497d-a808-2ff7488de04a
There are 4 metadata on this image:

Key                               Value
csi.ceph.com/cluster/name         my-cluster
csi.storage.k8s.io/pv/name        pvc-cd9e6b0d-a846-4b4a-91fd-734a13231527
csi.storage.k8s.io/pvc/name       raw-block-rbd-pvc
csi.storage.k8s.io/pvc/namespace  rook-ceph
```
