### PR TITLE
Revert "update templates for v3.16.2"

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,10 +9,10 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.16.2
+CSI_IMAGE_VERSION=v3.16-canary
 
 # cephcsi upgrade version
-CSI_UPGRADE_VERSION=v3.16.1
+CSI_UPGRADE_VERSION=v3.15.1
 
 # ceph-csi-operator version used for e2e test
 # TODO: use release tag which includes the bug fixes

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -138,7 +138,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.16.2
+      tag: v3.16-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -149,7 +149,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.16.2
+      tag: v3.16-canary
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -193,7 +193,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -125,7 +125,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -147,7 +147,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -47,7 +47,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -209,7 +209,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--type=controller"
             - "--v=5"
@@ -230,7 +230,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -28,7 +28,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -135,7 +135,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.16.2
+          image: quay.io/cephcsi/cephcsi:v3.16-canary
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This reverts commit 2bd98f3242ed51133f40d2cf056a192e10446247, which sets the image tags back to `canary` and sets the `CSI_UPGRADE_VERSION` to `v3.16.2`