### PR TITLE
e2e: use userID and userKey in cephfs tests

### DIFF
--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -167,13 +167,8 @@ func createCephfsSecret(f *framework.Framework, secretName, userName, userKey st
 	if secretName != "" {
 		sc.Name = secretName
 	}
-	// TODO: Update the secrets to use userID and userKey once
-	// the version used for upgrade testing does not depend on
-	// adminID and adminKey.
-	sc.StringData["adminID"] = userName
-	sc.StringData["adminKey"] = userKey
-	delete(sc.StringData, "userID")
-	delete(sc.StringData, "userKey")
+	sc.StringData["userID"] = userName
+	sc.StringData["userKey"] = userKey
 	sc.Namespace = cephCSINamespace
 	_, err = f.ClientSet.CoreV1().Secrets(cephCSINamespace).Create(context.TODO(), &sc, metav1.CreateOptions{})
 


### PR DESCRIPTION

# Describe what this PR does #
This patch removes the deprecated `adminID` and `adminKey` in favor of `userID` and `userKey` in the CephFS e2e tests.

Fixes: #5056

