### PR TITLE
e2e: cache mon IPs and clusterID as well as check csi pods readiness in parallel

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -330,18 +331,14 @@ var _ = Describe(cephfsType, func() {
 				logAndFail("failed getting cephFS metadata pool name: %v", getErr)
 			}
 
-			By("checking provisioner deployment is running", func() {
-				err := waitForDeploymentComplete(f.ClientSet, cephFSDeployment.getDeploymentName(), cephCSINamespace, deployTimeout)
-				if err != nil {
-					logAndFail("timeout waiting for deployment %s: %v", cephFSDeployment.getDeploymentName(), err)
-				}
-			})
-
-			By("checking nodeplugin daemonset pods are running", func() {
-				err := waitForDaemonSets(cephFSDeployment.getDaemonsetName(), cephCSINamespace, f.ClientSet, deployTimeout)
-				if err != nil {
-					logAndFail("timeout waiting for daemonset %s: %v", cephFSDeployment.getDaemonsetName(), err)
-				}
+			By("checking provisioner and nodeplugin are running", func() {
+				Expect(waitForCSI(
+					f.ClientSet,
+					cephFSDeployment.getDeploymentName(),
+					cephFSDeployment.getDaemonsetName(),
+					cephCSINamespace,
+					deployTimeout,
+				)).ShouldNot(HaveOccurred())
 			})
 
 			// test only if ceph-csi is deployed via helm

--- a/e2e/deployment.go
+++ b/e2e/deployment.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
@@ -185,6 +187,25 @@ func waitForDeploymentComplete(clientSet kubernetes.Interface, name, ns string, 
 	}
 
 	return nil
+}
+
+// waitForCSI waits for a CSI deployment and daemonset to be ready
+// concurrently.
+func waitForCSI(
+	clientSet kubernetes.Interface,
+	deploymentName, daemonsetName, ns string,
+	timeout int,
+) error {
+	var eg errgroup.Group
+	eg.Go(func() error {
+		return waitForDeploymentComplete(
+			clientSet, deploymentName, ns, timeout)
+	})
+	eg.Go(func() error {
+		return waitForDaemonSets(
+			daemonsetName, ns, clientSet, timeout)
+	})
+	return eg.Wait()
 }
 
 // ResourceDeployer provides a generic interface for deploying different

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -481,18 +482,14 @@ var _ = Describe("nfs", func() {
 				logAndFail("failed getting cephFS metadata pool name: %v", getErr)
 			}
 
-			By("checking provisioner deployment is running", func() {
-				err := waitForDeploymentComplete(f.ClientSet, nfsDeployment.getDeploymentName(), cephCSINamespace, deployTimeout)
-				if err != nil {
-					logAndFail("timeout waiting for deployment %s: %v", nfsDeployment.getDeploymentName(), err)
-				}
-			})
-
-			By("checking nodeplugin deamonset pods are running", func() {
-				err := waitForDaemonSets(nfsDeployment.getDaemonsetName(), cephCSINamespace, f.ClientSet, deployTimeout)
-				if err != nil {
-					logAndFail("timeout waiting for daemonset %s: %v", nfsDeployment.getDaemonsetName(), err)
-				}
+			By("checking provisioner and nodeplugin are running", func() {
+				Expect(waitForCSI(
+					f.ClientSet,
+					nfsDeployment.getDeploymentName(),
+					nfsDeployment.getDaemonsetName(),
+					cephCSINamespace,
+					deployTimeout,
+				)).ShouldNot(HaveOccurred())
 			})
 
 			By("verify mountOptions support", func() {

--- a/e2e/nvmeof-deploy.go
+++ b/e2e/nvmeof-deploy.go
@@ -116,20 +116,13 @@ func deployNVMeoFPlugin(f *framework.Framework, deployTimeout int) {
 
 	createORDeleteNVMeoFResources(kubectlCreate)
 
-	err = waitForDeploymentComplete(
+	Expect(waitForCSI(
 		f.ClientSet,
 		nvmeofDeploymentName,
-		cephCSINamespace,
-		deployTimeout,
-	)
-	Expect(err).ShouldNot(HaveOccurred())
-
-	err = waitForDaemonSets(
 		nvmeofDaemonsetName,
 		cephCSINamespace,
-		f.ClientSet,
-		deployTimeout)
-	Expect(err).ShouldNot(HaveOccurred())
+		deployTimeout,
+	)).ShouldNot(HaveOccurred())
 }
 
 func deleteNVMeoFPlugin() {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -405,17 +406,13 @@ var _ = Describe("RBD", func() {
 		}
 		deployVault(f.ClientSet, deployTimeout)
 
-		// wait for provisioner deployment
-		err = waitForDeploymentComplete(f.ClientSet, rbdDeployment.getDeploymentName(), cephCSINamespace, deployTimeout)
-		if err != nil {
-			logAndFail("timeout waiting for deployment %s: %v", rbdDeployment.getDeploymentName(), err)
-		}
-
-		// wait for nodeplugin deamonset pods
-		err = waitForDaemonSets(rbdDeployment.getDaemonsetName(), cephCSINamespace, f.ClientSet, deployTimeout)
-		if err != nil {
-			logAndFail("timeout waiting for daemonset %s: %v", rbdDeployment.getDaemonsetName(), err)
-		}
+		// wait for provisioner and nodeplugin
+		Expect(waitForCSI(
+			f.ClientSet,
+			rbdDeployment.getDeploymentName(),
+			rbdDeployment.getDaemonsetName(),
+			cephCSINamespace, deployTimeout,
+		)).ShouldNot(HaveOccurred())
 
 		kernelRelease, err = getKernelVersionFromDaemonset(f, cephCSINamespace, rbdDeployment.getDaemonsetName(), rbdContainerName)
 		if err != nil {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -359,7 +359,9 @@ func getClusterID(f *framework.Framework) (string, error) {
 		return "", fmt.Errorf("error getting fsid: %s", stdErr)
 	}
 	// remove new line present in fsID
-	return strings.Trim(fsID, "\n"), nil
+	clusterID = strings.Trim(fsID, "\n")
+
+	return clusterID, nil
 }
 
 func getStorageClass(path string) (scv1.StorageClass, error) {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -99,6 +99,7 @@ var (
 	clusterID          string
 	nfsDriverName      string
 	operatorDeployment bool
+	monsCache          = make(map[string][]string)
 )
 
 type cephfsFilesystem struct {
@@ -307,6 +308,10 @@ func validateOmapCount(f *framework.Framework, count int, driver, pool, mode str
 }
 
 func getMons(ns string, c kubernetes.Interface) ([]string, error) {
+	if mons, ok := monsCache[ns]; ok {
+		return mons, nil
+	}
+
 	opt := metav1.ListOptions{
 		LabelSelector: "app=rook-ceph-mon",
 	}
@@ -338,6 +343,8 @@ func getMons(ns string, c kubernetes.Interface) ([]string, error) {
 			svcList.Items[i].Spec.Ports[0].Port)
 		services = append(services, s)
 	}
+
+	monsCache[ns] = services
 
 	return services, nil
 }


### PR DESCRIPTION
# Describe what this PR does #

- e2e: parallelize deployment and daemonset readiness checks
- e2e: cache getMons() result
- e2e: cache clusterID in getClusterID

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
