### PR TITLE
nvmeof: add allowAnyHost StorageClass parameter

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -21,5 +21,7 @@
 - nvmeof: add Kubernetes ServiceAccount based volume access restriction
 - cephfs: add Kubernetes ServiceAccount based volume access restriction
 - nfs: add Kubernetes ServiceAccount based volume access restriction
+- nvmeof: the new `allowAnyHost` StorageClass option makes it possible to
+  expose created volumes to external clients
 
 ## NOTE

--- a/examples/nvmeof/storageclass.yaml
+++ b/examples/nvmeof/storageclass.yaml
@@ -28,6 +28,10 @@ parameters:
   # subsystemNQN is the NQN of the subsystem where all volumes belong to
   subsystemNQN: "nqn.2025-08.io.ceph:k8s-ceph-csi"
 
+  # allowAnyHost allows any host to connect to the subsystem. When enabled,
+  # explicit per-host access control is bypassed
+  # allowAnyHost: "true"
+
   # connection details for the gateway (management API)
   nvmeofGatewayAddress: 10.242.64.32
   nvmeofGatewayPort: "5500"

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -671,6 +671,7 @@ func ensureSubsystem(
 	subsystemNQN,
 	networkMask string,
 	listeners []nvmeof.ListenerDetails,
+	allowAnyHost bool,
 ) error {
 	exists, err := gateway.SubsystemExists(ctx, subsystemNQN)
 	if err != nil {
@@ -681,6 +682,14 @@ func ensureSubsystem(
 		err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask)
 		if err != nil {
 			return err
+		}
+
+		// If allowAnyHost is enabled, configure subsystem to allow any host
+		if allowAnyHost {
+			err = gateway.AllowAnyHost(ctx, subsystemNQN)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	// if the subsystem exists, we need to ensure the listeners are created. (if exists, it is OK)
@@ -769,6 +778,16 @@ func (cs *Server) createNVMeoFResources(
 	if err != nil {
 		return nil, fmt.Errorf("invalid nvmeofGatewayPort %s: %w", nvmeofGatewayPortStr, err)
 	}
+
+	// Parse allowAnyHost parameter (defaults to false if not provided)
+	allowAnyHost := false
+	if allowAnyHostStr := params["allowAnyHost"]; allowAnyHostStr != "" {
+		allowAnyHost, err = strconv.ParseBool(allowAnyHostStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid allowAnyHost value %s: %w", allowAnyHostStr, err)
+		}
+	}
+
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
 		SubsystemNQN:  params["subsystemNQN"],
 		NamespaceID:   0,   // will be set after namespace creation,
@@ -837,7 +856,8 @@ func (cs *Server) createNVMeoFResources(
 	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
 
 	// Step 3: Ensure subsystem exists (and listener)
-	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, networkMask, nvmeofData.ListenerInfo); err != nil {
+	err = ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, networkMask, nvmeofData.ListenerInfo, allowAnyHost)
+	if err != nil {
 		return nvmeofData, fmt.Errorf("subsystem setup failed: %w", err)
 	}
 

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -389,6 +389,19 @@ func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN s
 	return fmt.Errorf("gateway AddHost returned error (status=%d): %s", resp.GetStatus(), resp.GetErrorMessage())
 }
 
+// AllowAnyHost configures the subsystem to allow any host to connect by adding a wildcard host ("*").
+// This bypasses per-host access control.
+func (gw *GatewayRpcClient) AllowAnyHost(ctx context.Context, subsystemNQN string) error {
+	log.DebugLog(ctx, "Configuring subsystem %s to allow any host", subsystemNQN)
+
+	emptyDhchapKeys := DHCHAPKeys{}
+	if err := gw.AddHost(ctx, subsystemNQN, "*", emptyDhchapKeys); err != nil {
+		return fmt.Errorf("failed to add wildcard host to subsystem %s: %w", subsystemNQN, err)
+	}
+
+	return nil
+}
+
 func (gw *GatewayRpcClient) CreateListener(ctx context.Context, subsystemNQN string, listenerInfo ListenerDetails,
 ) error {
 	log.DebugLog(ctx, "Adding listener %s to subsystem %s", listenerInfo.Address, subsystemNQN)


### PR DESCRIPTION
The new optional allowAnyHost parameter allows subsystems to accept
connections from any NVMe initiator by adding a wildcard host ("*").
This bypasses per-host access control and enables volumes to be exposed
to external clients without explicit host registration.

The parameter defaults to false to maintain secure per-host access
control by default.

Test image: `quay.io/nixpanic/cephcsi:nvmeof-allowAnyHost`

/cc @gadididi @OdedViner