### PR TITLE
ci: autoqueue PRs and use `ok-to-test` label to queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,109 +11,87 @@ defaults:
 queue_rules:
   - name: default
     update_bot_account: ceph-csi-bot
-    merge_conditions:
-      # Conditions to get out of the queue (= merged)
-      - or:
-          - and:
-              - base~=^(release-.+)$
-              - "status-success=codespell"
-              - "status-success=multi-arch-build"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=mod-check"
-              - "status-success=lint-extras"
-              - "status-success=uncommitted-code-check"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-          - and:
-              - base=release-v3.15
-              - "status-success=codespell"
-              - "status-success=multi-arch-build"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=mod-check"
-              - "status-success=lint-extras"
-              - "status-success=uncommitted-code-check"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.31"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-          - and:
-              - base=devel
-              - "status-success=codespell"
-              - "status-success=multi-arch-build"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=mod-check"
-              - "status-success=lint-extras"
-              - "status-success=uncommitted-code-check"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.35"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-          - and:
-              - base=ci/centos
-              - "status-success=ci/centos/job-validation"
-              - "status-success=ci/centos/jjb-validate"
     merge_method: rebase
     update_method: rebase
     batch_size: 1
+    autoqueue: true
+    # only queue PRs that have completely been tested and reviewed
+    queue_conditions:
+      - and:
+          # requirements for any branch
+          - label!=DNM
+          - "#approved-reviews-by>=2"
+          - "#changes-requested-reviews-by=0"
+          - "approved-reviews-by=@ceph/ceph-csi-contributors"
+          - "approved-reviews-by=@ceph/ceph-csi-maintainers"
+          - "status-success=DCO"
+          - or:
+              # requirements for non ci/centos branches
+              - and:
+                  - base!=ci/centos
+                  - "status-success=codespell"
+                  - "status-success=go-test"
+                  - "status-success=golangci-lint"
+                  - "status-success=lint-extras"
+                  - "status-success=mod-check"
+                  - "status-success=multi-arch-build"
+                  - "status-success=uncommitted-code-check"
+                  - or:
+                      # dependabot has an invalid signed-off-by
+                      - author=dependabot[bot]
+                      - "status-success=commitlint"
+              # requirements for ci/centos branch
+              - and:
+                  - base=ci/centos
+                  - "status-success=ci/centos/job-validation"
+                  - "status-success=ci/centos/jjb-validate"
+          - or:
+              # requirenents per branch
+              - label=ci/skip/e2e
+              - and:
+                  - base~=^(release-.+)$
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.32"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.33"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.34"
+                  - "status-success=ci/centos/upgrade-tests-cephfs"
+                  - "status-success=ci/centos/upgrade-tests-rbd"
+              - and:
+                  - base=release-v3.15
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.31"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.32"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.33"
+                  - "status-success=ci/centos/upgrade-tests-cephfs"
+                  - "status-success=ci/centos/upgrade-tests-rbd"
+              - and:
+                  - base=devel
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.33"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.34"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.35"
+                  - "status-success=ci/centos/upgrade-tests-cephfs"
+                  - "status-success=ci/centos/upgrade-tests-rbd"
 
 merge_queue:
   max_parallel_checks: 1
 
 pull_request_rules:
-  - name: start CI jobs for PRs in the merge queue
-    conditions:
-      - -closed
-      - base~=^(devel)|(release-.+)$
-      - label!=conflicts
-      - label!=ci/skip/e2e
-      - label!=queued
-      - not:
-          check-pending~=^ci/centos
-      - not:
-          status-success~=^ci/centos
-      - or:
-          - "check-pending=Queue: Embarked in merge queue"
-          - author=mergify[bot]
-    actions:
-      label:
-        add:
-          - ok-to-test
-
   - name: remove outdated approvals
     conditions:
       - base~=^(devel)|(release-.+)$
@@ -131,209 +109,12 @@ pull_request_rules:
         # yamllint disable-line rule:truthy rule:line-length
         message: "This pull request now has conflicts with the target branch. Could you please resolve conflicts and force push the corrected changes? 🙏"
 
-  - name: update dependencies by dependabot (skip commitlint)
-    conditions:
-      - author=dependabot[bot]
-      - label!=DNM
-      - base=devel
-      - "#approved-reviews-by>=2"
-      - "#changes-requested-reviews-by=0"
-      - "approved-reviews-by=@ceph/ceph-csi-contributors"
-      - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-      - "status-success=codespell"
-      - "status-success=multi-arch-build"
-      - "status-success=go-test"
-      - "status-success=golangci-lint"
-      - "status-success=mod-check"
-      - "status-success=lint-extras"
-      - "status-success=DCO"
-      - or:
-          - label=ci/skip/e2e
-          - and:
-              - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-              - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-              - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
-              - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-              - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-              - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
-              - "status-success=ci/centos/mini-e2e/k8s-1.33"
-              - "status-success=ci/centos/mini-e2e/k8s-1.34"
-              - "status-success=ci/centos/mini-e2e/k8s-1.35"
-              - "status-success=ci/centos/upgrade-tests-cephfs"
-              - "status-success=ci/centos/upgrade-tests-rbd"
-    actions:
-      queue:
-        name: default
-      delete_head_branch: {}
-
   - name: dismiss review of merged pull request
     conditions:
       - base~=^(devel)|(release-.+)$
       - merged
     actions:
       dismiss_reviews: {}
-
-  - name: automatic merge
-    conditions:
-      - or:
-          - and:
-              - label!=DNM
-              - base~=^(release-.+)$
-              - "#approved-reviews-by>=2"
-              - "#changes-requested-reviews-by=0"
-              - "approved-reviews-by=@ceph/ceph-csi-contributors"
-              - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-              - "status-success=DCO"
-              - "status-success=codespell"
-              - "status-success=commitlint"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=lint-extras"
-              - "status-success=mod-check"
-              - "status-success=multi-arch-build"
-              - "status-success=uncommitted-code-check"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-          - and:
-              - label!=DNM
-              - base=release-v3.15
-              - "#approved-reviews-by>=2"
-              - "#changes-requested-reviews-by=0"
-              - "approved-reviews-by=@ceph/ceph-csi-contributors"
-              - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-              - "status-success=DCO"
-              - "status-success=codespell"
-              - "status-success=commitlint"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=lint-extras"
-              - "status-success=mod-check"
-              - "status-success=multi-arch-build"
-              - "status-success=uncommitted-code-check"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.31"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-          - and:
-              - label!=DNM
-              - base=devel
-              - "#approved-reviews-by>=2"
-              - "#changes-requested-reviews-by=0"
-              - "approved-reviews-by=@ceph/ceph-csi-contributors"
-              - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-              - "status-success=codespell"
-              - "status-success=multi-arch-build"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=commitlint"
-              - "status-success=mod-check"
-              - "status-success=lint-extras"
-              - "status-success=DCO"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.35"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-    actions:
-      queue:
-        name: default
-      delete_head_branch: {}
-
-  - name: automatic merge PR having ready-to-merge label
-    conditions:
-      - or:
-          - and:
-              - base~=^(release-.+)$
-              - label!=DNM
-              - label=ready-to-merge
-              - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-              - "status-success=codespell"
-              - "status-success=multi-arch-build"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=commitlint"
-              - "status-success=mod-check"
-              - "status-success=lint-extras"
-              - "#changes-requested-reviews-by=0"
-              - "status-success=uncommitted-code-check"
-              - "status-success=DCO"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-          - and:
-              - base=release-v3.15
-              - label!=DNM
-              - label=ready-to-merge
-              - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-              - "status-success=codespell"
-              - "status-success=multi-arch-build"
-              - "status-success=go-test"
-              - "status-success=golangci-lint"
-              - "status-success=commitlint"
-              - "status-success=mod-check"
-              - "status-success=lint-extras"
-              - "#changes-requested-reviews-by=0"
-              - "status-success=DCO"
-              - or:
-                  - label=ci/skip/e2e
-                  - and:
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.31"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                      - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.31"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.31"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.32"
-                      - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                      - "status-success=ci/centos/upgrade-tests-cephfs"
-                      - "status-success=ci/centos/upgrade-tests-rbd"
-    actions:
-      queue:
-        name: default
-      delete_head_branch: {}
 
   - name: backport patches to release-v3.15 branch
     conditions:
@@ -360,37 +141,6 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
-
-  - name: automatic merge on ci/centos
-    conditions:
-      - label!=DNM
-      - base=ci/centos
-      - "#approved-reviews-by>=2"
-      - "approved-reviews-by=@ceph/ceph-csi-contributors"
-      - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-      - "#changes-requested-reviews-by=0"
-      - "status-success=ci/centos/job-validation"
-      - "status-success=ci/centos/jjb-validate"
-      - "status-success=DCO"
-    actions:
-      queue:
-        name: default
-      delete_head_branch: {}
-
-  - name: automatic merge PR having ready-to-merge label on ci/centos
-    conditions:
-      - label!=DNM
-      - label=ready-to-merge
-      - base=ci/centos
-      - "approved-reviews-by=@ceph/ceph-csi-maintainers"
-      - "#changes-requested-reviews-by=0"
-      - "status-success=ci/centos/job-validation"
-      - "status-success=ci/centos/jjb-validate"
-      - "status-success=DCO"
-    actions:
-      queue:
-        name: default
-      delete_head_branch: {}
 
   ##
   ## Automatically set/remove labels


### PR DESCRIPTION
With these settings, Mergify should enable its internal
`allow_inplace_checks` option. This prevents creating special Merge PRs
for running CI jobs (hopefully).

Once this is merged, someone needs to add the `ok-to-test` label for
starting the CI jobs. There should not be any need for running
`@mergifyio queue` anymore.

Doc: https://docs.mergify.com/merge-queue/rules/#configuration-options
