### PR TITLE
ci: let mergify add `ok-to-test` again when a PR gets queued

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -92,6 +92,26 @@ merge_queue:
   max_parallel_checks: 1
 
 pull_request_rules:
+  - name: start CI jobs for PRs in the merge queue
+    conditions:
+      - -closed
+      - base~=^(devel)|(release-.+)$
+      - label!=conflicts
+      - label!=ci/skip/e2e
+      - label!=ci/in-progress/e2e
+      - not:
+          check-pending~=^ci/centos
+      - not:
+          status-success~=^ci/centos
+      - or:
+          - "check-pending=Queue: Embarked in merge queue"
+          - author=mergify[bot]
+    actions:
+      label:
+        add:
+          - ok-to-test
+          - ci/in-progress/e2e
+
   - name: remove outdated approvals
     conditions:
       - base~=^(devel)|(release-.+)$


### PR DESCRIPTION
By default Mergify adds the `queued` label immediately, so that can not
be used in a check. The new `ci/in-progress/e2e` label will prevent
Mergify from adding the `ok-to-test` label in a loop. When there is an
issue with merge ordering, it may be required to remove the
`ci/in-progress/e2e` label or manually add `ok-to-test` again.

Fixes: https://github.com/ceph/ceph-csi/pull/6138#issuecomment-3998550909
