### PR TITLE
rbd: add mounter type validation for ControllerModifyVolume

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -5781,6 +5781,7 @@ var _ = Describe("RBD", func() {
 				logAndFail("failed to delete storageclass: %v", err)
 			}
 			err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, map[string]string{
+				"mounter": "rbd-nbd",
 				"csi.storage.k8s.io/controller-modify-secret-namespace": cephCSINamespace,
 				"csi.storage.k8s.io/controller-modify-secret-name":      rbdProvisionerSecretName,
 			}, deletePolicy)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -2023,6 +2023,25 @@ func (cs *ControllerServer) ControllerModifyVolume(
 	}
 	defer cs.OperationLocks.ReleaseModifyLock(volID)
 
+	// QoS parameters only work with rbd-nbd mounter
+	usesNBD, err := rbdVol.UsesNBDMounter(ctx)
+	switch {
+	case errors.Is(err, rbderrors.ErrMounterUnknown):
+		// Volume created before mounter tracking - proceed with warning
+		log.WarningLog(ctx, "volume %s has unknown mounter type (created before mounter tracking), "+
+			"proceeding with modification but QoS may not work if volume does not use rbd-nbd", volID)
+	case err != nil:
+		log.ErrorLog(ctx, "failed to check mounter type for volume %s: %v", volID, err)
+
+		return nil, status.Errorf(codes.Internal, "failed to determine volume mounter type: %v", err)
+	case !usesNBD:
+		log.ErrorLog(ctx, "volume %s uses mounter %q, QoS modification requires %q",
+			volID, rbdVol.Mounter, rbdNbdMounter)
+
+		return nil, status.Errorf(codes.InvalidArgument,
+			"volume modification requires rbd-nbd mounter, volume uses %q", rbdVol.Mounter)
+	}
+
 	// set RequestedVolSize, because calcQosBasedOnCapacity use it.
 	rbdVol.RequestedVolSize = rbdVol.VolSize
 

--- a/internal/rbd/errors/errors.go
+++ b/internal/rbd/errors/errors.go
@@ -67,6 +67,9 @@ var (
 	ErrGroupNotConnected = fmt.Errorf("%w: RBD group is not connected", librados.ErrNotConnected)
 	// ErrGroupNotFound is returned when group is not found in the cluster on the given pool and/or namespace.
 	ErrGroupNotFound = fmt.Errorf("%w: RBD group not found", librbd.ErrNotFound)
+	// ErrMounterUnknown is returned when the mounter type for a volume is not stored in metadata.
+	// This can happen for volumes created before mounter metadata tracking was added.
+	ErrMounterUnknown = errors.New("mounter type unknown")
 )
 
 // ErrorCode is an interface that defines a method to return an error code.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -82,6 +82,9 @@ const (
 	// clusterNameKey cluster Key, set on RBD image.
 	clusterNameKey = "csi.ceph.com/cluster/name"
 
+	// mounterKey is the key used to store the mounter type.
+	mounterKey = "csi.ceph.com/mounter"
+
 	// clientAddressKey is the key used to store the client address.
 	// starts with `.` to avoid copying it to the mirrored image.
 	clientAddressKey = ".rbd.csi.ceph.com/clientaddress"
@@ -2304,6 +2307,14 @@ func (rv *rbdVolume) setAllMetadata(parameters map[string]string) error {
 		}
 	}
 
+	if rv.Mounter != "" {
+		err := rv.SetMetadata(mounterKey, rv.Mounter)
+		if err != nil {
+			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w",
+				mounterKey, rv.Mounter, err)
+		}
+	}
+
 	return nil
 }
 
@@ -2319,6 +2330,11 @@ func (rv *rbdVolume) unsetAllMetadata(keys []string) error {
 	err := rv.RemoveMetadata(clusterNameKey)
 	if err != nil && !errors.Is(err, librbd.ErrNotExist) {
 		return fmt.Errorf("failed to unset metadata key %q on %q: %w", clusterNameKey, rv, err)
+	}
+
+	err = rv.RemoveMetadata(mounterKey)
+	if err != nil && !errors.Is(err, librbd.ErrNotExist) {
+		return fmt.Errorf("failed to unset metadata key %q on %q: %w", mounterKey, rv, err)
 	}
 
 	return nil
@@ -2420,6 +2436,37 @@ func (rv *rbdVolume) getUsedBytes(ctx context.Context) (uint64, error) {
 		rv, rv.VolSize, end.Sub(start).Seconds())
 
 	return usedBytes, nil
+}
+
+// UsesNBDMounter checks if the volume uses the rbd-nbd mounter.
+// If the Mounter field is not set, it attempts to fetch it from the image metadata.
+// Returns rbderrors.ErrMounterUnknown if no mounter metadata is stored (e.g., for
+// volumes created before mounter tracking was added).
+func (rv *rbdVolume) UsesNBDMounter(ctx context.Context) (bool, error) {
+	// If Mounter is already set, use it
+	if rv.Mounter != "" {
+		return rv.Mounter == rbdNbdMounter, nil
+	}
+
+	// Try to fetch mounter from metadata
+	mounter, err := rv.GetMetadata(mounterKey)
+	if err != nil {
+		if errors.Is(err, librbd.ErrNotExist) {
+			// No mounter metadata stored - likely a volume created before mounter tracking
+			log.DebugLog(ctx, "no mounter metadata found for volume %s", rv.VolID)
+
+			return false, rbderrors.ErrMounterUnknown
+		}
+
+		return false, fmt.Errorf("failed to get mounter metadata: %w", err)
+	}
+
+	// Cache the mounter value
+	if mounter != "" {
+		rv.Mounter = mounter
+	}
+
+	return rv.Mounter == rbdNbdMounter, nil
 }
 
 func (rv *rbdVolume) modifyVolumeAttributes(


### PR DESCRIPTION

RBD QoS parameters are only supported with the rbd-nbd mounter, but
ControllerModifyVolume previously had no way to enforce this.

This adds infrastructure to track the mounter type of RBD volumes via image
metadata (mounterKey), stored at volume creation and cleaned up on deletion. A
new UsesNBDMounter() method fetches and caches this value lazily.

ControllerModifyVolume now validates the mounter type before applying QoS
changes:

- Volumes with unknown mounter (created before mounter tracking) log a warning
  and proceed
- Metadata fetch failures return an Internal error
- Volumes using a non-rbd-nbd mounter return InvalidArgument

Fixes: #6186
