### PR TITLE
api: add SecurityContextConstraints to nvmeof ServiceAccounts

### DIFF
--- a/api/deploy/kubernetes/nfs/csi-provisioner-rbac-cr.yaml
+++ b/api/deploy/kubernetes/nfs/csi-provisioner-rbac-cr.yaml
@@ -46,3 +46,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]

--- a/api/deploy/ocp/scc.yaml
+++ b/api/deploy/ocp/scc.yaml
@@ -45,3 +45,6 @@ users:
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-provisioner-sa"
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-plugin-sa"
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-provisioner-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nvmeof-plugin-sa"
+  # yamllint disable-line rule:line-length
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nvmeof-provisioner-sa"

--- a/deploy/scc.yaml
+++ b/deploy/scc.yaml
@@ -52,3 +52,6 @@ users:
   - "system:serviceaccount:ceph-csi:csi-cephfs-provisioner-sa"
   - "system:serviceaccount:ceph-csi:csi-nfs-plugin-sa"
   - "system:serviceaccount:ceph-csi:csi-nfs-provisioner-sa"
+  - "system:serviceaccount:ceph-csi:csi-nvmeof-plugin-sa"
+  # yamllint disable-line rule:line-length
+  - "system:serviceaccount:ceph-csi:csi-nvmeof-provisioner-sa"

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csi-provisioner-rbac-cr.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs/csi-provisioner-rbac-cr.yaml
@@ -46,3 +46,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
@@ -45,3 +45,6 @@ users:
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-cephfs-provisioner-sa"
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-plugin-sa"
   - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nfs-provisioner-sa"
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nvmeof-plugin-sa"
+  # yamllint disable-line rule:line-length
+  - "system:serviceaccount:{{ .Namespace }}:{{ .Prefix }}csi-nvmeof-provisioner-sa"


### PR DESCRIPTION
The NVMe-oF ServiceAccounts need an SCC so that they can be used on OpenShift.

This also showed a minor bug in the `api/` directory for NFS:

The RBAC for VolumeAttributesClasses was only added to the file under the deploy/ directory. Running

    make containerized-build TARGET=generate-deploy

caused the RBAC to be removed. With the RBAC added to the template in
the api/ directory, the RBAC will be included when generating the
deploy/ directory.

Fixes: aaab76514

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
