### PR TITLE
rbd: limit max number of key rotation operations per driver instance

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -151,6 +151,11 @@ func init() {
 		"Minimum number of snapshots required on rbd image to start flattening")
 	flag.BoolVar(&conf.SkipForceFlatten, "skipforceflatten", false,
 		"skip image flattening if kernel support mapping of rbd images which has the deep-flatten feature")
+	flag.IntVar(
+		&conf.MaxConcurrentKeyRotations,
+		"max-concurrent-key-rotations",
+		10,
+		"Maximum number of concurrent encryption key rotations")
 
 	flag.BoolVar(&conf.Version, "version", false, "Print cephcsi version information")
 	flag.BoolVar(&conf.EnableProfiling, "enableprofiling", false, "enable go profiling")

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -104,6 +104,8 @@ func (r *rbdDriver) Run(conf *util.Config) {
 	rbd.SetGlobalInt("minSnapshotsOnImageToStartFlatten", conf.MinSnapshotsOnImage)
 	// Create instances of the volume and snapshot journal
 	rbd.InitJournals(conf.InstanceID)
+	// Initialize encryption key rotation concurrency limit
+	rbd.InitEncryptionKeyRotationSemaphore(conf.MaxConcurrentKeyRotations)
 
 	// Initialize default library driver
 	r.cd = csicommon.NewCSIDriver(conf.DriverName, util.DriverVersion, conf.NodeID, conf.InstanceID,

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -542,6 +542,18 @@ func (rv *rbdVolume) RotateEncryptionKey(ctx context.Context) error {
 		return errors.New("key rotation not supported for unencrypted device")
 	}
 
+	// Do not allow more than the configured max rotations per driver
+	if encryptionKeyRotationSemaphore != nil {
+		if acquired := encryptionKeyRotationSemaphore.TryAcquire(); !acquired {
+			inUse := encryptionKeyRotationSemaphore.InUse()
+			log.WarningLog(ctx, "encryption key rotation limit reached (%d concurrent operations), "+
+				"rejecting request for volume %s", inUse, rv.VolID)
+
+			return fmt.Errorf("encryption key rotation capacity exceeded: %d operations in progress, please retry later", inUse)
+		}
+		defer encryptionKeyRotationSemaphore.Release()
+	}
+
 	// Call open Ioctx to create a new ioctx object
 	// if the obj already exists, no error is returned
 	err = rv.openIoctx()

--- a/internal/rbd/globals.go
+++ b/internal/rbd/globals.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	"github.com/ceph/ceph-csi/internal/journal"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 var (
@@ -40,6 +42,10 @@ var (
 
 	// krbd features supported by the loaded driver.
 	krbdFeatures uint
+
+	// encryptionKeyRotationSemaphore limits concurrent encryption key rotations
+	// to prevent OOM kills from too many cryptsetup processes.
+	encryptionKeyRotationSemaphore *util.Semaphore
 )
 
 // SetGlobalInt provides a way for the rbd-driver to configure global variables
@@ -89,4 +95,17 @@ func SetGlobalBool(name string, value bool) {
 func InitJournals(instance string) {
 	volJournal = journal.NewCSIVolumeJournal(instance)
 	snapJournal = journal.NewCSISnapshotJournal(instance)
+}
+
+// InitEncryptionKeyRotationSemaphore initializes the global semaphore that limits
+// concurrent encryption key rotations to prevent OOM kills.
+// This is called from the rbd-driver on startup.
+func InitEncryptionKeyRotationSemaphore(maxConcurrent int) {
+	if maxConcurrent <= 0 {
+		// Set to default of 10
+		maxConcurrent = 10
+	}
+	encryptionKeyRotationSemaphore = util.NewSemaphore(maxConcurrent)
+
+	log.DefaultLog("encryption key rotation concurrency limited to %d", maxConcurrent)
 }

--- a/internal/util/semaphore.go
+++ b/internal/util/semaphore.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+)
+
+// Semaphore is a counting semaphore for limiting concurrent operations.
+type Semaphore struct {
+	sem chan struct{}
+}
+
+// NewSemaphore creates a new semaphore with the given capacity.
+func NewSemaphore(capacity int) *Semaphore {
+	return &Semaphore{
+		sem: make(chan struct{}, capacity),
+	}
+}
+
+// TryAcquire attempts to acquire the semaphore without blocking.
+// Returns true if successful, false if at capacity.
+func (s *Semaphore) TryAcquire() bool {
+	select {
+	case s.sem <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Acquire acquires the semaphore, blocking until capacity is available or context is canceled.
+func (s *Semaphore) Acquire(ctx context.Context) error {
+	select {
+	case s.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("failed to acquire semaphore: %w", ctx.Err())
+	}
+}
+
+// Release releases the semaphore, making room for another operation.
+func (s *Semaphore) Release() {
+	select {
+	case <-s.sem:
+	default:
+		// Should not happen.
+	}
+}
+
+// Available returns the number of available slots in the semaphore.
+func (s *Semaphore) Available() int {
+	return cap(s.sem) - len(s.sem)
+}
+
+// InUse returns the number of currently acquired slots.
+func (s *Semaphore) InUse() int {
+	return len(s.sem)
+}

--- a/internal/util/semaphore_test.go
+++ b/internal/util/semaphore_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSemaphore_TryAcquire(t *testing.T) {
+	t.Parallel()
+	sem := NewSemaphore(2)
+
+	// Should acquire twice successfully
+	if !sem.TryAcquire() || !sem.TryAcquire() {
+		t.Error("TryAcquire() failed within capacity")
+	}
+
+	// Should fail when at capacity
+	if sem.TryAcquire() {
+		t.Error("TryAcquire() succeeded when at capacity")
+	}
+
+	// Should succeed after release
+	sem.Release()
+	if !sem.TryAcquire() {
+		t.Error("TryAcquire() failed after release")
+	}
+}
+
+func TestSemaphore_Acquire(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func() (*Semaphore, context.Context, context.CancelFunc)
+		wantErr bool
+	}{
+		{
+			name: "acquire with available slot",
+			setup: func() (*Semaphore, context.Context, context.CancelFunc) {
+				return NewSemaphore(2), context.Background(), func() {}
+			},
+			wantErr: false,
+		},
+		{
+			name: "acquire fails on canceled context",
+			setup: func() (*Semaphore, context.Context, context.CancelFunc) {
+				sem := NewSemaphore(1)
+				sem.TryAcquire() // Fill capacity
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel() // Cancel immediately
+
+				return sem, ctx, func() {}
+			},
+			wantErr: true,
+		},
+		{
+			name: "acquire fails on timeout",
+			setup: func() (*Semaphore, context.Context, context.CancelFunc) {
+				sem := NewSemaphore(1)
+				sem.TryAcquire() // Fill capacity
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+
+				return sem, ctx, cancel
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sem, ctx, cancel := tt.setup()
+			defer cancel()
+
+			err := sem.Acquire(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Acquire() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSemaphore_Release(t *testing.T) {
+	t.Parallel()
+	sem := NewSemaphore(3)
+
+	sem.TryAcquire()
+	sem.TryAcquire()
+
+	before := sem.Available()
+	sem.Release()
+	after := sem.Available()
+
+	if after != before+1 {
+		t.Errorf("Available() after release = %d, want %d", after, before+1)
+	}
+}
+
+func TestSemaphore_Counters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		capacity  int
+		acquires  int
+		releases  int
+		wantInUse int
+		wantAvail int
+	}{
+		{"initial state", 5, 0, 0, 0, 5},
+		{"after acquires", 5, 3, 0, 3, 2},
+		{"after acquire and release", 5, 3, 1, 2, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sem := NewSemaphore(tt.capacity)
+
+			for range tt.acquires {
+				sem.TryAcquire()
+			}
+			for range tt.releases {
+				sem.Release()
+			}
+
+			if sem.InUse() != tt.wantInUse {
+				t.Errorf("InUse() = %d, want %d", sem.InUse(), tt.wantInUse)
+			}
+			if sem.Available() != tt.wantAvail {
+				t.Errorf("Available() = %d, want %d", sem.Available(), tt.wantAvail)
+			}
+		})
+	}
+}
+
+func TestSemaphore_Concurrent(t *testing.T) {
+	t.Parallel()
+	capacity := 10
+	goroutines := 100
+	sem := NewSemaphore(capacity)
+
+	var successCount int
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	// Many goroutines try to acquire
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if sem.TryAcquire() {
+				mu.Lock()
+				successCount++
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if successCount != capacity {
+		t.Errorf("successful acquisitions = %d, want %d", successCount, capacity)
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -137,6 +137,10 @@ type Config struct {
 	// reached cephcsi will start flattening the older rbd images.
 	MinSnapshotsOnImage uint
 
+	// MaxConcurrentKeyRotations limits the number of concurrent encryption key rotations
+	// to prevent OOM kills from too many cryptsetup processes running simultaneously.
+	MaxConcurrentKeyRotations int
+
 	PidLimit    int           // PID limit to configure through cgroups")
 	MetricsPort int           // TCP port for liveness/grpc metrics requests
 	PollTime    time.Duration // time interval in seconds between each poll


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This patch adds semaphores that limit the maximum number of active key rotation processes per driver.

The default limit is: 10
