### PR TITLE
Fix go toolchain versions

### DIFF
--- a/build.env
+++ b/build.env
@@ -28,7 +28,7 @@ BASE_IMAGE=quay.io/ceph/ceph:v20
 CEPH_VERSION=tentacle
 
 # standard Golang options
-GOLANG_VERSION=1.24.6
+GOLANG_VERSION=1.26.2
 GO111MODULE=on
 
 # commitlint version

--- a/build.env
+++ b/build.env
@@ -35,7 +35,7 @@ GO111MODULE=on
 COMMITLINT_VERSION=latest
 
 # static checks and linters
-GOLANGCI_VERSION=v2.5.0
+GOLANGCI_VERSION=v2.9.0
 LYCHEE_VERSION=v0.23.0
 
 # external snapshotter version

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 
@@ -320,11 +321,5 @@ func (s *subVolumeClient) PurgeVolume(ctx context.Context, force bool) error {
 func checkSubvolumeHasFeature(feature string, subVolFeatures []string) bool {
 	// The subvolume "features" are based on the internal version of the subvolume.
 	// Verify if subvolume supports the required feature.
-	for _, subvolFeature := range subVolFeatures {
-		if subvolFeature == feature {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(subVolFeatures, feature)
 }

--- a/internal/cephfs/mounter/volumemounter.go
+++ b/internal/cephfs/mounter/volumemounter.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
@@ -113,12 +114,8 @@ func New(volOptions *store.VolumeOptions) (VolumeMounter, error) {
 
 	var chosenMounter string
 
-	for _, availMounter := range availableMounters {
-		if availMounter == wantMounter {
-			chosenMounter = wantMounter
-
-			break
-		}
+	if slices.Contains(availableMounters, wantMounter) {
+		chosenMounter = wantMounter
 	}
 
 	if chosenMounter == "" {

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -1043,11 +1044,11 @@ func (ns *NodeServer) setMountOptions(
 		mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
 		switch mnt.(type) {
 		case *mounter.FuseMounter:
-			if !csicommon.MountOptionContains(strings.Split(volOptions.FuseMountOptions, ","), readOnly) {
+			if !slices.Contains(strings.Split(volOptions.FuseMountOptions, ","), readOnly) {
 				volOptions.FuseMountOptions = util.MountOptionsAdd(volOptions.FuseMountOptions, readOnly)
 			}
 		case mounter.KernelMounter:
-			if !csicommon.MountOptionContains(strings.Split(volOptions.KernelMountOptions, ","), readOnly) {
+			if !slices.Contains(strings.Split(volOptions.KernelMountOptions, ","), readOnly) {
 				volOptions.KernelMountOptions = util.MountOptionsAdd(volOptions.KernelMountOptions, readOnly)
 			}
 		}

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/csi-addons/spec/lib/go/volumegroup"
@@ -247,9 +248,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 			err.Error())
 	}
 
-	for key, value := range req.GetParameters() {
-		csiVG.VolumeGroupContext[key] = value
-	}
+	maps.Copy(csiVG.GetVolumeGroupContext(), req.GetParameters())
 
 	return &volumegroup.CreateVolumeGroupResponse{
 		VolumeGroup: csiVG,

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -18,6 +18,7 @@ package csicommon
 
 import (
 	"context"
+	"slices"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	mount "k8s.io/mount-utils"
@@ -77,17 +78,8 @@ func (ns *DefaultNodeServer) NodeGetCapabilities(
 // ConstructMountOptions returns only unique mount options in slice.
 func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) []string {
 	if m := volCap.GetMount(); m != nil {
-		hasOption := func(options []string, opt string) bool {
-			for _, o := range options {
-				if o == opt {
-					return true
-				}
-			}
-
-			return false
-		}
 		for _, f := range m.GetMountFlags() {
-			if !hasOption(mountOptions, f) {
+			if !slices.Contains(mountOptions, f) {
 				mountOptions = append(mountOptions, f)
 			}
 		}
@@ -96,21 +88,10 @@ func ConstructMountOptions(mountOptions []string, volCap *csi.VolumeCapability) 
 	// add "ro" in case the capabilities indicate READER_ONLY
 	rOnly := "ro"
 	if IsReaderOnly([]*csi.VolumeCapability{volCap}) {
-		if !MountOptionContains(mountOptions, rOnly) {
+		if !slices.Contains(mountOptions, rOnly) {
 			mountOptions = append(mountOptions, rOnly)
 		}
 	}
 
 	return mountOptions
-}
-
-// MountOptionContains checks the opt is present in mountOptions.
-func MountOptionContains(mountOptions []string, opt string) bool {
-	for _, mnt := range mountOptions {
-		if mnt == opt {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -127,10 +127,10 @@ func NewMiddlewareServerOption(config MiddlewareServerOptionConfig) grpc.ServerO
 	if config.LogSlowOpInterval > 0 {
 		middleWare = append(middleWare, func(
 			ctx context.Context,
-			req interface{},
+			req any,
 			info *grpc.UnaryServerInfo,
 			handler grpc.UnaryHandler,
-		) (interface{}, error) {
+		) (any, error) {
 			return logSlowGRPC(
 				config.LogSlowOpInterval, ctx, req, info, handler,
 			)
@@ -149,7 +149,7 @@ func NewMiddlewareStreamServerOption() grpc.ServerOption {
 }
 
 // GetIDFromReplication returns the volumeID for Replication.
-func GetIDFromReplication(req interface{}) string {
+func GetIDFromReplication(req any) string {
 	getID := func(r interface {
 		GetVolumeId() string
 		GetReplicationSource() *replication.ReplicationSource
@@ -191,7 +191,7 @@ func GetIDFromReplication(req interface{}) string {
 }
 
 //nolint:gocyclo,cyclop // TODO: reduce complexity
-func getReqID(req interface{}) string {
+func getReqID(req any) string {
 	// if req is nil empty string will be returned
 	reqID := ""
 	switch r := req.(type) {
@@ -264,10 +264,10 @@ var id uint64
 
 func contextIDInjector(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	atomic.AddUint64(&id, 1)
 	ctx = context.WithValue(ctx, log.CtxKey, id)
 	if reqID := getReqID(req); reqID != "" {
@@ -292,7 +292,7 @@ func (s *wrapperServerStream) Context() context.Context {
 
 // RecvMsg wraps around grpc.ServerStream.RecvMsg to inject
 // ReqID and log request details.
-func (s *wrapperServerStream) RecvMsg(req interface{}) error {
+func (s *wrapperServerStream) RecvMsg(req any) error {
 	err := s.ServerStream.RecvMsg(req)
 
 	// reqID is intentionally extracted after .RecvMsg(req) as the req
@@ -343,10 +343,10 @@ func streamInterceptor(
 
 func logGRPC(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	log.ExtendedLog(ctx, "GRPC call: %s", info.FullMethod)
 	log.TraceLog(ctx, "GRPC request: %s", protosanitizer.StripSecrets(req))
 
@@ -363,10 +363,10 @@ func logGRPC(
 func logSlowGRPC(
 	logInterval time.Duration,
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (interface{}, error) {
+) (any, error) {
 	handlerFinished := make(chan struct{})
 	callStartTime := time.Now()
 
@@ -410,10 +410,10 @@ func logSlowGRPC(
 //nolint:nonamedreturns // named return used to send recovered panic error.
 func panicHandler(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (resp interface{}, err error) {
+) (resp any, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			klog.Errorf("panic occurred: %v", r)

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -32,7 +32,7 @@ var fakeID = "fake-id"
 
 func TestGetReqID(t *testing.T) {
 	t.Parallel()
-	req := []interface{}{
+	req := []any{
 		&csi.CreateVolumeRequest{
 			Name: fakeID,
 		},

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -450,9 +451,7 @@ func (vgjc *volumeGroupJournalConnection) GetVolumeGroupAttributes(
 	delete(values, cj.csiImageKey)
 	delete(values, cj.csiCreationTimeKey)
 	groupAttributes.VolumeMap = map[string]string{}
-	for k, v := range values {
-		groupAttributes.VolumeMap[k] = v
-	}
+	maps.Copy(groupAttributes.VolumeMap, values)
 
 	return groupAttributes, nil
 }

--- a/internal/kms/aws_metadata.go
+++ b/internal/kms/aws_metadata.go
@@ -183,13 +183,13 @@ func (kms *awsMetadataKMS) GetSecret(ctx context.Context, volumeID string) (stri
 	return "", ErrGetSecretUnsupported
 }
 
-func (kms *awsMetadataKMS) getSecrets() (map[string]interface{}, error) {
+func (kms *awsMetadataKMS) getSecrets() (map[string]any, error) {
 	secretData, err := k8s.GetSecret(kms.secretName, kms.namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w", kms.namespace, kms.secretName, err)
 	}
 
-	config := make(map[string]interface{})
+	config := make(map[string]any)
 
 	for k, v := range secretData {
 		switch k {

--- a/internal/kms/azure_vault.go
+++ b/internal/kms/azure_vault.go
@@ -182,13 +182,13 @@ func (kms *azureKMS) getService() (*azsecrets.Client, error) {
 	return azClient, nil
 }
 
-func (kms *azureKMS) getSecrets() (map[string]interface{}, error) {
+func (kms *azureKMS) getSecrets() (map[string]any, error) {
 	secretData, err := k8s.GetSecret(kms.secretName, kms.namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w", kms.namespace, kms.secretName, err)
 	}
 
-	config := make(map[string]interface{})
+	config := make(map[string]any)
 	for k, v := range secretData {
 		switch k {
 		case azureClientCertificate:

--- a/internal/kms/keyprotect.go
+++ b/internal/kms/keyprotect.go
@@ -198,13 +198,13 @@ func (kms *keyProtectKMS) GetSecret(ctx context.Context, volumeID string) (strin
 	return "", ErrGetSecretUnsupported
 }
 
-func (kms *keyProtectKMS) getSecrets() (map[string]interface{}, error) {
+func (kms *keyProtectKMS) getSecrets() (map[string]any, error) {
 	secretData, err := k8s.GetSecret(kms.secretName, kms.namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w", kms.namespace, kms.secretName, err)
 	}
 
-	config := make(map[string]interface{})
+	config := make(map[string]any)
 
 	for k, v := range secretData {
 		switch k {

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -503,7 +503,7 @@ func (kms *kmipKMS) discover(conn io.ReadWriter) error {
 func (kms *kmipKMS) send(
 	conn io.ReadWriter,
 	operation kmip14.Operation,
-	payload interface{},
+	payload any,
 ) (*kmip.ResponseMessage, *ttlv.Decoder, []byte, error) {
 	biID := uuid.New()
 

--- a/internal/kms/kmip.go
+++ b/internal/kms/kmip.go
@@ -560,11 +560,11 @@ func (kms *kmipKMS) verifyResponse(
 	uniqueBatchItemID []byte,
 ) (*kmip.ResponseBatchItem, error) {
 	if respMsg.ResponseHeader.BatchCount != 1 {
-		return nil, fmt.Errorf("batch count %q should be \"1\"",
+		return nil, fmt.Errorf("batch count %d should be 1",
 			respMsg.ResponseHeader.BatchCount)
 	}
 	if len(respMsg.BatchItem) != 1 {
-		return nil, fmt.Errorf("batch Intems list len %q should be \"1\"",
+		return nil, fmt.Errorf("batch items list len %d should be 1",
 			len(respMsg.BatchItem))
 	}
 	batchItem := respMsg.BatchItem[0]

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -82,7 +82,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 	}
 
 	// kmsConfig can have additional sub-sections
-	kmsConfig, ok := section.(map[string]interface{})
+	kmsConfig, ok := section.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("failed to convert KMS configuration "+
 			"section: %s", kmsID)
@@ -94,8 +94,8 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 // getKMSConfiguration reads the configuration file from the filesystem, or if
 // that fails the ConfigMap directly. The returned map contains all the KMS
 // configuration sections, each keyed by its own kmsID.
-func getKMSConfiguration() (map[string]interface{}, error) {
-	var config map[string]interface{}
+func getKMSConfiguration() (map[string]any, error) {
+	var config map[string]any
 	// #nosec
 	content, err := os.ReadFile(kmsConfigPath)
 	if err == nil {
@@ -150,7 +150,7 @@ func getKMSConfigMapName() string {
 // getKMSConfigMap returns the contents of the ConfigMap.
 //
 // FIXME: Ceph-CSI should not talk to Kubernetes directly.
-func getKMSConfigMap() (map[string]interface{}, error) {
+func getKMSConfigMap() (map[string]any, error) {
 	ns, err := getPodNamespace()
 	if err != nil {
 		return nil, err
@@ -163,9 +163,9 @@ func getKMSConfigMap() (map[string]interface{}, error) {
 	}
 
 	// convert cm.Data from map[string]interface{}
-	kmsConfig := make(map[string]interface{})
+	kmsConfig := make(map[string]any)
 	for kmsID, data := range cm.Data {
-		section := make(map[string]interface{})
+		section := make(map[string]any)
 		err = json.Unmarshal([]byte(data), &section)
 		if err != nil {
 			return nil, fmt.Errorf("could not convert contents "+
@@ -180,7 +180,7 @@ func getKMSConfigMap() (map[string]interface{}, error) {
 // getProvider inspects the configuration and tries to identify what
 // Provider is expected to be used with it. This returns the
 // Provider.UniqueID.
-func getProvider(config map[string]interface{}) (string, error) {
+func getProvider(config map[string]any) (string, error) {
 	var name string
 
 	providerName, ok := config[kmsTypeKey]
@@ -213,7 +213,7 @@ func getProvider(config map[string]interface{}) (string, error) {
 // Provider is initialized.
 type ProviderInitArgs struct {
 	Tenant  string
-	Config  map[string]interface{}
+	Config  map[string]any
 	Secrets map[string]string
 	// Namespace contains the Kubernetes Namespace where the Ceph-CSI Pods
 	// are running. This is an optional option, and might be unset when the
@@ -265,7 +265,7 @@ func RegisterProvider(provider Provider) bool {
 // Provider to instantiate.
 func (kf *kmsProviderList) buildKMS(
 	tenant string,
-	config map[string]interface{},
+	config map[string]any,
 	secrets map[string]string,
 ) (EncryptionKMS, error) {
 	providerName, err := getProvider(config)
@@ -385,7 +385,7 @@ func (i integratedDEK) GetSecret(ctx context.Context, volumeID string) (string, 
 
 // getKeys takes a map that uses strings for keys and returns a slice with the
 // keys.
-func getKeys(m map[string]interface{}) []string {
+func getKeys(m map[string]any) []string {
 	keys := make([]string, len(m))
 
 	i := 0

--- a/internal/kms/kms_util.go
+++ b/internal/kms/kms_util.go
@@ -25,7 +25,7 @@ import "fmt"
 // errConfigOptionMissing is returned.
 // In case the value is available, but can not be converted to a string,
 // errConfigOptionInvalid is returned.
-func setConfigInt(option *int, config map[string]interface{}, key string) error {
+func setConfigInt(option *int, config map[string]any, key string) error {
 	value, ok := config[key]
 	if !ok {
 		return fmt.Errorf("%w: %s", errConfigOptionMissing, key)

--- a/internal/kms/kms_util_test.go
+++ b/internal/kms/kms_util_test.go
@@ -27,7 +27,7 @@ func TestSetConfigInt(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		option *int
-		config map[string]interface{}
+		config map[string]any
 		key    string
 	}
 	option := 1
@@ -41,7 +41,7 @@ func TestSetConfigInt(t *testing.T) {
 			name: "valid value",
 			args: args{
 				option: &option,
-				config: map[string]interface{}{
+				config: map[string]any{
 					"a": 1.0,
 				},
 				key: "a",
@@ -53,7 +53,7 @@ func TestSetConfigInt(t *testing.T) {
 			name: "invalid value",
 			args: args{
 				option: &option,
-				config: map[string]interface{}{
+				config: map[string]any{
 					"a": "abc",
 				},
 				key: "a",
@@ -65,7 +65,7 @@ func TestSetConfigInt(t *testing.T) {
 			name: "missing value",
 			args: args{
 				option: &option,
-				config: map[string]interface{}{},
+				config: map[string]any{},
 				key:    "a",
 			},
 			err:   errConfigOptionMissing,

--- a/internal/kms/secretskms.go
+++ b/internal/kms/secretskms.go
@@ -237,7 +237,7 @@ func (kms secretsMetadataKMS) GetSecret(ctx context.Context, volumeID string) (s
 
 // fetchEncryptionPassphrase fetches encryptionPassphrase from user provided secret.
 func (kms secretsMetadataKMS) fetchEncryptionPassphrase(
-	config map[string]interface{},
+	config map[string]any,
 	defaultNamespace string,
 ) (string, error) {
 	var (

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -76,7 +77,7 @@ Example JSON structure in the KMS config is,
 
 type vaultConnection struct {
 	secrets     loss.Secrets
-	vaultConfig map[string]interface{}
+	vaultConfig map[string]any
 	keyContext  map[string]string
 
 	// vaultDestroyKeys will by default set to `true`, and causes secrets
@@ -105,7 +106,7 @@ type vaultKMS struct {
 // errConfigOptionMissing is returned.
 // In case the value is available, but can not be converted to a string,
 // errConfigOptionInvalid is returned.
-func setConfigString(option *string, config map[string]interface{}, key string) error {
+func setConfigString(option *string, config map[string]any, key string) error {
 	value, ok := config[key]
 	if !ok {
 		return fmt.Errorf("%w: %s", errConfigOptionMissing, key)
@@ -170,8 +171,8 @@ func (vc *vaultConnection) Destroy() {
 // vc.connectVault().
 //
 //nolint:gocyclo,cyclop // iterating through many config options, not complex at all.
-func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
-	vaultConfig := make(map[string]interface{})
+func (vc *vaultConnection) initConnection(config map[string]any) error {
+	vaultConfig := make(map[string]any)
 	keyContext := make(map[string]string)
 
 	firstInit := (vc.vaultConfig == nil)
@@ -279,16 +280,12 @@ func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 
 	// update the existing config only if no config is available yet
 	if vc.keyContext != nil {
-		for key, value := range keyContext {
-			vc.keyContext[key] = value
-		}
+		maps.Copy(vc.keyContext, keyContext)
 	} else {
 		vc.keyContext = keyContext
 	}
 	if vc.vaultConfig != nil {
-		for key, value := range vaultConfig {
-			vc.vaultConfig[key] = value
-		}
+		maps.Copy(vc.vaultConfig, vaultConfig)
 	} else {
 		vc.vaultConfig = vaultConfig
 	}
@@ -299,8 +296,8 @@ func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 // initCertificates sets VAULT_* environment variables in the vc.vaultConfig map,
 // these settings will be used when connecting to the Vault service with
 // vc.connectVault().
-func (vc *vaultConnection) initCertificates(config map[string]interface{}, secrets map[string]string) error {
-	vaultConfig := make(map[string]interface{})
+func (vc *vaultConnection) initCertificates(config map[string]any, secrets map[string]string) error {
+	vaultConfig := make(map[string]any)
 
 	vaultCAFromSecret := "" // optional
 	err := setConfigString(&vaultCAFromSecret, config, "vaultCAFromSecret")
@@ -321,9 +318,7 @@ func (vc *vaultConnection) initCertificates(config map[string]interface{}, secre
 		vaultConfig[api.EnvVaultCACert] = tf.Name()
 
 		// update the existing config
-		for key, value := range vaultConfig {
-			vc.vaultConfig[key] = value
-		}
+		maps.Copy(vc.vaultConfig, vaultConfig)
 	}
 
 	return nil
@@ -350,9 +345,7 @@ func (vc *vaultConnection) connectVault() error {
 // RemoveDEK() calls.
 func (vc *vaultConnection) getDeleteKeyContext() map[string]string {
 	keyContext := map[string]string{}
-	for k, v := range vc.keyContext {
-		keyContext[k] = v
-	}
+	maps.Copy(keyContext, vc.keyContext)
 	if vc.vaultDestroyKeys {
 		keyContext[loss.DestroySecret] = vaultDefaultDestroyKeys
 	}
@@ -401,8 +394,8 @@ func initVaultKMS(args ProviderInitArgs) (EncryptionKMS, error) {
 	err = setConfigString(&vaultPassphraseRoot, args.Config, "vaultPassphraseRoot")
 	if err == nil {
 		// the old example did have "/v1/secret/", convert that format
-		if strings.HasPrefix(vaultPassphraseRoot, "/v1/") {
-			kms.vaultConfig[vault.VaultBackendPathKey] = strings.TrimPrefix(vaultPassphraseRoot, "/v1/")
+		if after, ok := strings.CutPrefix(vaultPassphraseRoot, "/v1/"); ok {
+			kms.vaultConfig[vault.VaultBackendPathKey] = after
 		} else {
 			kms.vaultConfig[vault.VaultBackendPathKey] = vaultPassphraseRoot
 		}
@@ -437,7 +430,7 @@ func (kms *vaultKMS) FetchDEK(ctx context.Context, key string) (string, error) {
 		return "", err
 	}
 
-	data, ok := s["data"].(map[string]interface{})
+	data, ok := s["data"].(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("failed parsing data for get passphrase request for %q", key)
 	}
@@ -451,7 +444,7 @@ func (kms *vaultKMS) FetchDEK(ctx context.Context, key string) (string, error) {
 
 // StoreDEK saves new passphrase in Vault.
 func (kms *vaultKMS) StoreDEK(ctx context.Context, key, value string) error {
-	data := map[string]interface{}{
+	data := map[string]any{
 		"data": map[string]string{
 			"passphrase": value,
 		},
@@ -490,8 +483,8 @@ func detectAuthMountPath(path string) (string, error) {
 
 	// add all components between "login" and "auth" to authMountPath
 	match := false
-	parts := strings.Split(path, "/")
-	for _, part := range parts {
+	parts := strings.SplitSeq(path, "/")
+	for part := range parts {
 		if part == "auth" {
 			match = true
 

--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -159,7 +159,7 @@ func (kms *vaultTenantSA) Destroy() {
 	kms.vaultTenantConnection.Destroy()
 }
 
-func (kms *vaultTenantSA) configureTenant(config map[string]interface{}, tenant string) error {
+func (kms *vaultTenantSA) configureTenant(config map[string]any, tenant string) error {
 	kms.Tenant = tenant
 	tenantConfig, found := fetchTenantConfig(config, tenant)
 	if found {
@@ -189,7 +189,7 @@ func (kms *vaultTenantSA) configureTenant(config map[string]interface{}, tenant 
 // multiple times, for the different nested configuration layers.
 // parseTenantConfig() calls this as well, with a reduced set of options,
 // filtered by isTenantConfigOption().
-func (kms *vaultTenantSA) parseConfig(config map[string]interface{}) error {
+func (kms *vaultTenantSA) parseConfig(config map[string]any) error {
 	err := kms.vaultTenantConnection.parseConfig(config)
 	if err != nil {
 		return err
@@ -249,7 +249,7 @@ func isTenantSAConfigOption(opt string) bool {
 
 // setServiceAccountName stores the name of the ServiceAccount in the
 // configuration if it has been set in the options.
-func (kms *vaultTenantSA) setServiceAccountName(config map[string]interface{}) error {
+func (kms *vaultTenantSA) setServiceAccountName(config map[string]any) error {
 	err := setConfigString(&kms.tenantSAName, config, "tenantSAName")
 	if errors.Is(err, errConfigOptionInvalid) {
 		return err

--- a/internal/kms/vault_sa_test.go
+++ b/internal/kms/vault_sa_test.go
@@ -33,7 +33,7 @@ func TestTenantSAParseConfig(t *testing.T) {
 	t.Parallel()
 	vts := vaultTenantSA{}
 
-	config := make(map[string]interface{})
+	config := make(map[string]any)
 
 	// empty config map
 	err := vts.parseConfig(config)
@@ -55,7 +55,7 @@ func TestTenantSAParseConfig(t *testing.T) {
 	}
 
 	// tenant "bob" uses a different auth mount path
-	bob := make(map[string]interface{})
+	bob := make(map[string]any)
 	bob["vaultAuthPath"] = "/v1/auth/bobs-cluster/login"
 	err = vts.parseConfig(bob)
 	switch {

--- a/internal/kms/vault_test.go
+++ b/internal/kms/vault_test.go
@@ -46,7 +46,7 @@ func TestDetectAuthMountPath(t *testing.T) {
 func TestSetConfigString(t *testing.T) {
 	t.Parallel()
 	const defaultValue = "default-value"
-	options := make(map[string]interface{})
+	options := make(map[string]any)
 
 	// noSuchOption: no default value, option unavailable
 	noSuchOption := ""
@@ -88,7 +88,7 @@ func TestDefaultVaultDestroyKeys(t *testing.T) {
 	t.Parallel()
 
 	vc := &vaultConnection{}
-	config := make(map[string]interface{})
+	config := make(map[string]any)
 	config["vaultAddress"] = "https://vault.test.example.com"
 	err := vc.initConnection(config)
 	require.NoError(t, err)

--- a/internal/kms/vault_tokens.go
+++ b/internal/kms/vault_tokens.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"strconv"
 
@@ -116,7 +117,7 @@ func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 // map[string]interface{} configuration.
 //
 // FIXME: this can surely be simplified?!
-func transformConfig(svMap map[string]interface{}) (map[string]interface{}, error) {
+func transformConfig(svMap map[string]any) (map[string]any, error) {
 	// convert the map to JSON
 	data, err := json.Marshal(svMap)
 	if err != nil {
@@ -145,7 +146,7 @@ func transformConfig(svMap map[string]interface{}) (map[string]interface{}, erro
 	}
 
 	// convert the vaultTokenConf struct to a map[string]interface{}
-	jsonMap := make(map[string]interface{})
+	jsonMap := make(map[string]any)
 	err = json.Unmarshal(data, &jsonMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Unmarshal the CSI vault configuration: %w", err)
@@ -286,7 +287,7 @@ func (vtc *vaultTenantConnection) FetchDEK(ctx context.Context, key string) (str
 		return "", err
 	}
 
-	data, ok := s["data"].(map[string]interface{})
+	data, ok := s["data"].(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("failed parsing data for get passphrase request for %s", key)
 	}
@@ -300,7 +301,7 @@ func (vtc *vaultTenantConnection) FetchDEK(ctx context.Context, key string) (str
 
 // StoreDEK saves new passphrase in Vault.
 func (vtc *vaultTenantConnection) StoreDEK(ctx context.Context, key, value string) error {
-	data := map[string]interface{}{
+	data := map[string]any{
 		"data": map[string]string{
 			"passphrase": value,
 		},
@@ -325,7 +326,7 @@ func (vtc *vaultTenantConnection) RemoveDEK(ctx context.Context, key string) err
 	return nil
 }
 
-func (kms *vaultTokensKMS) configureTenant(config map[string]interface{}, tenant string) error {
+func (kms *vaultTokensKMS) configureTenant(config map[string]any, tenant string) error {
 	kms.Tenant = tenant
 	tenantConfig, found := fetchTenantConfig(config, tenant)
 	if found {
@@ -370,7 +371,7 @@ func (vtc *vaultTenantConnection) init() {
 // parseConfig updates the kms.vaultConfig with the options from config and
 // secrets. This method can be called multiple times, i.e. to override
 // configuration options from tenants.
-func (vtc *vaultTenantConnection) parseConfig(config map[string]interface{}) error {
+func (vtc *vaultTenantConnection) parseConfig(config map[string]any) error {
 	err := vtc.initConnection(config)
 	if err != nil {
 		return err
@@ -387,7 +388,7 @@ func (vtc *vaultTenantConnection) parseConfig(config map[string]interface{}) err
 // setTokenName updates the kms.TokenName with the options from config. This
 // method can be called multiple times, i.e. to override configuration options
 // from tenants.
-func (kms *vaultTokensKMS) setTokenName(config map[string]interface{}) error {
+func (kms *vaultTokensKMS) setTokenName(config map[string]any) error {
 	err := setConfigString(&kms.TokenName, config, "tenantTokenName")
 	if errors.Is(err, errConfigOptionInvalid) {
 		return err
@@ -400,8 +401,8 @@ func (kms *vaultTokensKMS) setTokenName(config map[string]interface{}) error {
 // it calls the kubernetes secrets and get the required data.
 
 //nolint:gocyclo,cyclop // iterating through many config options, not complex at all.
-func (vtc *vaultTenantConnection) initCertificates(config map[string]interface{}) error {
-	vaultConfig := make(map[string]interface{})
+func (vtc *vaultTenantConnection) initCertificates(config map[string]any) error {
+	vaultConfig := make(map[string]any)
 
 	csiNamespace := os.Getenv("POD_NAMESPACE")
 	vaultCAFromSecret := "" // optional
@@ -486,9 +487,7 @@ func (vtc *vaultTenantConnection) initCertificates(config map[string]interface{}
 		vaultConfig[api.EnvVaultClientKey] = ckey.Name()
 	}
 
-	for key, value := range vaultConfig {
-		vtc.vaultConfig[key] = value
-	}
+	maps.Copy(vtc.vaultConfig, vaultConfig)
 
 	return nil
 }
@@ -544,7 +543,7 @@ func isTenantConfigOption(opt string) bool {
 // parseTenantConfig gets the optional ConfigMap from the Tenants namespace,
 // and applies the allowable options (see isTenantConfigOption) to the KMS
 // configuration.
-func (vtc *vaultTenantConnection) parseTenantConfig() (map[string]interface{}, error) {
+func (vtc *vaultTenantConnection) parseTenantConfig() (map[string]any, error) {
 	if vtc.Tenant == "" || vtc.ConfigName == "" {
 		return nil, nil
 	}
@@ -561,7 +560,7 @@ func (vtc *vaultTenantConnection) parseTenantConfig() (map[string]interface{}, e
 
 	// create a new map with config options, but only include the options
 	// that a tenant may (re)configure
-	config := make(map[string]interface{})
+	config := make(map[string]any)
 	for k, v := range cm.Data {
 		if vtc.tenantConfigOptionFilter(k) {
 			config[k] = v
@@ -582,7 +581,7 @@ func (vtc *vaultTenantConnection) parseTenantConfig() (map[string]interface{}, e
 // even if the tenant has vaultNamespace configured. Users expect to have the
 // vaultAuthNamespace updated when they configure vaultNamespace, if
 // vaultAuthNamespace was not explicitly set in the global configuration.
-func (vtc *vaultTenantConnection) setTenantAuthNamespace(tenantConfig map[string]interface{}) {
+func (vtc *vaultTenantConnection) setTenantAuthNamespace(tenantConfig map[string]any) {
 	vaultAuthNamespace, ok := vtc.keyContext[loss.KeyVaultNamespace]
 	if !ok {
 		// nothing to do, global connection config does not have the
@@ -630,13 +629,13 @@ func (vtc *vaultTenantConnection) setTenantAuthNamespace(tenantConfig map[string
 }
 
 // fetchTenantConfig fetches the configuration for the tenant if it exists.
-func fetchTenantConfig(config map[string]interface{}, tenant string) (map[string]interface{}, bool) {
+func fetchTenantConfig(config map[string]any, tenant string) (map[string]any, bool) {
 	tenantsMap, ok := config["tenants"]
 	if !ok {
 		return nil, false
 	}
 	// tenants is a map per tenant, containing key/values
-	tenants, ok := tenantsMap.(map[string]map[string]interface{})
+	tenants, ok := tenantsMap.(map[string]map[string]any)
 	if !ok {
 		return nil, false
 	}

--- a/internal/kms/vault_tokens_test.go
+++ b/internal/kms/vault_tokens_test.go
@@ -32,7 +32,7 @@ func TestParseConfig(t *testing.T) {
 	t.Parallel()
 	vtc := vaultTenantConnection{}
 
-	config := make(map[string]interface{})
+	config := make(map[string]any)
 
 	// empty config map
 	err := vtc.parseConfig(config)
@@ -56,7 +56,7 @@ func TestParseConfig(t *testing.T) {
 	}
 
 	// tenant "bob" uses a different kms.ConfigName
-	bob := make(map[string]interface{})
+	bob := make(map[string]any)
 	bob["tenantConfigName"] = "the-config-from-bob"
 	bob["vaultNamespace"] = "bobs-place"
 	err = vtc.parseConfig(bob)
@@ -87,7 +87,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 
 	args := ProviderInitArgs{
 		Tenant:  "bob",
-		Config:  make(map[string]interface{}),
+		Config:  make(map[string]any),
 		Secrets: nil,
 	}
 
@@ -107,7 +107,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	}
 
 	// fill tenants
-	tenants := make(map[string]interface{})
+	tenants := make(map[string]any)
 	args.Config["tenants"] = tenants
 
 	// empty tenants list
@@ -117,10 +117,10 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	}
 
 	// add tenant "bob"
-	bob := make(map[string]interface{})
+	bob := make(map[string]any)
 	bob["vaultAddress"] = "https://vault.bob.example.org"
 	//nolint:forcetypeassert,errcheck // as its a test we dont need to check assertion here.
-	args.Config["tenants"].(map[string]interface{})["bob"] = bob
+	args.Config["tenants"].(map[string]any)["bob"] = bob
 
 	_, err = initVaultTokensKMS(args)
 	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
@@ -188,7 +188,7 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 
 func TestTransformConfig(t *testing.T) {
 	t.Parallel()
-	cm := make(map[string]interface{})
+	cm := make(map[string]any)
 	cm["KMS_PROVIDER"] = "vaulttokens"
 	cm["VAULT_ADDR"] = "https://vault.example.com"
 	cm["VAULT_BACKEND"] = "kv-v2"
@@ -220,7 +220,7 @@ func TestTransformConfig(t *testing.T) {
 
 func TestTransformConfigDefaults(t *testing.T) {
 	t.Parallel()
-	cm := make(map[string]interface{})
+	cm := make(map[string]any)
 	cm["KMS_PROVIDER"] = kmsTypeVaultTokens
 
 	config, err := transformConfig(cm)
@@ -248,11 +248,11 @@ func TestSetTenantAuthNamespace(t *testing.T) {
 		kms.keyContext = map[string]string{
 			loss.KeyVaultNamespace: "global",
 		}
-		kms.vaultConfig = map[string]interface{}{
+		kms.vaultConfig = map[string]any{
 			api.EnvVaultNamespace: "global",
 		}
 
-		config := map[string]interface{}{
+		config := map[string]any{
 			"vaultNamespace": vaultNamespace,
 		}
 
@@ -270,11 +270,11 @@ func TestSetTenantAuthNamespace(t *testing.T) {
 		kms.keyContext = map[string]string{
 			loss.KeyVaultNamespace: vaultAuthNamespace,
 		}
-		kms.vaultConfig = map[string]interface{}{
+		kms.vaultConfig = map[string]any{
 			api.EnvVaultNamespace: "global",
 		}
 
-		config := map[string]interface{}{
+		config := map[string]any{
 			"vaultNamespace": vaultNamespace,
 		}
 
@@ -292,11 +292,11 @@ func TestSetTenantAuthNamespace(t *testing.T) {
 		kms.keyContext = map[string]string{
 			// no vaultAuthNamespace configured
 		}
-		kms.vaultConfig = map[string]interface{}{
+		kms.vaultConfig = map[string]any{
 			api.EnvVaultNamespace: "global",
 		}
 
-		config := map[string]interface{}{
+		config := map[string]any{
 			"vaultNamespace": vaultNamespace,
 		}
 
@@ -315,11 +315,11 @@ func TestSetTenantAuthNamespace(t *testing.T) {
 		kms.keyContext = map[string]string{
 			// no vaultAuthNamespace configured
 		}
-		kms.vaultConfig = map[string]interface{}{
+		kms.vaultConfig = map[string]any{
 			// no vaultNamespace configured
 		}
 
-		config := map[string]interface{}{
+		config := map[string]any{
 			// no tenant namespaces configured
 		}
 

--- a/internal/nfs/types/volume.go
+++ b/internal/nfs/types/volume.go
@@ -158,7 +158,7 @@ func (nv *NFSVolume) CreateExport(backend *csi.Volume) error {
 
 	if secTypes != "" {
 		export.SecType = []nfs.SecType{}
-		for _, secType := range strings.Split(secTypes, ",") {
+		for secType := range strings.SplitSeq(secTypes, ",") {
 			export.SecType = append(export.SecType, nfs.SecType(secType))
 		}
 	}

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"strconv"
 
@@ -1069,9 +1070,7 @@ func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) er
 // populatePublishContext creates a publish context for the volume.
 func populatePublishContext(req *csi.ControllerPublishVolumeRequest, hostNqn string) map[string]string {
 	publishContext := make(map[string]string)
-	for key, value := range req.GetVolumeContext() {
-		publishContext[key] = value
-	}
+	maps.Copy(publishContext, req.GetVolumeContext())
 	publishContext[vcHostNQN] = hostNqn
 
 	return publishContext

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -847,7 +847,7 @@ func (ns *NodeServer) initNVMeMountedDevices(ctx context.Context) error {
 
 // getStagingTargetPath concats either NodeStageVolumeRequest's or
 // NodeUnstageVolumeRequest's target path with the volumeID.
-func getStagingTargetPath(req interface{}) string {
+func getStagingTargetPath(req any) string {
 	switch vr := req.(type) {
 	case *csi.NodeStageVolumeRequest:
 		return vr.GetStagingTargetPath() + "/" + vr.GetVolumeId()

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 
 	osdAdmin "github.com/ceph/go-ceph/common/admin/osd"
@@ -303,9 +304,7 @@ func buildCreateVolumeResponse(
 
 	volume.ContentSource = req.GetVolumeContentSource()
 
-	for param, value := range util.GetVolumeContext(req.GetParameters()) {
-		volume.VolumeContext[param] = value
-	}
+	maps.Copy(volume.GetVolumeContext(), util.GetVolumeContext(req.GetParameters()))
 
 	return &csi.CreateVolumeResponse{Volume: volume}, nil
 }

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1093,7 +1093,7 @@ func (ns *NodeServer) NodeUnpublishVolume(
 
 // getStagingTargetPath concats either NodeStageVolumeRequest's or
 // NodeUnstageVolumeRequest's target path with the volumeID.
-func getStagingTargetPath(req interface{}) string {
+func getStagingTargetPath(req any) string {
 	switch vr := req.(type) {
 	case *csi.NodeStageVolumeRequest:
 		return vr.GetStagingTargetPath() + "/" + vr.GetVolumeId()

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -282,7 +282,7 @@ func SetRbdNbdToolFeatures() {
 // returns mounter specific options.
 func parseMapOptions(mapOptions string) (string, string, error) {
 	var krbdMapOptions, nbdMapOptions string
-	for _, item := range strings.Split(mapOptions, ";") {
+	for item := range strings.SplitSeq(mapOptions, ";") {
 		var mounter, options string
 		if item == "" {
 			continue
@@ -420,8 +420,8 @@ func appendRbdNbdCliOptions(cmdArgs []string, userOptions, cookie string) []stri
 		cmdArgs = append(cmdArgs, "--cookie="+cookie)
 	}
 	if userOptions != "" {
-		options := strings.Split(userOptions, ",")
-		for _, opt := range options {
+		options := strings.SplitSeq(userOptions, ",")
+		for opt := range options {
 			cmdArgs = append(cmdArgs, "--"+opt)
 		}
 	}

--- a/internal/rbd/rbd_healer.go
+++ b/internal/rbd/rbd_healer.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"sync"
 
@@ -62,9 +63,7 @@ func getSecret(ns, name string) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to get Secret %s/%s: %w", ns, name, err)
 	}
 
-	for k, v := range secretData {
-		deviceSecret[k] = v
-	}
+	maps.Copy(deviceSecret, secretData)
 
 	return deviceSecret, nil
 }

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2421,7 +2421,7 @@ func (rv *rbdVolume) getUsedBytes(ctx context.Context) (uint64, error) {
 			Length:        uint64(rv.VolSize),
 			IncludeParent: librbd.IncludeParent,
 			WholeObject:   librbd.EnableWholeObject,
-			Callback: func(o, l uint64, _ int, _ interface{}) int {
+			Callback: func(o, l uint64, _ int, _ any) int {
 				usedBytes += l
 
 				return 0

--- a/internal/rbd/snap_diff.go
+++ b/internal/rbd/snap_diff.go
@@ -167,7 +167,7 @@ func createDiffIterateByIDCB(
 	luksHeaderPadding uint64,
 	sendResponse types.MetadataCallback,
 ) librbd.DiffIterateCallback {
-	return func(offset, sizeBytes uint64, _ int, _ interface{}) int {
+	return func(offset, sizeBytes uint64, _ int, _ any) int {
 		select {
 		case <-ctx.Done():
 			return int(codes.Canceled)

--- a/internal/util/log/log.go
+++ b/internal/util/log/log.go
@@ -54,37 +54,37 @@ func Log(ctx context.Context, format string) string {
 }
 
 // FatalLog helps in logging fatal errors.
-func FatalLogMsg(message string, args ...interface{}) {
+func FatalLogMsg(message string, args ...any) {
 	logMessage := fmt.Sprintf(message, args...)
 	klog.FatalDepth(1, logMessage)
 }
 
 // ErrorLogMsg helps in logging errors with message.
-func ErrorLogMsg(message string, args ...interface{}) {
+func ErrorLogMsg(message string, args ...any) {
 	logMessage := fmt.Sprintf(message, args...)
 	klog.ErrorDepth(1, logMessage)
 }
 
 // ErrorLog helps in logging errors with context.
-func ErrorLog(ctx context.Context, message string, args ...interface{}) {
+func ErrorLog(ctx context.Context, message string, args ...any) {
 	logMessage := fmt.Sprintf(Log(ctx, message), args...)
 	klog.ErrorDepth(1, logMessage)
 }
 
 // WarningLogMsg helps in logging warnings with message.
-func WarningLogMsg(message string, args ...interface{}) {
+func WarningLogMsg(message string, args ...any) {
 	logMessage := fmt.Sprintf(message, args...)
 	klog.WarningDepth(1, logMessage)
 }
 
 // WarningLog helps in logging warnings with context.
-func WarningLog(ctx context.Context, message string, args ...interface{}) {
+func WarningLog(ctx context.Context, message string, args ...any) {
 	logMessage := fmt.Sprintf(Log(ctx, message), args...)
 	klog.WarningDepth(1, logMessage)
 }
 
 // DefaultLog helps in logging with klog.level 1.
-func DefaultLog(message string, args ...interface{}) {
+func DefaultLog(message string, args ...any) {
 	logMessage := fmt.Sprintf(message, args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Default).Enabled() {
@@ -93,7 +93,7 @@ func DefaultLog(message string, args ...interface{}) {
 }
 
 // UsefulLog helps in logging with klog.level 2.
-func UsefulLog(ctx context.Context, message string, args ...interface{}) {
+func UsefulLog(ctx context.Context, message string, args ...any) {
 	logMessage := fmt.Sprintf(Log(ctx, message), args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Useful).Enabled() {
@@ -102,7 +102,7 @@ func UsefulLog(ctx context.Context, message string, args ...interface{}) {
 }
 
 // ExtendedLogMsg helps in logging a message with klog.level 3.
-func ExtendedLogMsg(message string, args ...interface{}) {
+func ExtendedLogMsg(message string, args ...any) {
 	logMessage := fmt.Sprintf(message, args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Extended).Enabled() {
@@ -111,7 +111,7 @@ func ExtendedLogMsg(message string, args ...interface{}) {
 }
 
 // ExtendedLog helps in logging with klog.level 3.
-func ExtendedLog(ctx context.Context, message string, args ...interface{}) {
+func ExtendedLog(ctx context.Context, message string, args ...any) {
 	logMessage := fmt.Sprintf(Log(ctx, message), args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Extended).Enabled() {
@@ -120,7 +120,7 @@ func ExtendedLog(ctx context.Context, message string, args ...interface{}) {
 }
 
 // DebugLogMsg helps in logging a message with klog.level 4.
-func DebugLogMsg(message string, args ...interface{}) {
+func DebugLogMsg(message string, args ...any) {
 	logMessage := fmt.Sprintf(message, args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Debug).Enabled() {
@@ -129,7 +129,7 @@ func DebugLogMsg(message string, args ...interface{}) {
 }
 
 // DebugLog helps in logging with klog.level 4.
-func DebugLog(ctx context.Context, message string, args ...interface{}) {
+func DebugLog(ctx context.Context, message string, args ...any) {
 	logMessage := fmt.Sprintf(Log(ctx, message), args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Debug).Enabled() {
@@ -138,7 +138,7 @@ func DebugLog(ctx context.Context, message string, args ...interface{}) {
 }
 
 // TraceLogMsg helps in logging a message with klog.level 5.
-func TraceLogMsg(message string, args ...interface{}) {
+func TraceLogMsg(message string, args ...any) {
 	logMessage := fmt.Sprintf(message, args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Trace).Enabled() {
@@ -147,7 +147,7 @@ func TraceLogMsg(message string, args ...interface{}) {
 }
 
 // TraceLog helps in logging with klog.level 5.
-func TraceLog(ctx context.Context, message string, args ...interface{}) {
+func TraceLog(ctx context.Context, message string, args ...any) {
 	logMessage := fmt.Sprintf(Log(ctx, message), args...)
 	// If logging is disabled, don't evaluate the arguments
 	if klog.V(Trace).Enabled() {

--- a/internal/util/reftracker/radoswrapper/fakerados.go
+++ b/internal/util/reftracker/radoswrapper/fakerados.go
@@ -18,6 +18,7 @@ package radoswrapper
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/ceph/go-ceph/rados"
 	"golang.org/x/sys/unix"
@@ -333,9 +334,7 @@ func (e *fakeWriteOpSetOmapExecutor) operate(w *FakeWriteOp) error {
 		return err
 	}
 
-	for k, v := range e.pairs {
-		obj.Omap[k] = v
-	}
+	maps.Copy(obj.Omap, e.pairs)
 
 	return nil
 }
@@ -419,10 +418,7 @@ func (e *fakeReadOpReadExecutor) operate(r *FakeReadOp) error {
 		return nil
 	}
 
-	end := e.offset + len(e.buffer)
-	if end > len(obj.Data) {
-		end = len(obj.Data)
-	}
+	end := min(e.offset+len(e.buffer), len(obj.Data))
 
 	nbytes := end - e.offset
 	e.step.BytesRead = int64(nbytes)

--- a/internal/util/stripsecrets/stripsecrets.go
+++ b/internal/util/stripsecrets/stripsecrets.go
@@ -65,15 +65,15 @@ func stripKey(out []string) bool {
 func stripSecret(out []string) bool {
 	for i := range out {
 		arg := out[i]
-		begin := strings.Index(arg, secretArg)
+		before, after, ok := strings.Cut(arg, secretArg)
 
-		if begin == -1 {
+		if !ok {
 			continue
 		}
 
-		end := strings.IndexByte(arg[begin+len(secretArg):], optionsArgSeparator)
+		end := strings.IndexByte(after, optionsArgSeparator)
 
-		out[i] = arg[:begin] + strippedSecret
+		out[i] = before + strippedSecret
 		if end != -1 {
 			out[i] += arg[end+len(secretArg):]
 		}

--- a/scripts/golangci.yml.in
+++ b/scripts/golangci.yml.in
@@ -122,6 +122,9 @@ linters:
     gosec:
       excludes:
         - G115
+    modernize:
+      disable:
+        - newexpr
     lll:
       line-length: 120
       tab-width: 1
@@ -142,6 +145,11 @@ linters:
         - -ST1001
     unparam:
       check-exported: false
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec
 
 formatters:
   enable:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
The k8s dependency bump set go.mod to go 1.26.0, but build.env
still had Go 1.24.6. Update to Go 1.26.2 (latest 1.26 patch)
so the build toolchain matches the module requirement.

golangci-lint v2.5.0 was built with Go 1.25 and refuses to lint
code targeting Go 1.26.0. Update to v2.9.0, the first version
with Go 1.26 support.
```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
