### PR TITLE
nvmeof: Implement safe controller disconnect logic

### DIFF
--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -32,6 +32,7 @@ import (
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/nvmeof"
+	nvmeutil "github.com/ceph/ceph-csi/internal/nvmeof/util"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
@@ -326,6 +327,8 @@ func (ns *NodeServer) NodeUnstageVolume(
 
 	stagingTargetPath := getStagingTargetPath(req)
 
+	devPath := getDeviceFromStagingPath(ctx, stagingTargetPath)
+
 	isMnt, err := ns.Mounter.IsMountPoint(stagingTargetPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -357,6 +360,20 @@ func (ns *NodeServer) NodeUnstageVolume(
 		}
 	}
 	log.DebugLog(ctx, "successfully removed staging path (%s)", stagingTargetPath)
+
+	// Disconnect controllers if this was the last mounted namespace on each controller.
+	// Non-fatal - a failed disconnect just means the connection lingers until the
+	// kernel's ctrl_loss_tmo expires or the next reconnect cycle.
+	if devPath != "" {
+		mountedDevices, err := getNVMeMountedDevices(ctx)
+		if err != nil {
+			log.WarningLog(ctx, "failed to get mounted devices: %v (skipping disconnect)", err)
+		} else {
+			if err := ns.initiator.DisconnectIfLastMount(ctx, devPath, mountedDevices); err != nil {
+				log.WarningLog(ctx, "failed to disconnect controller for device %s: %v", devPath, err)
+			}
+		}
+	}
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
@@ -394,18 +411,18 @@ func (ns *NodeServer) NodeExpandVolume(
 	mountPath := volumePath + "/" + volumeID
 
 	// Find device from mount (no metadata needed!)
-	devicePath, err := ns.getDeviceFromMount(ctx, mountPath)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to find device for mount %s: %v", mountPath, err)
+	devicePath := getDeviceFromStagingPath(ctx, mountPath)
+	if devicePath == "" {
+		log.ErrorLog(ctx, "failed to find device for mount %s", mountPath)
 
-		return nil, status.Errorf(codes.Internal, "failed to find device: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to find device for mount %s", mountPath)
 	}
 
 	log.DebugLog(ctx, "nvmeof: resizing filesystem on device %s at mount path %s", devicePath, mountPath)
 
 	resizer := mount.NewResizeFs(utilexec.New())
 	var ok bool
-	ok, err = resizer.Resize(devicePath, mountPath)
+	ok, err := resizer.Resize(devicePath, mountPath)
 	if !ok {
 		return nil, status.Errorf(codes.Internal,
 			"nvmeof: resize failed on path %s, error: %v", req.GetVolumePath(), err)
@@ -758,20 +775,19 @@ func getStagingTargetPath(req interface{}) string {
 	return ""
 }
 
-// getDeviceFromMount finds the device path for a given mount path.
-func (ns *NodeServer) getDeviceFromMount(ctx context.Context, mountPath string) (string, error) {
-	mountPoints, err := ns.Mounter.List()
+// getDeviceFromStagingPath returns the device path for either filesystem or block volumes.
+func getDeviceFromStagingPath(ctx context.Context, stagingTargetPath string) string {
+	device, err := nvmeutil.GetDeviceFromMountpoint(ctx, stagingTargetPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to list mounts: %w", err)
+		log.DebugLog(ctx, "could not get device from staging path %s: %v", stagingTargetPath, err)
+
+		return ""
 	}
 
-	for _, mp := range mountPoints {
-		if mp.Path == mountPath {
-			log.DebugLog(ctx, "found device %s for mount path %s", mp.Device, mountPath)
+	return device
+}
 
-			return mp.Device, nil
-		}
-	}
-
-	return "", fmt.Errorf("no mount found for path %s", mountPath)
+// getNVMeMountedDevices returns a map of all currently mounted NVMe devices.
+func getNVMeMountedDevices(ctx context.Context) (map[string]bool, error) {
+	return nvmeutil.GetAllNVMeMountedDevices(ctx)
 }

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -421,7 +421,6 @@ func (ns *NodeServer) NodeExpandVolume(
 	log.DebugLog(ctx, "nvmeof: resizing filesystem on device %s at mount path %s", devicePath, mountPath)
 
 	resizer := mount.NewResizeFs(utilexec.New())
-	var ok bool
 	ok, err := resizer.Resize(devicePath, mountPath)
 	if !ok {
 		return nil, status.Errorf(codes.Internal,
@@ -493,6 +492,10 @@ func (ns *NodeServer) stageTransaction(
 	return transaction, nil
 }
 
+// undoStagingTransaction rolls back a staging transaction based on the state of the transaction.
+// It attempts to unmount the staging path if it was mounted,
+// remove the staging path if it was created, and disconnect the NVMe device if it was connected
+// and it was the last mount for that device.
 func (ns *NodeServer) undoStagingTransaction(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest,
@@ -505,8 +508,7 @@ func (ns *NodeServer) undoStagingTransaction(
 		err = ns.Mounter.Unmount(stagingTargetPath)
 		if err != nil {
 			log.ErrorLog(ctx, "failed to unmount stagingtargetPath: %s with error: %v", stagingTargetPath, err)
-
-			return
+			// Continue anyway - try to clean up what we can
 		}
 	}
 
@@ -516,6 +518,18 @@ func (ns *NodeServer) undoStagingTransaction(
 		if err != nil {
 			log.ErrorLog(ctx, "failed to remove stagingtargetPath: %s with error: %v", stagingTargetPath, err)
 			// continue on failure to disconnect the image
+		}
+	}
+	// disconnect if we connected
+	if transaction.devicePath != "" {
+		mountedDevices, err := getNVMeMountedDevices(ctx)
+		if err != nil {
+			log.WarningLog(ctx, "failed to get mounted devices during rollback: %v (skipping disconnect)", err)
+		} else {
+			if err := ns.initiator.DisconnectIfLastMount(ctx, transaction.devicePath, mountedDevices); err != nil {
+				log.WarningLog(ctx, "failed to disconnect during rollback for device %s: %v",
+					transaction.devicePath, err)
+			}
 		}
 	}
 }

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -53,6 +53,15 @@ type NVMeInitiator interface {
 
 	// GetNamespaceDeviceByUUID returns the device path for a given namespace UUID
 	GetNamespaceDeviceByUUID(ctx context.Context, uuid string) (string, error)
+
+	// DisconnectIfLastMount disconnects from the NVMe controllers for the given device path,
+	// all-or-nothing (skip disconnect for all controllers
+	// if any controller has another mounted namespace).
+	// Safe for multipath - disconnects each controller individually.
+	//
+	// Example: If device /dev/nvme0n1 is connected via controllers nvme0 and nvme1,
+	// and both controllers have no other mounted namespaces, both will be disconnected.
+	DisconnectIfLastMount(ctx context.Context, devPath string, mountedDevices map[string]bool) error
 }
 
 // ConnectRequest represents a subsystem connection request.
@@ -78,11 +87,34 @@ type nvmePathAddress struct {
 }
 
 // nvmeHost represents the structure from nvme list-subsys output.
+// Example JSON structure:
+// [
+//   {
+//     "HostNQN":"nqn.2014-08.org.nvmexpress:gdidi-zwcq5-worker-2-7mppg",
+//     "HostID":"d48fbfbf-1b0e-45ce-93a4-b919224aff2c",
+//     "Subsystems":[
+//       {
+//         "Name":"nvme-subsys0",
+//         "NQN":"nqn.2016-06.io.ceph:subsystem.test-integration",
+//         "Paths":[
+//           {
+//             "Name":"nvme0",
+//             "Transport":"tcp",
+//             "Address":"traddr=10.131.0.225,trsvcid=4420,src_addr=10.131.0.2",
+//             "State":"live"
+//           }
+//         ]
+//       }
+//     ]
+//   }
+// ]
+
 type nvmeHost struct {
 	HostNQN    string `json:"HostNQN"`
 	Subsystems []struct {
 		NQN   string `json:"NQN"`
 		Paths []struct {
+			Name    string          `json:"Name"`
 			Address nvmePathAddress `json:"Address"`
 			State   string          `json:"State"`
 		} `json:"Paths"`
@@ -222,6 +254,82 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 	return true, nil
 }
 
+// DisconnectIfLastMount disconnects from ALL NVMe controllers for the given device path,
+// but only if NO controller has other mounted namespaces.
+//
+// In NVMe-oF multipath, all namespaces in a subsystem are accessible through all controllers.
+// This means if any namespace is mounted, it's using ALL controllers. Therefore, we use an
+// all-or-nothing approach: either disconnect all controllers or none.
+//
+// params:
+// - devPath: the device path of the namespace being unstaged (e.g. /dev/nvme0n1)
+// - mountedDevices: a map of currently MOUNTED device paths for quick lookup
+//
+// Algorithm:
+// 1. Check each controller to see if it has other mounted namespaces
+// 2. If ANY controller has other mounted namespaces, return early (don't disconnect anything)
+// 3. If NO controllers have other mounted namespaces, disconnect ALL controllers
+//
+// Example: Device /dev/nvme0n1 is connected via controllers nvme0 and nvme1
+//
+// Case 1 - Other namespace mounted:
+//   - Controller nvme0 has namespaces: [nvme0n1 (being unstaged), nvme0n2 (mounted)]
+//   - Controller nvme1 has namespaces: [nvme0n1 (being unstaged), nvme0n2 (mounted)]
+//   - Decision: nvme0n2 is still using both controllers -> Don't disconnect ANY controller
+//
+// Case 2 - No other namespaces mounted:
+//   - Controller nvme0 has namespaces: [nvme0n1 (being unstaged)]
+//   - Controller nvme1 has namespaces: [nvme0n1 (being unstaged)]
+//   - Decision: No other namespaces using the controllers -> Disconnect BOTH controllers
+func (ni *nvmeInitiator) DisconnectIfLastMount(ctx context.Context, devPath string,
+	mountedDevices map[string]bool,
+) error {
+	controllers, err := getControllersForDevice(ctx, devPath)
+	if err != nil {
+		return fmt.Errorf("failed to get controllers for %s: %w", devPath, err)
+	}
+
+	// PASS 1: Check if ANY controller has other mounted namespaces
+	for _, ctrl := range controllers {
+		hasOtherMounted, err := hasOtherMountedNamespaces(ctx, ctrl, devPath, mountedDevices)
+		if err != nil {
+			log.WarningLog(ctx, "Failed to check mounted namespaces for %s: %v (skipping disconnect)",
+				ctrl, err)
+
+			return nil // Safe: don't disconnect if we can't verify
+		}
+
+		if hasOtherMounted {
+			log.DebugLog(ctx, "Controller %s has other mounted namespaces, skipping disconnect for all controllers",
+				ctrl)
+
+			return nil // EXIT early, don't disconnect ANYTHING
+		}
+	}
+	// PASS 2: No mounted namespaces found, disconnect ALL controllers
+	log.DebugLog(ctx, "No other mounted namespaces found, disconnecting all controllers")
+
+	var disconnectErrors []string
+	for _, ctrl := range controllers {
+		log.DebugLog(ctx, "Disconnecting controller %s", ctrl)
+		_, _, err = util.ExecCommandWithTimeout(ctx, connectTimeout,
+			"nvme", "disconnect", "-d", "/dev/"+ctrl)
+		if err != nil {
+			disconnectErrors = append(disconnectErrors, fmt.Sprintf("%s: %v", ctrl, err))
+
+			continue
+		}
+		log.DebugLog(ctx, "Successfully disconnected controller %s", ctrl)
+	}
+
+	if len(disconnectErrors) > 0 {
+		return fmt.Errorf("failed to disconnect some controllers: %s",
+			strings.Join(disconnectErrors, "; "))
+	}
+
+	return nil
+}
+
 // GetNamespaceDeviceByUUID tries to find the path of the block device for the
 // namespace. While attaching there can be a delay, this function retries a few
 // times with a short delay.
@@ -347,4 +455,97 @@ func ResolveListeners(ctx context.Context, listeners []ListenerDetails) ([]Liste
 	log.DebugLog(ctx, "Successfully resolved %d listener(s)", len(validListeners))
 
 	return validListeners, nil
+}
+
+// getControllersForDevice returns all controller names for a given namespace
+// device (e.g. /dev/nvme0n1 -> ["nvme0", "nvme1"]).
+// Uses nvme list-subsys <device> which is multipath-aware.
+func getControllersForDevice(ctx context.Context, devPath string) ([]string, error) {
+	stdout, _, err := util.ExecCommandWithTimeout(ctx, listSubsysTimeout,
+		"nvme", "list-subsys", devPath, "-o", "json")
+	if err != nil {
+		return nil, fmt.Errorf("list-subsys failed for %s: %w", devPath, err)
+	}
+
+	var hosts nvmeHostConnections
+	if err := json.Unmarshal([]byte(stdout), &hosts); err != nil {
+		log.DebugLog(ctx, "Failed to parse list-subsys output for %s: %v (output: %s)", devPath, err, stdout)
+
+		return nil, fmt.Errorf("failed to parse list-subsys output: %w", err)
+	}
+
+	var controllers []string
+	for _, host := range hosts {
+		for _, subsys := range host.Subsystems {
+			for _, path := range subsys.Paths {
+				if path.Name != "" {
+					controllers = append(controllers, path.Name)
+				}
+			}
+		}
+	}
+	// This makes it idempotent - device may have been disconnected already
+	if len(controllers) == 0 {
+		log.DebugLog(ctx, "no controllers found for device %s (may be already disconnected)", devPath)
+	}
+
+	return controllers, nil
+}
+
+// hasOtherMountedNamespaces checks if a controller has any mounted
+// namespaces OTHER than the one we're about to unstage.
+func hasOtherMountedNamespaces(ctx context.Context, controllerName, currentDevPath string,
+	mountedDevices map[string]bool,
+) (bool, error) {
+	// Get all namespaces on this controller
+	nsids, err := getNamespacesForController(ctx, controllerName)
+	if err != nil {
+		return false, err
+	}
+
+	// Check if any OTHER namespace on this controller is mounted
+	for _, nsid := range nsids {
+		nsDevice := fmt.Sprintf("/dev/%sn%d", controllerName, nsid)
+
+		// Skip the device we're about to unmount
+		if nsDevice == currentDevPath {
+			continue
+		}
+
+		// If any other namespace is mounted, return true
+		if mountedDevices[nsDevice] {
+			log.DebugLog(ctx, "Found other mounted namespace %s on controller %s", nsDevice, controllerName)
+
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// getNamespacesForController returns list of namespace IDs on a controller.
+func getNamespacesForController(ctx context.Context, controllerName string) ([]int, error) {
+	controllerPath := "/dev/" + controllerName
+	stdout, _, err := util.ExecCommandWithTimeout(ctx, connectTimeout,
+		"nvme", "list-ns", controllerPath, "-o", "json")
+	if err != nil {
+		return nil, fmt.Errorf("list-ns failed for %s: %w", controllerPath, err)
+	}
+
+	// output: {"nsid_list":[{"nsid":1},{"nsid":2}]}
+	var result struct {
+		NSIDList []struct {
+			NSID int `json:"nsid"`
+		} `json:"nsid_list"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse list-ns output: %w", err)
+	}
+
+	nsids := make([]int, len(result.NSIDList))
+	for i, ns := range result.NSIDList {
+		nsids[i] = ns.NSID
+	}
+
+	return nsids, nil
 }

--- a/internal/nvmeof/nvmeof_test.go
+++ b/internal/nvmeof/nvmeof_test.go
@@ -263,6 +263,7 @@ func TestHasLivePathToGateway(t *testing.T) {
 			Subsystems: []struct {
 				NQN   string `json:"NQN"`
 				Paths []struct {
+					Name    string          `json:"Name"`
 					Address nvmePathAddress `json:"Address"`
 					State   string          `json:"State"`
 				} `json:"Paths"`
@@ -270,6 +271,7 @@ func TestHasLivePathToGateway(t *testing.T) {
 				{
 					NQN: "nqn.2016-06.io.ceph:subsystem.test",
 					Paths: []struct {
+						Name    string          `json:"Name"`
 						Address nvmePathAddress `json:"Address"`
 						State   string          `json:"State"`
 					}{

--- a/internal/nvmeof/util/mounter.go
+++ b/internal/nvmeof/util/mounter.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+// FindmntResult represents the output from findmnt -J command.
+type FindmntResult struct {
+	Filesystems []FindmntFilesystem `json:"filesystems"`
+}
+
+// FindmntFilesystem represents a single filesystem entry from findmnt.
+type FindmntFilesystem struct {
+	Source FindmntSource `json:"source"`
+	Target string        `json:"target,omitempty"`
+}
+
+// FindmntSource represents a device source from findmnt JSON output.
+// It automatically parses both filesystem volumes ("/dev/nvme0n2") and
+// block volumes ("devtmpfs[/nvme0n1]") during JSON unmarshaling.
+type FindmntSource string
+
+// String returns the parsed device path.
+func (f FindmntSource) String() string {
+	return string(f)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler to parse device paths
+// from findmnt output. It handles both filesystem and block volume formats.
+func (f *FindmntSource) UnmarshalText(text []byte) error {
+	*f = FindmntSource(parseNVMEDeviceFromRawSource(string(text)))
+
+	return nil
+}
+
+// devtmpfsRegex matches NVMe devices in devtmpfs format: devtmpfs[/nvme0n1] or devtmpfs[nvme0n1].
+var devtmpfsRegex = regexp.MustCompile(`devtmpfs\[/?(nvme\d+n\d+)\]`)
+
+// parseNVMEDeviceFromRawSource parses findmnt source to extract NVMe device path.
+// Handles both filesystem volumes ("/dev/nvme0n2") and block volumes ("devtmpfs[/nvme0n1]").
+func parseNVMEDeviceFromRawSource(source string) string {
+	// Case 1: devtmpfs[/nvme0n1] or devtmpfs[nvme0n1] format (block volumes)
+	if matches := devtmpfsRegex.FindStringSubmatch(source); len(matches) > 1 {
+		// Regex captures just "nvme0n1", so prepend /dev/
+		return "/dev/" + matches[1]
+	}
+
+	// Case 2: Direct device path like /dev/nvme0n2 (filesystem volumes)
+	if strings.HasPrefix(source, "/dev/nvme") {
+		return source
+	}
+
+	return ""
+}
+
+// GetDeviceFromMountpoint returns the NVMe device path for a given mount point.
+func GetDeviceFromMountpoint(ctx context.Context, mountpoint string) (string, error) {
+	stdout, _, err := util.ExecCommandWithTimeout(ctx, 5*time.Second,
+		"findmnt", "--mountpoint", mountpoint, "--output", "SOURCE",
+		"--noheadings", "--first-only", "-J")
+	if err != nil {
+		log.DebugLog(ctx, "findmnt failed for %s: %v", mountpoint, err)
+
+		return "", fmt.Errorf("findmnt failed: %w", err)
+	}
+
+	var result FindmntResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		return "", fmt.Errorf("failed to parse findmnt output: %w", err)
+	}
+
+	if len(result.Filesystems) == 0 {
+		return "", nil
+	}
+
+	device := result.Filesystems[0].Source.String()
+	if device != "" {
+		log.DebugLog(ctx, "found device %s for mountpoint %s", device, mountpoint)
+	}
+
+	return device, nil
+}
+
+// GetAllNVMeMountedDevices returns a map of all currently mounted NVMe devices.
+// Only checks staging paths to avoid counting the same device multiple times
+// (staging, publish, and pod paths all point to the same device).
+func GetAllNVMeMountedDevices(ctx context.Context) (map[string]bool, error) {
+	stdout, _, err := util.ExecCommandWithTimeout(ctx, 5*time.Second,
+		"findmnt", "-J", "--list", "--output", "SOURCE,TARGET")
+	if err != nil {
+		return nil, fmt.Errorf("failed to run findmnt: %w", err)
+	}
+
+	var result FindmntResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse findmnt output: %w", err)
+	}
+
+	mountedDevices := make(map[string]bool)
+	for _, fs := range result.Filesystems {
+		// Only check NVMe CSI staging paths
+		isNVMeOFStagingFS := strings.Contains(fs.Target, "nvmeof.csi.ceph.com") &&
+			strings.Contains(fs.Target, "/globalmount/")
+
+		isNVMeOFStagingBlock := strings.Contains(fs.Target, "volumeDevices") &&
+			strings.Contains(fs.Target, "/staging/")
+
+		if !isNVMeOFStagingFS && !isNVMeOFStagingBlock {
+			continue
+		}
+
+		device := fs.Source.String()
+		// Only consider valid NVMe devices
+		if device != "" && strings.HasPrefix(device, "/dev/nvme") {
+			mountedDevices[device] = true
+			log.DebugLog(ctx, "Found mounted NVMe device: %s at %s", device, fs.Target)
+		}
+	}
+
+	log.DebugLog(ctx, "Found %d mounted NVMe devices total", len(mountedDevices))
+
+	return mountedDevices, nil
+}

--- a/internal/nvmeof/util/mounter_test.go
+++ b/internal/nvmeof/util/mounter_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNVMEDeviceFromRawSource(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/dev/nvme0n2", "/dev/nvme0n2"},
+		{"devtmpfs[/nvme1n1]", "/dev/nvme1n1"},
+		{"devtmpfs[/nvme0n1]", "/dev/nvme0n1"},
+		{"devtmpfs[/sda]", ""},
+		{"blabla", ""},
+	}
+
+	for _, test := range tests {
+		result := parseNVMEDeviceFromRawSource(test.input)
+		require.Equal(t, test.expected, result)
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #


### Summary
This PR adds proper nvme-of controller disconnect logic to the CSI driver. When a pod is deleted and its volume is unstaged, we now safely disconnect from nvme-of **controllers** only when no other volumes are using them.

## Why We Need This
### The Original Problem
Before this change, when `NodeUnstageVolume` was called, we would unmount the volume but leave the NVMe-oF connection active. This meant NVMe controllers stayed connected even after all pods were deleted. In next Pod creation (in same nvmeof subsystem) in some environments (like in the e2e test here: https://github.com/ceph/ceph-csi/pull/6058 )  the orphaned connection was stuck, with no reason. **The cleanest way to handle it is to disconnect from the controller\s (host-subsystem pair\s) if this pod is the last mounted**  


### Why We Can't Just Always Disconnect
In NVMe-oF multipath setups, multiple volumes share the same controllers. For example:
```
Subsystem: nqn.2016-06.io.spdk:cnode1
├── Namespace 1 (nvme0n1) - Used by PVC-1 and the device mounted for POD-1
└── Namespace 2 (nvme0n2) - Used by PVC-2 and the device mounted for POD-2
```

Both namespaces are accessed via:
```
├── Controller nvme0 (gateway 10.0.0.1:4420)
└── Controller nvme1 (gateway 10.0.0.2:4420)
```
If we disconnect controllers when POD-1 is deleted, we break POD-2 mounting which is still using those same controllers!!! 

### The Challenge
We need to track which volumes are still in use and only disconnect controllers when:

The volume being unstaged is no longer mounted
No other volumes are using the same controllers

### Solution Overview
This PR implements a reference-counting approach 
(on demand, without metadata file. just using the current state):

- When `NodeUnstageVolume` is called, we first unmount the volume
- We then check if this was the last mounted namespace (=nvme device) on each controller
- Only if a controller has no other mounted namespaces, we disconnect it

FYI- the connection operation in `NodeStageVolume()` connects to entire listeners (it means every listener connection ==> creates a controller == that is host-listener of specific subsystem connection) . 
So actually, it is not possible that some nvmeof namespace (**in same subsystem**) 
will have different controllers. It means all nvme namespaces (**in same subsystem**) are sharing the same controllers!! 


### Implementation Details
New Functions:

`getDeviceFromStagingPath()`

- Finds the NVMe device path for a given staging path
- Uses findmnt with JSON output for reliable parsing
- Handles both filesystem and block volumes

`getNVMeMountedDevices()`

- Scans the entire mount table in a single findmnt call
- Returns a map of all currently mounted NVMe devices
- Filters for NVMe-oF CSI staging paths only

`DisconnectIfLastMount()`

- Core disconnect logic with reference counting
- Gets all controllers for the device being unstaged
- For each controller, checks if other namespaces are still mounted (as I wrote above , all controllers have the same data!!)  
- Only disconnects if no other namespaces are in use

`parseDeviceFromFindmntJSON()`

- Parses findmnt JSON output to extract device paths
- Handles two different mount formats (see below)



## Is there anything that requires special attention ##

** I did not add lock mechanism. I MUST add it. parallel calls of `NodeStageVolume()` + `NodeUnStageVolume()` can make issues.
I am going to add it in the next PR.
**


## Related issues\PR ##

https://github.com/ceph/ceph-csi/pull/6058

## Future concerns ##
Adding lock mechanism in the next PR 

## Example ##
```bash
[root@cephnvme-devel-server-gadi nvmeof]# kubectl get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                     VOLUMEATTRIBUTESCLASS   AGE
cephcsi-nvmeof-pvc    Bound    pvc-4149616b-39b6-4d15-8e11-55643a2e6c70   64Mi       RWO            ocs-storagecluster-ceph-nvmeof   <unset>                 4h58m
cephcsi-nvmeof-pvc3   Bound    pvc-96834e31-fff5-4a99-8a75-8bb9ff378675   64Mi       RWO            ocs-storagecluster-ceph-nvmeof   <unset>                 3s
raw-block-pvc         Bound    pvc-81024dbc-dc61-438d-88d5-8852964c7fb5   64Mi       RWO            ocs-storagecluster-ceph-nvmeof   <unset>                 4m32s
[root@cephnvme-devel-server-gadi nvmeof]# kubectl get pods
NAME                        READY   STATUS    RESTARTS   AGE
nvmeof-test-pod             1/1     Running   0          4h58m
nvmeof-test-pod3            1/1     Running   0          4s
pod-with-raw-block-volume   1/1     Running   0          4m36s
```
Delete pod3
```bash
I0308 14:22:06.339907  594156 utils.go:350] ID: 245 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd GRPC call: /csi.v1.Node/NodeUnpublishVolume
I0308 14:22:06.339966  594156 utils.go:351] ID: 245 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd GRPC request: {"target_path":"/var/lib/kubelet/pods/a70454ab-177d-46c7-ab6b-c2b1c85d7a5b/volumes/kubernetes.io~csi/pvc-96834e31-fff5-4a99-8a75-8bb9ff378675/mount","volume_id":"0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd"}
I0308 14:22:06.340261  594156 mount_linux.go:402] Unmounting /var/lib/kubelet/pods/a70454ab-177d-46c7-ab6b-c2b1c85d7a5b/volumes/kubernetes.io~csi/pvc-96834e31-fff5-4a99-8a75-8bb9ff378675/mount
I0308 14:22:06.342453  594156 nodeserver.go:297] ID: 245 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd nvmeof: successfully unbound volume 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd from /var/lib/kubelet/pods/a70454ab-177d-46c7-ab6b-c2b1c85d7a5b/volumes/kubernetes.io~csi/pvc-96834e31-fff5-4a99-8a75-8bb9ff378675/mount
I0308 14:22:06.342508  594156 utils.go:357] ID: 245 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd GRPC response: {}
I0308 14:22:06.447995  594156 utils.go:350] ID: 246 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0308 14:22:06.448022  594156 utils.go:351] ID: 246 GRPC request: {}
I0308 14:22:06.448104  594156 utils.go:357] ID: 246 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"EXPAND_VOLUME"}}]}
I0308 14:22:06.449180  594156 utils.go:350] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd GRPC call: /csi.v1.Node/NodeUnstageVolume
I0308 14:22:06.449224  594156 utils.go:351] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd GRPC request: {"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/f967c4f2ac08da70d983c7ff5c6f249783312f892ce4e7877f6cb15bb6031434/globalmount","volume_id":"0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd"}
I0308 14:22:06.452563  594156 cephcmds.go:165] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd command succeeded: findmnt [--mountpoint /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/f967c4f2ac08da70d983c7ff5c6f249783312f892ce4e7877f6cb15bb6031434/globalmount/0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd --output SOURCE --noheadings --first-only -J]
I0308 14:22:06.452684  594156 nodeserver.go:834] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd found filesystem volume device: /dev/nvme0n3
I0308 14:22:06.452715  594156 nodeserver.go:801] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd found device /dev/nvme0n3 for staging path /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/f967c4f2ac08da70d983c7ff5c6f249783312f892ce4e7877f6cb15bb6031434/globalmount/0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd
I0308 14:22:06.452796  594156 mount_linux.go:402] Unmounting /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/f967c4f2ac08da70d983c7ff5c6f249783312f892ce4e7877f6cb15bb6031434/globalmount/0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd
I0308 14:22:06.463632  594156 nodeserver.go:340] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd successfully unmounted volume (0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd) from staging path (/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/f967c4f2ac08da70d983c7ff5c6f249783312f892ce4e7877f6cb15bb6031434/globalmount/0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd)
I0308 14:22:06.463708  594156 nodeserver.go:354] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd successfully removed staging path (/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/f967c4f2ac08da70d983c7ff5c6f249783312f892ce4e7877f6cb15bb6031434/globalmount/0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd)
I0308 14:22:06.467335  594156 cephcmds.go:165] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd command succeeded: findmnt [-J --list --output SOURCE,TARGET]
I0308 14:22:06.467841  594156 nodeserver.go:834] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd found filesystem volume device: /dev/nvme0n1
I0308 14:22:06.467863  594156 nodeserver.go:883] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd Found mounted NVMe device: /dev/nvme0n1 at /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/d64c8b9ba97ceb85d4c4f7fc125175428c3058f314a9a9424da3da4655460538/globalmount/0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e
I0308 14:22:06.467885  594156 nodeserver.go:825] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd parsed block volume device: /dev/nvme0n2 from devtmpfs[/nvme0n2]
I0308 14:22:06.467895  594156 nodeserver.go:883] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd Found mounted NVMe device: /dev/nvme0n2 at /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10
I0308 14:22:06.467903  594156 nodeserver.go:887] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd Found 2 mounted NVMe devices total
I0308 14:22:06.473797  594156 cephcmds.go:165] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd command succeeded: nvme [list-subsys /dev/nvme0n3 -o json]
I0308 14:22:06.476624  594156 cephcmds.go:165] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd command succeeded: nvme [list-ns /dev/nvme0 -o json]
I0308 14:22:06.476716  594156 nvmeof_initiator.go:458] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd Found other mounted namespace /dev/nvme0n1 on controller nvme0
I0308 14:22:06.476728  594156 nvmeof_initiator.go:252] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd Controller nvme0 has other mounted namespaces, skipping disconnect
I0308 14:22:06.476772  594156 utils.go:357] ID: 247 Req-ID: 0001-0011-openshift-storage-0000000000000002-db4f7f3b-cce8-4bb4-8bf8-6d7283df35bd GRPC response: {}
```
Delete pod2:

```bash
I0308 14:26:37.800919  594156 utils.go:350] ID: 252 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e GRPC call: /csi.v1.Node/NodeUnpublishVolume
I0308 14:26:37.801105  594156 utils.go:351] ID: 252 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e GRPC request: {"target_path":"/var/lib/kubelet/pods/98d77833-d0c7-4f68-b546-28e22a7e92e5/volumes/kubernetes.io~csi/pvc-4149616b-39b6-4d15-8e11-55643a2e6c70/mount","volume_id":"0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e"}
I0308 14:26:37.801249  594156 mount_linux.go:402] Unmounting /var/lib/kubelet/pods/98d77833-d0c7-4f68-b546-28e22a7e92e5/volumes/kubernetes.io~csi/pvc-4149616b-39b6-4d15-8e11-55643a2e6c70/mount
I0308 14:26:37.803299  594156 nodeserver.go:297] ID: 252 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e nvmeof: successfully unbound volume 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e from /var/lib/kubelet/pods/98d77833-d0c7-4f68-b546-28e22a7e92e5/volumes/kubernetes.io~csi/pvc-4149616b-39b6-4d15-8e11-55643a2e6c70/mount
I0308 14:26:37.803395  594156 utils.go:357] ID: 252 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e GRPC response: {}
I0308 14:26:37.907448  594156 utils.go:350] ID: 253 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0308 14:26:37.907495  594156 utils.go:351] ID: 253 GRPC request: {}
I0308 14:26:37.907562  594156 utils.go:357] ID: 253 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"EXPAND_VOLUME"}}]}
I0308 14:26:37.908607  594156 utils.go:350] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e GRPC call: /csi.v1.Node/NodeUnstageVolume
I0308 14:26:37.908659  594156 utils.go:351] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e GRPC request: {"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/d64c8b9ba97ceb85d4c4f7fc125175428c3058f314a9a9424da3da4655460538/globalmount","volume_id":"0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e"}
I0308 14:26:37.911972  594156 cephcmds.go:165] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e command succeeded: findmnt [--mountpoint /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/d64c8b9ba97ceb85d4c4f7fc125175428c3058f314a9a9424da3da4655460538/globalmount/0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e --output SOURCE --noheadings --first-only -J]
I0308 14:26:37.912010  594156 nodeserver.go:834] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e found filesystem volume device: /dev/nvme0n1
I0308 14:26:37.912018  594156 nodeserver.go:801] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e found device /dev/nvme0n1 for staging path /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/d64c8b9ba97ceb85d4c4f7fc125175428c3058f314a9a9424da3da4655460538/globalmount/0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e
I0308 14:26:37.912090  594156 mount_linux.go:402] Unmounting /var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/d64c8b9ba97ceb85d4c4f7fc125175428c3058f314a9a9424da3da4655460538/globalmount/0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e
I0308 14:26:37.921283  594156 nodeserver.go:340] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e successfully unmounted volume (0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e) from staging path (/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/d64c8b9ba97ceb85d4c4f7fc125175428c3058f314a9a9424da3da4655460538/globalmount/0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e)
I0308 14:26:37.921374  594156 nodeserver.go:354] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e successfully removed staging path (/var/lib/kubelet/plugins/kubernetes.io/csi/nvmeof.csi.ceph.com/d64c8b9ba97ceb85d4c4f7fc125175428c3058f314a9a9424da3da4655460538/globalmount/0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e)
I0308 14:26:37.925000  594156 cephcmds.go:165] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e command succeeded: findmnt [-J --list --output SOURCE,TARGET]
I0308 14:26:37.925391  594156 nodeserver.go:825] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e parsed block volume device: /dev/nvme0n2 from devtmpfs[/nvme0n2]
I0308 14:26:37.925408  594156 nodeserver.go:883] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e Found mounted NVMe device: /dev/nvme0n2 at /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10
I0308 14:26:37.925414  594156 nodeserver.go:887] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e Found 1 mounted NVMe devices total
I0308 14:26:37.930972  594156 cephcmds.go:165] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e command succeeded: nvme [list-subsys /dev/nvme0n1 -o json]
I0308 14:26:37.933539  594156 cephcmds.go:165] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e command succeeded: nvme [list-ns /dev/nvme0 -o json]
I0308 14:26:37.933577  594156 nvmeof_initiator.go:458] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e Found other mounted namespace /dev/nvme0n2 on controller nvme0
I0308 14:26:37.933586  594156 nvmeof_initiator.go:252] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e Controller nvme0 has other mounted namespaces, skipping disconnect
I0308 14:26:37.933617  594156 utils.go:357] ID: 254 Req-ID: 0001-0011-openshift-storage-0000000000000002-90d76f35-08a3-4076-8ca3-4ed39dd7b18e GRPC response: {}
```
Delete pod1
```bash
I0308 14:28:46.898913  594156 utils.go:350] ID: 257 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 GRPC call: /csi.v1.Node/NodeUnpublishVolume
I0308 14:28:46.898987  594156 utils.go:351] ID: 257 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 GRPC request: {"target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/e94ae8c2-d23c-4b69-bb1b-be2c3e6c3e49","volume_id":"0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10"}
I0308 14:28:46.899093  594156 mount_linux.go:402] Unmounting /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/e94ae8c2-d23c-4b69-bb1b-be2c3e6c3e49
I0308 14:28:46.902139  594156 nodeserver.go:297] ID: 257 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 nvmeof: successfully unbound volume 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 from /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/e94ae8c2-d23c-4b69-bb1b-be2c3e6c3e49
I0308 14:28:46.902176  594156 utils.go:357] ID: 257 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 GRPC response: {}
I0308 14:28:46.990648  594156 utils.go:350] ID: 258 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0308 14:28:46.990676  594156 utils.go:351] ID: 258 GRPC request: {}
I0308 14:28:46.990751  594156 utils.go:357] ID: 258 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"EXPAND_VOLUME"}}]}
I0308 14:28:46.991734  594156 utils.go:350] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 GRPC call: /csi.v1.Node/NodeUnstageVolume
I0308 14:28:46.991772  594156 utils.go:351] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 GRPC request: {"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5","volume_id":"0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10"}
I0308 14:28:46.994900  594156 cephcmds.go:165] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 command succeeded: findmnt [--mountpoint /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 --output SOURCE --noheadings --first-only -J]
I0308 14:28:46.994976  594156 nodeserver.go:825] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 parsed block volume device: /dev/nvme0n2 from devtmpfs[/nvme0n2]
I0308 14:28:46.994987  594156 nodeserver.go:801] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 found device /dev/nvme0n2 for staging path /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10
I0308 14:28:46.995043  594156 mount_linux.go:402] Unmounting /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10
I0308 14:28:46.997507  594156 nodeserver.go:340] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 successfully unmounted volume (0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10) from staging path (/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10)
I0308 14:28:46.997558  594156 nodeserver.go:354] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 successfully removed staging path (/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-81024dbc-dc61-438d-88d5-8852964c7fb5/0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10)
I0308 14:28:47.000378  594156 cephcmds.go:165] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 command succeeded: findmnt [-J --list --output SOURCE,TARGET]
I0308 14:28:47.000696  594156 nodeserver.go:887] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 Found 0 mounted NVMe devices total
I0308 14:28:47.006121  594156 cephcmds.go:165] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 command succeeded: nvme [list-subsys /dev/nvme0n2 -o json]
I0308 14:28:47.008386  594156 cephcmds.go:165] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 command succeeded: nvme [list-ns /dev/nvme0 -o json]
I0308 14:28:47.008427  594156 nvmeof_initiator.go:257] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 Controller nvme0 has no other mounted namespaces, disconnecting
I0308 14:28:47.137969  594156 cephcmds.go:165] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 command succeeded: nvme [disconnect -d /dev/nvme0]
I0308 14:28:47.137998  594156 nvmeof_initiator.go:265] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 Successfully disconnected controller nvme0
I0308 14:28:47.138029  594156 utils.go:357] ID: 259 Req-ID: 0001-0011-openshift-storage-0000000000000002-30985858-2b93-4f70-96e0-8a12052f0e10 GRPC response: {}

```


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
