### PR TITLE
ci: manage ci/in-progress/e2e label via GitHub Actions and Mergify

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -119,6 +119,19 @@ jobs:
       github.event.pull_request.merged != true)
 
     steps:
+      - name: add ci/in-progress/e2e label before removing ok-to-test
+        # yamllint disable-line rule:line-length
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          github-token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["ci/in-progress/e2e"]
+            })
+
       - name: remove ok-to-test-label after commenting
         # yamllint disable-line rule:line-length
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -113,7 +113,6 @@ pull_request_rules:
       label:
         add:
           - ok-to-test
-          - ci/in-progress/e2e
 
   - name: remove outdated approvals
     conditions:
@@ -122,6 +121,9 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
+      label:
+        remove:
+          - ci/in-progress/e2e
 
   - name: ask to resolve conflict
     conditions:


### PR DESCRIPTION
Instead of adding the ci/in-progress/e2e label directly in the Mergify
"start CI jobs" rule, add it in the pull-request-commentor workflow
after the test comments are posted. Also remove it when outdated
approvals are dismissed, indicating tests need to be re-run.
