### PR TITLE
nvmeof: make nvmeofGatewayPort an optional StorageClass parameter

### DIFF
--- a/examples/nvmeof/storageclass.yaml
+++ b/examples/nvmeof/storageclass.yaml
@@ -30,7 +30,8 @@ parameters:
 
   # connection details for the gateway (management API)
   nvmeofGatewayAddress: 10.242.64.32
-  nvmeofGatewayPort: "5500"
+  # nvmeofGatewayPort is optional, defaults to 5500
+  # nvmeofGatewayPort: "5500"
 
   # connection details for the listeners (NVMe-oF data protocol)
   listeners: |

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -423,7 +423,7 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	// Validate required parameters
 	params := req.GetParameters()
 	requiredParams := []string{
-		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
+		"subsystemNQN", "nvmeofGatewayAddress",
 	}
 	for _, param := range requiredParams {
 		if params[param] == "" {
@@ -476,7 +476,7 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 func validatePublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
 	volumeContext := req.GetVolumeContext()
 	requiredParams := []string{
-		"subsystemNQN", "nvmeofGatewayAddress", "nvmeofGatewayPort",
+		"subsystemNQN", "nvmeofGatewayAddress",
 	}
 	for _, param := range requiredParams {
 		if volumeContext[param] == "" {
@@ -764,11 +764,6 @@ func (cs *Server) createNVMeoFResources(
 	params := req.GetParameters()
 
 	networkMask := params["networkMask"]
-	nvmeofGatewayPortStr := params["nvmeofGatewayPort"]
-	nvmeofGatewayPort, err := strconv.ParseUint(nvmeofGatewayPortStr, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("invalid nvmeofGatewayPort %s: %w", nvmeofGatewayPortStr, err)
-	}
 	nvmeofData := &nvmeof.NVMeoFVolumeData{
 		SubsystemNQN:  params["subsystemNQN"],
 		NamespaceID:   0,   // will be set after namespace creation,
@@ -776,12 +771,18 @@ func (cs *Server) createNVMeoFResources(
 		ListenerInfo:  nil, // will be set after listener creation or retrieval
 		GatewayManagementInfo: nvmeof.GatewayConfig{
 			Address: params["nvmeofGatewayAddress"],
-			Port:    uint32(nvmeofGatewayPort),
 		},
 		Security: nvmeof.NVMeoFSecurityConfig{
 			DhchapMode:          params["dhchapMode"],
 			AuthenticationKMSID: params["authenticationKMSID"],
 		},
+	}
+	if nvmeofGatewayPortStr := params["nvmeofGatewayPort"]; nvmeofGatewayPortStr != "" {
+		parsed, err := strconv.ParseUint(nvmeofGatewayPortStr, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid nvmeofGatewayPort %s: %w", nvmeofGatewayPortStr, err)
+		}
+		nvmeofData.GatewayManagementInfo.Port = uint32(parsed)
 	}
 
 	// setup listeners (if provided, otherwise it will be set by gateway based on network mask)
@@ -1302,22 +1303,18 @@ func getGatewayConfigFromRequest(params map[string]string) (*nvmeof.GatewayConfi
 		return nil, errors.New("nvmeofGatewayAddress parameter is required")
 	}
 
-	portStr := params["nvmeofGatewayPort"]
-
-	if portStr == "" {
-		return nil, errors.New("nvmeofGatewayPort parameter is required")
-	}
-
-	// Convert string to proper port type
-	port, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		return nil, fmt.Errorf("invalid port %s: %w", portStr, err)
-	}
-
-	return &nvmeof.GatewayConfig{
+	config := &nvmeof.GatewayConfig{
 		Address: address,
-		Port:    uint32(port),
-	}, nil
+	}
+	if portStr := params["nvmeofGatewayPort"]; portStr != "" {
+		parsed, err := strconv.ParseUint(portStr, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("invalid port %s: %w", portStr, err)
+		}
+		config.Port = uint32(parsed)
+	}
+
+	return config, nil
 }
 
 // connectGateway creates and connects a gateway client for this operation.

--- a/internal/nvmeof/controller/controllerserver_test.go
+++ b/internal/nvmeof/controller/controllerserver_test.go
@@ -122,42 +122,53 @@ func TestGetGatewayConfigFromRequest(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name       string
 		params     map[string]string
 		shouldFail bool
+		expectPort uint32
 	}{
 		{
+			name:       "nil params",
 			params:     nil,
 			shouldFail: true,
 		},
 		{
+			name: "address only, port defaults to 0 (NewGatewayRpcClient applies default)",
 			params: map[string]string{
 				"nvmeofGatewayAddress": "127.0.0.1",
 			},
-			shouldFail: true,
+			expectPort: 0,
 		},
 		{
+			name: "port only, address missing",
 			params: map[string]string{
 				"nvmeofGatewayPort": "5500",
 			},
 			shouldFail: true,
 		},
 		{
+			name: "address and port",
 			params: map[string]string{
 				"nvmeofGatewayAddress": "127.0.0.1",
 				"nvmeofGatewayPort":    "5500",
 			},
+			expectPort: 5500,
 		},
 	}
 
 	for _, test := range tests {
-		config, err := getGatewayConfigFromRequest(test.params)
-		if test.shouldFail {
-			require.Error(t, err)
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			config, err := getGatewayConfigFromRequest(test.params)
+			if test.shouldFail {
+				require.Error(t, err)
 
-			continue
-		}
+				return
+			}
 
-		require.NoError(t, err)
-		require.NotNil(t, config)
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			require.Equal(t, test.expectPort, config.Port)
+		})
 	}
 }

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -69,10 +69,16 @@ type GatewayRpcClient struct {
 const (
 	MaxAllowedSubsystemSerialNumber = 99999999999999
 	RandomNumberOffset              = 2 // skip reserved identifiers 0 and 1
+
+	// defaultGatewayPort is the default port for the NVMe-oF gateway management API.
+	defaultGatewayPort uint32 = 5500
 )
 
 // NewGatewayRpcClient creates a new gateway client.
 func NewGatewayRpcClient(config *GatewayConfig) (*GatewayRpcClient, error) {
+	if config.Port == 0 {
+		config.Port = defaultGatewayPort
+	}
 	client := &GatewayRpcClient{
 		config:    config,
 		maxSerial: big.NewInt(MaxAllowedSubsystemSerialNumber - RandomNumberOffset),


### PR DESCRIPTION

The nvmeofGatewayPort parameter in the StorageClass is now optional. When not
provided, the NVMe-oF gateway management API port defaults to 5500. The default
is applied in NewGatewayRpcClient when Port is 0, keeping the default out of
the controller layer.