### PR TITLE
nvmeof: fix removeHost bug

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -981,15 +981,16 @@ func (cs *Server) unpublishResources(ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("failed to list namespaces for subsystem %s: %w", subsystemNQN, err)
 	}
-	for _, ns := range namespaces.GetNamespaces() {
-		for _, host := range ns.GetHosts() {
-			if host == hostNQN {
-				log.DebugLog(ctx, "Host %s is still using namespace %s, not removing", hostNQN, ns.GetNsid())
+	// Count other namespaces in the subsystem (excluding this volume's namespace)
+	otherNamespacesCount := len(namespaces.GetNamespaces()) - 1
 
-				return nil
-			}
-		}
+	if otherNamespacesCount > 0 {
+		log.DebugLog(ctx, "Subsystem %s still has %d other namespaces, not removing host %s",
+			subsystemNQN, otherNamespacesCount, hostNQN)
+
+		return nil
 	}
+
 	// Remove host from subsystem
 	if err := gateway.RemoveHost(ctx, subsystemNQN, hostNQN); err != nil {
 		return fmt.Errorf("failed to remove host %s from subsystem %s: %w",


### PR DESCRIPTION
`ControllerUnPublishVolume()` was searching in host list. but host list
in Namespace is not belong to hostNqn we use.
this host list is for Namespace Masking feature.
(out of scope here).
I caught it, when I created 2 PVCs + 2 pods
then I remove 1 pod and I saw it deleted the host
even though there is still 1 live pod.

so in our case, we just need to check the len of the ns list (for specific subsystemNqn)
if left more than 1, don't remove the host!


**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
