### PR TITLE
ci: skip kubernetes.io link checking

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -9,6 +9,10 @@ exclude_path = [
     "vendor",
 ]
 
+exclude = [
+    '^https://kubernetes\.io', # often fails with GitHub network errors
+]
+
 # Output format
 format = "markdown"
 


### PR DESCRIPTION
lychee often fails with GitHub network errors while checking the
Kubernetes homepage for links to blogs or documentation. Prevent these
failures by excluding the Kubernetes URLs.

Fail-example: https://github.com/ceph/ceph-csi/actions/runs/22572471723/job/65383514439?pr=6139