### PR TITLE
nvmeof: Add GroupLock to coordinate stage and unstage operations and e2e tests

### DIFF
--- a/e2e/nvmeof.go
+++ b/e2e/nvmeof.go
@@ -18,7 +18,9 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -188,6 +190,126 @@ var _ = ginkgo.Describe("nvmeof", func() {
 			// validate created backend rbd images
 			validateRBDImageCount(f, 0, nvmeofPool)
 			validateOmapCount(f, 0, rbdType, nvmeofPool, volumesType)
+		})
+
+		ginkgo.It("Test GroupLock: Concurrent Create/Delete Pods Only", func() {
+			// This test validates the GroupLock implementation in the NVMeoF NodeServer
+			// by creating and deleting multiple Pods (not PVCs) concurrently.
+			//
+			// Test flow:
+			// 1. Create 3 PVCs sequentially and validate they're Bound
+			// 2. Create 3 Pods concurrently using those PVCs (triggers NodeStage -> Group A lock)
+			// 3. Wait for all Pods to be Running
+			// 4. Delete all 3 Pods concurrently (triggers NodeUnstage -> Group B lock)
+			// 5. Delete all 3 PVCs sequentially
+			// 6. Verify no timeouts/deadlocks and all operations succeed
+			//
+			// This tests GroupLock in the NodeServer without involving ControllerServer operations.
+			totalCount := 3
+
+			ginkgo.By("Creating PVCs sequentially")
+			pvc, err := loadPVC(pvcPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			pvc.Namespace = f.UniqueName
+			pvc.Spec.StorageClassName = &nvmeofStorageClass
+
+			pvcBaseName := uuid.NewString()
+			for i := range totalCount {
+				pvcName := fmt.Sprintf("%s-%d", pvcBaseName, i)
+				pvcCopy := pvc.DeepCopy()
+				pvcCopy.Name = pvcName
+
+				framework.Logf("Creating PVC %d/%d: %s", i+1, totalCount, pvcName)
+				err = createPVCAndvalidatePV(f.ClientSet, pvcCopy, deployTimeout)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+
+			ginkgo.By("Validating backend RBD images were created")
+			validateRBDImageCount(f, totalCount, nvmeofPool)
+			validateOmapCount(f, totalCount, rbdType, nvmeofPool, volumesType)
+
+			ginkgo.By("Creating Pods concurrently using those PVCs")
+			createResult := createConcurrentPods(totalCount, pvcBaseName, 0, appPath, f)
+
+			// Log any errors
+			if createResult.HasErrors() {
+				createResult.LogErrors()
+			}
+
+			// Verify all creations succeeded
+			Expect(createResult.failed).To(Equal(0),
+				"Expected all %d Pod create operations to succeed, but %d failed",
+				totalCount, createResult.failed)
+
+			ginkgo.By("Waiting for all Pods to be Running")
+			for i := range totalCount {
+				podName := fmt.Sprintf("%s-%d", createResult.uniqueName, i)
+				err = waitForPodInRunningState(podName, f.UniqueName, f.ClientSet, deployTimeout, noError)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+
+			ginkgo.By("Deleting Pods concurrently")
+			deleteResult := deleteConcurrentPods(createResult, f)
+
+			// Log any errors
+			if deleteResult.HasErrors() {
+				deleteResult.LogErrors()
+			}
+
+			// Verify all deletions succeeded
+			Expect(deleteResult.failed).To(Equal(0),
+				"Expected all %d Pod delete operations to succeed, but %d failed",
+				totalCount, deleteResult.failed)
+
+			ginkgo.By("Deleting PVCs sequentially")
+			for i := range totalCount {
+				pvcName := fmt.Sprintf("%s-%d", pvcBaseName, i)
+				pvcCopy := pvc.DeepCopy()
+				pvcCopy.Name = pvcName
+
+				framework.Logf("Deleting PVC %d/%d: %s", i+1, totalCount, pvcName)
+				err = deletePVCAndValidatePV(f.ClientSet, pvcCopy, deployTimeout)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+
+			ginkgo.By("Validating all backend RBD images were deleted")
+			validateRBDImageCount(f, 0, nvmeofPool)
+			validateOmapCount(f, 0, rbdType, nvmeofPool, volumesType)
+
+			framework.Logf("GroupLock test passed: %d concurrent Pod creates and %d concurrent Pod deletes completed successfully",
+				totalCount, totalCount)
+		})
+
+		ginkgo.It("Test GroupLock: Mixed Create/Delete Pods with Rapid Switching", func() {
+			// This test validates the GroupLock implementation under rapid switching
+			// between Group A (NodeStage) and Group B (NodeUnstage) operations.
+			//
+			// Test flow:
+			// 1. Create 15 PVCs sequentially
+			// 2. Create 5 Pods using PVCs 0-4 (Group A)
+			// 3. Concurrently: Create 5 Pods using PVCs 5-9 (Group A) + Delete previous 5 Pods (Group B)
+			// 4. Concurrently: Create 5 Pods using PVCs 10-14 (Group A) + Delete previous 5 Pods (Group B)
+			// 5. Delete final 5 Pods
+			// 6. Delete all 15 PVCs sequentially
+			//
+			// This tests rapid GroupLock switching between Group A and B in the NodeServer only,
+			// without involving ControllerServer operations.
+			totalCount := 15
+			batchSize := 5
+
+			ginkgo.By(fmt.Sprintf("Running Pods-only mixed test: %d total PVCs, batches of %d Pods",
+				totalCount, batchSize))
+
+			err := mixedCreateDeletePodsOnly(totalCount, batchSize, pvcPath, appPath, nvmeofStorageClass, f)
+			Expect(err).ShouldNot(HaveOccurred(),
+				"Mixed Pods-only operations should complete without errors")
+
+			ginkgo.By("Validating all backend RBD images were cleaned up")
+			validateRBDImageCount(f, 0, nvmeofPool)
+			validateOmapCount(f, 0, rbdType, nvmeofPool, volumesType)
+
+			framework.Logf("GroupLock Pods-only test passed: %d Pods created and deleted with rapid Group A/B switching",
+				totalCount)
 		})
 	})
 })

--- a/e2e/nvmeof_helper.go
+++ b/e2e/nvmeof_helper.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// concurrentPodsResult holds the result of concurrent Pod operations.
+type concurrentPodsResult struct {
+	// uniqueName is the base name used for all Pods
+	uniqueName string
+	// totalCount is the number of Pods created/deleted
+	totalCount int
+	// errors contains any errors that occurred during operations
+	errors []error
+	// failed is the count of failed operations
+	failed int
+}
+
+// String returns a human-readable summary of the result.
+func (r *concurrentPodsResult) String() string {
+	if r.failed == 0 {
+		return fmt.Sprintf("All %d operations succeeded", r.totalCount)
+	}
+
+	return fmt.Sprintf("%d out of %d operations failed", r.failed, r.totalCount)
+}
+
+// HasErrors returns true if any operations failed.
+func (r *concurrentPodsResult) HasErrors() bool {
+	return r.failed > 0
+}
+
+// LogErrors logs all errors to the framework.
+func (r *concurrentPodsResult) LogErrors() {
+	for i, err := range r.errors {
+		if err != nil {
+			framework.Logf("Operation %s-%d failed: %v", r.uniqueName, i, err)
+		}
+	}
+}
+
+// createConcurrentPods creates multiple Pods using existing PVCs.
+// This triggers NodeStage operations (Group A in GroupLock).
+//
+// Parameters:
+//   - totalCount: number of Pods to create
+//   - pvcBaseName: base name of existing PVCs to use
+//   - pvcStartIndex: starting index for PVC names (e.g., 0 uses pvcBaseName-0, pvcBaseName-1, ...)
+//   - appPath: path to Pod template YAML
+//   - f: test framework
+//
+// Returns:
+//   - *concurrentPodsResult: result containing uniqueName, errors, and counts
+func createConcurrentPods(
+	totalCount int,
+	pvcBaseName string,
+	pvcStartIndex int,
+	appPath string,
+	f *framework.Framework,
+) *concurrentPodsResult {
+	app, err := loadApp(appPath)
+	if err != nil {
+		return &concurrentPodsResult{
+			totalCount: totalCount,
+			errors:     []error{fmt.Errorf("failed to load app: %w", err)},
+			failed:     1,
+		}
+	}
+	app.Namespace = f.UniqueName
+
+	uniqueName := uuid.NewString()
+	framework.Logf("Creating %d Pods (base name: %s) using PVCs %s-%d to %s-%d",
+		totalCount, uniqueName, pvcBaseName, pvcStartIndex, pvcBaseName, pvcStartIndex+totalCount-1)
+
+	var wg sync.WaitGroup
+	wgErrs := make([]error, totalCount)
+
+	wg.Add(totalCount)
+	for i := range totalCount {
+		go func(n int) {
+			defer wg.Done()
+			// Deep copy to avoid data races on shared pod spec
+			pod := app.DeepCopy()
+			podName := fmt.Sprintf("%s-%d", uniqueName, n)
+			pvcName := fmt.Sprintf("%s-%d", pvcBaseName, pvcStartIndex+n)
+
+			// Update pod to use the specific PVC
+			pod.Name = podName
+			pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcName
+
+			wgErrs[n] = createApp(f.ClientSet, pod, deployTimeout)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Count failures
+	failed := 0
+	for _, err := range wgErrs {
+		if err != nil {
+			failed++
+		}
+	}
+
+	return &concurrentPodsResult{
+		uniqueName: uniqueName,
+		totalCount: totalCount,
+		errors:     wgErrs,
+		failed:     failed,
+	}
+}
+
+// deleteConcurrentPods deletes multiple Pods.
+// This triggers NodeUnstage operations (Group B in GroupLock).
+//
+// Parameters:
+//   - result: result from createConcurrentPods containing uniqueName
+//   - f: test framework
+//
+// Returns:
+//   - *concurrentPodsResult: result containing errors and counts
+func deleteConcurrentPods(
+	result *concurrentPodsResult,
+	f *framework.Framework,
+) *concurrentPodsResult {
+	framework.Logf("Deleting %d Pods (base name: %s)", result.totalCount, result.uniqueName)
+
+	var wg sync.WaitGroup
+	wgErrs := make([]error, result.totalCount)
+
+	wg.Add(result.totalCount)
+	for i := range result.totalCount {
+		go func(n int) {
+			defer wg.Done()
+			podName := fmt.Sprintf("%s-%d", result.uniqueName, n)
+			wgErrs[n] = deletePod(podName, f.UniqueName, f.ClientSet, deployTimeout)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Count failures
+	failed := 0
+	for _, err := range wgErrs {
+		if err != nil {
+			failed++
+		}
+	}
+
+	return &concurrentPodsResult{
+		uniqueName: result.uniqueName,
+		totalCount: result.totalCount,
+		errors:     wgErrs,
+		failed:     failed,
+	}
+}
+
+// mixedCreateDeletePodsOnly performs mixed create and delete operations on Pods only.
+// This function accurately tests the GroupLock in NodeServer by separating Controller
+// operations (PVC) from Node operations (Pod).
+//
+// Flow:
+//  1. Create all PVCs sequentially and validate they're Bound
+//  2. Create initial batch of Pods using first set of PVCs (using helper function)
+//  3. For each subsequent batch:
+//     - Create new batch of Pods using next set of PVCs (NodeStage - Group A, using helper)
+//     - Delete previous batch of Pods concurrently (NodeUnstage - Group B, using helper)
+//     - Wait for pods to be Running
+//  4. Delete final batch of Pods (using helper function)
+//  5. Delete all PVCs sequentially
+//
+// This approach is more accurate for testing GroupLock because:
+//   - PVC operations involve ControllerServer only
+//   - Pod operations involve NodeServer (NodeStage/NodeUnstage) - where GroupLock lives
+//
+// Parameters:
+//   - totalCount: total number of PVCs to create (must be evenly divisible by batchSize)
+//   - batchSize: number of Pods per batch
+//   - pvcPath: path to PVC template YAML
+//   - appPath: path to Pod template YAML
+//   - storageClassName: StorageClass name to use
+//   - f: test framework
+//
+// Returns:
+//   - error: any error that occurred during the operations
+func mixedCreateDeletePodsOnly(
+	totalCount, batchSize int,
+	pvcPath, appPath, storageClassName string,
+	f *framework.Framework,
+) error {
+	if batchSize <= 0 {
+		return fmt.Errorf("batchSize must be greater than 0")
+	}
+	if totalCount%batchSize != 0 {
+		return fmt.Errorf("totalCount (%d) must be evenly divisible by batchSize (%d)", totalCount, batchSize)
+	}
+
+	numBatches := totalCount / batchSize
+	framework.Logf("Starting Pods-only test: %d total PVCs, %d batches of %d Pods",
+		totalCount, numBatches, batchSize)
+
+	// Step 1: Create all PVCs sequentially (not in parallel) and validate
+	framework.Logf("Creating %d PVCs sequentially...", totalCount)
+
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC: %w", err)
+	}
+	pvc.Namespace = f.UniqueName
+	pvc.Spec.StorageClassName = &storageClassName
+
+	pvcBaseName := uuid.NewString()
+
+	// cleanupPodsAndPVCs cleans up pods (if result provided) and all PVCs
+	cleanupPodsAndPVCs := func(podResult *concurrentPodsResult) {
+		if podResult != nil {
+			framework.Logf("Cleaning up %d pods...", podResult.totalCount)
+			_ = deleteConcurrentPods(podResult, f)
+		}
+
+		framework.Logf("Cleaning up %d PVCs...", totalCount)
+		for i := range totalCount {
+			pvcName := fmt.Sprintf("%s-%d", pvcBaseName, i)
+			pvcCopy := pvc.DeepCopy()
+			pvcCopy.Name = pvcName
+			_ = deletePVCAndValidatePV(f.ClientSet, pvcCopy, deployTimeout)
+		}
+	}
+
+	// Create PVCs one by one
+	for i := range totalCount {
+		pvcName := fmt.Sprintf("%s-%d", pvcBaseName, i)
+		pvcCopy := pvc.DeepCopy()
+		pvcCopy.Name = pvcName
+
+		framework.Logf("Creating PVC %d/%d: %s", i+1, totalCount, pvcName)
+		err = createPVCAndvalidatePV(f.ClientSet, pvcCopy, deployTimeout)
+		if err != nil {
+			return fmt.Errorf("failed to create PVC %s: %w", pvcName, err)
+		}
+	}
+
+	framework.Logf("Successfully created all %d PVCs", totalCount)
+
+	var allErrors []error
+
+	// Step 2: Create initial batch of Pods
+	framework.Logf("Creating initial batch of %d Pods using PVCs %s-0 to %s-%d",
+		batchSize, pvcBaseName, pvcBaseName, batchSize-1)
+
+	previousResult := createConcurrentPods(batchSize, pvcBaseName, 0, appPath, f)
+	if previousResult.HasErrors() {
+		previousResult.LogErrors()
+
+		// cleanup and return error immediately
+		framework.Logf("Initial batch had %d failures, cleaning up...", previousResult.failed)
+		cleanupPodsAndPVCs(previousResult)
+
+		return fmt.Errorf("initial batch failed: %d out of %d pods failed to create",
+			previousResult.failed, previousResult.totalCount)
+	}
+
+	// Wait for initial batch pods to be Running
+	framework.Logf("Waiting for initial batch pods to be Running...")
+	for i := range batchSize {
+		podName := fmt.Sprintf("%s-%d", previousResult.uniqueName, i)
+		err = waitForPodInRunningState(podName, f.UniqueName, f.ClientSet, deployTimeout, noError)
+		if err != nil {
+			// Cleanup: delete pods first, then PVCs
+			framework.Logf("Initial batch failed to reach Running, cleaning up...")
+			cleanupPodsAndPVCs(previousResult)
+
+			return fmt.Errorf("initial batch pod %s did not reach Running state: %w", podName, err)
+		}
+	}
+
+	// Step 3: Process remaining batches with mixed create/delete
+	// Start from 1 because batch 0 was already pre-created above
+	for batch := 1; batch < numBatches; batch++ {
+		var createResult *concurrentPodsResult
+		var deleteResult *concurrentPodsResult
+
+		// Use WaitGroup to run create and delete truly concurrently
+		var wg sync.WaitGroup
+
+		// Calculate PVC offset for this batch (batch * batchSize)
+		pvcOffset := batch * batchSize
+
+		// Start creating current batch
+		wg.Add(1)
+		go func(batchNum int, offset int) {
+			defer wg.Done()
+			framework.Logf("Batch %d/%d: Creating %d Pods using PVCs %s-%d to %s-%d",
+				batchNum+1, numBatches, batchSize, pvcBaseName, offset, pvcBaseName, offset+batchSize-1)
+
+			createResult = createConcurrentPods(batchSize, pvcBaseName, offset, appPath, f)
+		}(batch, pvcOffset)
+
+		// Delete previous batch concurrently
+		wg.Add(1)
+		go func(batchNum int, prevResult *concurrentPodsResult) {
+			defer wg.Done()
+			framework.Logf("Batch %d/%d: Deleting previous batch (%d Pods) CONCURRENTLY with creates",
+				batchNum+1, numBatches, prevResult.totalCount)
+
+			deleteResult = deleteConcurrentPods(prevResult, f)
+		}(batch, previousResult)
+
+		// Wait for both operations to complete
+		wg.Wait()
+
+		// Check errors from create operation
+		if createResult.HasErrors() {
+			createResult.LogErrors()
+			for _, err := range createResult.errors {
+				if err != nil {
+					allErrors = append(allErrors, err)
+				}
+			}
+		}
+
+		// Check errors from delete operation
+		if deleteResult.HasErrors() {
+			deleteResult.LogErrors()
+			for _, err := range deleteResult.errors {
+				if err != nil {
+					allErrors = append(allErrors, err)
+				}
+			}
+		}
+
+		// Wait for current batch pods to be Running before next iteration
+		// This provides explicit validation that pods are ready, even though
+		// createApp() already waits internally.It is just a fast check.
+		framework.Logf("Batch %d/%d: Waiting for current batch (%s) pods to be Running",
+			batch+1, numBatches, createResult.uniqueName)
+		for i := range batchSize {
+			podName := fmt.Sprintf("%s-%d", createResult.uniqueName, i)
+			err = waitForPodInRunningState(podName, f.UniqueName, f.ClientSet, deployTimeout, noError)
+			if err != nil {
+				// Cleanup current batch pods and all remaining batches' PVCs, then return error
+				framework.Logf("Batch %d/%d: Pod %s did not reach Running, cleaning up...",
+					batch+1, numBatches, podName)
+				cleanupPodsAndPVCs(createResult)
+
+				return fmt.Errorf("batch %d/%d: pod %s did not reach Running state: %w",
+					batch+1, numBatches, podName, err)
+			}
+		}
+
+		// Save current batch for next iteration
+		previousResult = createResult
+	}
+
+	// Step 4: Delete final batch of Pods
+	if previousResult != nil {
+		framework.Logf("Deleting final batch (%d Pods)", previousResult.totalCount)
+		finalDeleteResult := deleteConcurrentPods(previousResult, f)
+
+		if finalDeleteResult.HasErrors() {
+			finalDeleteResult.LogErrors()
+			for _, err := range finalDeleteResult.errors {
+				if err != nil {
+					allErrors = append(allErrors, err)
+				}
+			}
+		}
+	}
+
+	// Step 5: Delete all PVCs sequentially
+	framework.Logf("Deleting all %d PVCs sequentially...", totalCount)
+	for i := range totalCount {
+		pvcName := fmt.Sprintf("%s-%d", pvcBaseName, i)
+		pvcCopy := pvc.DeepCopy()
+		pvcCopy.Name = pvcName
+
+		framework.Logf("Deleting PVC %d/%d: %s", i+1, totalCount, pvcName)
+		err = deletePVCAndValidatePV(f.ClientSet, pvcCopy, deployTimeout)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("failed to delete PVC %s: %w", pvcName, err))
+		}
+	}
+
+	if len(allErrors) > 0 {
+		return fmt.Errorf("%d operations failed during Pods-only test", len(allErrors))
+	}
+
+	framework.Logf("Pods-only test completed successfully: %d PVCs, %d batches of %d Pods",
+		totalCount, numBatches, batchSize)
+
+	return nil
+}

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/nvmeof"
 	nvmeutil "github.com/ceph/ceph-csi/internal/nvmeof/util"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/lock"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
@@ -57,6 +58,13 @@ type NodeServer struct {
 	// when it's safe to disconnect a device.
 	// it is initialized on startup and updated on each stage/unstage operation.
 	mountCache nvmeutil.MountCache
+
+	// stageUnstageLock is a GroupLock that ensures mutual exclusion
+	// between staging and unstaging operations.
+	// This allows multiple staging operations to run concurrently,
+	// and multiple unstaging operations to run concurrently,
+	// but prevents staging and unstaging from running at the same time.
+	stageUnstageLock *lock.GroupLock
 }
 
 // ConnectionInfo holds NVMe-oF connection details.
@@ -108,6 +116,7 @@ func NewNodeServer(
 		securityKeys:      nil, // Initialize lazily when needed
 		nodeID:            nodeID,
 		mountCache:        nvmeutil.NewMountCache(),
+		stageUnstageLock:  lock.NewGroupLock(),
 	}
 
 	// Load nvme kernel modules
@@ -173,6 +182,15 @@ func (ns *NodeServer) NodeStageVolume(
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer ns.volumeLocks.Release(volumeID)
+
+	// Acquire GroupLock - wrap the mounting + connection logic in a GroupLock
+	// to prevent staging and unstaging from happening at the same time,
+	//  as they can interfere with each other.
+	// This allows multiple staging operations to run concurrently,
+	// and multiple unstaging operations to run concurrently,
+	// but prevents staging and unstaging from running at the same time.
+	ns.stageUnstageLock.AcquireGroupA()
+	defer ns.stageUnstageLock.ReleaseGroupA()
 
 	volumeContext := req.GetVolumeContext()
 	stagingTargetPath := getStagingTargetPath(req)
@@ -337,6 +355,10 @@ func (ns *NodeServer) NodeUnstageVolume(
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer ns.volumeLocks.Release(volumeID)
+
+	// Acquire GroupLock - wrap the unstaging logic (unmounting + nvme disconnect) in a GroupLock
+	ns.stageUnstageLock.AcquireGroupB()
+	defer ns.stageUnstageLock.ReleaseGroupB()
 
 	stagingTargetPath := getStagingTargetPath(req)
 


### PR DESCRIPTION
# Describe what this PR does #

This PR adds a GroupLock to prevent race conditions between stage and unstage operations that could lead to premature NVMe controller disconnects.
Added group mutual lock into `NodeStageVolume()` and `NodeUnStageVolume()` , because these 2 operations cannot run together. but few calls of same type can run together.

### The Problem

Without coordination, a stage operation can connect to NVMe controllers while an unstage operation is simultaneously checking if it's safe to disconnect them. This creates a race:

1. Stage operation connects to controllers
2. Unstage operation checks cache, sees no devices
3. Unstage operation disconnects controllers
4. Stage operation tries to mount, but device is already disconnected

Result: Stage fails with "device not found" errors.

### The Solution

Add a GroupLock that allows:
- Multiple stage operations to run concurrently (Group A)
- Multiple unstage operations to run concurrently (Group B)
- But prevents stage and unstage from running at the same time


### Three Levels of Locking 

(after the PR: [nvmeof: Add mount cache and locking for safe nvme disconnect](https://github.com/ceph/ceph-csi/pull/6192) will be merged)

The code will have three levels of locks working together:

**Level 1: volumeLocks (per-volume mutex)**
this already exists in the code. 
- Scope: Single volume
- Purpose: Prevents concurrent operations on the same volume
- Example: Two NodeStageVolume calls for vol-123 cannot run at the same time

**Level 2: stageUnstageLock (GroupLock)**
the current PR introduces it. 
- Scope: All volumes, operation type
- Purpose: Prevents stage and unstage from interfering with each other
- Allows: Multiple stages together, multiple unstages together
- Prevents: Stage and unstage at the same time

**Level 3: mountCache.mu (cache mutex)**
this PR [nvmeof: Add mount cache and locking for safe nvme disconnect](https://github.com/ceph/ceph-csi/pull/6192) 
- Scope: Cache data structure
- Purpose: Protects cache reads and writes
- Duration: Nanoseconds (just for map operations)

### Lock Acquisition Order

Both NodeStageVolume and NodeUnstageVolume follow the same order:

1. volumeLocks.Lock(volumeID)        // Lock this specific volume
2. stageUnstageLock.AcquireGroup()   // Lock operation type (A or B)
3. mountCache operations              // Cache mutex acquired internally as needed
4. stageUnstageLock.ReleaseGroup()   // Release operation type
5. volumeLocks.Release(volumeID)     // Release volume lock


There are unit tests for group locking here: https://github.com/ceph/ceph-csi/blob/devel/internal/util/lock/group_lock_test.go

**Also, e2e tests were added.**


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
