### PR TITLE
Allow underscore in volume ID

### DIFF
--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -29,7 +29,7 @@ import (
 
 // A regex to verify the expected format: 0000-0000-arbitrary-number-of-000-and-chars.
 // First two blocks are hexadecimal.
-var validator = regexp.MustCompile(`^[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[a-zA-Z0-9\-]+$`)
+var validator = regexp.MustCompile(`^[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[a-zA-Z0-9\-_]+$`)
 
 // ValidateControllerPublishVolumeRequest validates the controller publish request.
 func ValidateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {

--- a/internal/util/validate_test.go
+++ b/internal/util/validate_test.go
@@ -34,6 +34,7 @@ func TestValidateVolumeID(t *testing.T) {
 		{"valid short", "0001-0024-pool-abc", false, false},
 		{"valid long", "0001-0024-cluster-pool-0000-0000-0000-0001", false, false},
 		{"valid very long", "0001-000b-clusterID-1-0000000000000001-c156bd07-e430-435f-b175-56c61a2d9297", false, false},
+		{"valid with underscore", "0001-0024-rook_ceph-pool-uuid", false, false},
 		{"invalid very long", "00fg-01bg-clusterID-1-0000000000000001-c156bd07-e430-435f-b175-56c61a2d9297", false, true},
 
 		// Static Volumes, skip enforcing format.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This updates the regex that handles volume ID validation to allow underscores in the volume ID. I have a volume with an underscore in the name, which when the volume ID is parsed in grpc requests & validate it returns an error since v3.16.1 I have updated the regex to include an `_` character in the last portion, as well as added a test validating the new behavior.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Yes

Are there concerns around backward compatibility?

No

Provide any external context for the change, if any.

For example:

Since v3.16.1 I get this error:

```
 MountVolume.MountDevice failed for volume "pvc-ce95e27a-d44d-4f8c-ac8c-bf06084bd98a" : rpc error: code = InvalidArgument desc = the volumeID has an unexpected format: "0001-0007-ceph_ec-0000000000000001-c3327f90-43ef-4f1a-8267-a388a49b9665"
```

This is a result of the fact that ceph_ec (my volume) has an underscore which is reading as invalid.

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
