### PR TITLE
ci: add markdown links validation action

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,0 +1,27 @@
+---
+# link-check is a GitHub Action that checks for broken links in markdown files
+# Reference https://github.com/lycheeverse/lychee-action
+name: link-check
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - '*'
+permissions:
+  contents: read
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  # yamllint disable-line rule:truthy rule:line-length
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  link-check:
+    name: link-check
+    runs-on: ubuntu-latest
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: link-check
+        run: make containerized-test TARGET=link-check

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 
 all: cephcsi
 
-.PHONY: go-test static-check mod-check go-lint lint-extras commitlint codespell
+.PHONY: go-test static-check mod-check go-lint lint-extras commitlint link-check codespell
 ifeq ($(CONTAINERIZED),no)
 # include mod-check in non-containerized runs
 test: go-test static-check mod-check
@@ -167,6 +167,9 @@ commitlint:
 	git fetch -v $(shell cut -d/ -f1 <<< "$(GIT_SINCE)") $(shell cut -d/ -f2- <<< "$(GIT_SINCE)")
 	@test $(REBASE) -eq 0 || git -c user.name=commitlint -c user.email=commitline@localhost rebase FETCH_HEAD
 	commitlint --verbose --from $(GIT_SINCE)
+
+link-check:
+	lychee --config lychee.toml .
 
 .PHONY: cephcsi
 cephcsi: check-env

--- a/build.env
+++ b/build.env
@@ -34,6 +34,7 @@ COMMITLINT_VERSION=latest
 
 # static checks and linters
 GOLANGCI_VERSION=v2.5.0
+LYCHEE_VERSION=v0.23.0
 
 # external snapshotter version
 # Refer: https://github.com/kubernetes-csi/external-snapshotter/releases

--- a/docs/cephfs/deploy.md
+++ b/docs/cephfs/deploy.md
@@ -83,7 +83,7 @@ you're running it inside a k8s cluster and find the config itself).
 | `extraDeploy` | no | array of extra objects to deploy with the release |
 
 **NOTE:** An accompanying CSI configuration file, needs to be provided to the
-running pods. Refer to [Creating CSI configuration](../examples/README.md#creating-csi-configuration)
+running pods. Refer to [Creating CSI configuration](../../examples/README.md#creating-csi-configuration)
 for more information.
 
 **NOTE:** A suggested way to populate and retain uniqueness of the clusterID is
@@ -105,7 +105,7 @@ for a zero-sized volume means no quota attribute will be set.
 
 Requires Kubernetes 1.14+
 
-Use the [cephfs templates](../deploy/cephfs/kubernetes)
+Use the [cephfs templates](../../deploy/cephfs/kubernetes)
 
 Your Kubernetes cluster must allow privileged pods (i.e. `--allow-privileged`
 flag must be set to true for both the API server and the kubelet). Moreover, as
@@ -140,7 +140,7 @@ kubectl create -f csi-config-map.yaml
 
 The configmap deploys an empty CSI configuration that is mounted as a volume
 within the Ceph CSI plugin pods. To add a specific Ceph clusters configuration
-details, refer to [Creating CSI configuration](../examples/README.md#creating-csi-configuration)
+details, refer to [Creating CSI configuration](../../examples/README.md#creating-csi-configuration)
 for more information.
 
 **Deploy Ceph configuration ConfigMap for CSI pods:**
@@ -152,7 +152,7 @@ kubectl create -f ../../ceph-conf.yaml
 **Deploy prerequisites for CSI Snapshot:**
 
 If you intend to use the snapshot functionality in Kubernetes cluster,
-please refer to [snap-clone.md](./snap-clone.md#prerequisite)
+please refer to [snap-clone.md](../snap-clone.md#prerequisite)
 
 **Deploy CSI sidecar containers:**
 
@@ -175,15 +175,15 @@ the CSI CephFS driver.
 **NOTE:**
 In case you want to use a different release version, replace canary with the
 release version in the
-[provisioner](../deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml)
-and [nodeplugin](../deploy/cephfs/kubernetes/csi-cephfsplugin.yaml) YAMLs.
+[provisioner](../../deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml)
+and [nodeplugin](../../deploy/cephfs/kubernetes/csi-cephfsplugin.yaml) YAMLs.
 
 ```yaml
 # for stable functionality replace canary with latest release version
     image: quay.io/cephcsi/cephcsi:canary
 ```
 
-Check the release version [here.](../README.md#ceph-csi-container-images-and-release-compatibility)
+Check the release version [here.](../../README.md#ceph-csi-container-images-and-release-compatibility)
 
 ## Verifying the deployment in Kubernetes
 
@@ -202,7 +202,7 @@ service/csi-cephfsplugin-provisioner   ClusterIP   10.101.78.75     <none>      
 
 Once the CSI plugin configuration is updated with details from a Ceph cluster of
 choice, you can try deploying a demo pod from examples/cephfs using the
-instructions [provided](../examples/README.md#deploying-the-storage-class) to
+instructions [provided](../../examples/README.md#deploying-the-storage-class) to
 test the deployment further.
 
 ### Notes on volume deletion
@@ -221,7 +221,7 @@ The Helm chart is located in `charts/ceph-csi-cephfs`.
 
 **Deploy Helm Chart:**
 
-[See the Helm chart readme for installation instructions.](../../../charts/ceph-csi-cephfs/README.md)
+[See the Helm chart readme for installation instructions.](../../charts/ceph-csi-cephfs/README.md)
 
 ## Read Affinity using crush locations for CephFS subvolumes
 
@@ -251,7 +251,7 @@ Requires fscrypt support in the Linux kernel and Ceph.
 Key management is compatible with the
 [fscrypt](https://github.com/google/fscrypt) userspace tool. See the
 design doc [Ceph Filesystem fscrypt
-Support](design/proposals/cephfs-fscrypt.md) for details.
+Support](../design/proposals/cephfs-fscrypt.md) for details.
 
 In general the KMS configuration is the same as for RBD encryption and
 can even be shared.

--- a/docs/csi-addons/disaster-recovery.md
+++ b/docs/csi-addons/disaster-recovery.md
@@ -190,7 +190,7 @@ status:
     ```
 
 >:bulb: We can also take backup using external tools like **Velero**.
-> Refer [velero documentation]((https://velero.io/docs/main/)) for more information.
+> Refer [velero documentation](https://velero.io/docs/main/) for more information.
 
 * Restoring on the secondary cluster(cluster-2)
 

--- a/docs/design/proposals/cephfs-snapshot-backed-volumes.md
+++ b/docs/design/proposals/cephfs-snapshot-backed-volumes.md
@@ -4,13 +4,13 @@ Snapshot-backed volumes allow CephFS subvolume snapshots to be exposed as
 regular read-only PVCs. No data cloning is performed and provisioning such
 volumes is done in constant time.
 
-For more details please refer to [Snapshots as shallow read-only volumes](./design/proposals/cephfs-snapshot-shallow-ro-vol.md)
+For more details please refer to [Snapshots as shallow read-only volumes](./cephfs-snapshot-shallow-ro-vol.md)
 design document.
 
 ## Prerequisites
 
 Prerequisites for this feature are the same as for creating PVCs with snapshot
-volume source. See [Create snapshot and Clone Volume](./snap-clone.md) for more
+volume source. See [Create snapshot and Clone Volume](../../snap-clone.md) for more
 information.
 
 ## Usage
@@ -34,7 +34,7 @@ for `ReadOnlyMany` PVC a clone will get created in ceph cluster.
 
 Steps for defining a PersistentVolume and PersistentVolumeClaim for
 pre-provisioned CephFS subvolumes are identical to those described in
-[Static PVC with ceph-csi](./static-pvc.md), except one additional parameter
+[Static PVC with ceph-csi](../../static-pvc.md), except one additional parameter
 must be specified: `backingSnapshotID`. CephFS-CSI driver will retrieve the
 snapshot identified by the given ID from within the specified subvolume, and
 expose it to workloads in read-only mode. Volume access mode must be set to

--- a/docs/design/proposals/encryption-with-vault-sa.md
+++ b/docs/design/proposals/encryption-with-vault-sa.md
@@ -27,14 +27,14 @@ An example of the per Tenant configuration options are in
 [`tenant-config.yaml`](../../../examples/kms/vault/tenant-config.yaml) and
 [`tenant-token.yaml`](../../../examples/kms/vault/tenant-token.yaml).
 
-Implementation is in [`vault_tokens.go`](../../../internal/util/vault_tokens.go)
+Implementation is in [`vault_tokens.go`](../../../internal/kms/vault_tokens.go)
 .
 
 ### Vault
 
 - uses Kubernetes Auth with single service account (aka storage admin account)
 
-Implementation is in [`vault.go`](../../../internal/util/vault.go).
+Implementation is in [`vault.go`](../../../internal/kms/vault.go).
 
 ## Extension or New KMS implementation
 

--- a/docs/design/proposals/intree-migrate.md
+++ b/docs/design/proposals/intree-migrate.md
@@ -11,7 +11,7 @@ redirecting in-tree operation calls to the CSI Driver instead of the in-tree
 driver, the external components will pick up these in-tree PV's and use a
 translation library to translate to CSI Source. For more information on CSI
 migration effort
-refer [design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md)
+refer [design doc](https://github.com/kubernetes/design-proposals-archive/blob/main/storage/csi-migration.md)
 
 ## RBD in-tree plugin to CSI migration
 

--- a/docs/design/proposals/rbd-nbd.md
+++ b/docs/design/proposals/rbd-nbd.md
@@ -60,7 +60,7 @@ storageclass yaml
       helm install --set cephLogDirHostPath=/var/log/ceph-csi/my-dir
       ```
 
-      - For standard templates edit [csi-rbdplugin.yaml](../deploy/rbd/kubernetes/csi-rbdplugin.yaml)
+      - For standard templates edit [csi-rbdplugin.yaml](../../../deploy/rbd/kubernetes/csi-rbdplugin.yaml)
       to update `hostPath` for `ceph-logdir`.
       to update `pathPrefix` spec entries.
    - Update the StorageClass with the customized log directory path

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -15,7 +15,7 @@ it is **highly** encouraged to:
 
 * [Download](https://golang.org/dl/) Go (>=1.17.x) and
    [install](https://golang.org/doc/install) it on your system.
-* Setup the [GOPATH](http://www.g33knotes.org/2014/07/60-second-count-down-to-go.html)
+* Setup the [GOPATH](https://go.dev/doc/gopath_code)
    environment.
 * `CGO_ENABLED` is enabled by default, if `CGO_ENABLED` is set to `0` we need
   to set it to `1` as we need to build with go-ceph bindings.

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -375,7 +375,7 @@ documentation](https://www.vaultproject.io/docs/auth/kubernetes.html).
 
 If token reviewer is used, you will need to configure service account for
 that also like in
-[example](../examples/kms/vault/csi-vaulttokenreview-rbac.yaml) to be able to
+[example](../../examples/kms/vault/csi-vaulttokenreview-rbac.yaml) to be able to
 review jwt tokens.
 
 Configure a role(s) for service accounts used for ceph-csi:

--- a/examples/nfs/README.md
+++ b/examples/nfs/README.md
@@ -69,5 +69,5 @@ storageclass.storage.k8s.io/csi-nfs-sc created
 - deploy the kubernetes-csi/csi-driver-nfs
 - create the CSIDriver object
 
-[rook_ceph]: https://rook.io/docs/rook/latest/ceph-nfs-crd.html
-[rook_toolbox]: https://rook.io/docs/rook/latest/ceph-toolbox.html
+[rook_ceph]: https://rook.io/docs/rook/latest/CRDs/ceph-nfs-crd/
+[rook_toolbox]: https://rook.io/docs/rook/latest/Troubleshooting/ceph-toolbox/

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,16 @@
+# lychee link checker configuration
+# See https://lychee.cli.rs for details
+
+# Exclude paths from being checked
+exclude_path = [
+    "actions/retest/vendor",
+    "api/vendor",
+    "e2e/vendor",
+    "vendor",
+]
+
+# Output format
+format = "markdown"
+
+# Maximum number of concurrent network requests
+max_concurrency = 14

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -62,6 +62,8 @@ RUN set -x \
     && npm init -y \
     && npm install @commitlint/cli@"${COMMITLINT_VERSION}" \
     && popd \
+    && ARCH=$(case "${GOARCH}" in amd64) echo "x86_64";; arm64) echo "aarch64";; *) echo "x86_64";; esac) \
+    && curl -sSfL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-${ARCH}-unknown-linux-gnu.tar.gz" | tar -xz -C /usr/local/bin \
     && git config --global --add safe.directory ${CEPHCSIPATH} \
     && go install github.com/augmentable-dev/tickgit/cmd/tickgit@latest \
     && true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

ci: add markdown link validation action

This PR adds a new GitHub Actions workflow to automatically validate links in markdown files across the repository.

The workflow:
- Runs on all pull requests using the lychee link checker
- Excludes vendor directories from all modules (main, e2e, api, actions/retest)
- Fails the build if broken links are detected

This helps maintain documentation quality by catching broken links before they are merged.

## Related issues ##

Depends-on: #6082
Fixes: #6089

## Future concerns ##

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
