### PR TITLE
rbd: correct error handling in flattenRbdImage and flatten functions

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -991,11 +991,11 @@ func (ri *rbdImage) flattenRbdImage(
 			err)
 		if forceFlatten || depth >= hardlimit {
 			flattenImageErr := ri.flatten()
-			if err != nil {
-				log.ErrorLog(ctx, "rbd failed to flatten image %s %s: %v", ri.Pool, ri.RbdImageName, err)
+			if flattenImageErr != nil {
+				log.ErrorLog(ctx, "rbd failed to flatten image %s %s: %v", ri.Pool, ri.RbdImageName, flattenImageErr)
 
 				return fmt.Errorf(
-					"failed to add task to remove image: %w, failed to flatten image: %w",
+					"failed to add task to flatten image: %w, failed to flatten image: %w",
 					knownErr,
 					flattenImageErr,
 				)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1006,21 +1006,6 @@ func (ri *rbdImage) flattenRbdImage(
 	return nil
 }
 
-func (ri *rbdImage) getParentName() (string, error) {
-	rbdImage, err := ri.open()
-	if err != nil {
-		return "", err
-	}
-	defer rbdImage.Close() //nolint:errcheck // not a critical failure
-
-	parentInfo, err := rbdImage.GetParent()
-	if err != nil {
-		return "", err
-	}
-
-	return parentInfo.Image.ImageName, nil
-}
-
 func (ri *rbdImage) flatten() error {
 	rbdImage, err := ri.open()
 	if err != nil {
@@ -1031,13 +1016,16 @@ func (ri *rbdImage) flatten() error {
 	err = rbdImage.Flatten()
 	if err != nil {
 		// rbd image flatten will fail if the rbd image does not have a parent
-		parent, pErr := ri.getParentName()
-		if pErr != nil {
-			return fmt.Errorf("Failed as %w (internal %w)", err, pErr)
-		}
-		if parent == "" {
+		_, pErr := rbdImage.GetParent()
+		if errors.Is(pErr, librbd.ErrNotFound) {
 			return nil
 		}
+
+		if pErr != nil {
+			return fmt.Errorf("failed to flatten: (%w) and get parent: (%w)", err, pErr)
+		}
+
+		return fmt.Errorf("failed to flatten image: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
# Describe what this PR does #

This PR fixes issues in the RBD flatten flow, mainly around fallback behavior when Ceph manager task scheduling is not available, and improves error handling to avoid hiding the real problem.
In `flattenRbdImage()`, the clone depth check was previously skipped when `forceFlatten` was not set, but the later fallback logic could still rely on the depth value when Ceph manager task scheduling was not used. In cases where the code could not schedule the flatten operation through the manager task interface, for example because of missing permissions to access the Ceph manager, it could fall back to direct flattening. However, since depth was only being calculated in the forceFlatten path, the value could remain zero when reaching the condition `forceFlatten || depth >= hardlimit`. Because of that, the condition would never be satisfied in some fallback cases, so the image would not be flattened when it should be.
This can become a real issue once the clone chain reaches the kernel RBD driver imposed limit of 16, because at that point the image can no longer be mapped on a node.
The previous error handling also made this harder to debug, because it could return an irrelevant error and hide the actual reason why flattening never happened.

In addition, the `flatten()` function has been fixed to stop silently ignoring unexpected errors. Previously, it implicitly assumed that a flatten failure could only happen when the image had no parent. With this change, the code now explicitly checks for `librbd.ErrNotFound` from `GetParent()` as the only acceptable case to ignore, and all other errors are returned properly with context.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
