### PR TITLE
rbd: fix ProcessMetadata and getRBDSnapID to use clone image consistently

### DIFF
--- a/internal/rbd/snap_diff.go
+++ b/internal/rbd/snap_diff.go
@@ -42,9 +42,16 @@ func (rbdSnap *rbdSnapshot) ProcessMetadata(
 ) error {
 	var fromSnapID uint64
 
-	image, err := rbdSnap.open()
+	// Open the snapshot (clone) image, not the source volume.
+	// The snapshot image contains the data and has snapshots
+	// whose IDs correspond to what getRBDSnapID() returns.
+	vol := rbdSnap.toVolume()
+	vol.conn = rbdSnap.conn.Copy()
+	defer vol.Destroy(ctx)
+
+	image, err := vol.open()
 	if err != nil {
-		return fmt.Errorf("failed to open image %q: %w", rbdSnap, err)
+		return fmt.Errorf("failed to open image %q: %w", vol, err)
 	}
 	defer func() {
 		cErr := image.Close()

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -445,7 +445,7 @@ func (rbdSnap *rbdSnapshot) getRBDSnapID(ctx context.Context) (uint64, error) {
 
 	for _, snap := range snapInfos {
 		if snap.Name == rbdSnap.RbdSnapName {
-			return snap.ID, nil
+			return snap.Id, nil
 		}
 	}
 

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -438,10 +438,16 @@ func (rbdSnap *rbdSnapshot) getRBDSnapID(ctx context.Context) (uint64, error) {
 		}
 	}()
 
-	parentInfo, err := image.GetParent()
+	snapInfos, err := image.GetSnapshotNames()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to list snapshots on image %q: %w", vol.RbdImageName, err)
 	}
 
-	return parentInfo.Snap.ID, nil
+	for _, snap := range snapInfos {
+		if snap.Name == rbdSnap.RbdSnapName {
+			return snap.ID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("snapshot %q not found on image %q", rbdSnap.RbdSnapName, vol.RbdImageName)
 }


### PR DESCRIPTION
## Summary

- Fix `getRBDSnapID()` to use `GetSnapshotNames()` instead of `GetParent()` for reliable snapshot ID lookup
- Fix `ProcessMetadata` to open the clone (snapshot) image instead of the source volume, consistent with `getRBDSnapID()`

## Problem

`GetMetadataAllocated` returns empty streams for non-LUKS volumes despite `rbd diff` working at the Ceph level.

**Root cause:** Image/snapshot ID mismatch between `ProcessMetadata` and `getRBDSnapID`:

1. `getRBDSnapID()` used `GetParent()` on the clone image to find the snapshot ID. This only works when the clone has an intact parent relationship — it fails for flattened clones or non-clone snapshots.

2. Even when `GetParent()` succeeded, it returned the snapshot ID on the **source volume**, while `ProcessMetadata` was also opening the **source volume** — this happened to work by coincidence for unflattened clones but was architecturally fragile.

## Fix

**`getRBDSnapID()`**: Replace `GetParent()` with `GetSnapshotNames()`, which lists snapshots on the clone image and finds the one matching `RbdSnapName`. This works regardless of clone/parent state. (`GetSnapshotNames()` is already used elsewhere in the codebase, e.g., `checkSnapExists`.)

**`ProcessMetadata`**: Open the clone image via `toVolume()` instead of opening the source volume via `rbdSnap.open()`. This ensures `SetSnapByID()` applies the snapshot ID to the same image that `getRBDSnapID()` looked it up on.

## Test plan

- [ ] Verify build passes in CI
- [ ] Verify existing `snap_diff_test.go` tests still pass
- [ ] E2E: `GetMetadataAllocated` returns blocks for non-LUKS RBD volumes

Ref: https://github.com/kaovilai/cephcsi-cbt-e2e/issues/2

> [!Note]
> Responses generated with Claude

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)