### PR TITLE
nvmeof: add check return status at removeHost

### DIFF
--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -475,18 +475,28 @@ func (gw *GatewayRpcClient) RemoveHost(ctx context.Context, subsystemNQN, hostNQ
 	if err != nil {
 		return fmt.Errorf("failed to remove host %s from subsystem %s: %w", hostNQN, subsystemNQN, err)
 	}
-	if resp.GetStatus() == 0 {
+	switch resp.GetStatus() {
+	case 0:
 		log.DebugLog(ctx, "Host %s removed successfully from subsystem %s", hostNQN, subsystemNQN)
 
 		return nil
-	}
-	if resp.GetStatus() == int32(syscall.ENOENT) { // ENOENT
+	case int32(syscall.EBUSY):
+		// we check there is no more namespace in the subsystem before we remove the host.
+		// so we dont care if there are still open connections with this host to subsystem,
+		//  because there is no more namespace to access.
+		log.DebugLog(ctx, "All ok, There are still open connections with this host %s to subsystem %s",
+			hostNQN, subsystemNQN)
+
+		// Host still has open connections, but we never run nvme disconnect,
+		//  so we can treat this as success for our use case
+		return nil
+	case int32(syscall.ENOENT):
 		log.DebugLog(ctx, "Host %s already removed from subsystem %s (not found)", hostNQN, subsystemNQN)
 
-		return nil
+		return nil // Host already removed, no error
+	default:
+		return fmt.Errorf("gateway RemoveHost returned error (status=%d): %s", resp.GetStatus(), resp.GetErrorMessage())
 	}
-
-	return fmt.Errorf("gateway RemoveHost returned error (status=%d): %s", resp.GetStatus(), resp.GetErrorMessage())
 }
 
 // List namespaces in a subsystem.


### PR DESCRIPTION
When there is an open connection (which means `nvme connect` was called before- in `NodeStageVolume()`)
and then we would like to remove the host (in The GW) in `ControllerUnPublishVolume()` the GW removes it, but return an error\warning - there is an open connection (from host to the gw). and it makes `ControllerUnPublishVolume()` run twice with no reason..
in the 2nd time , when it tries to remove again the host, it returns the host is already removed..

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
