### PR TITLE
Add service account based volume access restriction

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,9 +2,24 @@
 
 ## Breaking changes
 
+- NFS CSIDriver object's `spec.attachRequired` is now set to `true`
+  to accommodate Kubernetes ServiceAccount based volume access restriction
+  feature. This is a breaking change for users who have already deployed the
+  NFS driver and are upgrading to v3.17. Users will need to delete and recreate
+  the CSIDriver object for NFS during upgradie to v3.17.
+- NVME-OF Storageclass now needs publish secrets to accommodate the
+  Kubernetes ServiceAccount based volume access restriction.
+  This is a breaking change for users who have already deployed the NVME-OF driver
+  and are upgrading to v3.17. Users will need to recreate the NVME-OF Storageclass
+  with publish secrets during upgrade to v3.17.
+
 ## Features
 
 - nfs: allow changing NFS-server through ControllerModifyVolume [PR](https://github.com/ceph/ceph-csi/pull/5829)
 - util: add support for GKLM KMS over KMIP [PR](https://github.com/ceph/ceph-csi/pull/6048)
+- rbd: add Kubernetes ServiceAccount based volume access restriction
+- nvmeof: add Kubernetes ServiceAccount based volume access restriction
+- cephfs: add Kubernetes ServiceAccount based volume access restriction
+- nfs: add Kubernetes ServiceAccount based volume access restriction
 
 ## NOTE

--- a/api/deploy/kubernetes/cephfs/csidriver.yaml
+++ b/api/deploy/kubernetes/cephfs/csidriver.yaml
@@ -5,6 +5,6 @@ metadata:
   name: "{{ .Name }}"
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   fsGroupPolicy: File
   seLinuxMount: true

--- a/api/deploy/kubernetes/nfs/csidriver.yaml
+++ b/api/deploy/kubernetes/nfs/csidriver.yaml
@@ -4,7 +4,8 @@ kind: CSIDriver
 metadata:
   name: "{{ .Name }}"
 spec:
-  attachRequired: false
+  attachRequired: true
+  podInfoOnMount: true
   fsGroupPolicy: File
   seLinuxMount: true
   volumeLifecycleModes:

--- a/api/deploy/kubernetes/rbd/csidriver.yaml
+++ b/api/deploy/kubernetes/rbd/csidriver.yaml
@@ -5,6 +5,6 @@ metadata:
   name: "{{ .Name }}"
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   seLinuxMount: true
   fsGroupPolicy: File

--- a/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-cephfs/templates/csidriver-crd.yaml
@@ -10,6 +10,6 @@ metadata:
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:
   attachRequired: {{ .Values.provisioner.attacher.enabled }}
-  podInfoOnMount: false
+  podInfoOnMount: true
   fsGroupPolicy: {{ .Values.CSIDriver.fsGroupPolicy }}
   seLinuxMount: {{ .Values.CSIDriver.seLinuxMount }}

--- a/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
+++ b/charts/ceph-csi-rbd/templates/csidriver-crd.yaml
@@ -10,6 +10,6 @@ metadata:
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   fsGroupPolicy: {{ .Values.CSIDriver.fsGroupPolicy }}
   seLinuxMount: {{ .Values.CSIDriver.seLinuxMount }}

--- a/deploy/cephfs/kubernetes/csidriver.yaml
+++ b/deploy/cephfs/kubernetes/csidriver.yaml
@@ -12,6 +12,6 @@ metadata:
   name: "cephfs.csi.ceph.com"
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   fsGroupPolicy: File
   seLinuxMount: true

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -97,6 +97,29 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
+          args:
+            - "--v=1"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election=true"
+            - "--retry-interval-start=500ms"
+            - "--http-endpoint=$(POD_IP):8093"
+          env:
+            - name: ADDRESS
+              value: /csi/csi-provisioner.sock
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 8093
+              name: attacher
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: csi-resizer
           image: gcr.io/k8s-staging-sig-storage/csi-resizer:canary
           args:

--- a/deploy/nfs/kubernetes/csidriver.yaml
+++ b/deploy/nfs/kubernetes/csidriver.yaml
@@ -11,7 +11,8 @@ kind: CSIDriver
 metadata:
   name: "nfs.csi.ceph.com"
 spec:
-  attachRequired: false
+  attachRequired: true
+  podInfoOnMount: true
   fsGroupPolicy: File
   seLinuxMount: true
   volumeLifecycleModes:

--- a/deploy/nvmeof/kubernetes/csidriver.yaml
+++ b/deploy/nvmeof/kubernetes/csidriver.yaml
@@ -5,6 +5,6 @@ metadata:
   name: "nvmeof.csi.ceph.com"
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   seLinuxMount: true
   fsGroupPolicy: File

--- a/deploy/rbd/kubernetes/csidriver.yaml
+++ b/deploy/rbd/kubernetes/csidriver.yaml
@@ -12,6 +12,6 @@ metadata:
   name: "rbd.csi.ceph.com"
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   seLinuxMount: true
   fsGroupPolicy: File

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -302,6 +302,11 @@ we have successfully upgraded RBD csi from v3.15 to v3.16
 
 ### Upgrading NFS
 
+> **Note:** Only for upgrade from v3.16 to v3.17, old NFS csidriver
+object will need to be deleted and created again since
+the `spec.attachRequired` field is being updated to `true` in
+v3.17 release. Refer to v3.17 release notes for more details.
+
 Upgrading nfs csi includes upgrade of nfs driver and as well as
 kubernetes sidecar containers and also the permissions required for the
 kubernetes sidecar containers, lets upgrade the things one by one

--- a/docs/cephfs/deploy.md
+++ b/docs/cephfs/deploy.md
@@ -266,3 +266,92 @@ plain password (Kubernetes Secrets) work.
 Requires subvolumegroup to be created before provisioning the PVC.
 If the subvolumegroup provided in `ceph-csi-config` ConfigMap is missing
 in the ceph cluster, the PVC creation will fail and will stay in `Pending` state.
+
+## Kubernetes ServiceAccount Based Volume Access
+
+Ceph-CSI supports optionally restricting CephFS subvolume
+access to specific Kubernetes ServiceAccounts. When
+configured, only Pods running with one of the allowed
+ServiceAccounts can mount the subvolume. One or more
+ServiceAccounts can be specified as a comma-separated
+list. This feature uses CephFS subvolume metadata to
+store the restriction and the CSI
+[`podInfoOnMount`][pod-info-on-mount] mechanism to
+identify the Pod's ServiceAccount during mount.
+
+[pod-info-on-mount]:
+<https://kubernetes-csi.github.io/docs/pod-info.html#pod-info-on-mount-with-csi-driver-object>
+
+### How it works
+
+1. A storage admin sets the
+   `.cephfs.csi.ceph.com/serviceaccount` metadata on a
+   CephFS subvolume to specify the allowed
+   ServiceAccount name(s) as a comma-separated list.
+1. During `ControllerPublishVolume`, Ceph-CSI reads this metadata and passes
+   it to the node via publish context.
+1. During `NodePublishVolume`, Ceph-CSI splits the
+   comma-separated value and checks whether the Pod's
+   ServiceAccount (provided via volume context by
+   Kubelet) matches any entry.
+1. If the ServiceAccount was set in metadata and does
+   not match any of the allowed ServiceAccounts, the
+   mount is rejected with a `PermissionDenied` error.
+
+### Prerequisites
+
+The [`podInfoOnMount`][pod-info-on-mount] field must be
+set to `true` in the CSIDriver spec so that Kubelet
+passes Pod information (including ServiceAccount name)
+in the volume context during `NodePublishVolume`.
+Without this, the restriction cannot be enforced and
+all mounts are allowed.
+
+This feature requires controller-publish-secret set in storageclass
+for newer PVCs. For existing PVCs, the workaround mentioned
+[here](../design/proposals/non-graceful-node-shutdown.md#workaround-for-older-pvs)
+can be used.
+
+### Setting the restriction on a CephFS subvolume
+
+Use the `ceph fs subvolume metadata set` command to
+set the allowed ServiceAccount(s). Multiple
+ServiceAccounts can be specified as a
+comma-separated list:
+
+```bash
+ceph fs subvolume metadata set \
+  <filesystem> <subvolume> --group_name=<group> \
+  .cephfs.csi.ceph.com/serviceaccount \
+  <service-account-name>[,<service-account-name>...]
+```
+
+For example, to restrict a subvolume to the
+`my-app-sa` ServiceAccount:
+
+```bash
+ceph fs subvolume metadata set myfs \
+  csi-vol-abc123 --group_name=csi \
+  .cephfs.csi.ceph.com/serviceaccount my-app-sa
+```
+
+To allow multiple ServiceAccounts:
+
+```bash
+ceph fs subvolume metadata set myfs \
+  csi-vol-abc123 --group_name=csi \
+  .cephfs.csi.ceph.com/serviceaccount \
+  my-app-sa,my-worker-sa
+```
+
+### Removing the restriction
+
+To remove the restriction and allow any ServiceAccount to mount the subvolume:
+
+```bash
+ceph fs subvolume metadata rm <filesystem> <subvolume> --group_name=<group> \
+  .cephfs.csi.ceph.com/serviceaccount
+```
+
+All the Pods using the PVC should be scaled down completely and then scaled up for
+removing the restriction after removing metadata from the subvolume.

--- a/docs/design/proposals/k8s-sa-based-volume-access-restriction.md
+++ b/docs/design/proposals/k8s-sa-based-volume-access-restriction.md
@@ -1,0 +1,167 @@
+# Kubernetes ServiceAccount Based Volume Access Restriction
+
+## Introduction
+
+This proposal introduces an optional mechanism to restrict volume access based
+on the Kubernetes ServiceAccount of the Pod mounting the volume. When
+configured, only Pods running with one of the specified
+ServiceAccounts are allowed to mount the volume. All
+other mount attempts are rejected with a
+`PermissionDenied` error.
+
+The restriction is stored as metadata on the backend Ceph object (RBD image
+metadata or CephFS subvolume metadata) and is enforced at mount time through
+the CSI [`podInfoOnMount`][pod-info-on-mount] mechanism.
+This design depends solely on Kubernetes providing the Pod's ServiceAccount
+name in the volume context during `NodePublishVolume` calls via the standard
+key `csi.storage.k8s.io/serviceAccount.name: {pod.Spec.ServiceAccountName}`.
+No other validation is performed on the ServiceAccount name.
+
+[pod-info-on-mount]:
+<https://kubernetes-csi.github.io/docs/pod-info.html#pod-info-on-mount-with-csi-driver-object>
+
+## Motivation
+
+Ceph-CSI volumes are accessible to any Pod that has a valid PVC reference and
+the necessary RBAC to use the StorageClass. In multi-tenant and data pipeline
+environments, this is insufficient. There are scenarios where a volume should
+be exclusively accessible to a specific workload identity even when other Pods
+in the same namespace can reference the PVC.
+
+### Use Case: Ceph VolSync Plugin Replication Destination PVC Protection
+
+A primary motivator for this feature is the custom
+[Ceph VolSync Plugin](https://github.com/RamenDR/ceph-volsync-plugin) that
+performs incremental data replication across clusters. In a disaster recovery
+or migration workflow:
+
+1. A `ReplicationDestination` controller creates a PVC on the destination
+   cluster to receive replicated data.
+1. A replication worker Pod, running under a dedicated ServiceAccount (e.g.
+   `volsync-worker-sa`), incrementally syncs data from the source cluster into
+   this destination PVC.
+1. The destination PVC must remain writable only by the replication worker
+   until the replication is complete and a failover is triggered.
+
+Without ServiceAccount based restriction, any Pod in the namespace with a
+reference to the destination PVC could write to it, potentially corrupting the
+replicated data or breaking the incremental sync state. By binding the
+destination volume to the replication worker's ServiceAccount, the volume is
+protected from unintended writes throughout the replication lifecycle. On
+failover, the restriction is removed so the application workload can mount
+the volume.
+
+### Other Potential Use Cases
+
+- **Sensitive data volumes**: Restrict access to volumes containing regulated
+  data to only the ServiceAccount authorized to process them.
+- **Custom usecases**: Similar usecases where a
+  workload identity needs exclusive access to a volume
+  for data integrity or security reasons.
+
+## Dependency
+
+- The [`podInfoOnMount`][pod-info-on-mount] field must
+  be set to `true` in the CSIDriver specification.
+  This causes Kubelet to inject Pod information
+  (including the ServiceAccount name) into the volume
+  context during `NodePublishVolume`. Without this,
+  the restriction cannot be enforced. Since this
+  parameter is a mutable field in the CSIDriver spec,
+  it will be enabled by default going
+  forward(cephcsi v3.17.0+).
+
+## Design
+
+### Metadata Keys
+
+Each driver type uses a driver-specific metadata key to
+store the allowed ServiceAccount name(s) as a
+comma-separated list (e.g. `sa1,sa2,sa3`):
+
+| Driver | Metadata Key | Storage |
+|--------|-------------|---------|
+| RBD | `.rbd.csi.ceph.com/serviceaccount` | RBD image metadata |
+| CephFS | `.cephfs.csi.ceph.com/serviceaccount` | CephFS subvolume metadata |
+| NVMe-oF | `.rbd.csi.ceph.com/serviceaccount` | RBD image metadata (via RBD backend) |
+| NFS | `.cephfs.csi.ceph.com/serviceaccount` | CephFS subvolume metadata (via CephFS backend) |
+
+One or more ServiceAccounts can be specified per volume,
+separated by commas.
+
+### CSI Flow
+
+The restriction is enforced across two CSI RPCs:
+
+1. **ControllerPublishVolume**: The controller reads the ServiceAccount
+   metadata from the Ceph backend. If present, it is included in the publish
+   context passed to the node.
+
+1. **NodePublishVolume**: The node plugin splits the
+   publish context value on commas and checks whether
+   the Pod's ServiceAccount (provided by Kubelet via
+   `csi.storage.k8s.io/serviceAccount.name` in the
+   volume context) matches any entry. A mismatch
+   results in a `PermissionDenied` error. If no
+   restriction is set, or if `podInfoOnMount` is not
+   enabled, the mount is allowed.
+
+### Implementation
+
+A shared validation function `ValidateServiceAccountRestriction` in
+`internal/util/validate.go` is called at the beginning of `NodePublishVolume`
+in all four drivers (RBD, CephFS, NFS, NVMe-oF), ensuring consistent
+enforcement.
+
+Each driver reads the restriction metadata in `ControllerPublishVolume` using
+its backend:
+
+- **RBD**: reads via `GetMetadata` in `internal/rbd/controllerserver.go`.
+- **CephFS**: reads via `ListMetadata` in
+  `internal/cephfs/controllerserver.go`.
+- **NVMe-oF**: delegates to the RBD backend and propagates the publish context
+  in `internal/nvmeof/controller/controllerserver.go`.
+- **NFS**: delegates to the CephFS backend in
+  `internal/nfs/controller/controllerserver.go`.
+
+## Setting and Removing the Restriction
+
+The restriction is managed through Ceph CLI commands. Refer to the
+"Kubernetes ServiceAccount Based Volume Access" sections in
+[RBD deploy.md](../../rbd/deploy.md) and
+[CephFS deploy.md](../../cephfs/deploy.md) for usage
+instructions and examples.
+
+## Ceph VolSync Plugin Integration Example
+
+1. The replication destination worker sets the
+   ServiceAccount restriction on the backing Ceph
+   object(RBD image or CephFS subvolume) to the
+   replication worker's ServiceAccount
+   (e.g.`volsync-worker-sa`) on first use.
+1. Only the worker Pod mounts the destination PVC successfully because its
+   ServiceAccount matches. Any other Pod attempting to mount the same PVC is
+   rejected with `PermissionDenied` during NodePublish call, protecting data
+   integrity during incremental sync.
+1. On replication destination deletion, the controller spins up a cleanup job
+   that removes the ServiceAccount restriction
+   metadata, allowing the application workload to
+   mount the volume.
+
+## Limitations
+
+- Enforced at CSI mount time only; does not prevent direct access to the
+  underlying Ceph storage from outside Kubernetes.
+- If `podInfoOnMount` is not enabled, the restriction is silently unenforced.
+- Changing the restriction on an already-mounted volume does not affect
+  existing mounts. The volume must be unmounted and remounted.
+- Managed through Ceph CLI commands, not Kubernetes-native APIs.
+
+## Future Enhancements
+
+- Support restriction based on other attributes (e.g. name, namespace) in
+  addition to ServiceAccount.
+- Provide more flexible configuration key value options (e.g. receiving both
+  expected key-value pairs in the volume context instead of a single
+  ServiceAccount name).
+- Support restriction for static volumes.

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -602,3 +602,88 @@ Additional Resources:
 
 * External Snapshot Metadata sidecar project:
   [repository](https://github.com/kubernetes-csi/external-snapshot-metadata)
+
+## Kubernetes ServiceAccount Based Volume Access
+
+Ceph-CSI supports optionally restricting RBD volume
+access to specific Kubernetes ServiceAccounts. When
+configured, only Pods running with one of the allowed
+ServiceAccounts can mount the volume. One or more
+ServiceAccounts can be specified as a comma-separated
+list. This feature uses RBD image metadata to store
+the restriction and the CSI
+[`podInfoOnMount`][pod-info-on-mount] mechanism to identify
+the Pod's ServiceAccount during mount.
+
+[pod-info-on-mount]:
+<https://kubernetes-csi.github.io/docs/pod-info.html#pod-info-on-mount-with-csi-driver-object>
+
+### How it works
+
+1. A storage admin sets the
+   `.rbd.csi.ceph.com/serviceaccount` metadata on an
+   RBD image to specify the allowed ServiceAccount
+   name(s) as a comma-separated list.
+1. During `ControllerPublishVolume`, Ceph-CSI reads this metadata and passes
+   it to the node via publish context.
+1. During `NodePublishVolume`, Ceph-CSI splits the
+   comma-separated value and checks whether the Pod's
+   ServiceAccount (provided via volume context by
+   Kubelet) matches any entry.
+1. If the ServiceAccount was set in metadata and does
+   not match any of the allowed ServiceAccounts, the
+   mount is rejected with a `PermissionDenied` error.
+
+### Prerequisites
+
+The [`podInfoOnMount`][pod-info-on-mount] field must be
+set to `true` in the CSIDriver spec so that Kubelet
+passes Pod information (including ServiceAccount name)
+in the volume context during `NodePublishVolume`.
+Without this, the restriction cannot be enforced and
+all mounts are allowed.
+
+This feature requires controller-publish-secret set in storageclass
+for newer PVCs. For existing PVCs, the workaround mentioned
+[here](../design/proposals/non-graceful-node-shutdown.md#workaround-for-older-pvs)
+can be used.
+
+### Setting the restriction on an RBD image
+
+Use the `rbd image-meta set` command to set the
+allowed ServiceAccount(s). Multiple ServiceAccounts
+can be specified as a comma-separated list:
+
+```bash
+rbd image-meta set <pool>/<image> \
+  .rbd.csi.ceph.com/serviceaccount \
+  <service-account-name>[,<service-account-name>...]
+```
+
+For example, to restrict a volume to the
+`my-app-sa` ServiceAccount:
+
+```bash
+rbd image-meta set mypool/csi-vol-abc123 \
+  .rbd.csi.ceph.com/serviceaccount my-app-sa
+```
+
+To allow multiple ServiceAccounts:
+
+```bash
+rbd image-meta set mypool/csi-vol-abc123 \
+  .rbd.csi.ceph.com/serviceaccount \
+  my-app-sa,my-worker-sa
+```
+
+### Removing the restriction
+
+To remove the restriction and allow any ServiceAccount to mount the volume:
+
+```bash
+rbd image-meta remove <pool>/<image> .rbd.csi.ceph.com/serviceaccount
+```
+
+All the Pods using the PVC should be scaled down completely and
+then scaled up for removing the restriction after
+removing metadata from the image.

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -1733,6 +1733,19 @@ var _ = Describe(cephfsType, func() {
 			}
 		})
 
+		It("test service account based volume access restriction", func() {
+			err := validateCephFSServiceAccountVolumeRestriction(
+				pvcPath, appPath,
+				".cephfs.csi.ceph.com/serviceaccount",
+				f)
+			if err != nil {
+				logAndFail("service account volume restriction test failed: %v", err)
+			}
+			// validate no subvolumes remain
+			validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+			validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
+		})
+
 		if testCephFSFscrypt {
 			for _, kmsID := range []string{"secrets-metadata-test", "vault-test"} {
 				It("checking encrypted snapshot-backed volume with KMS "+kmsID, func() {

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -691,6 +691,278 @@ func verifyClientAddressMetadataSnapshotBacked(
 	return nil
 }
 
+func setCephFSSubvolumeMetadata(
+	f *framework.Framework,
+	filesystem,
+	subvolume,
+	groupname,
+	key,
+	value string,
+) error {
+	_, stdErr, err := execCommandInToolBoxPod(
+		f,
+		fmt.Sprintf("ceph fs subvolume metadata set %s %s --group_name=%s %s %q",
+			filesystem, subvolume, groupname, key, value),
+		rookNamespace)
+	if err != nil {
+		return err
+	}
+	if stdErr != "" {
+		return fmt.Errorf("%s", stdErr)
+	}
+
+	return nil
+}
+
+func removeCephFSSubvolumeMetadata(
+	f *framework.Framework,
+	filesystem,
+	subvolume,
+	groupname,
+	key string,
+) error {
+	_, stdErr, err := execCommandInToolBoxPod(
+		f,
+		fmt.Sprintf("ceph fs subvolume metadata rm %s %s --group_name=%s %s",
+			filesystem, subvolume, groupname, key),
+		rookNamespace)
+	if err != nil {
+		return err
+	}
+	if stdErr != "" {
+		return fmt.Errorf("%s", stdErr)
+	}
+
+	return nil
+}
+
+// validateCephFSServiceAccountVolumeRestriction tests that CephFS volume access
+// can be restricted to a specific Kubernetes service account. It creates a PVC,
+// sets the given saMetadataKey metadata on the backing CephFS subvolume, then
+// verifies:
+//   - A pod using the allowed service account can mount the volume.
+//   - A pod using a different service account is rejected with PermissionDenied.
+func validateCephFSServiceAccountVolumeRestriction(
+	pvcPath, appPath, saMetadataKey string,
+	f *framework.Framework,
+) error {
+	allowedSA := "allowed-sa-" + f.UniqueName
+	deniedSA := "denied-sa-" + f.UniqueName
+	thirdSA := "third-sa-" + f.UniqueName
+
+	// Create service accounts.
+	_, err := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Create(
+		context.TODO(),
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: allowedSA},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create allowed ServiceAccount: %w", err)
+	}
+	defer func() {
+		delErr := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Delete(
+			context.TODO(), allowedSA, metav1.DeleteOptions{})
+		if delErr != nil {
+			framework.Logf("failed to delete ServiceAccount %s: %v", allowedSA, delErr)
+		}
+	}()
+
+	_, err = f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Create(
+		context.TODO(),
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: deniedSA},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create denied ServiceAccount: %w", err)
+	}
+	defer func() {
+		delErr := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Delete(
+			context.TODO(), deniedSA, metav1.DeleteOptions{})
+		if delErr != nil {
+			framework.Logf("failed to delete ServiceAccount %s: %v", deniedSA, delErr)
+		}
+	}()
+
+	_, err = f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Create(
+		context.TODO(),
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: thirdSA},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create third ServiceAccount: %w", err)
+	}
+	defer func() {
+		delErr := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Delete(
+			context.TODO(), thirdSA, metav1.DeleteOptions{})
+		if delErr != nil {
+			framework.Logf("failed to delete ServiceAccount %s: %v", thirdSA, delErr)
+		}
+	}()
+
+	// Create PVC and wait for it to be bound.
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC: %w", err)
+	}
+	pvc.Namespace = f.UniqueName
+	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create PVC: %w", err)
+	}
+
+	defer func() {
+		delErr := deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+		if delErr != nil {
+			framework.Logf("failed to delete PVC: %v", delErr)
+		}
+	}()
+
+	// Get the subvolume name from the PVC.
+	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
+	if err != nil {
+		return fmt.Errorf("failed to get image info from PVC: %w", err)
+	}
+
+	// Set the service account restriction metadata on the subvolume.
+	err = setCephFSSubvolumeMetadata(f, fileSystemName, imageData.imageName, subvolumegroup,
+		saMetadataKey, allowedSA)
+	if err != nil {
+		return fmt.Errorf("failed to set service account metadata: %w", err)
+	}
+	defer func() {
+		delErr := removeCephFSSubvolumeMetadata(f, fileSystemName, imageData.imageName, subvolumegroup,
+			saMetadataKey)
+		if delErr != nil {
+			framework.Logf("failed to remove service account metadata: %v", delErr)
+		}
+	}()
+
+	// Verify the metadata was set correctly.
+	saValue, err := getCephFSSubvolumeMetadata(f, fileSystemName, imageData.imageName,
+		subvolumegroup, saMetadataKey)
+	if err != nil {
+		return fmt.Errorf("failed to get service account metadata: %w", err)
+	}
+	if saValue != allowedSA {
+		return fmt.Errorf("expected service account metadata %q, got %q", allowedSA, saValue)
+	}
+
+	// Test 1: Pod with the allowed service account should succeed.
+	app, err := loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-allowed-pod"
+	app.Spec.ServiceAccountName = allowedSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createApp(f.ClientSet, app, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("pod with allowed service account %q should have started but failed: %w", allowedSA, err)
+	}
+	framework.Logf("pod with allowed service account %q started successfully", allowedSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete allowed pod: %w", err)
+	}
+
+	// Test 2: Pod with a denied service account should fail with PermissionDenied.
+	app, err = loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app for denied test: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-denied-pod"
+	app.Spec.ServiceAccountName = deniedSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createAppErr(
+		f.ClientSet, app, deployTimeout,
+		[]string{"PermissionDenied", "is restricted to service account"},
+	)
+	if err != nil {
+		return fmt.Errorf("pod with denied service account should have failed with PermissionDenied: %w", err)
+	}
+	framework.Logf("pod with denied service account %q was correctly rejected", deniedSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete denied pod: %w", err)
+	}
+
+	// Wait for volume to be fully detached before updating metadata
+	// to ensure fresh ControllerPublishVolume call with new metadata.
+	err = waitForPVCVolumeAttachmentsCleanup(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to wait for volume detachment: %w", err)
+	}
+
+	// Test 3: Update metadata to a comma-separated list of allowed service accounts and verify access.
+	err = setCephFSSubvolumeMetadata(
+		f, fileSystemName, imageData.imageName, subvolumegroup, saMetadataKey, allowedSA+","+thirdSA)
+	if err != nil {
+		return fmt.Errorf("failed to set comma-separated service account metadata: %w", err)
+	}
+
+	// Verify the metadata was set correctly.
+	saValue, err = getCephFSSubvolumeMetadata(f, fileSystemName, imageData.imageName,
+		subvolumegroup, saMetadataKey)
+	if err != nil {
+		return fmt.Errorf("failed to get service account metadata: %w", err)
+	}
+	if saValue != (allowedSA + "," + thirdSA) {
+		return fmt.Errorf("expected service account metadata %q, got %q", allowedSA+","+thirdSA, saValue)
+	}
+	// Pod with thirdSA should succeed (in the list).
+	app, err = loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app for multi-SA test: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-third-pod"
+	app.Spec.ServiceAccountName = thirdSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createApp(f.ClientSet, app, deployTimeout)
+	if err != nil {
+		return fmt.Errorf(
+			"pod with third service account %q should have started but failed: %w", thirdSA, err)
+	}
+	framework.Logf("pod with third service account %q started successfully (comma-separated list)", thirdSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete third pod: %w", err)
+	}
+
+	// Pod with deniedSA should still be rejected.
+	app, err = loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app for multi-SA denied test: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-denied-multi-pod"
+	app.Spec.ServiceAccountName = deniedSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createAppErr(
+		f.ClientSet, app, deployTimeout,
+		[]string{"PermissionDenied", "is restricted to service account"},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"pod with denied SA should have failed with PermissionDenied (comma-separated list): %w", err)
+	}
+	framework.Logf("pod with denied service account %q was correctly rejected (comma-separated list)", deniedSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete denied multi pod: %w", err)
+	}
+
+	return nil
+}
+
 func verifyUserIdMappingMetadataSnapshotBacked(
 	f *framework.Framework,
 	pvc *v1.PersistentVolumeClaim,

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -179,6 +179,9 @@ func createNFSStorageClass(
 	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/controller-expand-secret-name"] = cephFSProvisionerSecretName
 
+	sc.Parameters["csi.storage.k8s.io/controller-publish-secret-namespace"] = cephCSINamespace
+	sc.Parameters["csi.storage.k8s.io/controller-publish-secret-name"] = cephFSProvisionerSecretName
+
 	sc.Parameters["csi.storage.k8s.io/node-publish-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/node-publish-secret-name"] = cephFSNodePluginSecretName
 
@@ -751,6 +754,19 @@ var _ = Describe("nfs", func() {
 			if err != nil {
 				logAndFail("failed to delete PVC or application: %v", err)
 			}
+		})
+
+		It("test service account based volume access restriction", func() {
+			err := validateCephFSServiceAccountVolumeRestriction(
+				pvcPath, appPath,
+				".cephfs.csi.ceph.com/serviceaccount",
+				f)
+			if err != nil {
+				logAndFail("service account volume restriction test failed: %v", err)
+			}
+			// validate no subvolumes remain
+			validateSubvolumeCount(f, 0, fileSystemName, defaultSubvolumegroup)
+			validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
 		})
 
 		It("Mount pvc as readonly in pod", func() {

--- a/e2e/nvmeof.go
+++ b/e2e/nvmeof.go
@@ -120,6 +120,7 @@ var _ = ginkgo.Describe("nvmeof", func() {
 	ginkgo.Context("Test NVMe CSI", ginkgo.Ordered, func() {
 
 		pvcPath := nvmeofExamplePath + "pvc.yaml"
+		appPath := nvmeofExamplePath + "pod.yaml"
 
 		ginkgo.It("create a PVC and delete it", func() {
 			ginkgo.By("prepare PVC")
@@ -138,6 +139,13 @@ var _ = ginkgo.Describe("nvmeof", func() {
 
 			ginkgo.By("delete the PVC again")
 			err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			ginkgo.By("test service account based volume access restriction")
+			err = validateServiceAccountVolumeRestriction(
+				pvcPath, appPath,
+				".rbd.csi.ceph.com/serviceaccount", nvmeofPool,
+				&nvmeofStorageClass, f)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// validate created backend rbd images

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -483,6 +483,63 @@ func deletePodWithLabel(label, ns string, skipNotFound bool) error {
 	return err
 }
 
+// waitForPVCVolumeAttachmentsCleanup waits until all
+// VolumeAttachments for a PVC's backing PV are deleted. This ensures
+// the volume is fully detached from all nodes before proceeding.
+// This is necessary to force Kubernetes to call ControllerPublishVolume
+// again with fresh metadata when a new pod mounts the volume.
+func waitForPVCVolumeAttachmentsCleanup(
+	c kubernetes.Interface,
+	pvc *v1.PersistentVolumeClaim,
+	timeout int,
+) error {
+	timeoutDuration := time.Duration(timeout) * time.Minute
+	ctx := context.TODO()
+
+	return wait.PollUntilContextTimeout(ctx, poll, timeoutDuration, true,
+		func(ctx context.Context) (bool, error) {
+			// Fetch fresh PVC to get current volume name
+			freshPVC, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).
+				Get(ctx, pvc.Name, metav1.GetOptions{})
+			if err != nil {
+				if apierrs.IsNotFound(err) {
+					// PVC already deleted
+					return true, nil
+				}
+				return false, err
+			}
+
+			pvName := freshPVC.Spec.VolumeName
+			if pvName == "" {
+				// PVC not yet bound, continue waiting
+				return false, nil
+			}
+
+			// List all VolumeAttachments
+			VAList, err := c.StorageV1().VolumeAttachments().List(ctx,
+				metav1.ListOptions{})
+			if err != nil {
+				if apierrs.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+
+			// Check if any VolumeAttachment references this PV
+			for _, va := range VAList.Items {
+				if va.Spec.Source.PersistentVolumeName != nil &&
+					*va.Spec.Source.PersistentVolumeName == pvName {
+					// VolumeAttachment still exists
+					return false, nil
+				}
+			}
+
+			// All VolumeAttachments cleaned up
+			framework.Logf("Volume %s fully detached", pvName)
+			return true, nil
+		})
+}
+
 // calculateSHA512sum returns the sha512sum of a file inside a pod.
 func calculateSHA512sum(f *framework.Framework, app *v1.Pod, filePath string, opt *metav1.ListOptions) (string, error) {
 	cmd := "sha512sum " + filePath

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -5300,6 +5300,19 @@ var _ = Describe("RBD", func() {
 			}
 		})
 
+		It("test service account based volume access restriction", func() {
+			err := validateServiceAccountVolumeRestriction(
+				pvcPath, appPath,
+				".rbd.csi.ceph.com/serviceaccount", defaultRBDPool,
+				nil, f)
+			if err != nil {
+				logAndFail("service account volume restriction test failed: %v", err)
+			}
+			// validate created backend rbd images
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+		})
+
 		It("restore snapshot to a bigger size PVC", func() {
 			By("restore snapshot to bigger size pvc", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -284,9 +284,16 @@ func getImageInfoFromPVC(pvcNamespace, pvcName string, f *framework.Framework) (
 	imageIDRegex := regexp.MustCompile(`(\w+\-?){5}$`)
 	imageID := imageIDRegex.FindString(pv.Spec.CSI.VolumeHandle)
 
+	prefix := "csi-vol-"
+	if pv.Spec.CSI.VolumeAttributes != nil {
+		if val, ok := pv.Spec.CSI.VolumeAttributes["volumeNamePrefix"]; ok {
+			prefix = val
+		}
+	}
+
 	imageData = imageInfoFromPVC{
 		imageID:         imageID,
-		imageName:       "csi-vol-" + imageID,
+		imageName:       prefix + imageID,
 		csiVolumeHandle: pv.Spec.CSI.VolumeHandle,
 		pvName:          pv.Name,
 	}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1227,7 +1227,7 @@ type imageInfo struct {
 	StripeUnit  int    `json:"stripe_unit"`
 	StripeCount int    `json:"stripe_count"`
 	ObjectSize  int    `json:"object_size"`
-	DataPool    string  `json:"data_pool"`
+	DataPool    string `json:"data_pool"`
 }
 
 // getImageInfo queries rbd about the given image and returns its metadata, and returns
@@ -1342,9 +1342,270 @@ func validateDataPool(f *framework.Framework, imageName, poolName string, wants 
 	if err != nil {
 		return fmt.Errorf("unmarshal failed: %w. raw buffer response: %s", err, imgInfoStr)
 	}
-	
+
 	if imgInfo.DataPool != wants {
 		return fmt.Errorf("unexpected data_pool: got %q, want %q", imgInfo.DataPool, wants)
+	}
+
+	return nil
+}
+
+// setImageMeta sets a metadata key-value pair on an RBD image.
+func setImageMeta(rbdImageSpec, metaKey, metaValue string, f *framework.Framework) error {
+	cmd := fmt.Sprintf("rbd image-meta set %s %s %q", rbdImageSpec, metaKey, metaValue)
+	_, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+	if err != nil {
+		return err
+	}
+	if stdErr != "" {
+		return fmt.Errorf("failed to set image metadata: %s", stdErr)
+	}
+
+	return nil
+}
+
+// removeImageMeta removes a metadata key from an RBD image.
+func removeImageMeta(rbdImageSpec, metaKey string, f *framework.Framework) error {
+	cmd := fmt.Sprintf("rbd image-meta remove %s %s", rbdImageSpec, metaKey)
+	_, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+	if err != nil {
+		return err
+	}
+	if stdErr != "" {
+		return fmt.Errorf("failed to remove image metadata: %s", stdErr)
+	}
+
+	return nil
+}
+
+// validateServiceAccountVolumeRestriction tests that volume access can be
+// restricted to a specific Kubernetes service account. It creates a PVC,
+// sets the given saMetadataKey metadata on the backing RBD image, then
+// verifies:
+//   - A pod using the allowed service account can mount the volume.
+//   - A pod using a different service account is rejected with PermissionDenied.
+//
+// The pool parameter specifies the RBD pool for the image. If scName is
+// non-nil the storage class is set on the PVC.
+func validateServiceAccountVolumeRestriction(
+	pvcPath, appPath, saMetadataKey, pool string,
+	scName *string,
+	f *framework.Framework,
+) error {
+	allowedSA := "allowed-sa-" + f.UniqueName
+	deniedSA := "denied-sa-" + f.UniqueName
+	thirdSA := "third-sa-" + f.UniqueName
+
+	// Create service accounts.
+	_, err := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Create(
+		context.TODO(),
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: allowedSA},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create allowed ServiceAccount: %w", err)
+	}
+	defer func() {
+		delErr := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Delete(
+			context.TODO(), allowedSA, metav1.DeleteOptions{})
+		if delErr != nil {
+			framework.Logf("failed to delete ServiceAccount %s: %v", allowedSA, delErr)
+		}
+	}()
+
+	_, err = f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Create(
+		context.TODO(),
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: deniedSA},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create denied ServiceAccount: %w", err)
+	}
+	defer func() {
+		delErr := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Delete(
+			context.TODO(), deniedSA, metav1.DeleteOptions{})
+		if delErr != nil {
+			framework.Logf("failed to delete ServiceAccount %s: %v", deniedSA, delErr)
+		}
+	}()
+
+	_, err = f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Create(
+		context.TODO(),
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: thirdSA},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create third ServiceAccount: %w", err)
+	}
+	defer func() {
+		delErr := f.ClientSet.CoreV1().ServiceAccounts(f.UniqueName).Delete(
+			context.TODO(), thirdSA, metav1.DeleteOptions{})
+		if delErr != nil {
+			framework.Logf("failed to delete ServiceAccount %s: %v", thirdSA, delErr)
+		}
+	}()
+
+	// Create PVC and wait for it to be bound.
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC: %w", err)
+	}
+	pvc.Namespace = f.UniqueName
+	if scName != nil {
+		pvc.Spec.StorageClassName = scName
+	}
+	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create PVC: %w", err)
+	}
+
+	defer func() {
+		delErr := deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+		if delErr != nil {
+			framework.Logf("failed to delete PVC: %v", delErr)
+		}
+	}()
+
+	// Get the RBD image info from the PVC.
+	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
+	if err != nil {
+		return fmt.Errorf("failed to get image info from PVC: %w", err)
+	}
+	rbdImageSpec := imageSpec(pool, imageData.imageName)
+
+	// Set the service account restriction metadata on the RBD image.
+	err = setImageMeta(rbdImageSpec, saMetadataKey, allowedSA, f)
+	if err != nil {
+		return fmt.Errorf("failed to set service account metadata: %w", err)
+	}
+	defer func() {
+		// Clean up the metadata regardless of test outcome.
+		delErr := removeImageMeta(rbdImageSpec, saMetadataKey, f)
+		if delErr != nil {
+			framework.Logf("failed to remove service account metadata: %v", delErr)
+		}
+	}()
+
+	// Verify the metadata was set correctly.
+	saValue, err := getImageMeta(rbdImageSpec, saMetadataKey, f)
+	if err != nil {
+		return fmt.Errorf("failed to get service account metadata: %w", err)
+	}
+	if saValue != allowedSA {
+		return fmt.Errorf("expected service account metadata %q, got %q", allowedSA, saValue)
+	}
+
+	// Test 1: Pod with the allowed service account should succeed.
+	app, err := loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-allowed-pod"
+	app.Spec.ServiceAccountName = allowedSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createApp(f.ClientSet, app, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("pod with allowed service account %q should have started but failed: %w", allowedSA, err)
+	}
+	framework.Logf("pod with allowed service account %q started successfully", allowedSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete allowed pod: %w", err)
+	}
+
+	// Test 2: Pod with a denied service account should fail with PermissionDenied.
+	app, err = loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app for denied test: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-denied-pod"
+	app.Spec.ServiceAccountName = deniedSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createAppErr(
+		f.ClientSet, app, deployTimeout,
+		[]string{"PermissionDenied", "is restricted to service account"},
+	)
+	if err != nil {
+		return fmt.Errorf("pod with denied service account should have failed with PermissionDenied: %w", err)
+	}
+	framework.Logf("pod with denied service account %q was correctly rejected", deniedSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete denied pod: %w", err)
+	}
+
+	// Test 3: Update metadata to a comma-separated list of allowed service accounts and verify access.
+	err = setImageMeta(rbdImageSpec, saMetadataKey, allowedSA+","+thirdSA, f)
+	if err != nil {
+		return fmt.Errorf("failed to set comma-separated service account metadata: %w", err)
+	}
+
+	// Verify the metadata was set correctly.
+	saValue, err = getImageMeta(rbdImageSpec, saMetadataKey, f)
+	if err != nil {
+		return fmt.Errorf("failed to get service account metadata: %w", err)
+	}
+	if saValue != (allowedSA + "," + thirdSA) {
+		return fmt.Errorf("expected service account metadata %q, got %q",
+			(allowedSA + "," + thirdSA), saValue)
+	}
+
+	// Wait for volume to be fully detached before updating metadata
+	// to ensure fresh ControllerPublishVolume call with new metadata.
+	err = waitForPVCVolumeAttachmentsCleanup(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to wait for volume detachment: %w", err)
+	}
+
+	// Pod with thirdSA should succeed (in the list).
+	app, err = loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app for multi-SA test: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-third-pod"
+	app.Spec.ServiceAccountName = thirdSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createApp(f.ClientSet, app, deployTimeout)
+	if err != nil {
+		return fmt.Errorf(
+			"pod with third service account %q should have started but failed: %w", thirdSA, err)
+	}
+	framework.Logf("pod with third service account %q started successfully (comma-separated list)", thirdSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete third pod: %w", err)
+	}
+
+	// Pod with deniedSA should still be rejected.
+	app, err = loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app for multi-SA denied test: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	app.Name = "sa-denied-multi-pod"
+	app.Spec.ServiceAccountName = deniedSA
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+	err = createAppErr(
+		f.ClientSet, app, deployTimeout,
+		[]string{"PermissionDenied", "is restricted to service account"},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"pod with denied SA should have failed with PermissionDenied (comma-separated list): %w", err)
+	}
+	framework.Logf("pod with denied service account %q was correctly rejected (comma-separated list)", deniedSA)
+	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete denied multi pod: %w", err)
 	}
 
 	return nil

--- a/examples/nfs/storageclass.yaml
+++ b/examples/nfs/storageclass.yaml
@@ -38,6 +38,8 @@ parameters:
   csi.storage.k8s.io/provisioner-secret-namespace: default
   csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-secret
   csi.storage.k8s.io/controller-expand-secret-namespace: default
+  csi.storage.k8s.io/controller-publish-secret-name: csi-cephfs-secret
+  csi.storage.k8s.io/controller-publish-secret-namespace: default
   csi.storage.k8s.io/controller-modify-secret-name: csi-cephfs-secret
   csi.storage.k8s.io/controller-modify-secret-namespace: default
   # publish-secret is needed for parameters set by a VolumeAttributeClass

--- a/examples/nvmeof/storageclass.yaml
+++ b/examples/nvmeof/storageclass.yaml
@@ -14,6 +14,8 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-namespace: default
   csi.storage.k8s.io/node-stage-secret-name: csi-nvmeof-secret
   csi.storage.k8s.io/node-stage-secret-namespace: default
+  csi.storage.k8s.io/controller-publish-secret-name: csi-nvmeof-secret
+  csi.storage.k8s.io/controller-publish-secret-namespace: default
   csi.storage.k8s.io/provisioner-secret-name: csi-nvmeof-secret
   csi.storage.k8s.io/provisioner-secret-namespace: default
 

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -1128,15 +1128,85 @@ func deleteSnapshotAndUndoReservation(
 }
 
 // ControllerPublishVolume implements the CSI ControllerPublishVolume RPC.
-// This function is a no-op for CephFS CSI driver since only
-// ControllerUnPublishVolume is used for fencing nodes and removing
-// node related metadata but still needs to be implemented to
-// satisfy the CSI spec.
+// It reads the service account restriction metadata from the backing CephFS
+// subvolume and passes it to the node via publish context.
 func (cs *ControllerServer) ControllerPublishVolume(
 	ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest,
 ) (*csi.ControllerPublishVolumeResponse, error) {
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	publishContext := map[string]string{}
+
+	// Read service account restriction from subvolume metadata, if set.
+	serviceAccount, err := cs.getServiceAccountRestriction(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if serviceAccount != "" {
+		publishContext[util.PublishContextServiceAccount] = serviceAccount
+	}
+
+	return &csi.ControllerPublishVolumeResponse{
+		PublishContext: publishContext,
+	}, nil
+}
+
+// getServiceAccountRestriction reads the service account restriction metadata
+// from the CephFS subvolume backing the volume. Returns empty string if no
+// restriction is set.
+func (cs *ControllerServer) getServiceAccountRestriction(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+) (string, error) {
+	volumeID := req.GetVolumeId()
+	secrets := req.GetSecrets()
+
+	if secrets == nil {
+		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeID, util.CephFsType)
+		if err != nil {
+			log.WarningLog(ctx, "controller publish secret not found: %v", err)
+
+			return "", nil
+		}
+
+		secrets, err = k8s.GetSecret(secretName, secretNamespace)
+		if err != nil {
+			return "", status.Errorf(codes.Internal,
+				"failed to get controller publish secret from k8s: %v", err)
+		}
+	}
+
+	volOptions, _, err := store.NewVolumeOptionsFromVolID(ctx, volumeID, nil, secrets,
+		cs.ClusterName, cs.SetMetadata)
+	if err != nil {
+		return "", status.Errorf(codes.Internal,
+			"failed to find volume %q for service account check: %v", volumeID, err)
+	}
+	defer volOptions.Destroy()
+
+	handler, err := cs.getSubvolumeMetadataHandler(ctx, volOptions, secrets)
+	if err != nil {
+		return "", status.Errorf(codes.Internal,
+			"failed to get metadata handler for volume %s: %v", volumeID, err)
+	}
+
+	metadata, err := handler.listMetadataFunc()
+	if err != nil {
+		if errors.Is(err, core.ErrSubVolMetadataNotSupported) {
+			return "", nil
+		}
+
+		return "", status.Errorf(codes.Internal,
+			"failed to list metadata for volume %s: %v", volumeID, err)
+	}
+
+	serviceAccount, exists := metadata[core.ServiceAccountKey]
+	if !exists || serviceAccount == "" {
+		return "", nil
+	}
+
+	log.DebugLog(ctx, "volume %s has service account restriction: %q", volumeID, serviceAccount)
+
+	return serviceAccount, nil
 }
 
 // ControllerUnpublishVolume implements the CSI ControllerUnpublishVolume RPC.

--- a/internal/cephfs/core/metadata.go
+++ b/internal/cephfs/core/metadata.go
@@ -35,6 +35,10 @@ const (
 	// userIdMappingKey is the key used to store the userID mapping.
 	// starts with `.` to avoid copying it to the mirrored subvolume.
 	userIdMappingKey = ".cephfs.csi.ceph.com/userid"
+
+	// ServiceAccountKey is the key used to restrict volume access to a specific
+	// Kubernetes service account. Starts with `.` to avoid copying it to the mirrored subvolume.
+	ServiceAccountKey = ".cephfs.csi.ceph.com/serviceaccount"
 )
 
 // ErrSubVolMetadataNotSupported is returned when set/get/list/remove subvolume metadata options are not supported.

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -626,6 +626,14 @@ func (ns *NodeServer) NodePublishVolume(
 		return nil, err
 	}
 
+	// Validate that the pod's service account is allowed to mount this volume
+	if err := util.ValidateServiceAccountRestriction(ctx,
+		req.GetPublishContext()[util.PublishContextServiceAccount],
+		req.GetVolumeContext()[util.VolumeContextServiceAccountKey],
+		req.GetVolumeId()); err != nil {
+		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
 	stagingTargetPath := req.GetStagingTargetPath()
 	targetPath := req.GetTargetPath()
 	volID := fsutil.VolumeID(req.GetVolumeId())

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -179,6 +179,24 @@ func (cs *Server) DeleteVolume(
 	return cs.backendServer.DeleteVolume(ctx, req)
 }
 
+// ControllerPublishVolume delegates to the CephFS backend to read the service
+// account restriction metadata from the backing CephFS subvolume and pass it
+// to the node via publish context.
+func (cs *Server) ControllerPublishVolume(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+) (*csi.ControllerPublishVolumeResponse, error) {
+	return cs.backendServer.ControllerPublishVolume(ctx, req)
+}
+
+// ControllerUnpublishVolume is a no-op for the NFS CSI driver.
+func (cs *Server) ControllerUnpublishVolume(
+	ctx context.Context,
+	req *csi.ControllerUnpublishVolumeRequest,
+) (*csi.ControllerUnpublishVolumeResponse, error) {
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
+}
+
 // ControllerExpandVolume calls the backend (CephFS) procedure to expand the
 // volume. There is no interaction with the NFS-server needed to publish the
 // new size.

--- a/internal/nfs/driver/driver.go
+++ b/internal/nfs/driver/driver.go
@@ -52,6 +52,7 @@ func (fs *nfsDriver) Run(conf *util.Config) {
 	if conf.IsControllerServer || !conf.IsNodeServer {
 		cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 			csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -75,6 +75,15 @@ func (ns *NodeServer) NodePublishVolume(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// Validate that the pod's service account is allowed to mount this volume
+	err = util.ValidateServiceAccountRestriction(ctx,
+		req.GetPublishContext()[util.PublishContextServiceAccount],
+		req.GetVolumeContext()[util.VolumeContextServiceAccountKey],
+		req.GetVolumeId())
+	if err != nil {
+		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
 	volumeID := req.GetVolumeId()
 	volCap := req.GetVolumeCapability()
 	targetPath := req.GetTargetPath()

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -253,6 +253,15 @@ func (cs *Server) ControllerPublishVolume(
 	// populate publish context
 	publishContext := populatePublishContext(req, hostNqn)
 
+	// Delegate to RBD backend to get service account restriction from image metadata.
+	rbdResp, err := cs.backendServer.ControllerPublishVolume(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if sa := rbdResp.GetPublishContext()[util.PublishContextServiceAccount]; sa != "" {
+		publishContext[util.PublishContextServiceAccount] = sa
+	}
+
 	return &csi.ControllerPublishVolumeResponse{
 		PublishContext: publishContext,
 	}, nil

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -211,6 +211,15 @@ func (ns *NodeServer) NodePublishVolume(
 		return nil, err
 	}
 
+	// Validate that the pod's service account is allowed to mount this volume
+	err = util.ValidateServiceAccountRestriction(ctx,
+		req.GetPublishContext()[util.PublishContextServiceAccount],
+		req.GetVolumeContext()[util.VolumeContextServiceAccountKey],
+		req.GetVolumeId())
+	if err != nil {
+		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
 	targetPath := req.GetTargetPath()
 	stagingPath := req.GetStagingTargetPath()
 	volID := req.GetVolumeId()

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1692,15 +1692,84 @@ func (cs *ControllerServer) ControllerExpandVolume(
 }
 
 // ControllerPublishVolume implements the CSI ControllerPublishVolume RPC.
-// This function is a no-op for RBD CSI driver since only
-// ControllerUnPublishVolume is used for fencing nodes and removing
-// node related metadata but still needs to be implemented to
-// satisfy the CSI spec.
+// It reads the service account restriction metadata from the backing RBD image
+// and passes it to the node via publish context.
 func (cs *ControllerServer) ControllerPublishVolume(
 	ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest,
 ) (*csi.ControllerPublishVolumeResponse, error) {
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	publishContext := map[string]string{}
+
+	// Read service account restriction from RBD image metadata, if set.
+	serviceAccount, err := cs.getServiceAccountRestriction(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if serviceAccount != "" {
+		publishContext[util.PublishContextServiceAccount] = serviceAccount
+	}
+
+	return &csi.ControllerPublishVolumeResponse{
+		PublishContext: publishContext,
+	}, nil
+}
+
+// getServiceAccountRestriction reads the service account restriction metadata
+// from the RBD image backing the volume. Returns empty string if no restriction
+// is set.
+func (cs *ControllerServer) getServiceAccountRestriction(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+) (string, error) {
+	volumeID := req.GetVolumeId()
+	secrets := req.GetSecrets()
+
+	if secrets == nil {
+		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeID, util.RBDType)
+		if err != nil {
+			log.WarningLog(ctx, "controller publish secret not found: %v", err)
+
+			return "", nil
+		}
+
+		secrets, err = k8s.GetSecret(secretName, secretNamespace)
+		if err != nil {
+			return "", status.Errorf(codes.Internal,
+				"failed to get controller publish secret from k8s: %v", err)
+		}
+	}
+
+	cr, err := util.NewUserCredentials(secrets)
+	if err != nil {
+		return "", status.Errorf(codes.InvalidArgument,
+			"failed to create credentials for volume %s: %v", volumeID, err)
+	}
+	defer cr.DeleteCredentials()
+
+	rv, err := GenVolFromVolID(ctx, volumeID, cr, secrets)
+	if err != nil {
+		if rv != nil {
+			rv.Destroy(ctx)
+		}
+
+		return "", status.Errorf(codes.Internal,
+			"failed to find volume %q for service account check: %v", volumeID, err)
+	}
+	defer rv.Destroy(ctx)
+
+	serviceAccount, err := rv.GetMetadata(serviceAccountKey)
+	if err != nil {
+		if !errors.Is(err, librbd.ErrNotFound) {
+			return "", status.Errorf(codes.Internal,
+				"failed to get service account metadata for volume %s: %v", volumeID, err)
+		}
+		// No service account restriction set on this image
+		return "", nil
+	}
+
+	log.DebugLog(ctx, "volume %s has service account restriction: %q", volumeID, serviceAccount)
+
+	return serviceAccount, nil
 }
 
 // ControllerUnpublishVolume implements the CSI ControllerUnpublishVolume RPC.

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -834,6 +834,16 @@ func (ns *NodeServer) NodePublishVolume(
 	if err != nil {
 		return nil, err
 	}
+
+	// Validate that the pod's service account is allowed to mount this volume
+	err = util.ValidateServiceAccountRestriction(ctx,
+		req.GetPublishContext()[util.PublishContextServiceAccount],
+		req.GetVolumeContext()[util.VolumeContextServiceAccountKey],
+		req.GetVolumeId())
+	if err != nil {
+		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
 	targetPath := req.GetTargetPath()
 	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	stagingPath := req.GetStagingTargetPath()

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -90,6 +90,10 @@ const (
 	// starts with `.` to avoid copying it to the mirrored image.
 	userIdMappingKey = ".rbd.csi.ceph.com/userid"
 
+	// serviceAccountKey is the key used to restrict volume access to a specific
+	// Kubernetes service account. starts with `.` to avoid copying it to the mirrored image.
+	serviceAccountKey = ".rbd.csi.ceph.com/serviceaccount"
+
 	// Suffix added to the temp cloned image name.
 	// This will always be (rbd image name + "-temp").
 	tempImageSuffix = "-temp"

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -17,14 +17,29 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+const (
+	// VolumeContextServiceAccountKey is the key in the volume context that
+	// contains the pod's service account name, set by Kubelet when
+	// podInfoOnMount is enabled in the CSIDriver spec.
+	VolumeContextServiceAccountKey = "csi.storage.k8s.io/serviceAccount.name"
+
+	// PublishContextServiceAccount is the publish context key for the allowed
+	// service account, set during ControllerPublishVolume.
+	PublishContextServiceAccount = "serviceAccount"
 )
 
 // A regex to verify the expected format: 0000-0000-arbitrary-number-of-000-and-chars.
@@ -194,4 +209,43 @@ func IsStaticVol(volAttrs map[string]string) bool {
 	}
 
 	return false
+}
+
+// ValidateServiceAccountRestriction checks whether the pod's service
+// account is allowed to mount the volume. allowedSA is a
+// comma-separated list of permitted service accounts (empty means no
+// restriction). podSA is the service account of the requesting pod.
+// volumeID is used only for log/error messages.
+func ValidateServiceAccountRestriction(
+	ctx context.Context,
+	allowedSA, podSA, volumeID string,
+) error {
+	if allowedSA == "" {
+		return nil
+	}
+
+	if podSA == "" {
+		// podInfoOnMount is not enabled, cannot enforce restriction
+		log.WarningLog(ctx,
+			"volume %s has service account restriction "+
+				"but podInfoOnMount is not enabled, "+
+				"skipping check",
+			volumeID)
+
+		return nil
+	}
+
+	allowedSAs := strings.Split(allowedSA, ",")
+	if !slices.Contains(allowedSAs, podSA) {
+		return fmt.Errorf(
+			"volume %s service account restriction "+
+				"does not match pod's service account",
+			volumeID)
+	}
+
+	log.DebugLog(ctx,
+		"service account is allowed to mount volume %s",
+		volumeID)
+
+	return nil
 }

--- a/internal/util/validate_test.go
+++ b/internal/util/validate_test.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateVolumeID(t *testing.T) {
@@ -72,6 +74,94 @@ func TestValidateVolumeID(t *testing.T) {
 			err := ValidateVolumeID(tt.volumeID, tt.skipFormat)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateVolumeID(%q) error = %v, wantErr %v", tt.volumeID, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateServiceAccountRestriction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		allowedSA string
+		podSA     string
+		expectErr bool
+	}{
+		{
+			name:      "no restriction set, allow all",
+			allowedSA: "",
+			podSA:     "default",
+			expectErr: false,
+		},
+		{
+			name:      "restriction matches pod SA",
+			allowedSA: "my-app-sa",
+			podSA:     "my-app-sa",
+			expectErr: false,
+		},
+		{
+			name:      "restriction does not match pod SA",
+			allowedSA: "my-app-sa",
+			podSA:     "other-sa",
+			expectErr: true,
+		},
+		{
+			name:      "restriction set but podInfoOnMount not enabled",
+			allowedSA: "my-app-sa",
+			podSA:     "",
+			expectErr: false,
+		},
+		{
+			name:      "comma-separated list, match first",
+			allowedSA: "sa1,sa2,sa3",
+			podSA:     "sa1",
+			expectErr: false,
+		},
+		{
+			name:      "comma-separated list, match middle",
+			allowedSA: "sa1,sa2,sa3",
+			podSA:     "sa2",
+			expectErr: false,
+		},
+		{
+			name:      "comma-separated list, match last",
+			allowedSA: "sa1,sa2,sa3",
+			podSA:     "sa3",
+			expectErr: false,
+		},
+		{
+			name:      "comma-separated list, no match",
+			allowedSA: "sa1,sa2,sa3",
+			podSA:     "sa4",
+			expectErr: true,
+		},
+		{
+			name:      "two SAs, match second",
+			allowedSA: "sa1,sa2",
+			podSA:     "sa2",
+			expectErr: false,
+		},
+		{
+			name:      "partial name should not match",
+			allowedSA: "my-app-sa,other-sa",
+			podSA:     "my-app",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			err := ValidateServiceAccountRestriction(
+				ctx, tt.allowedSA, tt.podSA, "test-vol-id")
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs/csidriver.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs/csidriver.yaml
@@ -5,6 +5,6 @@ metadata:
   name: "{{ .Name }}"
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   fsGroupPolicy: File
   seLinuxMount: true

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csidriver.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csidriver.yaml
@@ -4,7 +4,8 @@ kind: CSIDriver
 metadata:
   name: "{{ .Name }}"
 spec:
-  attachRequired: false
+  attachRequired: true
+  podInfoOnMount: true
   fsGroupPolicy: File
   seLinuxMount: true
   volumeLifecycleModes:

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd/csidriver.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd/csidriver.yaml
@@ -5,6 +5,6 @@ metadata:
   name: "{{ .Name }}"
 spec:
   attachRequired: true
-  podInfoOnMount: false
+  podInfoOnMount: true
   seLinuxMount: true
   fsGroupPolicy: File


### PR DESCRIPTION
# Describe what this PR does #


## Service Account Based Volume Access Restriction

Ceph-CSI supports optionally restricting RBD/CephFS volume access to specific Kubernetes
service accounts. When configured, only pods running with the allowed service account
can mount the volume. This feature uses RBD image/cephFS subvolume metadata to store the
restriction and the CSI `podInfoOnMount` mechanism to identify the pod's service
account during mount. Refer https://kubernetes-csi.github.io/docs/pod-info.html#pod-info-on-mount-with-csi-driver-object.

### How it works

1. A user sets the `.rbd.csi.ceph.com/serviceaccount` metadata on an
   RBD image to specify the allowed service account name.
2. During `ControllerPublishVolume`, Ceph-CSI reads this metadata and passes
   it to the node via publish context.
3. During `NodePublishVolume`, Ceph-CSI compares the value against the
   pod's service account (provided via volume context by Kubelet).
4. If the service account was set in metadata and does not match the pod's
   service account, the mount is rejected with a `PermissionDenied` error.

### Prerequisites

The `podInfoOnMount` field must be set to `true` in the CSIDriver spec so that
Kubelet passes pod information (including service account name) in the volume
context during `NodePublishVolume`. Without this, the restriction cannot be
enforced and all mounts are allowed.

### Setting the restriction on an RBD image/nvmeof


Use the `rbd image-meta set` command to set the allowed service account:

```bash
rbd image-meta set <pool>/<image> .rbd.csi.ceph.com/serviceaccount <service-account-name>
```

For example, to restrict a volume to the `my-app-sa` service account:

```bash
rbd image-meta set mypool/csi-vol-abc123 .rbd.csi.ceph.com/serviceaccount my-app-sa
```

### Removing the restriction

To remove the restriction and allow any service account to mount the volume:

```bash
rbd image-meta remove <pool>/<image> .rbd.csi.ceph.com/serviceaccount
```

The Deployment should be scaled down completely and then scaled up for this removing
the restriction after removing metadata from the image.

### Setting the restriction on a CephFS subvolume/nfs export

Use the `ceph fs subvolume metadata set` command to set the allowed service account:

```bash
ceph fs subvolume metadata set <filesystem> <subvolume> --group_name=<group> \
  .cephfs.csi.ceph.com/serviceaccount <service-account-name>
```

For example, to restrict a volume to the `my-app-sa` service account:

```bash
ceph fs subvolume metadata set myfs csi-vol-abc123 --group_name=csi \
  .cephfs.csi.ceph.com/serviceaccount my-app-sa
```

### Removing the restriction

To remove the restriction and allow any service account to mount the volume:

```bash
ceph fs subvolume metadata rm <filesystem> <subvolume> --group_name=<group> \
  .cephfs.csi.ceph.com/serviceaccount
```

The Deployment should be scaled down completely and then scaled up for
removing the restriction after removing metadata from the subvolume.

---

### Use Case: Ceph VolSync Plugin Replication Destination PVC Protection

A primary motivator for this feature is the custom
[Ceph VolSync Plugin](https://github.com/RamenDR/ceph-volsync-plugin) that
performs incremental data replication across clusters. In a disaster recovery
or migration workflow:

1. A `ReplicationDestination` controller creates a PVC on the destination
   cluster to receive replicated data.
1. A replication worker pod, running under a dedicated service account (e.g.
   `volsync-worker-sa`), incrementally syncs data from the source cluster into
   this destination PVC.
1. The destination PVC must remain writable only by the replication worker
   until the replication is complete and a failover is triggered.

Without service account based restriction, any pod in the namespace with a
reference to the destination PVC could write to it, potentially corrupting the
replicated data or breaking the incremental sync state. By binding the
destination volume to the replication worker's service account, the volume is
protected from unintended writes throughout the replication lifecycle. On
failover, the restriction is removed so the application workload can mount
the volume.

---

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
