### PR TITLE
csi: use GA versions of sidecars everywhere

### DIFF
--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -73,7 +73,7 @@ spec:
             - name: keys-tmp-dir
               mountPath: /tmp/csi/keys
         - name: csi-provisioner
-          image: gcr.io/k8s-staging-sig-storage/csi-provisioner:canary
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"
@@ -121,7 +121,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:canary
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"

--- a/deploy/nvmeof/kubernetes/csi-nvmeofplugin-provisioner.yaml
+++ b/deploy/nvmeof/kubernetes/csi-nvmeofplugin-provisioner.yaml
@@ -79,7 +79,7 @@ spec:
               mountPath: /run/secrets/tokens
               readOnly: true
         - name: csi-provisioner
-          image: gcr.io/k8s-staging-sig-storage/csi-provisioner:canary
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"
@@ -108,7 +108,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: gcr.io/k8s-staging-sig-storage/csi-resizer:canary
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=1"


### PR DESCRIPTION
The deployments for nvmeof and nfs still used the :canary images for the
external-provisioner and external-resizer. The latest releases of those
images have support for secrets in the ControllerModifyVolume request,
so these can be used instead.
