### PR TITLE
util: return success from ControllerUnpublish when volume is not found

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -1247,6 +1247,14 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 
 	volOptions, _, err := store.NewVolumeOptionsFromVolID(ctx, volumeId, nil, secrets, cs.ClusterName)
 	if err != nil {
+		if errors.Is(err, util.ErrPoolNotFound) ||
+			errors.Is(err, util.ErrKeyNotFound) ||
+			errors.Is(err, cerrors.ErrVolumeNotFound) {
+			log.WarningLog(ctx, "failed to get backend volume for %s: %v", volumeId, err)
+
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+
 		return nil, status.Errorf(codes.Internal, "failed to generate volume from volume ID %s: %v", volumeId, err)
 	}
 	defer volOptions.Destroy()

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1813,6 +1813,14 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 
 	rv, err := GenVolFromVolID(ctx, volumeId, credentials, secrets)
 	if err != nil {
+		if errors.Is(err, util.ErrPoolNotFound) ||
+			errors.Is(err, util.ErrKeyNotFound) ||
+			errors.Is(err, rbderrors.ErrImageNotFound) {
+			log.WarningLog(ctx, "failed to get backend volume for %s: %v", volumeId, err)
+
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+
 		return nil, status.Errorf(codes.Internal, "failed to generate volume from volume ID %s: %v",
 			volumeId, err)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
When the backing pool or volume is force deleted before ControllerUnpublish is called,
the RPC fails with codes.Internal and the external-attacher retries indefinitely,
blocking PV deletion.

Return success when the volume is not found, consistent with how DeleteVolume
already handles these errors.
```

Resolves: https://github.com/rook/rook/pull/17462#discussion_r3193304883

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
