### PR TITLE
nvmeof: fix CSI node plugin crash on immutable Linux distributions

### DIFF
--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -125,20 +125,27 @@ func NewNVMeInitiator() NVMeInitiator {
 
 // LoadKernelModules ensures required kernel modules are loaded.
 func (ni *nvmeInitiator) LoadKernelModules(ctx context.Context) error {
-	modules := []string{
-		"nvme_tcp",
-		"nvme_fabrics",
-	}
-	log.DebugLog(ctx, "Loading NVMe-oF kernel modules: %s, and %s", modules[0], modules[1])
+	module := "nvme_tcp"
+	log.DebugLog(ctx, "Loading NVMe-oF kernel module: %s", module)
 
-	for _, module := range modules {
-		err := kmod.Modprobe(ctx, module)
-		if err != nil {
-			return fmt.Errorf("failed to load kernel module %q: %w", module, err)
+	err := kmod.Modprobe(ctx, module)
+	if err != nil {
+		return fmt.Errorf("failed to load kernel module %q: %w", module, err)
+	}
+	log.DebugLog(ctx, "NVMe-oF kernel module: %s, is loaded successfully", module)
+	// verify nvme_fabrics is functional by checking its device node.
+	// On immutable Operating Systems like Talos Linux (CONFIG_NVME_FABRICS=y), the module
+	// is baked into the kernel and /sys/module/nvme_fabrics may not exist,
+	// but /dev/nvme-fabrics is always created by the kernel on init if the
+	// fabrics framework is operational.
+	if _, err := os.Stat("/dev/nvme-fabrics"); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("nvme_fabrics is not functional, /dev/nvme-fabrics not found: %w", err)
 		}
-	}
 
-	log.DebugLog(ctx, "All NVMe-oF kernel modules: %s, and %s, loaded successfully", modules[0], modules[1])
+		return fmt.Errorf("nvme_fabrics is not functional, failed to stat /dev/nvme-fabrics: %w", err)
+	}
+	log.DebugLog(ctx, "NVMe-oF fabrics framework is functional with /dev/nvme-fabrics present")
 
 	return nil
 }


### PR DESCRIPTION
On distributions like Talos Linux, NVMe modules are compiled directly into the kernel (CONFIG_NVME_TCP=y, CONFIG_NVME_FABRICS=y) instead of being loadable .ko files.
Explicitly calling modprobe on nvme_fabrics fails on these systems since there is no .ko file present,
causing the CSI node plugin to crash on startup.

Removing nvme_fabrics from the module load list is safe because it is always a dependency of nvme_tcp.
On normal distributions modprobe loads it automatically as part of the nvme_tcp dependency chain. On immutable distributions it is already baked into the kernel.

We verify the fabrics framework is functional after loading nvme_tcp by checking that
/dev/nvme-fabrics exists.
This device node is created by the kernel on init regardless of whether nvme_fabrics was loaded as a module or compiled in, making it a reliable indicator that NVMe-oF TCP is ready to use.



## Related issues ##

Fixes: https://github.com/ceph/ceph-csi/issues/6158


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
