### PR TITLE
ci: prevent Mergifybot from adding `ok-to-test` label on closed PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -97,6 +97,7 @@ merge_queue:
 pull_request_rules:
   - name: start CI jobs for PRs in the merge queue
     conditions:
+      - -closed
       - base~=^(devel)|(release-.+)$
       - label!=conflicts
       - label!=ci/skip/e2e


### PR DESCRIPTION
On occasion Mergifybot is confused about the testing state of a PR. When that happens, it can add the `ok-to-test` label every time after Ceph-CSI-bot removed it.

Fixes: #6023

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
