### PR TITLE
rbd: use StorageClass image features for temp clones and snapshots

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -1870,6 +1870,130 @@ var _ = Describe("RBD", func() {
 				validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
 			})
 
+		It("verify temp clone and snapshot backing images inherit StorageClass image features",
+			func() {
+				if !kernel.CheckKernelSupport(kernelRelease, fastDiffSupport) {
+					Skip("kernel does not support fast-diff, skipping image features inheritance test")
+				}
+
+				imageFeatures := "layering,exclusive-lock,object-map,fast-diff,deep-flatten"
+				expectedFeatures := []string{
+					"layering", "exclusive-lock", "object-map", "fast-diff", "deep-flatten",
+				}
+
+				err := deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					logAndFail("failed to delete storageclass: %v", err)
+				}
+				err = createRBDStorageClass(
+					f.ClientSet,
+					f,
+					defaultSCName,
+					nil,
+					map[string]string{
+						"imageFeatures": imageFeatures,
+					},
+					deletePolicy)
+				if err != nil {
+					logAndFail("failed to create storageclass: %v", err)
+				}
+				defer func() {
+					err = deleteResource(rbdExamplePath + "storageclass.yaml")
+					if err != nil {
+						logAndFail("failed to delete storageclass: %v", err)
+					}
+					err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+					if err != nil {
+						logAndFail("failed to create storageclass: %v", err)
+					}
+				}()
+
+				// create source PVC
+				pvc, err := loadPVC(pvcPath)
+				if err != nil {
+					logAndFail("failed to load PVC: %v", err)
+				}
+				pvc.Namespace = f.UniqueName
+				err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create PVC: %v", err)
+				}
+
+				// create a snapshot and verify the backing image (csi-snap-*)
+				// inherits StorageClass image features
+				err = createRBDSnapshotClass(f)
+				if err != nil {
+					logAndFail("failed to create snapshotclass: %v", err)
+				}
+				defer func() {
+					err = deleteRBDSnapshotClass()
+					if err != nil {
+						logAndFail("failed to delete snapshotclass: %v", err)
+					}
+				}()
+
+				snap := getSnapshot(snapshotPath)
+				snap.Namespace = f.UniqueName
+				snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+				err = createSnapshot(&snap, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create snapshot: %v", err)
+				}
+
+				snapImageName, err := getSnapName(snap.Namespace, snap.Name)
+				if err != nil {
+					logAndFail("failed to get snapshot image name: %v", err)
+				}
+				err = validateImageFeatures(f, snapImageName, defaultRBDPool, expectedFeatures)
+				if err != nil {
+					logAndFail("snapshot backing image %s features validation failed: %v",
+						snapImageName, err)
+				}
+
+				err = deleteSnapshot(&snap, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete snapshot: %v", err)
+				}
+
+				// create a PVC-PVC clone and verify the temp clone image
+				// (csi-vol-*-temp) inherits StorageClass image features
+				pvcSmartClone, err := loadPVC(pvcSmartClonePath)
+				if err != nil {
+					logAndFail("failed to load PVC: %v", err)
+				}
+				pvcSmartClone.Namespace = f.UniqueName
+				pvcSmartClone.Spec.DataSource.Name = pvc.Name
+				err = createPVCAndvalidatePV(f.ClientSet, pvcSmartClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create cloned PVC: %v", err)
+				}
+
+				// the temp clone image name is the clone image name + "-temp"
+				imageData, err := getImageInfoFromPVC(pvcSmartClone.Namespace, pvcSmartClone.Name, f)
+				if err != nil {
+					logAndFail("failed to get image info from source PVC: %v", err)
+				}
+				tempCloneImageName := imageData.imageName + "-temp"
+				err = validateImageFeatures(f, tempCloneImageName, defaultRBDPool, expectedFeatures)
+				if err != nil {
+					logAndFail("temp clone image %s features validation failed: %v",
+						tempCloneImageName, err)
+				}
+
+				// clean up clone and source
+				err = deletePVCAndValidatePV(f.ClientSet, pvcSmartClone, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete cloned PVC: %v", err)
+				}
+				err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				if err != nil {
+					logAndFail("failed to delete source PVC: %v", err)
+				}
+
+				validateRBDImageCount(f, 0, defaultRBDPool)
+				validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+			})
+
 		It("create PVC without layering,deep-flatten image-features and bind it to an app",
 			func() {
 				err := deleteResource(rbdExamplePath + "storageclass.yaml")

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1230,11 +1230,12 @@ func waitToRemoveImagesFromTrash(f *framework.Framework, poolName string, t int)
 
 // imageInfo strongly typed JSON spec for image info.
 type imageInfo struct {
-	Name        string `json:"name"`
-	StripeUnit  int    `json:"stripe_unit"`
-	StripeCount int    `json:"stripe_count"`
-	ObjectSize  int    `json:"object_size"`
-	DataPool    string `json:"data_pool"`
+	Name        string   `json:"name"`
+	StripeUnit  int      `json:"stripe_unit"`
+	StripeCount int      `json:"stripe_count"`
+	ObjectSize  int      `json:"object_size"`
+	DataPool    string   `json:"data_pool"`
+	Features    []string `json:"features"`
 }
 
 // getImageInfo queries rbd about the given image and returns its metadata, and returns
@@ -1308,6 +1309,40 @@ func validateStripe(f *framework.Framework,
 
 	if imgInfo.StripeCount != stripeCount {
 		return fmt.Errorf("stripeCount %d does not match expected %d", imgInfo.StripeCount, stripeCount)
+	}
+
+	return nil
+}
+
+// validateImageFeatures checks that the given RBD image has all the expected
+// image features enabled.
+func validateImageFeatures(
+	f *framework.Framework,
+	imageName, pool string,
+	expectedFeatures []string,
+) error {
+	var imgInfo imageInfo
+
+	imgInfoStr, err := getImageInfo(f, imageName, pool)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal([]byte(imgInfoStr), &imgInfo)
+	if err != nil {
+		return fmt.Errorf("unmarshal failed: %w. raw buffer response: %s", err, imgInfoStr)
+	}
+
+	actualSet := make(map[string]bool, len(imgInfo.Features))
+	for _, feat := range imgInfo.Features {
+		actualSet[feat] = true
+	}
+
+	for _, want := range expectedFeatures {
+		if !actualSet[want] {
+			return fmt.Errorf("image %s missing expected feature %q, got features: %v",
+				imageName, want, imgInfo.Features)
+		}
 	}
 
 	return nil

--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -109,9 +109,11 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 func (rv *rbdVolume) generateTempClone() *rbdVolume {
 	tempClone := rbdVolume{}
 	tempClone.conn = rv.conn.Copy()
-	// The temp clone image need to have deep flatten feature
+	// Use the parent volume's image features (from StorageClass) and ensure
+	// that layering and deep-flatten are always enabled, as these are
+	// required for the flatten operation on the temporary clone.
 	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
-	tempClone.ImageFeatureSet = librbd.FeatureSetFromNames(f)
+	tempClone.ImageFeatureSet = rv.ImageFeatureSet | librbd.FeatureSetFromNames(f)
 	tempClone.ClusterID = rv.ClusterID
 	tempClone.Monitors = rv.Monitors
 	tempClone.Pool = rv.Pool

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1391,9 +1391,10 @@ func (cs *ControllerServer) doSnapshotClone(
 	// generate cloned volume details from snapshot
 	cloneRbd := rbdSnap.toVolume()
 	defer cloneRbd.Destroy(ctx)
-	// add image feature for cloneRbd
+	// Use the parent volume's image features and ensure that layering and
+	// deep-flatten are always enabled for the snapshot backing image.
 	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
-	cloneRbd.ImageFeatureSet = librbd.FeatureSetFromNames(f)
+	cloneRbd.ImageFeatureSet = parentVol.ImageFeatureSet | librbd.FeatureSetFromNames(f)
 
 	// For snapshot creation, the temporary clone must use the same data pool as the parent
 	// volume to ensure correct storage placement for erasure-coded pools.

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -292,9 +292,10 @@ func (rv *rbdVolume) NewSnapshotByID(
 		return nil, err
 	}
 
-	// set the features for the clone image.
+	// Use the parent volume's image features and ensure that layering and
+	// deep-flatten are always enabled for the snapshot backing image.
 	f := []string{librbd.FeatureNameLayering, librbd.FeatureNameDeepFlatten}
-	rv.ImageFeatureSet = librbd.FeatureSetFromNames(f)
+	rv.ImageFeatureSet |= librbd.FeatureSetFromNames(f)
 
 	options, err := rv.constructImageOptions(ctx)
 	if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
Previously, temporary clone images (-temp) and snapshot backing images
had their features hard-coded to only layering and deep-flatten.

Inherit the image features from the parent volume (configured via
StorageClass imageFeatures) while ensuring layering and deep-flatten
are always enabled, as they are required for the flatten operation.
```

Fixes: https://github.com/ceph/ceph-csi/issues/4936

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow. guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
