### PR TITLE
nvmeof: fix dhchap key-value bug in rbd metadata

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -1183,6 +1183,8 @@ func (cs *Server) getNVMeoFMetadata(
 		toRBDMetadataKey(vcListeners),
 		toRBDMetadataKey(vcGatewayAddress),
 		toRBDMetadataKey(vcGatewayPort),
+	}
+	optionalKeys := []string{
 		toRBDMetadataKey(vcDHCHAPMode),
 		toRBDMetadataKey(vcAuthenticationKMSID),
 	}
@@ -1197,6 +1199,22 @@ func (cs *Server) getNVMeoFMetadata(
 		if value == "" {
 			return nil, fmt.Errorf("%w: metadata %s is empty",
 				nvmeoferrors.ErrMetadataNotFound, key)
+		}
+		metadata[key] = value
+	}
+
+	// Optional metadata keys
+	for _, key := range optionalKeys {
+		value, err := rbdVol.GetMetadata(key)
+		if err != nil {
+			log.DebugLog(ctx, "Optional metadata %s not found: %v", key, err)
+
+			continue
+		}
+		if value == "" {
+			log.DebugLog(ctx, "Optional metadata %s is empty", key)
+
+			continue
 		}
 		metadata[key] = value
 	}


### PR DESCRIPTION
dh-chap key-value in rbd metadata was mandatory by mistake. it failed if dh-chap key was not found (in case of not using dh-chap feature..)
make it as optional.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
