### PR TITLE
e2e: add setEnableFencing for operator deployment

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -248,6 +248,11 @@ var _ = Describe(cephfsType, func() {
 			logAndFail("failed to set cluster name: %v", err)
 		}
 
+		err = cephFSDeployment.setEnableFencing(true)
+		if err != nil {
+			logAndFail("failed to set enableFencing as true: %v", err)
+		}
+
 		err = createSubvolumegroup(f, fileSystemName, subvolumegroup)
 		if err != nil {
 			logAndFail("failed to create subvolumegroup %s: %v", subvolumegroup, err)

--- a/e2e/operator.go
+++ b/e2e/operator.go
@@ -76,6 +76,24 @@ func (OperatorDeployment) setEnableMetadata(value bool) error {
 	return nil
 }
 
+func (OperatorDeployment) setEnableFencing(value bool) error {
+	command := []string{
+		"operatorconfigs.csi.ceph.io",
+		OperatorConfigName,
+		"--type=merge",
+		"-p",
+		fmt.Sprintf(`{"spec": {"driverSpecDefaults": {"enableFencing": %t}}}`, value),
+	}
+
+	// Patch the operator config
+	err := retryKubectlArgs(cephCSINamespace, kubectlPatch, deployTimeout, command...)
+	if err != nil {
+		return fmt.Errorf("failed to set enableFencing: %w", err)
+	}
+
+	return nil
+}
+
 func (OperatorDeployment) setClusterName(value string) error {
 	command := []string{
 		"operatorconfigs.csi.ceph.io",

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -450,6 +450,11 @@ var _ = Describe("RBD", func() {
 		if err != nil {
 			logAndFail("failed to set cluster name: %v", err)
 		}
+
+		err = rbdDeployment.setEnableFencing(true)
+		if err != nil {
+			logAndFail("failed to set enableFencing as true: %v", err)
+		}
 	}, OncePerOrdered)
 
 	AfterEach(func() {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -112,6 +112,7 @@ type DeploymentMethod interface {
 	getDaemonsetName() string
 	getPodSelector() string
 	setClusterName(clusterName string) error
+	setEnableFencing(value bool) error
 }
 type RBDDeploymentMethod interface {
 	DeploymentMethod
@@ -120,6 +121,7 @@ type RBDDeploymentMethod interface {
 }
 type CephFSDeploymentMethod interface {
 	DeploymentMethod
+
 }
 
 type NFSDeploymentMethod interface {
@@ -155,6 +157,10 @@ func (d *DriverInfo) setClusterName(clusterName string) error {
 		return fmt.Errorf("timeout waiting for clustername arg update %s/%s: %v", cephCSINamespace, d.deploymentName, err)
 	}
 
+	return nil
+}
+
+func (d *DriverInfo) setEnableFencing(value bool) error {
 	return nil
 }
 


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Add setEnableFencing to the DeploymentMethod interface with a default no-op on DriverInfo for template-based deployments. OperatorDeployment overrides it to patch the operator config (spec.driverSpecDefaults.enableFencing).

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
