### PR TITLE
nvmeof: Support resolving IP address for NVMe-oF gateway listeners

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -478,6 +478,26 @@ func validatePublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error
 	return util.ValidateControllerPublishVolumeRequest(req)
 }
 
+// parseListeners parses the listeners JSON parameter and validates its contents.
+// it possible to have zero listeners if networkMask is provided,
+// because in that case the gateway will automatically create listeners
+// for all interfaces in the specified network mask.
+// Also it possible to have listeners with empty address or port,
+// in that case the gateway will listen on all
+// interfaces (0.0.0.0) and use the default port (4420).
+// example of listeners JSON:
+// [
+//
+//	{
+//	  "hostname": "gateway-1",
+//	  "address": "192.168.234.123",
+//	  "port": 4420
+//	},
+//	{
+//	  "hostname": "gateway-2.ceph.example.net"
+//	}
+//
+// ].
 func parseListeners(listenersJSON string) ([]nvmeof.ListenerDetails, error) {
 	if listenersJSON == "" { // No "listeners" entry was provided
 		return []nvmeof.ListenerDetails{}, nil
@@ -492,9 +512,11 @@ func parseListeners(listenersJSON string) ([]nvmeof.ListenerDetails, error) {
 	}
 
 	// Validate each listener
+	// Listener address can be empty. it will set to default 0.0.0.0
+	// Port can be empty (will use default - 4420).
 	for i, listener := range listeners {
-		if listener.Address == "" || listener.Port == 0 || listener.Hostname == "" {
-			return nil, fmt.Errorf("listener %d: missing required fields (address, port, hostname)", i)
+		if listener.Hostname == "" {
+			return nil, fmt.Errorf("listener %d: missing required fields (hostname)", i)
 		}
 	}
 
@@ -732,11 +754,6 @@ func (cs *Server) createNVMeoFResources(
 	// Step 1: Extract parameters (already validated)
 	params := req.GetParameters()
 
-	// Parse listeners from JSON
-	listeners, err := parseListeners(params["listeners"])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse listeners: %w", err)
-	}
 	networkMask := params["networkMask"]
 	nvmeofGatewayPortStr := params["nvmeofGatewayPort"]
 	nvmeofGatewayPort, err := strconv.ParseUint(nvmeofGatewayPortStr, 10, 32)
@@ -745,9 +762,9 @@ func (cs *Server) createNVMeoFResources(
 	}
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
 		SubsystemNQN:  params["subsystemNQN"],
-		NamespaceID:   0,  // will be set after namespace creation,
-		NamespaceUUID: "", // will be set after namespace creation
-		ListenerInfo:  listeners,
+		NamespaceID:   0,   // will be set after namespace creation,
+		NamespaceUUID: "",  // will be set after namespace creation
+		ListenerInfo:  nil, // will be set after listener creation or retrieval
 		GatewayManagementInfo: nvmeof.GatewayConfig{
 			Address: params["nvmeofGatewayAddress"],
 			Port:    uint32(nvmeofGatewayPort),
@@ -756,6 +773,12 @@ func (cs *Server) createNVMeoFResources(
 			DhchapMode:          params["dhchapMode"],
 			AuthenticationKMSID: params["authenticationKMSID"],
 		},
+	}
+
+	// setup listeners (if provided, otherwise it will be set by gateway based on network mask)
+	err = setupDefaultListenersValues(params["listeners"], nvmeofData)
+	if err != nil {
+		return nil, err
 	}
 
 	// If dhchapMode was explicitly provided and is not "none", and authenticationKMSID is empty,
@@ -1278,4 +1301,30 @@ func connectGateway(ctx context.Context, config *nvmeof.GatewayConfig) (*nvmeof.
 	log.DebugLog(ctx, "Connected to the gateway %s", config)
 
 	return gateway, nil
+}
+
+// setupDefaultListeners validates and sets up default values for NVMe-oF listeners.
+// if listeners are provided, it ensures they are fully populated with
+// default values if needed (port and address).
+func setupDefaultListenersValues(listenersJSON string, info *nvmeof.NVMeoFVolumeData) error {
+	// Parse listeners from JSON
+	listeners, err := parseListeners(listenersJSON)
+	if err != nil {
+		return fmt.Errorf("failed to parse listeners: %w", err)
+	}
+
+	// ensure listeners are fully populated with default values if needed (port and address)
+	// before storing in metadata and creating subsystem/listeners
+	for i := range listeners {
+		if listeners[i].Port == 0 {
+			listeners[i].Port = 4420
+		}
+		// if address is empty, set it to default 0.0.0.0
+		if listeners[i].Address == "" {
+			listeners[i].Address = "0.0.0.0"
+		}
+	}
+	info.ListenerInfo = listeners
+
+	return nil
 }

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -55,13 +55,13 @@ type NodeServer struct {
 
 // ConnectionInfo holds NVMe-oF connection details.
 type NvmeConnectionInfo struct {
-	SubsystemNQN  string                  `json:"subsystemNQN"`
-	NamespaceID   uint32                  `json:"namespaceID"`
-	NamespaceUUID string                  `json:"namespaceUUID"`
-	Listeners     []nvmeof.GatewayAddress `json:"listeners"`
-	HostNQN       string                  `json:"hostNQN,omitempty"`
-	Transport     string                  `json:"transport"`
-	DhchapMode    string                  `json:"dhchapMode,omitempty"`
+	SubsystemNQN  string                   `json:"subsystemNQN"`
+	NamespaceID   uint32                   `json:"namespaceID"`
+	NamespaceUUID string                   `json:"namespaceUUID"`
+	Listeners     []nvmeof.ListenerDetails `json:"listeners"`
+	HostNQN       string                   `json:"hostNQN,omitempty"`
+	Transport     string                   `json:"transport"`
+	DhchapMode    string                   `json:"dhchapMode,omitempty"`
 }
 
 // stageTransaction struct represents the state a transaction was when it either completed
@@ -576,7 +576,7 @@ func (ns *NodeServer) getNvmeConnection(volumeContext, publishContext map[string
 		return nil, errors.New("missing listeners in volume context")
 	}
 
-	var listeners []nvmeof.GatewayAddress
+	var listeners []nvmeof.ListenerDetails
 	if err := json.Unmarshal([]byte(listenersJSON), &listeners); err != nil {
 		return nil, fmt.Errorf("failed to parse listeners JSON: %w", err)
 	}
@@ -616,7 +616,6 @@ func (ns *NodeServer) connectToSubsystem(
 	// Create connect request
 	connectReq := &nvmeof.ConnectRequest{
 		SubsystemNQN: info.SubsystemNQN,
-		Listeners:    info.Listeners,
 		Transport:    info.Transport,
 		HostNQN:      info.HostNQN,
 	}
@@ -628,8 +627,15 @@ func (ns *NodeServer) connectToSubsystem(
 		}
 	}
 
+	// Resolve listener IP addresses
+	validListeners, err := nvmeof.ResolveListeners(ctx, info.Listeners)
+	if err != nil {
+		return "", fmt.Errorf("failed to setup listeners: %w", err)
+	}
+
+	connectReq.Listeners = validListeners
 	// Connect to subsystem
-	_, err := ns.initiator.ConnectSubsystem(ctx, connectReq)
+	_, err = ns.initiator.ConnectSubsystem(ctx, connectReq)
 	if err != nil {
 		return "", fmt.Errorf("failed to connect to subsystem: %w", err)
 	}

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -58,7 +58,7 @@ type NVMeInitiator interface {
 // ConnectRequest represents a subsystem connection request.
 type ConnectRequest struct {
 	SubsystemNQN string
-	Listeners    []GatewayAddress
+	Listeners    []ListenerDetails
 	Transport    string // "tcp"
 	HostNQN      string // Optional - empty means use system default
 	// Optional - In-band authentication controller secret for bi-directional authentication.
@@ -298,4 +298,46 @@ func (nhc nvmeHostConnections) hasPathToGateway(subsystemNQN, hostNQN,
 	}
 
 	return false
+}
+
+// ResolveListeners resolves listener IP addresses from hostnames and returns only valid listeners.
+// Returns error only if all listeners fail to resolve.
+func ResolveListeners(ctx context.Context, listeners []ListenerDetails) ([]ListenerDetails, error) {
+	var resolveErrors []string
+	var validListeners []ListenerDetails
+
+	for i := range listeners {
+		// if the address was empty, and the controller assigned it to default 0.0.0.0,
+		// resolve the IP address from hostname for the node to connect to the subsystem
+		if listeners[i].Address == "0.0.0.0" {
+			addrs, err := ResolveIPAddress(listeners[i].Hostname)
+			if err != nil {
+				errMsg := fmt.Sprintf("listener %d (%s): %v", i, listeners[i].Hostname, err)
+				log.WarningLog(ctx, "%s", errMsg)
+				resolveErrors = append(resolveErrors, errMsg)
+
+				continue // Skip this listener
+			}
+			listeners[i].Address = addrs
+			log.DebugLog(ctx, "Resolved %s to %s", listeners[i].Hostname, listeners[i].Address)
+		}
+
+		// Add to valid listeners (either resolved or already had an address)
+		validListeners = append(validListeners, listeners[i])
+	}
+
+	// If no listeners succeeded, return error
+	if len(validListeners) == 0 {
+		return nil, fmt.Errorf("failed to resolve any listener hostnames: %v", strings.Join(resolveErrors, "; "))
+	}
+
+	// If some failed, log warning but continue
+	if len(resolveErrors) > 0 {
+		log.WarningLog(ctx, "Some listeners failed to resolve (using %d valid listeners): %v",
+			len(validListeners), strings.Join(resolveErrors, "; "))
+	}
+
+	log.DebugLog(ctx, "Successfully resolved %d listener(s)", len(validListeners))
+
+	return validListeners, nil
 }

--- a/internal/nvmeof/util.go
+++ b/internal/nvmeof/util.go
@@ -17,6 +17,8 @@ limitations under the License.
 package nvmeof
 
 import (
+	"fmt"
+	"net"
 	"strings"
 
 	"github.com/google/uuid"
@@ -38,4 +40,21 @@ func formatUUID(rawUUID string) string {
 	}
 
 	return newUUID.String()
+}
+
+// ResolveIPAddress resolves the given host to an IP address.
+// It returns the first resolved IP address as a string, or an error if resolution fails.
+func ResolveIPAddress(host string) (string, error) {
+	// TODO - IPv6 support: we currently return the first resolved address,
+	// which may be an IPv4 or IPv6 address. We should consider how to handle this
+	// in a way that supports both protocols.
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve %s: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("no IP addresses for %s", host)
+	}
+
+	return addrs[0], nil
 }


### PR DESCRIPTION
# Describe what this PR does #

This PR adds the ability to specify gateway hostnames in the (e.g.) StorageClass listeners parameter instead of hardcoded IP addresses. The CSI driver now resolves hostnames to IP addresses at connection time, enabling stable configuration even when gateway pods restart with new IPs.


now the user can config just once like this:

```yaml
listeners: |
 [
  {
      "hostname": "ceph-nvmeof-gateway-0"
   },
  {
      "hostname": "ceph-nvmeof-gateway-1"
  }
]
```


Is the change backward compatible? 
**yes. it still possible to set manually the listener's parameters.** 

## Related issues\PR ##
Niels solution PR: https://github.com/ceph/ceph-csi/pull/5996
rook_issue - https://github.com/rook/rook/issues/16949

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
