### PR TITLE
e2e: enable fail-fast to abort suite on first test failure

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -80,7 +80,9 @@ func TestE2E(t *testing.T) {
 	}
 	isOpenShift = ocpDetected
 
-	RunSpecs(t, "E2e Suite")
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	suiteConfig.FailFast = true
+	RunSpecs(t, "E2e Suite", suiteConfig, reporterConfig)
 }
 
 func handleFlags() {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Configure Ginkgo's FailFast option so that when any spec fails,
all remaining specs are skipped immediately instead of continuing
to run the rest of the suite.

Saves a lot of ci resources.

Example run
https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/organizations/jenkins/mini-e2e_k8s-1.34/detail/mini-e2e_k8s-1.34/567/pipeline/

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
