### PR TITLE
build: add go-lint-fix Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 
 all: cephcsi
 
-.PHONY: go-test static-check mod-check go-lint lint-extras commitlint link-check codespell
+.PHONY: go-test static-check mod-check go-lint go-lint-fix lint-extras commitlint link-check codespell
 ifeq ($(CONTAINERIZED),no)
 # include mod-check in non-containerized runs
 test: go-test static-check mod-check
@@ -126,6 +126,9 @@ scripts/golangci.yml: scripts/golangci.yml.in
 
 go-lint: scripts/golangci.yml
 	./scripts/lint-go.sh
+
+go-lint-fix: scripts/golangci.yml
+	./scripts/lint-go.sh --fix
 
 lint-extras:
 	./scripts/lint-extras.sh lint-all

--- a/scripts/lint-go.sh
+++ b/scripts/lint-go.sh
@@ -3,7 +3,7 @@
 set -o pipefail
 
 if [[ -x "$(command -v golangci-lint)" ]]; then
-  golangci-lint --config=scripts/golangci.yml run ./... -v
+  golangci-lint --config=scripts/golangci.yml run ./... -v "$@"
 else
   echo "WARNING: golangci-lint not found, skipping lint tests" >&2
 fi


### PR DESCRIPTION
## Summary
- Add `go-lint-fix` Makefile target that passes `--fix` to golangci-lint
- Update `scripts/lint-go.sh` to forward additional arguments (`"$@"`) to golangci-lint

Usage: `make containerized-test TARGET=go-lint-fix`

## Test plan
- [ ] `make containerized-test TARGET=go-lint` still works as before
- [ ] `make containerized-test TARGET=go-lint-fix` auto-fixes lint issues

> [!Note]
> Responses generated with Claude

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)