### PR TITLE
ci: mirror Rook 1.19.2

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -7,7 +7,7 @@
 #
 
 # ceph-csi devel
-quay.io/rook/ceph:v1.18.4        rook/ceph:v1.18.4
+quay.io/rook/ceph:v1.19.2        rook/ceph:v1.19.2
 quay.io/ceph/ceph:v20            ceph/ceph:v20
 
 # ceph-csi-operator


### PR DESCRIPTION
Rook 1.19.2 has been releases a few weeks ago. Include it in the CI
registry to that we can run e2e with it.

See-also: #5672
Depends-on: #6199
