### PR TITLE
rbd: fix missing data pool

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1195,6 +1195,400 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("create a PVC in replica pool, snapshot it, and clone to erasure coded pool", func() {
+				// This test validates cross-pool cloning from replica to erasure-coded pool
+				// 1. Create PVC in replica pool (defaultRBDPool)
+				// 2. Create snapshot in same pool
+				// 3. Clone snapshot to new PVC with erasure-coded pool storageclass
+
+				// Create snapshot class
+				err := createRBDSnapshotClass(f)
+				if err != nil {
+					logAndFail("failed to create snapshotclass: %v", err)
+				}
+				defer func() {
+					err = deleteRBDSnapshotClass()
+					if err != nil {
+						logAndFail("failed to delete VolumeSnapshotClass: %v", err)
+					}
+				}()
+
+				// Create PVC in replica pool
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					logAndFail("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create PVC: %v", err)
+				}
+
+				// Create app and write data
+				app, err := loadApp(appPath)
+				if err != nil {
+					logAndFail("failed to load app: %v", err)
+				}
+				label := make(map[string]string)
+				label[appKey] = appLabel
+				app.Namespace = f.UniqueName
+				app.Labels = label
+				opt := metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
+				}
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+				checkSum, err := writeDataAndCalChecksum(app, &opt, f)
+				if err != nil {
+					logAndFail("failed to calculate checksum: %v", err)
+				}
+
+				// Validate image is in replica pool
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				// Create snapshot
+				snap := getSnapshot(snapshotPath)
+				snap.Namespace = f.UniqueName
+				snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+				err = createSnapshot(&snap, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create snapshot: %v", err)
+				}
+
+				// Validate snapshot is created (1 parent image + 1 snapshot)
+				validateRBDImageCount(f, 2, defaultRBDPool)
+
+				// Create storageclass with erasure-coded pool
+				ecSCName := "ec-storageclass"
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					ecSCName,
+					nil,
+					map[string]string{
+						"dataPool": erasureCodedPool,
+						"pool":     defaultRBDPool,
+					},
+					deletePolicy)
+				if err != nil {
+					logAndFail("failed to create erasure-coded storageclass: %v", err)
+				}
+
+				// Clone snapshot to PVC with erasure-coded pool
+				pvcClone, err := loadPVC(pvcClonePath)
+				if err != nil {
+					logAndFail("failed to load clone PVC: %v", err)
+				}
+				pvcClone.Namespace = f.UniqueName
+				pvcClone.Spec.DataSource.Name = snap.Name
+				pvcClone.Spec.StorageClassName = &ecSCName
+
+				err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create clone PVC: %v", err)
+				}
+
+				// Validate clone is in erasure-coded pool
+				err = checkPVCDataPoolForImageInPool(f, pvcClone, defaultRBDPool, erasureCodedPool)
+				if err != nil {
+					logAndFail("failed to check data pool for image: %v", err)
+				}
+
+				validateRBDImageCount(f, 3, defaultRBDPool)
+
+				// Create app with cloned PVC and verify data
+				appClone, err := loadApp(appClonePath)
+				if err != nil {
+					logAndFail("failed to load clone app: %v", err)
+				}
+				appClone.Namespace = f.UniqueName
+				appClone.Labels = label
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
+
+				err = createApp(f.ClientSet, appClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create clone app: %v", err)
+				}
+
+				// Verify data integrity
+				filePath := appClone.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
+				newCheckSum, err := calculateSHA512sum(f, appClone, filePath, &opt)
+				if err != nil {
+					logAndFail("failed to calculate checksum for clone: %v", err)
+				}
+				if newCheckSum != checkSum {
+					logAndFail(
+						"checksum mismatch in clone, expected %s got %s",
+						checkSum,
+						newCheckSum)
+				}
+
+				// Cleanup
+				err = deletePod(appClone.Name, appClone.Namespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete clone app: %v", err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete clone PVC: %v", err)
+				}
+
+				err = deleteSnapshot(&snap, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete snapshot: %v", err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete PVC: %v", err)
+				}
+				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				// Delete erasure-coded storageclass and restore default
+				err = c.StorageV1().StorageClasses().Delete(context.TODO(), ecSCName, metav1.DeleteOptions{})
+				if err != nil {
+					logAndFail("failed to delete erasure-coded storageclass: %v", err)
+				}
+			})
+
+			By("create a PVC in erasure coded pool, snapshot it, and clone to replica pool", func() {
+				// This test validates cross-pool cloning from erasure-coded to replica pool
+				// 1. Create EC storageclass
+				// 2. Create PVC from it and verify it's created in correct dataPool
+				// 3. Create snapshot and verify rbd image created in correct pool
+				// 4. Clone the PVC to a replica pool storageclass and verify clone is in replica pool
+
+				// Create storageclass with erasure-coded pool
+				ecSCName := "ec-storageclass"
+				err := createRBDStorageClass(
+					f.ClientSet,
+					f,
+					ecSCName,
+					nil,
+					map[string]string{
+						"dataPool": erasureCodedPool,
+						"pool":     defaultRBDPool,
+					},
+					deletePolicy)
+				if err != nil {
+					logAndFail("failed to create erasure-coded storageclass: %v", err)
+				}
+
+				// Create snapshot class
+				err = createRBDSnapshotClass(f)
+				if err != nil {
+					logAndFail("failed to create snapshotclass: %v", err)
+				}
+				defer func() {
+					err = deleteRBDSnapshotClass()
+					if err != nil {
+						logAndFail("failed to delete VolumeSnapshotClass: %v", err)
+					}
+				}()
+
+				// Create PVC in erasure-coded pool
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					logAndFail("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+				pvc.Spec.StorageClassName = &ecSCName
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create PVC: %v", err)
+				}
+
+				// Verify PVC is created in erasure-coded pool
+				err = checkPVCDataPoolForImageInPool(f, pvc, defaultRBDPool, erasureCodedPool)
+				if err != nil {
+					logAndFail("failed to check data pool for image: %v", err)
+				}
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				// Create app and write data
+				app, err := loadApp(appPath)
+				if err != nil {
+					logAndFail("failed to load app: %v", err)
+				}
+				label := make(map[string]string)
+				label[appKey] = appLabel
+				app.Namespace = f.UniqueName
+				app.Labels = label
+				opt := metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s", appKey, label[appKey]),
+				}
+				app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+				checkSum, err := writeDataAndCalChecksum(app, &opt, f)
+				if err != nil {
+					logAndFail("failed to calculate checksum: %v", err)
+				}
+
+				// Create snapshot
+				snap := getSnapshot(snapshotPath)
+				snap.Namespace = f.UniqueName
+				snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+				err = createSnapshot(&snap, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create snapshot: %v", err)
+				}
+
+				// Validate snapshot is created in erasure-coded pool (1 parent image + 1 snapshot)
+				validateRBDImageCount(f, 2, defaultRBDPool)
+
+				// Validate if the backing snapshot image has data-pool set
+				snapshotImageName, err := getSnapName(snap.Namespace, snap.Name)
+				if err != nil {
+					logAndFail("failed to get snapshot name: %v", err)
+				}
+
+				err = validateDataPool(f, snapshotImageName, defaultRBDPool, erasureCodedPool)
+				if err != nil {
+					logAndFail("failed to validate data_pool: %v", err)
+				}
+
+				// Clone snapshot to PVC with replica pool
+				pvcClone, err := loadPVC(pvcClonePath)
+				if err != nil {
+					logAndFail("failed to load clone PVC: %v", err)
+				}
+				pvcClone.Namespace = f.UniqueName
+				pvcClone.Spec.DataSource.Name = snap.Name
+				// StorageClassName is not set, will use the default storageclass
+
+				err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create clone PVC: %v", err)
+				}
+
+				// Validate clone is in replica pool
+				validateRBDImageCount(f, 3, defaultRBDPool)
+
+				// Create app with cloned PVC and verify data
+				appClone, err := loadApp(appClonePath)
+				if err != nil {
+					logAndFail("failed to load clone app: %v", err)
+				}
+				appClone.Namespace = f.UniqueName
+				appClone.Labels = label
+				appClone.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcClone.Name
+
+				err = createApp(f.ClientSet, appClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create clone app: %v", err)
+				}
+
+				// Verify data integrity
+				filePath := appClone.Spec.Containers[0].VolumeMounts[0].MountPath + "/test"
+				newCheckSum, err := calculateSHA512sum(f, appClone, filePath, &opt)
+				if err != nil {
+					logAndFail("failed to calculate checksum for clone: %v", err)
+				}
+				if newCheckSum != checkSum {
+					logAndFail(
+						"checksum mismatch in clone, expected %s got %s",
+						checkSum,
+						newCheckSum)
+				}
+
+				// Cleanup
+				err = deletePod(appClone.Name, appClone.Namespace, f.ClientSet, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete clone app: %v", err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete clone PVC: %v", err)
+				}
+
+				err = deleteSnapshot(&snap, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete snapshot: %v", err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete PVC: %v", err)
+				}
+				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				// Delete erasure-coded storageclass
+				err = c.StorageV1().StorageClasses().Delete(context.TODO(), ecSCName, metav1.DeleteOptions{})
+				if err != nil {
+					logAndFail("failed to delete erasure-coded storageclass: %v", err)
+				}
+			})
+
+			By("clone a PVC from default pool to erasure-coded pool and validate temp image data pool", func() {
+				// Create PVC in default pool
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					logAndFail("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create PVC: %v", err)
+				}
+				validateRBDImageCount(f, 1, defaultRBDPool)
+
+				// Create EC storageclass for the clone
+				ecSCName := "ec-storageclass"
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					ecSCName,
+					nil,
+					map[string]string{
+						"dataPool": erasureCodedPool,
+						"pool":     defaultRBDPool,
+					},
+					deletePolicy)
+				if err != nil {
+					logAndFail("failed to create erasure-coded storageclass: %v", err)
+				}
+
+				// Create PVC clone with EC storageclass
+				pvcClone, err := loadPVC(pvcSmartClonePath)
+				if err != nil {
+					logAndFail("failed to load clone PVC: %v", err)
+				}
+				pvcClone.Namespace = f.UniqueName
+				pvcClone.Spec.DataSource.Name = pvc.Name
+				pvcClone.Spec.StorageClassName = &ecSCName
+				err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create clone PVC: %v", err)
+				}
+
+				// parent + temp + clone = 3 images
+				validateRBDImageCount(f, 3, defaultRBDPool)
+
+				// Validate that the temp image has data_pool set to erasure-coded pool
+				cloneImageData, err := getImageInfoFromPVC(pvcClone.Namespace, pvcClone.Name, f)
+				if err != nil {
+					logAndFail("failed to get clone image info: %v", err)
+				}
+				tempImageName := cloneImageData.imageName + "-temp"
+				err = validateDataPool(f, tempImageName, defaultRBDPool, erasureCodedPool)
+				if err != nil {
+					logAndFail("failed to validate data_pool on temp image: %v", err)
+				}
+
+				// Cleanup
+				err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete clone PVC: %v", err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete PVC: %v", err)
+				}
+				validateRBDImageCount(f, 0, defaultRBDPool)
+
+				// Delete EC storageclass
+				err = c.StorageV1().StorageClasses().Delete(context.TODO(), ecSCName, metav1.DeleteOptions{})
+				if err != nil {
+					logAndFail("failed to delete erasure-coded storageclass: %v", err)
+				}
+			})
+
 			By("create a PVC and bind it to an app with ext4 as the FS ", func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")
 				if err != nil {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1227,6 +1227,7 @@ type imageInfo struct {
 	StripeUnit  int    `json:"stripe_unit"`
 	StripeCount int    `json:"stripe_count"`
 	ObjectSize  int    `json:"object_size"`
+	DataPool    string  `json:"data_pool"`
 }
 
 // getImageInfo queries rbd about the given image and returns its metadata, and returns
@@ -1325,6 +1326,25 @@ func validateQOS(f *framework.Framework,
 		if qosVal != v {
 			return fmt.Errorf("%s: %s does not match expected %s", k, qosVal, v)
 		}
+	}
+
+	return nil
+}
+
+func validateDataPool(f *framework.Framework, imageName, poolName string, wants string) error {
+	var imgInfo imageInfo
+	imgInfoStr, err := getImageInfo(f, imageName, poolName)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal([]byte(imgInfoStr), &imgInfo)
+	if err != nil {
+		return fmt.Errorf("unmarshal failed: %w. raw buffer response: %s", err, imgInfoStr)
+	}
+	
+	if imgInfo.DataPool != wants {
+		return fmt.Errorf("unexpected data_pool: got %q, want %q", imgInfo.DataPool, wants)
 	}
 
 	return nil

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -48,6 +48,10 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 	tempClone := rv.generateTempClone()
 	defer tempClone.Destroy(ctx)
 
+	// Use the data pool from the destination volume's StorageClass
+	// This ensures the temporary clone uses the same data pool configuration as the final volume.
+	tempClone.DataPool = rv.DataPool
+
 	snap := &rbdSnapshot{}
 	defer snap.Destroy(ctx)
 	snap.RbdSnapName = rv.RbdImageName
@@ -186,6 +190,10 @@ func (rv *rbdVolume) doSnapClone(ctx context.Context, parentVol *rbdVolume) erro
 	// generate temp cloned volume
 	tempClone := rv.generateTempClone()
 	defer tempClone.Destroy(ctx)
+
+	// Use the data pool from the destination volume's StorageClass
+	// This ensures the temporary clone uses the same data pool configuration as the final volume.
+	tempClone.DataPool = rv.DataPool
 
 	// snapshot name is same as temporary cloned image, This helps to
 	// flatten the temporary cloned images as we cannot have more than 510

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1395,6 +1395,10 @@ func (cs *ControllerServer) doSnapshotClone(
 	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
 	cloneRbd.ImageFeatureSet = librbd.FeatureSetFromNames(f)
 
+	// For snapshot creation, the temporary clone must use the same data pool as the parent
+	// volume to ensure correct storage placement for erasure-coded pools.
+	cloneRbd.DataPool = parentVol.DataPool
+
 	err := cloneRbd.Connect(cr)
 	if err != nil {
 		return cloneRbd, err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -536,6 +536,47 @@ func (ri *rbdImage) getImageID() error {
 	return nil
 }
 
+// getDataPoolID returns the pool ID where the image data is stored.
+// For an image with an erasure-coded data pool, this returns the EC poolID.
+// For an image without a separate data pool, this returns the regular poolID.
+func (ri *rbdImage) getDataPoolID() (int64, error) {
+	image, err := ri.open()
+	if err != nil {
+		return util.InvalidPoolID, err
+	}
+	defer image.Close() //nolint:errcheck // not a critical failure
+
+	return image.GetDataPoolID()
+}
+
+// populateDataPool retrieves and sets the data pool name for the volume.
+// This ensures the DataPool field is populated so that clone and snapshot
+// preserve the data pool configuration.
+func (rv *rbdVolume) populateDataPool(ctx context.Context, cr *util.Credentials, poolId int64) error {
+	dataPoolID, err := rv.getDataPoolID()
+	if err != nil {
+		log.ErrorLog(ctx, "failed to get data pool ID for volume %s: %v", rv, err)
+
+		return err
+	}
+	if poolId == dataPoolID {
+		return nil
+	}
+
+	dataPoolName, err := util.GetPoolName(rv.Monitors, cr, dataPoolID)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to get data pool name for volume %s (pool ID %d): %v",
+			rv, dataPoolID, err)
+
+		return err
+	}
+
+	rv.DataPool = dataPoolName
+	log.DebugLog(ctx, "set data pool %q for volume %s", dataPoolName, rv)
+
+	return nil
+}
+
 // open the rbdImage after it has been connected.
 // ErrPoolNotFound or ErrImageNotFound are returned in case the pool or image
 // can not be found, other errors will contain more details about other issues
@@ -1242,8 +1283,16 @@ func generateVolumeFromVolumeID(
 		}
 	}
 	err = rbdVol.getImageInfo()
+	if err != nil {
+		return rbdVol, err
+	}
 
-	return rbdVol, err
+	err = rbdVol.populateDataPool(ctx, cr, vi.LocationID)
+	if err != nil {
+		return rbdVol, err
+	}
+
+	return rbdVol, nil
 }
 
 // ShouldRetryVolumeGeneration determines whether the process of finding or generating


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

## Problem:

This commit adds populateDataPool() to retrieve the data pool
from the source RBD image, ensuring the data pool is present
in snapshot image.

Fixes: #4761 

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages followguidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
