### PR TITLE
Cleanup/typos

### DIFF
--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -330,7 +330,7 @@ func (kms *kmipKMS) connect() (*tls.Conn, error) {
 		}
 	}
 	if kms.writeTimeout != 0 {
-		err = conn.SetReadDeadline(time.Now().Add(time.Second * time.Duration(kms.writeTimeout)))
+		err = conn.SetWriteDeadline(time.Now().Add(time.Second * time.Duration(kms.writeTimeout)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to set write deadline: %w", err)
 		}

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -186,7 +186,7 @@ func (kms *kmipKMS) EncryptDEK(ctx context.Context, _, plainDEK string) (string,
 	}
 	defer conn.Close() //nolint:errcheck // more important errors are returned
 
-	emd := encryptedMetedataDEK{}
+	emd := encryptedMetadataDEK{}
 	emd.Nonce, err = generateNonce(nonceSize)
 	if err != nil {
 		return "", fmt.Errorf("failed to generated nonce: %w", err)
@@ -228,7 +228,7 @@ func (kms *kmipKMS) EncryptDEK(ctx context.Context, _, plainDEK string) (string,
 	emdData, err := json.Marshal(&emd)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert "+
-			"encryptedMetedataDEK to JSON: %w", err)
+			"encryptedMetadataDEK to JSON: %w", err)
 	}
 
 	return string(emdData), nil
@@ -242,11 +242,11 @@ func (kms *kmipKMS) DecryptDEK(ctx context.Context, _, encryptedDEK string) (str
 	}
 	defer conn.Close() //nolint:errcheck // more important errors are returned
 
-	emd := encryptedMetedataDEK{}
+	emd := encryptedMetadataDEK{}
 	err = json.Unmarshal([]byte(encryptedDEK), &emd)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert data to "+
-			"encryptedMetedataDEK: %w", err)
+			"encryptedMetadataDEK: %w", err)
 	}
 
 	respMsg, decoder, uniqueBatchItemID, err := kms.send(conn,

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -162,10 +162,10 @@ func (kms secretsMetadataKMS) RequiresDEKStore() DEKStoreType {
 	return DEKStoreMetadata
 }
 
-// encryptedMetedataDEK contains the encrypted DEK and the Nonce that was used
+// encryptedMetadataDEK contains the encrypted DEK and the Nonce that was used
 // during encryption. This structure is stored (in JSON format) in the DEKStore
 // that is linked to this KMS provider.
-type encryptedMetedataDEK struct {
+type encryptedMetadataDEK struct {
 	// DEK is the encrypted data-encryption-key for the volume.
 	DEK []byte `json:"dek"`
 	// Nonce is a random byte slice to guarantee the uniqueness of the
@@ -189,7 +189,7 @@ func (kms secretsMetadataKMS) EncryptDEK(ctx context.Context, volumeID, plainDEK
 		return "", fmt.Errorf("failed to generate cipher: %w", err)
 	}
 
-	emd := encryptedMetedataDEK{}
+	emd := encryptedMetadataDEK{}
 	emd.Nonce, err = generateNonce(aead.NonceSize())
 	if err != nil {
 		return "", fmt.Errorf("failed to generated nonce: %w", err)
@@ -199,7 +199,7 @@ func (kms secretsMetadataKMS) EncryptDEK(ctx context.Context, volumeID, plainDEK
 	emdData, err := json.Marshal(&emd)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert "+
-			"encryptedMetedataDEK to JSON: %w", err)
+			"encryptedMetadataDEK to JSON: %w", err)
 	}
 
 	return string(emdData), nil
@@ -219,11 +219,11 @@ func (kms secretsMetadataKMS) DecryptDEK(ctx context.Context, volumeID, encrypte
 		return "", fmt.Errorf("failed to generate cipher: %w", err)
 	}
 
-	emd := encryptedMetedataDEK{}
+	emd := encryptedMetadataDEK{}
 	err = json.Unmarshal([]byte(encryptedDEK), &emd)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert data to "+
-			"encryptedMetedataDEK: %w", err)
+			"encryptedMetadataDEK: %w", err)
 	}
 
 	dek, err := aead.Open(nil, emd.Nonce, emd.DEK, nil)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

- Fixes a typo  encryptedMetedataDEK --> encryptedMetadataDEK.
- writeTimeout was calling SetReadDeadline instead of SetWriteDeadline in the KMIP connection setup.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
