### PR TITLE
ci: skip build-multi-stage workflow for draft PRs

### DIFF
--- a/.github/workflows/build-multi-stage.yaml
+++ b/.github/workflows/build-multi-stage.yaml
@@ -18,6 +18,7 @@ jobs:
   codespell:
     name: multi-arch-build
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: delay a minute to have labels added
         run: sleep 1m

--- a/.github/workflows/build-multi-stage.yaml
+++ b/.github/workflows/build-multi-stage.yaml
@@ -3,6 +3,7 @@ name: multi-arch-build
 # yamllint disable-line rule:truthy
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '*'
 permissions:


### PR DESCRIPTION
Add condition to prevent the multi-arch-build job from running on draft
pull requests, saving CI resources during PR preparation.
