### PR TITLE
ci: update lychee config to check offline links only

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -9,12 +9,8 @@ exclude_path = [
     "vendor",
 ]
 
-exclude = [
-    '^https://kubernetes\.io', # often fails with GitHub network errors
-]
+# Only check local/offline links (no network requests).
+offline = true
 
 # Output format
 format = "markdown"
-
-# Maximum number of concurrent network requests
-max_concurrency = 14


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

@iPraveenParihar for lychee maybe we should do `--offline`, [ref](https://lychee.cli.rs/guides/cli/#--offline)? This will remove the flakiness that we currently have. Most sites block link crawling/have filters/captchas anyways.

The goal was to check for broken MD links, right?

_Originally posted by @black-dragon74 in https://github.com/ceph/ceph-csi/issues/6048#issuecomment-3996499513_
            

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
