### PR TITLE
ci: use minikube 1.38.1

### DIFF
--- a/build.env
+++ b/build.env
@@ -52,7 +52,7 @@ HELM_SCRIPT=https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 HELM_VERSION=v3.19.0
 
 # minikube settings
-MINIKUBE_VERSION=v1.38.0
+MINIKUBE_VERSION=v1.38.1
 VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 


### PR DESCRIPTION
minikube 1.38.1 has official support for Kubernetes 1.35. It seems to
work with minikube 1.38.0 already too, but maybe there are improvements
that the CI benefits from.

See-also: https://github.com/kubernetes/minikube/releases/tag/v1.38.1
Depends-on: #6139