### PR TITLE
nvmeof: Add mount cache and locking for safe nvme disconnect

### DIFF
--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -802,6 +802,6 @@ func getDeviceFromStagingPath(ctx context.Context, stagingTargetPath string) str
 }
 
 // getNVMeMountedDevices returns a map of all currently mounted NVMe devices.
-func getNVMeMountedDevices(ctx context.Context) (map[string]bool, error) {
+func getNVMeMountedDevices(ctx context.Context) (map[string]string, error) {
 	return nvmeutil.GetAllNVMeMountedDevices(ctx)
 }

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -52,6 +52,11 @@ type NodeServer struct {
 
 	// node ID of this node server
 	nodeID string
+
+	// mountedDevices is a cache of currently mounted NVMe devices, used to determine
+	// when it's safe to disconnect a device.
+	// it is initialized on startup and updated on each stage/unstage operation.
+	mountCache nvmeutil.MountCache
 }
 
 // ConnectionInfo holds NVMe-oF connection details.
@@ -102,11 +107,19 @@ func NewNodeServer(
 		volumeLocks:       util.NewIDLocker(),
 		securityKeys:      nil, // Initialize lazily when needed
 		nodeID:            nodeID,
+		mountCache:        nvmeutil.NewMountCache(),
 	}
 
 	// Load nvme kernel modules
 	if err := nvmeInitiator.LoadKernelModules(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to load NVMe kernel modules: %w", err)
+	}
+
+	// Initialize mounted devices cache on startup to ensure we have an accurate view.
+	// Failing to initialize this cache can lead to incorrect disconnect decisions, so
+	// treat initialization failures as fatal and fail NodeServer construction.
+	if err := ns.initNVMeMountedDevices(context.Background()); err != nil {
+		return nil, fmt.Errorf("failed to initialize mounted devices cache on startup: %w", err)
 	}
 
 	return ns, nil
@@ -327,7 +340,15 @@ func (ns *NodeServer) NodeUnstageVolume(
 
 	stagingTargetPath := getStagingTargetPath(req)
 
-	devPath := getDeviceFromStagingPath(ctx, stagingTargetPath)
+	devPath, exists := ns.mountCache.GetDevice(stagingTargetPath)
+	if !exists {
+		log.WarningLog(ctx, "device not in cache for %s, querying system", stagingTargetPath)
+		// Fallback to findmnt if not in cache
+		devPath, err = nvmeutil.GetDeviceFromMountpoint(ctx, stagingTargetPath)
+		if err != nil {
+			log.WarningLog(ctx, "failed to get device from mountpoint for %s: %v", stagingTargetPath, err)
+		}
+	}
 
 	isMnt, err := ns.Mounter.IsMountPoint(stagingTargetPath)
 	if err != nil {
@@ -365,13 +386,13 @@ func (ns *NodeServer) NodeUnstageVolume(
 	// Non-fatal - a failed disconnect just means the connection lingers until the
 	// kernel's ctrl_loss_tmo expires or the next reconnect cycle.
 	if devPath != "" {
-		mountedDevices, err := getNVMeMountedDevices(ctx)
-		if err != nil {
-			log.WarningLog(ctx, "failed to get mounted devices: %v (skipping disconnect)", err)
-		} else {
-			if err := ns.initiator.DisconnectIfLastMount(ctx, devPath, mountedDevices); err != nil {
-				log.WarningLog(ctx, "failed to disconnect controller for device %s: %v", devPath, err)
-			}
+		// Remove from cache
+		ns.mountCache.RemoveByDevice(devPath)
+
+		// Get remaining devices
+		remainingDevices := ns.mountCache.GetCopyAllDevices()
+		if err := ns.initiator.DisconnectIfLastMount(ctx, devPath, remainingDevices); err != nil {
+			log.WarningLog(ctx, "failed to disconnect controller for device %s: %v", devPath, err)
 		}
 	}
 
@@ -489,6 +510,16 @@ func (ns *NodeServer) stageTransaction(
 	}
 	transaction.isMounted = true
 
+	// Resolve real device and update cache
+	realDevice, err := nvmeutil.GetDeviceFromMountpoint(ctx, stagingTargetPath)
+	if err != nil {
+		log.WarningLog(ctx, "failed to resolve device: %v", err)
+		// Fallback - try to continue
+		realDevice = devicePath
+	}
+
+	ns.mountCache.Add(realDevice, stagingTargetPath)
+
 	return transaction, nil
 }
 
@@ -520,16 +551,17 @@ func (ns *NodeServer) undoStagingTransaction(
 			// continue on failure to disconnect the image
 		}
 	}
-	// disconnect if we connected
+
+	// try to remove from cache if we created the staging path - idempotent.
+	ns.mountCache.RemoveByMountPoint(stagingTargetPath)
+
+	// if devicePath is not empty, it means we connected to the subsystem,
+	// so we should try to disconnect if this was the last mount
 	if transaction.devicePath != "" {
-		mountedDevices, err := getNVMeMountedDevices(ctx)
-		if err != nil {
-			log.WarningLog(ctx, "failed to get mounted devices during rollback: %v (skipping disconnect)", err)
-		} else {
-			if err := ns.initiator.DisconnectIfLastMount(ctx, transaction.devicePath, mountedDevices); err != nil {
-				log.WarningLog(ctx, "failed to disconnect during rollback for device %s: %v",
-					transaction.devicePath, err)
-			}
+		mountedDevices := ns.mountCache.GetCopyAllDevices()
+		if err := ns.initiator.DisconnectIfLastMount(ctx, transaction.devicePath, mountedDevices); err != nil {
+			log.WarningLog(ctx, "failed to disconnect during rollback for device %s: %v",
+				transaction.devicePath, err)
 		}
 	}
 }
@@ -776,6 +808,21 @@ func (ns *NodeServer) mountVolumeToStagePath(
 	return err
 }
 
+// initNVMeMountedDevices initializes the mount cache with currently mounted NVMe devices on startup.
+func (ns *NodeServer) initNVMeMountedDevices(ctx context.Context) error {
+	mountedDevices, err := nvmeutil.GetAllNVMeMountedDevices(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Add mounted devices to cache
+	for device, mountPoint := range mountedDevices {
+		ns.mountCache.Add(device, mountPoint)
+	}
+
+	return nil
+}
+
 // getStagingTargetPath concats either NodeStageVolumeRequest's or
 // NodeUnstageVolumeRequest's target path with the volumeID.
 func getStagingTargetPath(req interface{}) string {
@@ -799,9 +846,4 @@ func getDeviceFromStagingPath(ctx context.Context, stagingTargetPath string) str
 	}
 
 	return device
-}
-
-// getNVMeMountedDevices returns a map of all currently mounted NVMe devices.
-func getNVMeMountedDevices(ctx context.Context) (map[string]string, error) {
-	return nvmeutil.GetAllNVMeMountedDevices(ctx)
 }

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -61,7 +61,7 @@ type NVMeInitiator interface {
 	//
 	// Example: If device /dev/nvme0n1 is connected via controllers nvme0 and nvme1,
 	// and both controllers have no other mounted namespaces, both will be disconnected.
-	DisconnectIfLastMount(ctx context.Context, devPath string, mountedDevices map[string]bool) error
+	DisconnectIfLastMount(ctx context.Context, devPath string, mountedDevices map[string]string) error
 }
 
 // ConnectRequest represents a subsystem connection request.
@@ -282,7 +282,7 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 //   - Controller nvme1 has namespaces: [nvme0n1 (being unstaged)]
 //   - Decision: No other namespaces using the controllers -> Disconnect BOTH controllers
 func (ni *nvmeInitiator) DisconnectIfLastMount(ctx context.Context, devPath string,
-	mountedDevices map[string]bool,
+	mountedDevices map[string]string,
 ) error {
 	controllers, err := getControllersForDevice(ctx, devPath)
 	if err != nil {
@@ -495,7 +495,7 @@ func getControllersForDevice(ctx context.Context, devPath string) ([]string, err
 // hasOtherMountedNamespaces checks if a controller has any mounted
 // namespaces OTHER than the one we're about to unstage.
 func hasOtherMountedNamespaces(ctx context.Context, controllerName, currentDevPath string,
-	mountedDevices map[string]bool,
+	mountedDevices map[string]string,
 ) (bool, error) {
 	// Get all namespaces on this controller
 	nsids, err := getNamespacesForController(ctx, controllerName)
@@ -513,7 +513,7 @@ func hasOtherMountedNamespaces(ctx context.Context, controllerName, currentDevPa
 		}
 
 		// If any other namespace is mounted, return true
-		if mountedDevices[nsDevice] {
+		if _, ok := mountedDevices[nsDevice]; ok {
 			log.DebugLog(ctx, "Found other mounted namespace %s on controller %s", nsDevice, controllerName)
 
 			return true, nil

--- a/internal/nvmeof/util/mounter.go
+++ b/internal/nvmeof/util/mounter.go
@@ -105,10 +105,11 @@ func GetDeviceFromMountpoint(ctx context.Context, mountpoint string) (string, er
 	return device, nil
 }
 
-// GetAllNVMeMountedDevices returns a map of all currently mounted NVMe devices.
-// Only checks staging paths to avoid counting the same device multiple times
-// (staging, publish, and pod paths all point to the same device).
-func GetAllNVMeMountedDevices(ctx context.Context) (map[string]bool, error) {
+// The map keys are NVMe device paths (for example, /dev/nvme0n1), and the values
+// are their corresponding CSI staging mount targets. Only staging paths are
+// checked to avoid counting the same device multiple times (staging, publish,
+// and pod paths all point to the same device).
+func GetAllNVMeMountedDevices(ctx context.Context) (map[string]string, error) {
 	stdout, _, err := util.ExecCommandWithTimeout(ctx, 5*time.Second,
 		"findmnt", "-J", "--list", "--output", "SOURCE,TARGET")
 	if err != nil {
@@ -120,7 +121,7 @@ func GetAllNVMeMountedDevices(ctx context.Context) (map[string]bool, error) {
 		return nil, fmt.Errorf("failed to parse findmnt output: %w", err)
 	}
 
-	mountedDevices := make(map[string]bool)
+	mountedDevices := make(map[string]string)
 	for _, fs := range result.Filesystems {
 		// Only check NVMe CSI staging paths
 		isNVMeOFStagingFS := strings.Contains(fs.Target, "nvmeof.csi.ceph.com") &&
@@ -136,7 +137,7 @@ func GetAllNVMeMountedDevices(ctx context.Context) (map[string]bool, error) {
 		device := fs.Source.String()
 		// Only consider valid NVMe devices
 		if device != "" && strings.HasPrefix(device, "/dev/nvme") {
-			mountedDevices[device] = true
+			mountedDevices[device] = fs.Target
 			log.DebugLog(ctx, "Found mounted NVMe device: %s at %s", device, fs.Target)
 		}
 	}

--- a/internal/nvmeof/util/mounter_cache.go
+++ b/internal/nvmeof/util/mounter_cache.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"maps"
+	"sync"
+)
+
+// MountCache defines the contract for managing mount cache operations.
+type MountCache interface {
+	Add(device, stagingPath string)
+	GetDevice(stagingPath string) (string, bool)
+	RemoveByDevice(device string)
+	RemoveByMountPoint(stagingPath string)
+	GetCopyAllDevices() map[string]string
+}
+
+// mountCache is the concrete implementation of MountCache interface.
+// it is a thread-safe cache that maintains the mapping between staging paths and devices.
+// Note: This map is 1:1, meaning each staging path corresponds to exactly one device.
+// device can only be mounted to one staging path at a time, and each staging path can only have one device.
+type mountCache struct {
+	pathToDevice map[string]string // stagingPath -> device
+	deviceToPath map[string]string // device -> stagingPath
+	mu           sync.Mutex        // protects concurrent access
+}
+
+// NewMountCache initializes and returns a new empty instance of MountCache.
+func NewMountCache() MountCache {
+	return &mountCache{
+		pathToDevice: make(map[string]string),
+		deviceToPath: make(map[string]string),
+	}
+}
+
+// Add adds a new mapping between the given device and staging path to the cache.
+func (mc *mountCache) Add(device, stagingPath string) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	// Check if already exists - extra safety to prevent overwriting existing mappings
+	// even though the caller should ensure this, we want to avoid accidentally overwriting
+	// existing mappings in the cache.
+	if _, exists := mc.pathToDevice[stagingPath]; exists {
+		// Already in cache, do nothing
+		return
+	}
+
+	if _, exists := mc.deviceToPath[device]; exists {
+		// Already in cache, do nothing
+		return
+	}
+
+	mc.deviceToPath[device] = stagingPath
+	mc.pathToDevice[stagingPath] = device
+}
+
+// GetDevice returns the device associated with the given staging path,
+// along with a boolean indicating if the mapping exists.
+func (mc *mountCache) GetDevice(stagingPath string) (string, bool) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	device, exists := mc.pathToDevice[stagingPath]
+
+	return device, exists
+}
+
+// RemoveByDevice removes the mapping for the given device and
+// its associated staging path from the cache.
+func (mc *mountCache) RemoveByDevice(device string) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	stagingPath, exists := mc.deviceToPath[device]
+	if !exists {
+		return // Device not in cache, nothing to do
+	}
+	delete(mc.deviceToPath, device)
+	delete(mc.pathToDevice, stagingPath)
+}
+
+// RemoveByMountPoint removes the mapping for the given staging path
+// and its associated device from the cache.
+func (mc *mountCache) RemoveByMountPoint(stagingPath string) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	device, exists := mc.pathToDevice[stagingPath]
+	if !exists {
+		return // Staging path not in cache, nothing to do
+	}
+	delete(mc.pathToDevice, stagingPath)
+	delete(mc.deviceToPath, device)
+}
+
+// GetCopyAllDevices returns a copy of all devices currently in the cache.
+// The returned map has device paths as keys and staging paths as values.
+func (mc *mountCache) GetCopyAllDevices() map[string]string {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	return maps.Clone(mc.deviceToPath)
+}

--- a/internal/nvmeof/util/mounter_cache_test.go
+++ b/internal/nvmeof/util/mounter_cache_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMountCache(t *testing.T) {
+	t.Parallel()
+	cache := NewMountCache()
+
+	// Test adding and retrieving mappings
+	cache.Add("/dev/nvme0n1", "/mnt/staging1")
+	cache.Add("/dev/nvme1n1", "/mnt/staging2")
+
+	device, exists := cache.GetDevice("/mnt/staging1")
+	require.True(t, exists)
+	require.Equal(t, "/dev/nvme0n1", device)
+
+	device, exists = cache.GetDevice("/mnt/staging2")
+	require.True(t, exists)
+	require.Equal(t, "/dev/nvme1n1", device)
+
+	// Test retrieving a non-existent mapping
+	_, exists = cache.GetDevice("/mnt/nonexistent")
+	require.False(t, exists)
+
+	// Test removing a mapping by device
+	cache.RemoveByDevice("/dev/nvme0n1")
+
+	_, exists = cache.GetDevice("/mnt/staging1")
+	require.False(t, exists)
+
+	// Ensure the other mapping still exists
+	device, exists = cache.GetDevice("/mnt/staging2")
+	require.True(t, exists)
+	require.Equal(t, "/dev/nvme1n1", device)
+}
+
+func TestMountCacheConcurrency(t *testing.T) {
+	t.Parallel()
+	cache := NewMountCache()
+	done := make(chan bool)
+
+	// Start multiple goroutines to add mappings concurrently
+	for i := range [10]int{} {
+		go func(i int) {
+			cache.Add(fmt.Sprintf("/dev/nvme%dn1", i),
+				fmt.Sprintf("/mnt/staging%d", i))
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines to finish
+	for range [10]int{} {
+		<-done
+	}
+
+	// Verify that all mappings were added correctly
+	for i := range [10]int{} {
+		device, exists := cache.GetDevice(fmt.Sprintf("/mnt/staging%d", i))
+		require.True(t, exists)
+		require.Equal(t, fmt.Sprintf("/dev/nvme%dn1", i), device)
+	}
+}
+
+func TestMountCacheRemoveByMountPoint(t *testing.T) {
+	t.Parallel()
+	cache := NewMountCache()
+
+	cache.Add("/dev/nvme0n1", "/mnt/staging1")
+	cache.Add("/dev/nvme1n1", "/mnt/staging2")
+
+	// Remove by mount point
+	cache.RemoveByMountPoint("/mnt/staging1")
+
+	_, exists := cache.GetDevice("/mnt/staging1")
+	require.False(t, exists)
+
+	// Ensure the other mapping still exists
+	device, exists := cache.GetDevice("/mnt/staging2")
+	require.True(t, exists)
+	require.Equal(t, "/dev/nvme1n1", device)
+}
+
+func TestMountCacheRemoveNonExistent(t *testing.T) {
+	t.Parallel()
+	cache := NewMountCache()
+
+	cache.Add("/dev/nvme0n1", "/mnt/staging1")
+
+	// Attempt to remove a non-existent device
+	cache.RemoveByDevice("/dev/nvme2n1")
+
+	// Ensure the existing mapping still exists
+	device, exists := cache.GetDevice("/mnt/staging1")
+	require.True(t, exists)
+	require.Equal(t, "/dev/nvme0n1", device)
+
+	// Attempt to remove a non-existent staging path
+	cache.RemoveByMountPoint("/mnt/nonexistent")
+
+	// Ensure the existing mapping still exists
+	device, exists = cache.GetDevice("/mnt/staging1")
+	require.True(t, exists)
+	require.Equal(t, "/dev/nvme0n1", device)
+}
+
+func TestMountCacheEmpty(t *testing.T) {
+	t.Parallel()
+	cache := NewMountCache()
+
+	// Attempt to retrieve from an empty cache
+	_, exists := cache.GetDevice("/mnt/staging1")
+	require.False(t, exists)
+
+	// Attempt to remove from an empty cache
+	cache.RemoveByDevice("/dev/nvme0n1")
+	cache.RemoveByMountPoint("/mnt/staging1")
+
+	// Ensure the cache is still empty
+	_, exists = cache.GetDevice("/mnt/staging1")
+	require.False(t, exists)
+}
+
+func TestMountCacheOverwriteFailed(t *testing.T) {
+	t.Parallel()
+	cache := NewMountCache()
+
+	cache.Add("/dev/nvme0n1", "/mnt/staging1")
+	cache.Add("/dev/nvme0n1", "/mnt/staging2") // Overwrite existing mapping
+
+	// Ensure the new mapping is not in place
+	_, exists := cache.GetDevice("/mnt/staging2")
+	require.False(t, exists)
+
+	// Ensure the old mapping is still in place
+	device, exists := cache.GetDevice("/mnt/staging1")
+	require.True(t, exists)
+	require.Equal(t, "/dev/nvme0n1", device)
+}


### PR DESCRIPTION
# Describe what this PR does #

Adds an in-memory cache to track which nvme devices are currently mounted at staging paths. This eliminates expensive `findmnt --list` system calls on every unstage operation.

**Structure:**
The cache maintains bidirectional maps for fast lookups:
- `pathToDevice`: staging path -> device path
- `deviceToPath`: device path -> staging path (reverse)

**Initialization:**
Cache is populated at node server startup by scanning existing mounts, then kept up to date as volumes are staged and unstaged.

**Thread Safety:**
Protected by `sync.Mutex`. We use a simple mutex instead of `sync.RWMutex` because:
- Operations are very fast ( map lookups or remove. just 1 call for get copy , which it is called once per delete pod.. )
- Read/write ratio is - not read-heavy

**Why copying the map is safe:**
When `GetAllDevices()` returns a copy of the cache, callers get a consistent snapshot at that moment. The copy happens after cache updates (first, the pod unmounts, then deletes itself, and last fetch the copy of cache), so concurrent `unstage` operations each see current state. Even if two unstages run simultaneously, each removes its device from the cache first, then gets a fresh snapshot showing remaining devices.
So the last of them who call to `GetAllDevices()` will get the update list, and will know if disconnect or not. (**NodeStage cannot run at this time** !!) 


## Related PR##
after this pr: https://github.com/ceph/ceph-csi/pull/6183 will be merged, group locking (between NodeStage\NodeUnStage) will added.


## Future concerns ##
**next step is to add group lock** after https://github.com/ceph/ceph-csi/pull/6183 will be merged.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
