### PR TITLE
Add cgroup v2 QoS support for RBD volumes

### DIFF
--- a/api/deploy/kubernetes/csi-config-map.go
+++ b/api/deploy/kubernetes/csi-config-map.go
@@ -60,6 +60,9 @@ type RBD struct {
 	// ControllerPublishSecretRef contains the secret reference for controller
 	// publish operations.
 	ControllerPublishSecretRef corev1.SecretReference `json:"controllerPublishSecretRef"`
+	// NodePublishSecretRef contains the secret reference for node publish
+	// operations. Used for retrieving QoS metadata during NodePublishVolume.
+	NodePublishSecretRef corev1.SecretReference `json:"nodePublishSecretRef"`
 }
 
 type NFS struct {

--- a/deploy/csi-config-map-sample.yaml
+++ b/deploy/csi-config-map-sample.yaml
@@ -72,6 +72,10 @@ data:
            "netNamespaceFilePath": "<kubeletRootPath>/plugins/rbd.csi.ceph.com/net",
            "radosNamespace": "<rados-namespace>",
            "mirrorDaemonCount": 1,
+           "nodePublishSecretRef": {
+             "name": "<secret-name>",
+             "namespace": "<secret-namespace>"
+           }
         },
         "monitors": [
           "<MONValue1>",

--- a/docs/design/proposals/rbd-qos.md
+++ b/docs/design/proposals/rbd-qos.md
@@ -93,47 +93,25 @@ above `kubepods-besteffort.slice` or `kubepods-burstable.slice` or
 `kubepods.slice` (Guaranteed QoS) cgroup. The 3 QoS classes are defined
 [here](https://kubernetes.io/docs/concepts/workloads/pods/pod-QoS/#quality-of-service-classes)
 
-To identify the right cgroup file, we need pod UUID and container UUID from the
-`pod yaml` output
+To identify the right cgroup file, we need pod UUID from the `pod yaml` output
 
 ```bash
 [$]kubectl get po csi-rbd-demo-pod -oyaml |grep uid
   uid: cdf7b785-4eb7-44f7-99cc-ef53890f4dfd
-[$]kubectl get po csi-rbd-demo-pod -oyaml |grep -i containerID
-  - containerID: cri-o://77e57fbbc0f0630f41f9f154f4b5fe368b6dcf7bef7dcd75a9c4b56676f10bc9
 [$]kubectl get po csi-rbd-demo-pod -oyaml |grep -i qosClass
   qosClass: BestEffort
 ```
 
 Now check in the `kubepods-besteffort.slice` and identify the right path using
-pod UID and container UID
+pod UID (hyphens replaced with underscores).
 
-Before that check `io.max` on the application pod and see if there is any limit
-
-```bash
-[$]kubectl exec -it csi-rbd-demo-pod -- sh
-sh-4.4# cat /sys/fs/cgroup/io.max
-sh-4.4#
-```
-
-Come back to the Node and find the right cgroup scope
+Come back to the Node and navigate to the pod's cgroup slice
 
 ```bash
-sh-5.1# cd kubepods-besteffort.slice/kubepods-besteffort-podcdf7b785_4eb7_44f7_99cc_ef53890f4dfd.slice/crio-77e57fbbc0f0630f41f9f154f4b5fe368b6dcf7bef7dcd75a9c4b56676f10bc9.scope/
-
-
+sh-5.1# cd kubepods-besteffort.slice/kubepods-besteffort-podcdf7b785_4eb7_44f7_99cc_ef53890f4dfd.slice/
 sh-5.1# echo "252:0 wbps=1048576" > io.max
 sh-5.1# cat io.max
 252:0 rbps=max wbps=1048576 riops=max wiops=max
-```
-
-Now go back to the application pod and check if we have the right limit set
-
-```bash
-[$]kubectl exec -it csi-rbd-demo-pod -- sh
-sh-4.4# cat /sys/fs/cgroup/io.max
-252:0 rbps=max wbps=1048576 riops=max wiops=max
-sh-4.4#
 ```
 
 Note:- We can only support the QoS that cgroup v2 io controller supports, this
@@ -143,10 +121,10 @@ Below are the configurations that will be supported
 
 |  Parameter     |  Description     |
 |  ---  |  ---  |
-|  MaxReadIOPS     | Max read IO operations per second      |
-|  MaxWriteIOPS     | Max write IO operations per second      |
-|  MaxReadBytesPerSecond     |  Max read bytes per second     |
-|  MaxWriteBytesPerSecond     |  Max write bytes per second     |
+|  maxReadIops     | Max read IO operations per second      |
+|  maxWriteIops     | Max write IO operations per second      |
+|  maxReadBps     |  Max read bytes per second     |
+|  maxWriteBps     |  Max write bytes per second     |
 
 ## Implementation Approach
 
@@ -160,10 +138,10 @@ kind: VolumeAttributesClass
 metadata:
   name: silver
 parameters:
-  MaxReadIOPS: ""
-  MaxWriteIOPS: ""
-  MaxReadBytesPerSecond: ""
-  MaxWriteBytesPerSecond: ""
+  maxReadIops: ""
+  maxWriteIops: ""
+  maxReadBps: ""
+  maxWriteBps: ""
 ```
 
 VolumeAttributesClassName is a new parameter in the PVC object the user can
@@ -182,41 +160,52 @@ QoS at the storage level which means setting some configuration at the storage
 1. During NodePublishVolume operation retrieve the QoS from image metadata
 1. Whenever a new pod comes in apply the QoS
 
-#### Container Discovery and QoS Application
+#### Pod-Level QoS Application
 
 When kubelet invokes the NodePublishVolume RPC call, it provides the pod UUID
-as part of the request. Ceph-CSI will use this pod UUID to locate the correct
-cgroup hierarchy path, following the same approach demonstrated in the manual
-steps above.
+as part of the request. Ceph-CSI uses this pod UUID to locate the pod's cgroup
+hierarchy path and applies QoS limits at the pod level.
 
-Since Ceph-CSI cannot determine which specific container within the pod the
-RBD volume is being mounted to, the QoS limits (io.max) must be applied to
-**all containers** found in the pod's cgroup directory. This ensures that the
-QoS limits are enforced regardless of which container is using the volume.
+##### Key Design Decision: Pod-Level io.max
 
-The container discovery process follows these steps:
+QoS limits are applied to the pod's io.max file, not individual container
+io.max files. This design choice provides several benefits:
+
+1. **Automatic Propagation**: cgroup v2 hierarchical design ensures pod-level
+   limits automatically apply to all containers within the pod
+1. **Simplified Implementation**: Single write operation instead of discovering
+   and updating multiple container cgroups
+1. **Timing Independence**: No dependency on container creation timing - works
+   even if containers start after volume mount
+1. **Consistent Behavior**: Same enforcement regardless of container runtime
+   (CRI-O, containerd, etc.)
+
+The QoS application process follows these steps:
 
 1. Kubelet provides pod UUID in NodePublishVolume request (via pod info in
    volume context)
 1. Ceph-CSI identifies the pod's QoS class (BestEffort, Burstable, or
-   Guaranteed) from the cgroup hierarchy
+   Guaranteed) by probing the cgroup hierarchy
 1. Navigate to the appropriate kubepods slice based on QoS class:
    * `kubepods-besteffort.slice` for BestEffort
    * `kubepods-burstable.slice` for Burstable
    * `kubepods.slice` for Guaranteed
-1. Locate the pod-specific slice using the pod UUID:
-   `kubepods-<qos>-pod<uuid>.slice/`
-1. Enumerate all container scopes (e.g., `crio-<container-id>.scope/`) within
-   the pod slice
-1. Apply io.max limits to each container's cgroup by writing to
-   `<container-scope>/io.max`
+1. Locate the pod-specific slice using the normalized pod UUID (hyphens
+   replaced with underscores): `kubepods-<qos>-pod<normalized-uuid>.slice/`
+1. Apply io.max limits to the pod's cgroup by writing to `<pod-slice>/io.max`
+1. cgroup v2 automatically enforces these limits on all containers in the pod
 
-Example path construction:
-`/sys/fs/cgroup/kubepods-besteffort.slice/kubepods-besteffort-podcdf7b785_4eb7_44f7_99cc_ef53890f4dfd.slice/crio-77e57fbbc0f0630f41f9f154f4b5fe368b6dcf7bef7dcd75a9c4b56676f10bc9.scope/io.max`
+##### Example path construction
 
-This approach ensures QoS enforcement across all containers in the pod,
-addressing the limitation that the specific target container is not known at
-NodePublishVolume time.
+For a BestEffort pod with UUID `cdf7b785-4eb7-44f7-99cc-ef53890f4dfd`:
+
+```text
+/sys/fs/cgroup/kubepods-besteffort.slice/kubepods-besteffort-podcdf7b785_4eb7_44f7_99cc_ef53890f4dfd.slice/io.max
+```
+
+This pod-level approach leverages cgroup v2's hierarchical design to
+automatically enforce QoS limits on all containers, eliminating the need for
+container discovery and individual container updates.
 
 #### Secret Management
 

--- a/docs/volumeattributesclass.md
+++ b/docs/volumeattributesclass.md
@@ -65,9 +65,22 @@ fetch updated parameters when the Volume is _staged_ or _published_. The
 secrets for staging and publishing can not (easily) be updated after the fact,
 these are part of the fixed parameters in the PersistentVolume.
 
-## Use VolumeAttributesClass for rbd-nbd volume qos
+## RBD Volume QoS with VolumeAttributesClass
 
-### Create a VolumeAttributesClass
+Ceph-CSI supports two types of QoS for RBD volumes:
+
+1. **Traditional QoS** (for rbd-nbd mounter only)
+1. **Cgroup v2 QoS** (for krbd/kernel mounter, requires cgroup v2)
+
+**Note**: You cannot mix traditional QoS parameters and cgroup v2 QoS parameters
+in the same VolumeAttributesClass.
+
+### Traditional QoS for rbd-nbd
+
+Traditional QoS is applied at the RBD device level using rbd-nbd's built-in
+QoS capabilities. This approach only works with the rbd-nbd mounter.
+
+#### Create a VolumeAttributesClass for rbd-nbd QoS
 
 - Define a VolumeAttributesClass
 
@@ -183,3 +196,127 @@ $ kubectl get pvc
 NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      VOLUMEATTRIBUTESCLASS   AGE
 rbd-pvc-vac   Bound    pvc-8b2fcb47-233a-4bcf-bb94-f94e9aa1150a   30Gi       RWO            csi-rbd-sc        gold                    2m
 ```
+
+### Cgroup v2 QoS for krbd
+
+Cgroup v2 QoS applies io.max limits at the container cgroup level, providing
+QoS for volumes mapped using the krbd (kernel RBD) mounter. This approach works
+on systems with cgroup v2 enabled.
+
+#### Prerequisites for Cgroup v2 QoS
+
+- Cgroup v2 must be enabled on all Kubernetes nodes
+- `podInfoOnMount` must be enabled in the CSIDriver spec (enabled by default)
+- NodePublishVolume secret must be configured in StorageClass parameters
+  (`csi.storage.k8s.io/node-publish-secret-name`) or CSI ConfigMap
+  (`rbd.nodePublishSecretRef`)
+
+#### Create a VolumeAttributesClass for Cgroup v2 QoS
+
+- Define a VolumeAttributesClass
+
+```console
+---
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: cgroup-qos
+driverName: rbd.csi.ceph.com
+parameters:
+  # Cgroup v2 QoS parameters
+  maxReadIops: "1000"         # 1000 read IOPS
+  maxWriteIops: "2000"        # 2000 write IOPS
+  maxReadBps: "104857600"     # 100 MiB/s
+  maxWriteBps: "209715200"    # 200 MiB/s
+```
+
+```console
+kubectl create -f volumeattributesclass-cgroup.yaml
+```
+
+- Verify VolumeAttributesClass has been created
+
+```console
+$ kubectl get vac
+NAME          DRIVERNAME                   AGE
+cgroup-qos    rbd.csi.ceph.com             2s
+```
+
+#### Configure NodePublishVolume Secret
+
+##### Option 1: StorageClass Parameters (Recommended)
+
+Add the following parameters to your StorageClass:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-rbd-sc
+provisioner: rbd.csi.ceph.com
+parameters:
+  clusterID: <cluster-id>
+  pool: <rbd-pool-name>
+  # ... other parameters ...
+  csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: default
+```
+
+##### Option 2: CSI ConfigMap Fallback
+
+Alternatively, configure the default secret in the CSI ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-config
+data:
+  config.json: |-
+    [
+      {
+        "clusterID": "<cluster-id>",
+        "monitors": ["<mon1>", "<mon2>", "<mon3>"],
+        "rbd": {
+          "nodePublishSecretRef": {
+            "name": "csi-rbd-secret",
+            "namespace": "default"
+          }
+        }
+      }
+    ]
+```
+
+#### Create PVC with Cgroup v2 QoS
+
+```console
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rbd-pvc-cgroup-qos
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-rbd-sc
+  volumeMode: Block
+  volumeAttributesClassName: cgroup-qos
+```
+
+```console
+$ kubectl create -f pvc.yaml
+persistentvolumeclaim/rbd-pvc-cgroup-qos created
+```
+
+#### How Cgroup v2 QoS Works
+
+1. QoS parameters are stored in RBD image metadata during
+  `CreateVolume` or `ControllerModifyVolume`.
+1. During `NodePublishVolume`, Ceph-CSI retrieves the QoS metadata
+1. The device major:minor number is determined from the mapped RBD device
+1. io.max limits are applied to the pod's cgroup
+1. QoS limits can be dynamically modified by updating the VolumeAttributesClass
+1. Pod need to be restart to get the new QoS limits applied.

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -5836,7 +5836,6 @@ var _ = Describe("RBD", func() {
 			// create silver vac
 			err = createRBDVolumeAttributesClass(
 				f.ClientSet,
-				f,
 				qosSilverVACName,
 				qosParameters)
 			if err != nil {
@@ -5886,7 +5885,6 @@ var _ = Describe("RBD", func() {
 			// create gold vac
 			err = createRBDVolumeAttributesClass(
 				f.ClientSet,
-				f,
 				qosGoldVACName,
 				qosParameters)
 			if err != nil {
@@ -5951,7 +5949,6 @@ var _ = Describe("RBD", func() {
 			// create flex vac
 			err = createRBDVolumeAttributesClass(
 				f.ClientSet,
-				f,
 				qosFlexVACName,
 				qosParameters)
 			if err != nil {
@@ -6146,6 +6143,786 @@ var _ = Describe("RBD", func() {
 			// END: validate created backend rbd images
 			validateRBDImageCount(f, 0, defaultRBDPool)
 			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+		})
+
+		It("validate cgroup v2 qos by volumeattributesclass", func() {
+			if !supportsVolumeAttributesClass(c, f) {
+				framework.Logf("skipping VolumeAttributesClass test, needs Kubernetes >= 1.34 and ceph-csi >= 3.17")
+
+				return
+			}
+
+			// Recreate the StorageClass with krbd mounter and controller-modify-secret
+			// for VAC modifications.
+			err := deleteResource(rbdExamplePath + "storageclass.yaml")
+			if err != nil {
+				logAndFail("failed to delete storageclass: %v", err)
+			}
+			err = createKRBDStorageClassWithModifySecret(f, defaultSCName)
+			if err != nil {
+				logAndFail("failed to create storageclass with krbd mounter: %v", err)
+			}
+			defer func() {
+				err = deleteResource(rbdExamplePath + "storageclass.yaml")
+				if err != nil {
+					logAndFail("failed to delete storageclass: %v", err)
+				}
+				err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, nil, deletePolicy)
+				if err != nil {
+					logAndFail("failed to create storageclass: %v", err)
+				}
+			}()
+
+			var (
+				cgroupLowVACName    = "cgroup-qos-low"
+				cgroupMediumVACName = "cgroup-qos-medium"
+				cgroupHighVACName   = "cgroup-qos-high"
+			)
+
+			// Create low-tier VAC
+			lowQosParams := map[string]string{
+				"maxReadIops":            "500",
+				"maxWriteIops":           "500",
+				"maxReadBps":  "52428800", // 50 MB/s
+				"maxWriteBps": "52428800",
+			}
+			err = createRBDVolumeAttributesClass(f.ClientSet, cgroupLowVACName, lowQosParams)
+			if err != nil {
+				logAndFail("failed to create cgroup-qos-low volumeattributesclass: %v", err)
+			}
+			defer func() {
+				err = deleteRBDVolumeAttributesClass(f.ClientSet, f, cgroupLowVACName)
+				if err != nil {
+					logAndFail("failed to delete cgroup-qos-low volumeattributesclass: %v", err)
+				}
+			}()
+
+			// Create medium-tier VAC
+			mediumQosParams := map[string]string{
+				"maxReadIops":            "1000",
+				"maxWriteIops":           "1000",
+				"maxReadBps":  "104857600", // 100 MB/s
+				"maxWriteBps": "104857600",
+			}
+			err = createRBDVolumeAttributesClass(f.ClientSet, cgroupMediumVACName, mediumQosParams)
+			if err != nil {
+				logAndFail("failed to create cgroup-qos-medium volumeattributesclass: %v", err)
+			}
+			defer func() {
+				err = deleteRBDVolumeAttributesClass(f.ClientSet, f, cgroupMediumVACName)
+				if err != nil {
+					logAndFail("failed to delete cgroup-qos-medium volumeattributesclass: %v", err)
+				}
+			}()
+
+			// Create high-tier VAC
+			highQosParams := map[string]string{
+				"maxReadIops":            "2000",
+				"maxWriteIops":           "2000",
+				"maxReadBps":  "209715200", // 200 MB/s
+				"maxWriteBps": "209715200",
+			}
+			err = createRBDVolumeAttributesClass(f.ClientSet, cgroupHighVACName, highQosParams)
+			if err != nil {
+				logAndFail("failed to create cgroup-qos-high volumeattributesclass: %v", err)
+			}
+			defer func() {
+				err = deleteRBDVolumeAttributesClass(f.ClientSet, f, cgroupHighVACName)
+				if err != nil {
+					logAndFail("failed to delete cgroup-qos-high volumeattributesclass: %v", err)
+				}
+			}()
+
+			// Scenario 1: RWO Filesystem with cgroup QoS
+			By("testing basic RWO filesystem volume with cgroup QoS")
+			pvc, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC: %v", err)
+			}
+			pvc.Namespace = f.UniqueName
+			pvc.Spec.VolumeAttributesClassName = &cgroupMediumVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+			validateOmapCount(f, 1, rbdType, defaultRBDPool, volumesType)
+
+			// Validate metadata
+			wantsMedium := map[string]string{
+				"maxReadIops":            "1000",
+				"maxWriteIops":           "1000",
+				"maxReadBps":  "104857600",
+				"maxWriteBps": "104857600",
+			}
+			err = validateCgroupQoS(f, pvc, wantsMedium)
+			if err != nil {
+				logAndFail("failed to validate cgroup QoS metadata: %v", err)
+			}
+
+			app, err := loadApp(appPath)
+			if err != nil {
+				logAndFail("failed to load app: %v", err)
+			}
+			app.Namespace = f.UniqueName
+			app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvc.Name
+			err = createApp(f.ClientSet, app, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create app: %v", err)
+			}
+			err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete app: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 2: RWO Block with cgroup QoS + I/O enforcement
+			By("testing RWO block volume with cgroup QoS")
+			pvcBlock, err := loadPVC(rawPvcPath)
+			if err != nil {
+				logAndFail("failed to load raw PVC: %v", err)
+			}
+			pvcBlock.Namespace = f.UniqueName
+			pvcBlock.Spec.VolumeAttributesClassName = &cgroupLowVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcBlock, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create raw PVC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			wantsLow := map[string]string{
+				"maxReadIops":            "500",
+				"maxWriteIops":           "500",
+				"maxReadBps":  "52428800",
+				"maxWriteBps": "52428800",
+			}
+			err = validateCgroupQoS(f, pvcBlock, wantsLow)
+			if err != nil {
+				logAndFail("failed to validate cgroup QoS metadata for block volume: %v", err)
+			}
+
+			appBlock, err := loadApp(rawAppPath)
+			if err != nil {
+				logAndFail("failed to load raw app: %v", err)
+			}
+			appBlock.Namespace = f.UniqueName
+			appBlock.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcBlock.Name
+			err = createApp(f.ClientSet, appBlock, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create raw app: %v", err)
+			}
+
+			// Test I/O enforcement
+			err = testIOEnforcement(f, appBlock, "/dev/xvda", true, wantsLow)
+			if err != nil {
+				framework.Logf("I/O enforcement test: %v (best-effort, continuing)", err)
+			}
+
+			err = deletePod(appBlock.Name, appBlock.Namespace, f.ClientSet, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete raw app: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcBlock, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete raw PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 3: RWOP with cgroup QoS
+			By("testing RWOP volume with cgroup QoS")
+			pvcRWOP, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC for RWOP: %v", err)
+			}
+			pvcRWOP.Namespace = f.UniqueName
+			rwopMode := v1.PersistentVolumeAccessMode("ReadWriteOncePod")
+			pvcRWOP.Spec.AccessModes = []v1.PersistentVolumeAccessMode{rwopMode}
+			pvcRWOP.Spec.VolumeAttributesClassName = &cgroupHighVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcRWOP, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create RWOP PVC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			wantsHigh := map[string]string{
+				"maxReadIops":            "2000",
+				"maxWriteIops":           "2000",
+				"maxReadBps":  "209715200",
+				"maxWriteBps": "209715200",
+			}
+			err = validateCgroupQoS(f, pvcRWOP, wantsHigh)
+			if err != nil {
+				logAndFail("failed to validate cgroup QoS for RWOP: %v", err)
+			}
+
+			appRWOP, err := loadApp(appPath)
+			if err != nil {
+				logAndFail("failed to load app for RWOP: %v", err)
+			}
+			appRWOP.Namespace = f.UniqueName
+			appRWOP.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcRWOP.Name
+			err = createApp(f.ClientSet, appRWOP, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create RWOP app: %v", err)
+			}
+			err = deletePod(appRWOP.Name, appRWOP.Namespace, f.ClientSet, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete RWOP app: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcRWOP, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete RWOP PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 6: Multi-PVC Pod (CRITICAL - tests updateIOMaxForDevice)
+			By("testing multi-PVC pod (critical for updateIOMaxForDevice)")
+			pvc0, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC-0: %v", err)
+			}
+			pvc0.Name = "rbd-pvc-0"
+			pvc0.Namespace = f.UniqueName
+			pvc0.Spec.VolumeAttributesClassName = &cgroupLowVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvc0, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC-0: %v", err)
+			}
+
+			pvc1, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC-1: %v", err)
+			}
+			pvc1.Name = "rbd-pvc-1"
+			pvc1.Namespace = f.UniqueName
+			pvc1.Spec.VolumeAttributesClassName = &cgroupMediumVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvc1, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC-1: %v", err)
+			}
+
+			pvc2, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC-2: %v", err)
+			}
+			pvc2.Name = "rbd-pvc-2"
+			pvc2.Namespace = f.UniqueName
+			pvc2.Spec.VolumeAttributesClassName = &cgroupHighVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvc2, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC-2: %v", err)
+			}
+			validateRBDImageCount(f, 3, defaultRBDPool)
+			validateOmapCount(f, 3, rbdType, defaultRBDPool, volumesType)
+
+			// Validate each PVC's QoS metadata
+			err = validateCgroupQoS(f, pvc0, wantsLow)
+			if err != nil {
+				logAndFail("failed to validate cgroup QoS for PVC-0: %v", err)
+			}
+			err = validateCgroupQoS(f, pvc1, wantsMedium)
+			if err != nil {
+				logAndFail("failed to validate cgroup QoS for PVC-1: %v", err)
+			}
+			err = validateCgroupQoS(f, pvc2, wantsHigh)
+			if err != nil {
+				logAndFail("failed to validate cgroup QoS for PVC-2: %v", err)
+			}
+
+			// Create multi-PVC pod
+			pvcs := []*v1.PersistentVolumeClaim{pvc0, pvc1, pvc2}
+			multiPod, err := createMultiPVCPod(f, pvcs, "pod-multi-pvc-fs", false)
+			if err != nil {
+				logAndFail("failed to create multi-PVC pod: %v", err)
+			}
+
+			// Delete multi-PVC pod and PVCs
+			err = deletePod(multiPod.Name, multiPod.Namespace, f.ClientSet, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete multi-PVC pod: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvc0, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC-0: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvc1, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC-1: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvc2, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC-2: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 7: VAC Modification
+			By("testing VAC modification")
+			pvc, err = loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC for VAC modification: %v", err)
+			}
+			pvc.Namespace = f.UniqueName
+			pvc.Spec.VolumeAttributesClassName = &cgroupLowVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC for VAC modification: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			// Validate initial QoS
+			err = validateCgroupQoS(f, pvc, wantsLow)
+			if err != nil {
+				logAndFail("failed to validate initial cgroup QoS: %v", err)
+			}
+
+			// Modify VAC from low to high
+			err = modifyPVCVolumeAttributesClass(f.ClientSet, pvc, cgroupHighVACName)
+			if err != nil {
+				logAndFail("failed to modify VAC: %v", err)
+			}
+
+			// Validate modified QoS
+			err = validateCgroupQoS(f, pvc, wantsHigh)
+			if err != nil {
+				logAndFail("failed to validate modified cgroup QoS: %v", err)
+			}
+
+			err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 8: Partial VAC Update
+			By("testing partial VAC update")
+			partialVACName := "cgroup-qos-partial"
+			partialQosParams := map[string]string{
+				"maxReadIops":  "750",
+				"maxWriteIops": "750",
+			}
+			err = createRBDVolumeAttributesClass(f.ClientSet, partialVACName, partialQosParams)
+			if err != nil {
+				logAndFail("failed to create partial VAC: %v", err)
+			}
+			defer func() {
+				err = deleteRBDVolumeAttributesClass(f.ClientSet, f, partialVACName)
+				if err != nil {
+					logAndFail("failed to delete partial VAC: %v", err)
+				}
+			}()
+
+			pvc, err = loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC for partial VAC: %v", err)
+			}
+			pvc.Namespace = f.UniqueName
+			pvc.Spec.VolumeAttributesClassName = &cgroupMediumVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC: %v", err)
+			}
+
+			// Modify to partial VAC (only IOPS, no BPS)
+			err = modifyPVCVolumeAttributesClass(f.ClientSet, pvc, partialVACName)
+			if err != nil {
+				logAndFail("failed to modify to partial VAC: %v", err)
+			}
+
+			// Validate only IOPS parameters present
+			wantsPartial := map[string]string{
+				"maxReadIops":  "750",
+				"maxWriteIops": "750",
+			}
+			err = validateCgroupQoS(f, pvc, wantsPartial)
+			if err != nil {
+				logAndFail("failed to validate partial cgroup QoS: %v", err)
+			}
+
+			err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 11: Snapshot/Clone Non-Propagation
+			By("testing snapshot/clone QoS non-propagation")
+			pvcParent, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load parent PVC: %v", err)
+			}
+			pvcParent.Namespace = f.UniqueName
+			pvcParent.Spec.VolumeAttributesClassName = &cgroupMediumVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcParent, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create parent PVC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			// Validate parent QoS
+			err = validateCgroupQoS(f, pvcParent, wantsMedium)
+			if err != nil {
+				logAndFail("failed to validate parent cgroup QoS: %v", err)
+			}
+
+			// Create snapshot class
+			err = createRBDSnapshotClass(f)
+			if err != nil {
+				logAndFail("failed to create snapshot class: %v", err)
+			}
+			defer func() {
+				err = deleteRBDSnapshotClass()
+				if err != nil {
+					logAndFail("failed to delete snapshot class: %v", err)
+				}
+			}()
+
+			// Create snapshot
+			snap := getSnapshot(snapshotPath)
+			snap.Namespace = f.UniqueName
+			snap.Spec.Source.PersistentVolumeClaimName = &pvcParent.Name
+			err = createSnapshot(&snap, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create snapshot: %v", err)
+			}
+			validateRBDImageCount(f, 2, defaultRBDPool) // parent + snapshot
+
+			// Create clone from snapshot with different VAC
+			pvcClone, err := loadPVC(pvcClonePath)
+			if err != nil {
+				logAndFail("failed to load clone PVC: %v", err)
+			}
+			pvcClone.Namespace = f.UniqueName
+			pvcClone.Spec.VolumeAttributesClassName = &cgroupLowVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create clone PVC: %v", err)
+			}
+			validateRBDImageCount(f, 3, defaultRBDPool) // parent + snapshot + clone
+
+			// Validate clone has its own QoS (low), NOT parent's (medium)
+			err = validateCgroupQoS(f, pvcClone, wantsLow)
+			if err != nil {
+				logAndFail("failed to validate clone cgroup QoS: %v", err)
+			}
+
+			// Cleanup
+			err = deleteSnapshot(&snap, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete snapshot: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete clone PVC: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcParent, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete parent PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 4: RWX Block with deployment
+			By("testing RWX block volume with deployment")
+			pvcRWX, err := loadPVC(rawPvcPath)
+			if err != nil {
+				logAndFail("failed to load RWX raw PVC: %v", err)
+			}
+			pvcRWX.Namespace = f.UniqueName
+			pvcRWX.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteMany}
+			pvcRWX.Spec.VolumeAttributesClassName = &cgroupMediumVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcRWX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create RWX raw PVC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			// Validate QoS metadata
+			err = validateCgroupQoS(f, pvcRWX, wantsMedium)
+			if err != nil {
+				logAndFail("failed to validate RWX cgroup QoS: %v", err)
+			}
+
+			// Create deployment with 3 replicas
+			deployRWX, err := loadAppDeployment(deployBlockAppPath)
+			if err != nil {
+				logAndFail("failed to load block deployment: %v", err)
+			}
+			deployRWX.Namespace = f.UniqueName
+			deployRWX.Name = "deploy-rwx-qos"
+			replicas := int32(3)
+			deployRWX.Spec.Replicas = &replicas
+			deployRWX.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcRWX.Name
+
+			err = createDeploymentApp(f.ClientSet, deployRWX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create RWX deployment: %v", err)
+			}
+
+			// Delete deployment and PVC
+			err = deleteDeploymentApp(f.ClientSet, deployRWX.Name, deployRWX.Namespace, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete RWX deployment: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcRWX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete RWX PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 5: ROX Filesystem with clone + deployment
+			By("testing ROX filesystem volume with clone and deployment")
+			pvcROXParent, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load ROX parent PVC: %v", err)
+			}
+			pvcROXParent.Namespace = f.UniqueName
+			pvcROXParent.Spec.VolumeAttributesClassName = &cgroupLowVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcROXParent, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create ROX parent PVC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			snapROX := getSnapshot(snapshotPath)
+			snapROX.Namespace = f.UniqueName
+			snapROX.Spec.Source.PersistentVolumeClaimName = &pvcROXParent.Name
+			err = createSnapshot(&snapROX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create snapshot for ROX: %v", err)
+			}
+			validateRBDImageCount(f, 2, defaultRBDPool)
+
+			// Create ROX clone from snapshot
+			pvcROX, err := loadPVC(pvcClonePath)
+			if err != nil {
+				logAndFail("failed to load ROX clone PVC: %v", err)
+			}
+			pvcROX.Namespace = f.UniqueName
+			pvcROX.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}
+			pvcROX.Spec.VolumeAttributesClassName = &cgroupMediumVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcROX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create ROX clone PVC: %v", err)
+			}
+			validateRBDImageCount(f, 3, defaultRBDPool)
+
+			// Validate ROX QoS
+			err = validateCgroupQoS(f, pvcROX, wantsMedium)
+			if err != nil {
+				logAndFail("failed to validate ROX cgroup QoS: %v", err)
+			}
+
+			// Create deployment with ROX volume
+			deployROX, err := loadAppDeployment(deployFSAppPath)
+			if err != nil {
+				logAndFail("failed to load ROX deployment: %v", err)
+			}
+			deployROX.Namespace = f.UniqueName
+			deployROX.Name = "deploy-rox-qos"
+			replicas = int32(3)
+			deployROX.Spec.Replicas = &replicas
+			deployROX.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcROX.Name
+			deployROX.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ReadOnly = true
+
+			err = createDeploymentApp(f.ClientSet, deployROX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create ROX deployment: %v", err)
+			}
+
+			// Cleanup ROX resources
+			err = deleteDeploymentApp(f.ClientSet, deployROX.Name, deployROX.Namespace, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete ROX deployment: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcROX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete ROX PVC: %v", err)
+			}
+			err = deleteSnapshot(&snapROX, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete ROX snapshot: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcROXParent, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete ROX parent PVC: %v", err)
+			}
+
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 10: Add VAC to Existing PVC
+			By("testing add VAC to existing PVC")
+			pvc, err = loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC without VAC: %v", err)
+			}
+			pvc.Namespace = f.UniqueName
+			// No VAC initially
+			err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC without VAC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			// Validate no QoS metadata initially
+			err = validateCgroupQoS(f, pvc, map[string]string{})
+			if err != nil {
+				logAndFail("failed to validate no QoS initially: %v", err)
+			}
+
+			// Add VAC to existing PVC
+			err = modifyPVCVolumeAttributesClass(f.ClientSet, pvc, cgroupHighVACName)
+			if err != nil {
+				logAndFail("failed to add VAC to existing PVC: %v", err)
+			}
+
+			// Validate QoS metadata now present
+			err = validateCgroupQoS(f, pvc, wantsHigh)
+			if err != nil {
+				logAndFail("failed to validate QoS after adding VAC: %v", err)
+			}
+
+			err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 14: Cgroup QoS with volume expansion
+			By("testing cgroup QoS with volume expansion")
+			pvcExpand, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC for expansion: %v", err)
+			}
+			pvcExpand.Namespace = f.UniqueName
+			pvcExpand.Spec.VolumeAttributesClassName = &cgroupLowVACName
+			pvcExpand.Spec.Resources.Requests[v1.ResourceStorage] = resource.MustParse("1Gi")
+			err = createPVCAndvalidatePV(f.ClientSet, pvcExpand, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC for expansion: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			// Validate initial QoS
+			err = validateCgroupQoS(f, pvcExpand, wantsLow)
+			if err != nil {
+				logAndFail("failed to validate QoS before expansion: %v", err)
+			}
+
+			app, err = loadApp(appPath)
+			if err != nil {
+				logAndFail("failed to load app: %v", err)
+			}
+			app.Namespace = f.UniqueName
+			app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcExpand.Name
+			err = createApp(f.ClientSet, app, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create app: %v", err)
+			}
+
+			// Expand volume
+			err = expandPVCSize(f.ClientSet, pvcExpand, "2Gi", deployTimeout)
+			if err != nil {
+				logAndFail("failed to expand PVC: %v", err)
+			}
+
+			// Validate QoS still present after expansion
+			err = validateCgroupQoS(f, pvcExpand, wantsLow)
+			if err != nil {
+				logAndFail("failed to validate QoS after expansion: %v", err)
+			}
+
+			err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete app: %v", err)
+			}
+
+			err = deletePVCAndValidatePV(f.ClientSet, pvcExpand, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete expanded PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Scenario 15: Cgroup QoS with encrypted volumes
+			By("testing cgroup QoS with encrypted volumes")
+			// Temporarily recreate SC with encryption + krbd + controller-modify-secret
+			err = deleteResource(rbdExamplePath + "storageclass.yaml")
+			if err != nil {
+				logAndFail("failed to delete storageclass for encryption: %v", err)
+			}
+			encryptionParams := map[string]string{
+				"encrypted": "true",
+				"csi.storage.k8s.io/controller-modify-secret-namespace": cephCSINamespace,
+				"csi.storage.k8s.io/controller-modify-secret-name":      rbdProvisionerSecretName,
+			}
+			err = createRBDStorageClass(f.ClientSet, f, defaultSCName, nil, encryptionParams, deletePolicy)
+			if err != nil {
+				logAndFail("failed to create encrypted storageclass: %v", err)
+			}
+
+			pvcEncrypted, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC for encryption: %v", err)
+			}
+			pvcEncrypted.Namespace = f.UniqueName
+			pvcEncrypted.Spec.VolumeAttributesClassName = &cgroupMediumVACName
+			err = createPVCAndvalidatePV(f.ClientSet, pvcEncrypted, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create encrypted PVC: %v", err)
+			}
+			validateRBDImageCount(f, 1, defaultRBDPool)
+
+			// Validate QoS on encrypted volume
+			err = validateCgroupQoS(f, pvcEncrypted, wantsMedium)
+			if err != nil {
+				logAndFail("failed to validate QoS on encrypted volume: %v", err)
+			}
+
+			// Mount and verify encryption + QoS
+			appEncrypted, err := loadApp(appPath)
+			if err != nil {
+				logAndFail("failed to load app for encrypted volume: %v", err)
+			}
+			appEncrypted.Namespace = f.UniqueName
+			appEncrypted.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcEncrypted.Name
+			err = createApp(f.ClientSet, appEncrypted, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create app with encrypted volume: %v", err)
+			}
+
+			err = deletePod(appEncrypted.Name, appEncrypted.Namespace, f.ClientSet, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete encrypted app: %v", err)
+			}
+			err = deletePVCAndValidatePV(f.ClientSet, pvcEncrypted, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete encrypted PVC: %v", err)
+			}
+			validateRBDImageCount(f, 0, defaultRBDPool)
+			validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+
+			// Restore original SC (krbd + controller-modify-secret, no encryption)
+			err = deleteResource(rbdExamplePath + "storageclass.yaml")
+			if err != nil {
+				logAndFail("failed to delete encrypted storageclass: %v", err)
+			}
+			err = createKRBDStorageClassWithModifySecret(f, defaultSCName)
+			if err != nil {
+				logAndFail("failed to recreate krbd storageclass: %v", err)
+			}
 		})
 
 		It("create a PVC and bind it to an app with encrypted RBD volume (default type setting)", func() {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1977,7 +1977,8 @@ func modifyPVCVolumeAttributesClass(
 			return false, fmt.Errorf("failed to get pvc: %w", err)
 		}
 
-		if *updatedPVC.Status.CurrentVolumeAttributesClassName != vacName {
+		if updatedPVC.Status.CurrentVolumeAttributesClassName == nil ||
+			*updatedPVC.Status.CurrentVolumeAttributesClassName != vacName {
 			return false, nil
 		}
 

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -19,7 +19,9 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -195,6 +197,23 @@ func createRBDStorageClass(
 
 		return true, nil
 	})
+}
+
+// createKRBDStorageClassWithModifySecret creates a StorageClass configured for
+// krbd mounter (default) with controller-modify-secret for VolumeAttributesClass support.
+// This is required for testing cgroup v2 QoS with VAC modification.
+func createKRBDStorageClassWithModifySecret(f *framework.Framework, scName string) error {
+	deletePolicy := v1.PersistentVolumeReclaimDelete
+
+	parameters := map[string]string{
+		// Empty mounter = krbd (default mounter)
+		"mounter": "",
+		// controller-modify-secret required for VAC modification
+		"csi.storage.k8s.io/controller-modify-secret-namespace": cephCSINamespace,
+		"csi.storage.k8s.io/controller-modify-secret-name":      rbdProvisionerSecretName,
+	}
+
+	return createRBDStorageClass(f.ClientSet, f, scName, nil, parameters, deletePolicy)
 }
 
 func createRadosNamespace(f *framework.Framework) error {
@@ -1382,6 +1401,192 @@ func validateQOS(f *framework.Framework,
 	return nil
 }
 
+// validateCgroupQoS validates cgroup v2 QoS parameters stored in RBD image metadata.
+// The wants map uses VolumeAttributesClass parameter names as keys:
+//   - "maxReadIops", "maxWriteIops"
+//   - "maxReadBps", "maxWriteBps"
+func validateCgroupQoS(f *framework.Framework,
+	pvc *v1.PersistentVolumeClaim,
+	wants map[string]string,
+) error {
+	// Cgroup QoS metadata keys are prefixed to prevent clone/snapshot propagation
+	metadataPrefix := ".rbd.csi.ceph.com/cgroup_qos_"
+
+	// Map VolumeAttributesClass parameter names to metadata keys
+	paramToMetadataKey := map[string]string{
+		"maxReadIops":  metadataPrefix + "max_read_iops",
+		"maxWriteIops": metadataPrefix + "max_write_iops",
+		"maxReadBps":   metadataPrefix + "max_read_bps",
+		"maxWriteBps":  metadataPrefix + "max_write_bps",
+	}
+
+	imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
+	if err != nil {
+		return err
+	}
+
+	rbdImageSpec := imageSpec(defaultRBDPool, imageData.imageName)
+	for param, metadataKey := range paramToMetadataKey {
+		expectedValue, shouldExist := wants[param]
+
+		actualValue, err := getImageMeta(rbdImageSpec, metadataKey, f)
+		if shouldExist {
+			if err != nil {
+				return fmt.Errorf("failed to get %s: %w", metadataKey, err)
+			}
+			if actualValue != expectedValue {
+				return fmt.Errorf("%s: got %q, want %q", param, actualValue, expectedValue)
+			}
+		} else if err == nil {
+			return fmt.Errorf("%s should be absent but found value %q", param, actualValue)
+		}
+	}
+
+	return nil
+}
+
+// testIOEnforcement validates that I/O operations respect cgroup QoS limits.
+// Uses dd with direct I/O to measure write throughput and compares against expected limits.
+// Allows 20% tolerance margin to account for measurement variance and kernel overhead.
+func testIOEnforcement(f *framework.Framework,
+	pod *v1.Pod,
+	volumePath string,
+	isBlock bool,
+	limits map[string]string,
+) error {
+	// Parse expected write bandwidth limit
+	maxWriteBpsStr, ok := limits["maxWriteBps"]
+	if !ok {
+		return fmt.Errorf("maxWriteBps not specified in limits")
+	}
+
+	maxWriteBps, err := strconv.ParseInt(maxWriteBpsStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse maxWriteBps: %w", err)
+	}
+
+	containerName := pod.Spec.Containers[0].Name
+
+	// For block devices, write directly to the device path.
+	// For filesystem volumes, create a test file under the mount path.
+	target := volumePath
+	if !isBlock {
+		target = volumePath + "/qos_test_file"
+	}
+
+	// Run dd write test: 100MB with direct I/O.
+	// Using direct I/O (oflag=direct) bypasses page cache and hits cgroup limits.
+	// dd outputs: "N bytes copied, T s, R MB/s" — parse the rate and unit to compute bytes/sec.
+	cmd := fmt.Sprintf(
+		"dd if=/dev/zero of=%s bs=1M count=100 oflag=direct 2>&1 | "+
+			"awk -F', ' '/copied/ {print $(NF)}' | "+
+			"awk '{rate=$1; unit=$2; m=1; "+
+			"if(unit==\"GB/s\") m=1e9; "+
+			"else if(unit==\"MB/s\") m=1e6; "+
+			"else if(unit==\"kB/s\") m=1e3; "+
+			"else if(unit==\"GiB/s\") m=1073741824; "+
+			"else if(unit==\"MiB/s\") m=1048576; "+
+			"else if(unit==\"KiB/s\") m=1024; "+
+			"printf \"%%.0f\\n\", rate*m}'",
+		target)
+
+	framework.Logf("running I/O enforcement test with command: %s", cmd)
+	output, stdErr, err := execCommandInContainerByPodName(f, cmd, pod.Namespace, pod.Name, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to run dd test: %w (stderr: %s)", err, stdErr)
+	}
+
+	// Parse throughput from dd output
+	actualBpsStr := strings.TrimSpace(output)
+	actualBps, err := strconv.ParseInt(actualBpsStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse throughput from output %q: %w", output, err)
+	}
+
+	// Allow 20% tolerance for measurement variance
+	toleranceMargin := 1.20
+	maxAllowedBps := int64(float64(maxWriteBps) * toleranceMargin)
+
+	framework.Logf("I/O enforcement test: actual=%d bps, limit=%d bps, max_allowed=%d bps (%.0f%% tolerance)",
+		actualBps, maxWriteBps, maxAllowedBps, (toleranceMargin-1)*100)
+
+	if actualBps > maxAllowedBps {
+		return fmt.Errorf("write throughput %d bps exceeds limit %d bps (with %.0f%% tolerance margin)",
+			actualBps, maxWriteBps, (toleranceMargin-1)*100)
+	}
+
+	framework.Logf("I/O enforcement validated: actual throughput within limits")
+
+	return nil
+}
+
+// createMultiPVCPod creates a pod with multiple RBD volumes attached.
+// Critical for testing updateIOMaxForDevice read-modify-write logic.
+// When a pod has multiple volumes, each volume's QoS must be written to the same
+// io.max file without overwriting others.
+func createMultiPVCPod(f *framework.Framework,
+	pvcs []*v1.PersistentVolumeClaim,
+	podName string,
+	isBlock bool,
+) (*v1.Pod, error) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: f.UniqueName,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "app-container",
+					Image:           "quay.io/centos/centos:latest",
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Command:         []string{"/bin/sleep", "infinity"},
+				},
+			},
+		},
+	}
+
+	// Add volumes and volume mounts/devices
+	for i, pvc := range pvcs {
+		volumeName := fmt.Sprintf("vol-%d", i)
+
+		// Add volume source
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			Name: volumeName,
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvc.Name,
+				},
+			},
+		})
+
+		if isBlock {
+			// Block mode - add volume device
+			devicePath := fmt.Sprintf("/dev/xvd%c", 'a'+i)
+			pod.Spec.Containers[0].VolumeDevices = append(pod.Spec.Containers[0].VolumeDevices,
+				v1.VolumeDevice{
+					Name:       volumeName,
+					DevicePath: devicePath,
+				})
+		} else {
+			// Filesystem mode - add volume mount
+			mountPath := fmt.Sprintf("/mnt/vol-%d", i)
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts,
+				v1.VolumeMount{
+					Name:      volumeName,
+					MountPath: mountPath,
+				})
+		}
+	}
+
+	err := createApp(f.ClientSet, pod, deployTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return pod, nil
+}
+
 func validateDataPool(f *framework.Framework, imageName, poolName string, wants string) error {
 	var imgInfo imageInfo
 	imgInfoStr, err := getImageInfo(f, imageName, poolName)
@@ -1664,43 +1869,41 @@ func validateServiceAccountVolumeRestriction(
 
 func createRBDVolumeAttributesClass(
 	c kubernetes.Interface,
-	f *framework.Framework,
 	name string,
 	params map[string]string,
 ) error {
-	vacPath := fmt.Sprintf("%s/%s", rbdExamplePath, "volumeattributesclass.yaml")
-	vac, err := getVolumeAttributesClass(vacPath)
-	if err != nil {
-		return fmt.Errorf("failed to get vac: %w", err)
+	if name == "" {
+		return errors.New("name is required for VolumeAttributesClass")
 	}
-	if name != "" {
-		vac.Name = name
+	// Create a clean VolumeAttributesClass instead of loading from template
+	// to avoid mixing NBD QoS parameters from the template with cgroup QoS parameters.
+	vac := scv1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		DriverName: "rbd.csi.ceph.com",
+		Parameters: make(map[string]string),
 	}
 
-	// overload any parameters that were passed
-	if params == nil {
-		// create an empty params, so that params["clusterID"] below
-		// does not panic
-		params = map[string]string{}
-	}
-	for param, value := range params {
-		vac.Parameters[param] = value
+	// Add provided parameters
+	if params != nil {
+		maps.Copy(vac.Parameters, params)
 	}
 
 	timeout := time.Duration(deployTimeout) * time.Minute
 
 	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(ctx context.Context) (bool, error) {
-		_, err = c.StorageV1().VolumeAttributesClasses().Create(ctx, &vac, metav1.CreateOptions{})
-		if err != nil {
-			framework.Logf("error creating VolumeAttributesClass %q: %v", vac.Name, err)
-			if apierrs.IsAlreadyExists(err) {
+		_, createErr := c.StorageV1().VolumeAttributesClasses().Create(ctx, &vac, metav1.CreateOptions{})
+		if createErr != nil {
+			framework.Logf("error creating VolumeAttributesClass %q: %v", vac.Name, createErr)
+			if apierrs.IsAlreadyExists(createErr) {
 				return true, nil
 			}
-			if isRetryableAPIError(err) {
+			if isRetryableAPIError(createErr) {
 				return false, nil
 			}
 
-			return false, fmt.Errorf("failed to create VolumeAttributesClass %q: %w", vac.Name, err)
+			return false, fmt.Errorf("failed to create VolumeAttributesClass %q: %w", vac.Name, createErr)
 		}
 
 		return true, nil

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -156,6 +156,9 @@ func createRBDStorageClass(
 	sc.Parameters["csi.storage.k8s.io/node-stage-secret-namespace"] = cephCSINamespace
 	sc.Parameters["csi.storage.k8s.io/node-stage-secret-name"] = rbdNodePluginSecretName
 
+	sc.Parameters["csi.storage.k8s.io/node-publish-secret-namespace"] = cephCSINamespace
+	sc.Parameters["csi.storage.k8s.io/node-publish-secret-name"] = rbdNodePluginSecretName
+
 	fsID, err := getClusterID(f)
 	if err != nil {
 		return fmt.Errorf("failed to get clusterID: %w", err)

--- a/e2e/resize.go
+++ b/e2e/resize.go
@@ -49,10 +49,10 @@ func expandPVCSize(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, size s
 	Expect(err).ShouldNot(HaveOccurred())
 
 	start := time.Now()
-	framework.Logf("Waiting up to %v to be in Resized state", pvc)
+	framework.Logf("Waiting up to %v to be in Resized state", updatedPVC)
 
 	return wait.PollUntilContextTimeout(ctx, poll, timeout, true, func(ctx context.Context) (bool, error) {
-		framework.Logf("waiting for PVC %s (%d seconds elapsed)", pvcName, int(time.Since(start).Seconds()))
+		framework.Logf("waiting for PVC %s to be resized (%d seconds elapsed)", pvcName, int(time.Since(start).Seconds()))
 		updatedPVC, err = c.CoreV1().
 			PersistentVolumeClaims(pvcNamespace).
 			Get(ctx, pvcName, metav1.GetOptions{})
@@ -66,6 +66,9 @@ func expandPVCSize(c kubernetes.Interface, pvc *v1.PersistentVolumeClaim, size s
 		}
 		pvcConditions := updatedPVC.Status.Conditions
 		if len(pvcConditions) > 0 {
+			for _, con := range pvcConditions {
+				framework.Logf("pvc %s condition %v", pvcName, con)
+			}
 			framework.Logf("pvc state %v", pvcConditions[0].Type)
 			if pvcConditions[0].Type == v1.PersistentVolumeClaimResizing ||
 				pvcConditions[0].Type == v1.PersistentVolumeClaimFileSystemResizePending {

--- a/e2e/templates/rbd-multi-pvc-pod-block.yaml
+++ b/e2e/templates/rbd-multi-pvc-pod-block.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-multi-pvc-block
+spec:
+  containers:
+    - name: app-container
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      volumeDevices:
+        - name: vol-0
+          devicePath: /dev/xvda
+        - name: vol-1
+          devicePath: /dev/xvdb
+        - name: vol-2
+          devicePath: /dev/xvdc
+  volumes:
+    - name: vol-0
+      persistentVolumeClaim:
+        claimName: rbd-pvc-0
+    - name: vol-1
+      persistentVolumeClaim:
+        claimName: rbd-pvc-1
+    - name: vol-2
+      persistentVolumeClaim:
+        claimName: rbd-pvc-2

--- a/e2e/templates/rbd-multi-pvc-pod-fs.yaml
+++ b/e2e/templates/rbd-multi-pvc-pod-fs.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-multi-pvc-fs
+spec:
+  containers:
+    - name: app-container
+      image: quay.io/centos/centos:latest
+      command: ["/bin/sleep", "infinity"]
+      volumeMounts:
+        - name: vol-0
+          mountPath: /mnt/vol-0
+        - name: vol-1
+          mountPath: /mnt/vol-1
+        - name: vol-2
+          mountPath: /mnt/vol-2
+  volumes:
+    - name: vol-0
+      persistentVolumeClaim:
+        claimName: rbd-pvc-0
+    - name: vol-1
+      persistentVolumeClaim:
+        claimName: rbd-pvc-1
+    - name: vol-2
+      persistentVolumeClaim:
+        claimName: rbd-pvc-2

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -93,6 +93,9 @@ parameters:
    # controller-modify-secret
    csi.storage.k8s.io/controller-modify-secret-name: csi-rbd-secret
    csi.storage.k8s.io/controller-modify-secret-namespace: default
+   # publish-secret is needed krbd qos
+   csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
+   csi.storage.k8s.io/node-publish-secret-namespace: default
 
    # (optional) Specify the filesystem type of the volume. If not specified,
    # csi-provisioner will set default as `ext4`.

--- a/examples/rbd/volumeattributesclass-cgroup-high.yaml
+++ b/examples/rbd/volumeattributesclass-cgroup-high.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: cgroup-qos-high
+driverName: rbd.csi.ceph.com
+parameters:
+  # High-tier QoS limits
+  # 2000 IOPS for both read and write
+  maxReadIops: "2000"
+  maxWriteIops: "2000"
+  # 200 MB/s for both read and write
+  maxReadBps: "209715200"
+  maxWriteBps: "209715200"

--- a/examples/rbd/volumeattributesclass-cgroup-low.yaml
+++ b/examples/rbd/volumeattributesclass-cgroup-low.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: cgroup-qos-low
+driverName: rbd.csi.ceph.com
+parameters:
+  # Low-tier QoS limits
+  # 500 IOPS for both read and write
+  maxReadIops: "500"
+  maxWriteIops: "500"
+  # 50 MB/s for both read and write
+  maxReadBps: "52428800"
+  maxWriteBps: "52428800"

--- a/examples/rbd/volumeattributesclass-cgroup-medium.yaml
+++ b/examples/rbd/volumeattributesclass-cgroup-medium.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: cgroup-qos-medium
+driverName: rbd.csi.ceph.com
+parameters:
+  # Medium-tier QoS limits
+  # 1000 IOPS for both read and write
+  maxReadIops: "1000"
+  maxWriteIops: "1000"
+  # 100 MB/s for both read and write
+  maxReadBps: "104857600"
+  maxWriteBps: "104857600"

--- a/examples/rbd/volumeattributesclass-cgroup.yaml
+++ b/examples/rbd/volumeattributesclass-cgroup.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: cgroup-qos-vac
+driverName: rbd.csi.ceph.com
+parameters:
+  # Cgroup v2 QoS for krbd (kernel RBD) mounter.
+  # This QoS type applies io.max limits at the container cgroup level,
+  # providing QoS for krbd-mapped volumes.
+  #
+  # Cgroup v2 io.max parameters:
+  # Format for each parameter is a positive integer representing
+  # the limit value.
+  #
+  # (optional) Max read IOPS per second for the device.
+  # Example: "1000" allows up to 1000 read operations per second.
+  maxReadIops: "1000"
+  #
+  # (optional) Max write IOPS per second for the device.
+  # Example: "2000" allows up to 2000 write operations per second.
+  maxWriteIops: "2000"
+  #
+  # (optional) Max read bytes per second for the device.
+  # Example: "104857600" = 100 MiB/s (100 * 1024 * 1024 bytes)
+  maxReadBps: "104857600"
+  #
+  # (optional) Max write bytes per second for the device.
+  # Example: "209715200" = 200 MiB/s (200 * 1024 * 1024 bytes)
+  maxWriteBps: "209715200"

--- a/internal/rbd/cgroup_qos.go
+++ b/internal/rbd/cgroup_qos.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+const (
+
+	// cgroup v2 base path.
+	cgroupV2BasePath = "/sys/fs/cgroup"
+
+	// Kubernetes cgroup slices based on QoS class.
+	kubepodsBestEffortSlice = "kubepods-besteffort.slice"
+	kubepodsBurstableSlice  = "kubepods-burstable.slice"
+	kubepodsGuaranteedSlice = "kubepods.slice"
+
+	// io.max file for cgroup v2.
+	ioMaxFile = "io.max"
+)
+
+// qosClassInfo holds pre-computed cgroup path information for each QoS class.
+// Ordered by most common QoS class in production (Guaranteed > Burstable > BestEffort)
+// to minimize stat() syscalls on average.
+var qosClassInfo = [...]struct {
+	name      string
+	sliceName string
+	podPrefix string
+}{
+	{"Guaranteed", kubepodsGuaranteedSlice, "kubepods-pod"},
+	{"Burstable", kubepodsBurstableSlice, "kubepods-burstable-pod"},
+	{"BestEffort", kubepodsBestEffortSlice, "kubepods-besteffort-pod"},
+}
+
+// cgroupQoS holds cgroup v2 QoS parameters.
+type cgroupQoS struct {
+	// Device major:minor number.
+	deviceID string
+	// Max read IOPS.
+	maxReadIops string
+	// Max write IOPS.
+	maxWriteIops string
+	// Max read bytes per second.
+	maxReadBps string
+	// Max write bytes per second.
+	maxWriteBps string
+}
+
+// parseCgroupQoSParams extracts cgroup v2 QoS parameters from VolumeAttributesClass.
+func parseCgroupQoSParams(params map[string]string) *cgroupQoS {
+	qos := &cgroupQoS{
+		maxReadIops:  "max",
+		maxWriteIops: "max",
+		maxReadBps:   "max",
+		maxWriteBps:  "max",
+	}
+
+	if val, ok := params[maxReadIops]; ok && val != "" {
+		qos.maxReadIops = val
+	}
+	if val, ok := params[maxWriteIops]; ok && val != "" {
+		qos.maxWriteIops = val
+	}
+	if val, ok := params[maxReadBps]; ok && val != "" {
+		qos.maxReadBps = val
+	}
+	if val, ok := params[maxWriteBps]; ok && val != "" {
+		qos.maxWriteBps = val
+	}
+
+	return qos
+}
+
+// hasCgroupQoSParams checks if any cgroup v2 QoS parameters are present.
+func hasCgroupQoSParams(params map[string]string) bool {
+	cgroupParams := []string{maxReadIops, maxWriteIops, maxReadBps, maxWriteBps}
+	for _, param := range cgroupParams {
+		if val, ok := params[param]; ok && val != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getDeviceID returns the device major:minor number for the given device path.
+func getDeviceID(ctx context.Context, devicePath string) (string, error) {
+	// Get the real path if devicePath is a symlink.
+	realPath, err := filepath.EvalSymlinks(devicePath)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to resolve symlink for device %s: %v", devicePath, err)
+
+		return "", err
+	}
+
+	// Read /proc/partitions to get major:minor for the device.
+	data, err := os.ReadFile("/proc/partitions")
+	if err != nil {
+		log.ErrorLog(ctx, "failed to read /proc/partitions: %v", err)
+
+		return "", err
+	}
+
+	deviceName := filepath.Base(realPath)
+	for line := range strings.SplitSeq(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 4 && fields[3] == deviceName {
+			major := fields[0]
+			minor := fields[1]
+
+			return fmt.Sprintf("%s:%s", major, minor), nil
+		}
+	}
+
+	return "", fmt.Errorf("device %s not found in /proc/partitions", deviceName)
+}
+
+// formatIOMax formats the io.max line for cgroup v2.
+// Format: <major>:<minor> rbps=<value> wbps=<value> riops=<value> wiops=<value>.
+func (qos *cgroupQoS) formatIOMax() string {
+	return fmt.Sprintf("%s rbps=%s wbps=%s riops=%s wiops=%s",
+		qos.deviceID, qos.maxReadBps, qos.maxWriteBps, qos.maxReadIops, qos.maxWriteIops)
+}
+
+// writeIOMax writes a single device's QoS line to the cgroup io.max file.
+// Per cgroup v2 conventions, each write targets one device — the kernel
+// merges it with existing entries for other devices atomically.
+func writeIOMax(ioMaxPath, ioMaxLine string) error {
+	return os.WriteFile(ioMaxPath, []byte(ioMaxLine+"\n"), 0o600)
+}
+
+// findPodCgroupPath tries to find the pod's cgroup path by attempting all QoS classes.
+// Optimized to minimize allocations and stat() syscalls per lookup.
+func findPodCgroupPath(ctx context.Context, podUID string) (string, error) {
+	if podUID == "" {
+		return "", errors.New("pod UID is empty")
+	}
+
+	// Normalize pod UID once: replace hyphens with underscores.
+	normalizedUID := strings.ReplaceAll(podUID, "-", "_")
+
+	// Try each QoS class path using pre-computed path prefixes.
+	// Ordered by most common in production: Guaranteed → Burstable → BestEffort.
+	// This minimizes average syscalls (1-2 stat() calls instead of always 3).
+	for i := range qosClassInfo {
+		qos := &qosClassInfo[i]
+		// Construct pod slice name directly (e.g., "kubepods-guaranteed-pod<uid>.slice").
+		// Using string concatenation instead of fmt.Sprintf reduces allocations.
+		podSliceName := qos.podPrefix + normalizedUID + ".slice"
+		podPath := filepath.Join(cgroupV2BasePath, qos.sliceName, podSliceName)
+
+		if _, err := os.Stat(podPath); err == nil {
+			log.DebugLog(ctx, "found pod cgroup path: %s for QoS class: %s", podPath, qos.name)
+
+			return podPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("pod cgroup path not found for pod UID: %s", podUID)
+}
+
+// findContainerCgroups finds all container cgroup directories within a pod's cgroup.
+func findContainerCgroups(ctx context.Context, podCgroupPath string) ([]string, error) {
+	entries, err := os.ReadDir(podCgroupPath)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to read pod cgroup directory %s: %v", podCgroupPath, err)
+
+		return nil, err
+	}
+
+	var containerPaths []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		// Container scopes follow pattern: crio-<container-id>.scope or containerd-<container-id>.scope.
+		if strings.HasPrefix(name, "crio-") || strings.HasPrefix(name, "containerd-") {
+			containerPath := filepath.Join(podCgroupPath, name)
+			containerPaths = append(containerPaths, containerPath)
+			log.DebugLog(ctx, "found container cgroup: %s", containerPath)
+		}
+	}
+
+	if len(containerPaths) == 0 {
+		return nil, fmt.Errorf("no container cgroups found in pod path: %s", podCgroupPath)
+	}
+
+	return containerPaths, nil
+}
+
+// applyCgroupQoS applies QoS limits to all containers in a pod.
+func (qos *cgroupQoS) applyCgroupQoS(ctx context.Context, podUID string) error {
+	if qos.deviceID == "" {
+		return errors.New("device ID is not set for cgroup QoS")
+	}
+
+	// Find the pod's cgroup path.
+	podCgroupPath, err := findPodCgroupPath(ctx, podUID)
+	if err != nil {
+		return fmt.Errorf("failed to find pod cgroup path for pod %s: %w", podUID, err)
+	}
+
+	// Find all container cgroups within the pod.
+	containerPaths, err := findContainerCgroups(ctx, podCgroupPath)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to find container cgroups for pod %s: %v", podUID, err)
+
+		return err
+	}
+
+	// Apply io.max to each container.
+	// Per cgroup v2 conventions, writing a single device line is atomic —
+	// the kernel merges it with existing entries for other devices.
+	ioMaxValue := qos.formatIOMax()
+	for _, containerPath := range containerPaths {
+		ioMaxPath := filepath.Join(containerPath, ioMaxFile)
+		log.DebugLog(ctx, "applying QoS to container: %s, io.max: %s", containerPath, ioMaxValue)
+
+		err = writeIOMax(ioMaxPath, ioMaxValue)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to write io.max for device %s at %s: %v",
+				qos.deviceID, ioMaxPath, err)
+
+			return err
+		}
+
+		log.DebugLog(ctx, "successfully applied QoS to container: %s for device %s",
+			containerPath, qos.deviceID)
+	}
+
+	log.UsefulLog(ctx, "successfully applied cgroup QoS to %d containers in pod %s",
+		len(containerPaths), podUID)
+
+	return nil
+}
+
+// validateCgroupQoSParams validates cgroup QoS parameters.
+func validateCgroupQoSParams(params map[string]string) error {
+	cgroupParams := []string{maxReadIops, maxWriteIops, maxReadBps, maxWriteBps}
+	for _, key := range cgroupParams {
+		if val, ok := params[key]; ok && val != "" {
+			if _, err := strconv.ParseInt(val, 10, 64); err != nil {
+				return fmt.Errorf("invalid value for %s: %s, must be a positive integer", key, val)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/rbd/cgroup_qos.go
+++ b/internal/rbd/cgroup_qos.go
@@ -67,8 +67,9 @@ const (
 	cgroupV2BasePath = "/sys/fs/cgroup"
 
 	// Kubernetes cgroup slices based on QoS class.
-	kubepodsBestEffortSlice = "kubepods-besteffort.slice"
-	kubepodsBurstableSlice  = "kubepods-burstable.slice"
+	// BestEffort and Burstable are nested under kubepods.slice parent.
+	kubepodsBestEffortSlice = "kubepods.slice/kubepods-besteffort.slice"
+	kubepodsBurstableSlice  = "kubepods.slice/kubepods-burstable.slice"
 	kubepodsGuaranteedSlice = "kubepods.slice"
 
 	// io.max file for cgroup v2.
@@ -272,38 +273,8 @@ func findPodCgroupPath(ctx context.Context, podUID string) (string, error) {
 	return "", fmt.Errorf("pod cgroup path not found for pod UID: %s", podUID)
 }
 
-// findContainerCgroups finds all container cgroup directories within a pod's cgroup.
-func findContainerCgroups(ctx context.Context, podCgroupPath string) ([]string, error) {
-	entries, err := os.ReadDir(podCgroupPath)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to read pod cgroup directory %s: %v", podCgroupPath, err)
-
-		return nil, err
-	}
-
-	var containerPaths []string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		name := entry.Name()
-		// Container scopes follow pattern: crio-<container-id>.scope or containerd-<container-id>.scope.
-		if strings.HasPrefix(name, "crio-") || strings.HasPrefix(name, "containerd-") {
-			containerPath := filepath.Join(podCgroupPath, name)
-			containerPaths = append(containerPaths, containerPath)
-			log.DebugLog(ctx, "found container cgroup: %s", containerPath)
-		}
-	}
-
-	if len(containerPaths) == 0 {
-		return nil, fmt.Errorf("no container cgroups found in pod path: %s", podCgroupPath)
-	}
-
-	return containerPaths, nil
-}
-
-// applyCgroupQoS applies QoS limits to all containers in a pod.
+// applyCgroupQoS applies QoS limits at the pod cgroup level.
+// QoS is applied to the pod's io.max file, which automatically applies to all containers.
 func (qos *cgroupQoS) applyCgroupQoS(ctx context.Context, podUID string) error {
 	if qos.deviceID == "" {
 		return errors.New("device ID is not set for cgroup QoS")
@@ -315,36 +286,21 @@ func (qos *cgroupQoS) applyCgroupQoS(ctx context.Context, podUID string) error {
 		return fmt.Errorf("failed to find pod cgroup path for pod %s: %w", podUID, err)
 	}
 
-	// Find all container cgroups within the pod.
-	containerPaths, err := findContainerCgroups(ctx, podCgroupPath)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to find container cgroups for pod %s: %v", podUID, err)
-
-		return err
-	}
-
-	// Apply io.max to each container.
+	// Apply io.max at the pod level.
 	// Per cgroup v2 conventions, writing a single device line is atomic —
 	// the kernel merges it with existing entries for other devices.
+	ioMaxPath := filepath.Join(podCgroupPath, ioMaxFile)
 	ioMaxValue := qos.formatIOMax()
-	for _, containerPath := range containerPaths {
-		ioMaxPath := filepath.Join(containerPath, ioMaxFile)
-		log.DebugLog(ctx, "applying QoS to container: %s, io.max: %s", containerPath, ioMaxValue)
+	log.DebugLog(ctx, "applying QoS to pod cgroup: %s, io.max: %s", podCgroupPath, ioMaxValue)
 
-		err = writeIOMax(ioMaxPath, ioMaxValue)
-		if err != nil {
-			log.ErrorLog(ctx, "failed to write io.max for device %s at %s: %v",
-				qos.deviceID, ioMaxPath, err)
-
-			return err
-		}
-
-		log.DebugLog(ctx, "successfully applied QoS to container: %s for device %s",
-			containerPath, qos.deviceID)
+	err = writeIOMax(ioMaxPath, ioMaxValue)
+	if err != nil {
+		return fmt.Errorf("failed to write io.max for device %s at %s: %w",
+			qos.deviceID, ioMaxPath, err)
 	}
 
-	log.UsefulLog(ctx, "successfully applied cgroup QoS to %d containers in pod %s",
-		len(containerPaths), podUID)
+	log.UsefulLog(ctx, "successfully applied cgroup QoS to pod %s at %s",
+		podUID, ioMaxPath)
 
 	return nil
 }
@@ -424,4 +380,46 @@ func (rv *rbdVolume) getCgroupQoS(ctx context.Context) (map[string]string, error
 	}
 
 	return qosParams, nil
+}
+
+// applyCgroupQoSForVolume applies cgroup v2 QoS limits to the pod mounting this volume.
+func (rv *rbdVolume) applyCgroupQoSForVolume(ctx context.Context, devicePath, podUID string) error {
+	if podUID == "" {
+		log.DebugLog(ctx, "pod UID not available, skipping cgroup QoS (podInfoOnMount may not be enabled)")
+
+		return nil
+	}
+
+	// Retrieve cgroup QoS parameters from image metadata.
+	qosParams, err := rv.getCgroupQoS(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cgroup QoS for volume %s: %w", rv.VolID, err)
+	}
+
+	// If no QoS parameters configured, nothing to do.
+	if len(qosParams) == 0 {
+		log.DebugLog(ctx, "no cgroup QoS configured for volume %s", rv.VolID)
+
+		return nil
+	}
+
+	// Get device ID (major:minor).
+	qos := parseCgroupQoSParams(qosParams)
+	qos.deviceID, err = getDeviceID(ctx, devicePath)
+	if err != nil {
+		return fmt.Errorf("failed to get device ID for %s: %w", devicePath, err)
+	}
+
+	log.UsefulLog(ctx, "applying cgroup QoS for volume %s on device %s to pod %s",
+		rv.VolID, qos.deviceID, podUID)
+
+	// Apply QoS to all containers in the pod.
+	err = qos.applyCgroupQoS(ctx, podUID)
+	if err != nil {
+		return fmt.Errorf("failed to apply cgroup QoS for volume %s: %w", rv.VolID, err)
+	}
+
+	log.UsefulLog(ctx, "successfully applied cgroup QoS for volume %s", rv.VolID)
+
+	return nil
 }

--- a/internal/rbd/cgroup_qos.go
+++ b/internal/rbd/cgroup_qos.go
@@ -25,10 +25,43 @@ import (
 	"strconv"
 	"strings"
 
+	librbd "github.com/ceph/go-ceph/rbd"
+
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
+// QoSHandler defines the interface for different QoS implementations.
+// This abstraction allows clean separation between:
+//   - Traditional NBD QoS (applied via librbd to rbd-nbd device)
+//   - Cgroup v2 QoS (applied via cgroup io.max to krbd device)
+type QoSHandler interface {
+	// HasParams checks if this QoS type has parameters in the request.
+	HasParams(params map[string]string) bool
+
+	// Validate validates the QoS parameters.
+	Validate(params map[string]string) error
+
+	// Apply saves QoS parameters and applies them to the volume.
+	// For cgroup QoS: stores metadata to be applied later during NodePublishVolume.
+	// For NBD QoS: applies immediately to the rbd-nbd device configuration.
+	Apply(ctx context.Context, params map[string]string) error
+
+	// Clear removes all QoS settings for this type.
+	Clear(ctx context.Context) error
+}
+
 const (
+
+	// qosMetadataKeyPrefix is the prefix for QoS metadata keys stored in RBD image.
+	// Keys starting with `.` are not copied to cloned or snapshotted volumes.
+	qosMetadataKeyPrefix = ".rbd.csi.ceph.com/"
+
+	// RBD image metadata keys for cgroup QoS parameters.
+	// Prefixed to prevent propagation during clone/snapshot operations.
+	qosMetadataMaxReadIops  = qosMetadataKeyPrefix + "cgroup_qos_max_read_iops"
+	qosMetadataMaxWriteIops = qosMetadataKeyPrefix + "cgroup_qos_max_write_iops"
+	qosMetadataMaxReadBps   = qosMetadataKeyPrefix + "cgroup_qos_max_read_bps"
+	qosMetadataMaxWriteBps  = qosMetadataKeyPrefix + "cgroup_qos_max_write_bps"
 
 	// cgroup v2 base path.
 	cgroupV2BasePath = "/sys/fs/cgroup"
@@ -53,6 +86,63 @@ var qosClassInfo = [...]struct {
 	{"Guaranteed", kubepodsGuaranteedSlice, "kubepods-pod"},
 	{"Burstable", kubepodsBurstableSlice, "kubepods-burstable-pod"},
 	{"BestEffort", kubepodsBestEffortSlice, "kubepods-besteffort-pod"},
+}
+
+// qosParamToMetadataKey maps VolumeAttributesClass parameter keys to RBD image metadata keys.
+// Metadata keys are prefixed with `.rbd.csi.ceph.com/` to prevent copying during clone/snapshot.
+var qosParamToMetadataKey = map[string]string{
+	maxReadIops:  qosMetadataMaxReadIops,
+	maxWriteIops: qosMetadataMaxWriteIops,
+	maxReadBps:   qosMetadataMaxReadBps,
+	maxWriteBps:  qosMetadataMaxWriteBps,
+}
+
+// qosMetadataToParamKey is the reverse mapping: RBD image metadata keys to parameter keys.
+var qosMetadataToParamKey = func() map[string]string {
+	m := make(map[string]string, len(qosParamToMetadataKey))
+	for k, v := range qosParamToMetadataKey {
+		m[v] = k
+	}
+
+	return m
+}()
+
+// cgroupQoSHandler implements QoSHandler for cgroup v2 QoS (krbd mounter).
+type cgroupQoSHandler struct {
+	volume *rbdVolume
+}
+
+// newCgroupQoSHandler creates a new cgroup QoS handler.
+func newCgroupQoSHandler(volume *rbdVolume) QoSHandler {
+	return &cgroupQoSHandler{volume: volume}
+}
+
+// HasParams checks if cgroup v2 QoS parameters are present in the request.
+// Cgroup QoS only applies to krbd-mounted volumes; rbd-nbd volumes use the
+// NBD QoS handler even though the parameter names overlap.
+func (h *cgroupQoSHandler) HasParams(params map[string]string) bool {
+	if h.volume.Mounter == rbdNbdMounter {
+		return false
+	}
+
+	return hasCgroupQoSParams(params)
+}
+
+// Validate validates cgroup v2 QoS parameters.
+func (h *cgroupQoSHandler) Validate(params map[string]string) error {
+	return validateCgroupQoSParams(params)
+}
+
+// Apply saves cgroup v2 QoS parameters to RBD image metadata.
+// The actual QoS is applied during NodePublishVolume via cgroup io.max.
+func (h *cgroupQoSHandler) Apply(ctx context.Context, params map[string]string) error {
+	return h.volume.saveCgroupQoS(ctx, params)
+}
+
+// Clear removes all cgroup v2 QoS metadata from the RBD image.
+func (h *cgroupQoSHandler) Clear(ctx context.Context) error {
+	// Pass empty params to trigger removal of all cgroup QoS metadata.
+	return h.volume.saveCgroupQoS(ctx, map[string]string{})
 }
 
 // cgroupQoS holds cgroup v2 QoS parameters.
@@ -261,14 +351,77 @@ func (qos *cgroupQoS) applyCgroupQoS(ctx context.Context, podUID string) error {
 
 // validateCgroupQoSParams validates cgroup QoS parameters.
 func validateCgroupQoSParams(params map[string]string) error {
-	cgroupParams := []string{maxReadIops, maxWriteIops, maxReadBps, maxWriteBps}
-	for _, key := range cgroupParams {
+	for key := range qosParamToMetadataKey {
 		if val, ok := params[key]; ok && val != "" {
-			if _, err := strconv.ParseInt(val, 10, 64); err != nil {
+			parsed, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
 				return fmt.Errorf("invalid value for %s: %s, must be a positive integer", key, val)
+			}
+			if parsed <= 0 {
+				return fmt.Errorf("invalid value for %s: %s, must be greater than 0", key, val)
 			}
 		}
 	}
 
 	return nil
+}
+
+// saveCgroupQoS saves cgroup v2 QoS parameters to RBD image metadata.
+// If params is empty or contains no cgroup QoS keys, existing QoS metadata is removed.
+func (rv *rbdVolume) saveCgroupQoS(ctx context.Context, params map[string]string) error {
+	// Check if we need to remove existing QoS (when VAC is removed or keys not present).
+	if !hasCgroupQoSParams(params) {
+		// Remove all cgroup QoS metadata.
+		for _, metadataKey := range qosParamToMetadataKey {
+			err := rv.RemoveMetadata(metadataKey)
+			if err != nil && !errors.Is(err, librbd.ErrNotExist) {
+				return fmt.Errorf("failed to remove cgroup QoS metadata %s: %w", metadataKey, err)
+			}
+			log.DebugLog(ctx, "removed cgroup QoS metadata %s", metadataKey)
+		}
+
+		return nil
+	}
+
+	err := validateCgroupQoSParams(params)
+	if err != nil {
+		return err
+	}
+
+	// Save or update cgroup QoS parameters.
+	for param, metadataKey := range qosParamToMetadataKey {
+		if val, ok := params[param]; ok && val != "" {
+			err := rv.SetMetadata(metadataKey, val)
+			if err != nil {
+				return fmt.Errorf("failed to save cgroup QoS %s: %s, %w", param, val, err)
+			}
+			log.DebugLog(ctx, "saved cgroup QoS metadata %s: %s", metadataKey, val)
+		} else {
+			// Remove metadata if parameter not provided (allows partial updates).
+			err := rv.RemoveMetadata(metadataKey)
+			if err != nil && !errors.Is(err, librbd.ErrNotExist) {
+				return fmt.Errorf("failed to remove cgroup QoS metadata %s: %w", metadataKey, err)
+			}
+			log.DebugLog(ctx, "removed cgroup QoS metadata %s (not in request)", metadataKey)
+		}
+	}
+
+	return nil
+}
+
+// getCgroupQoS retrieves cgroup v2 QoS parameters from RBD image metadata.
+func (rv *rbdVolume) getCgroupQoS(ctx context.Context) (map[string]string, error) {
+	qosParams := make(map[string]string)
+	for metadataKey, param := range qosMetadataToParamKey {
+		val, err := rv.GetMetadata(metadataKey)
+		if err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			return nil, fmt.Errorf("failed to get metadata %s: %w", metadataKey, err)
+		}
+		if val != "" {
+			qosParams[param] = val
+			log.DebugLog(ctx, "retrieved cgroup QoS metadata %s: %s", metadataKey, val)
+		}
+	}
+
+	return qosParams, nil
 }

--- a/internal/rbd/cgroup_qos_test.go
+++ b/internal/rbd/cgroup_qos_test.go
@@ -1,0 +1,482 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseCgroupQoSParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		want   *cgroupQoS
+	}{
+		{
+			name: "all parameters set",
+			params: map[string]string{
+				maxReadIops:  "1000",
+				maxWriteIops: "2000",
+				maxReadBps:   "10485760",
+				maxWriteBps:  "20971520",
+			},
+			want: &cgroupQoS{
+				maxReadIops:  "1000",
+				maxWriteIops: "2000",
+				maxReadBps:   "10485760",
+				maxWriteBps:  "20971520",
+			},
+		},
+		{
+			name: "partial parameters",
+			params: map[string]string{
+				maxReadIops:  "1000",
+				maxWriteIops: "2000",
+			},
+			want: &cgroupQoS{
+				maxReadIops:  "1000",
+				maxWriteIops: "2000",
+				maxReadBps:   "max",
+				maxWriteBps:  "max",
+			},
+		},
+		{
+			name:   "no parameters",
+			params: map[string]string{},
+			want: &cgroupQoS{
+				maxReadIops:  "max",
+				maxWriteIops: "max",
+				maxReadBps:   "max",
+				maxWriteBps:  "max",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseCgroupQoSParams(tt.params)
+			if got.maxReadIops != tt.want.maxReadIops {
+				t.Errorf("parseCgroupQoSParams() maxReadIops = %v, want %v", got.maxReadIops, tt.want.maxReadIops)
+			}
+			if got.maxWriteIops != tt.want.maxWriteIops {
+				t.Errorf("parseCgroupQoSParams() maxWriteIops = %v, want %v", got.maxWriteIops, tt.want.maxWriteIops)
+			}
+			if got.maxReadBps != tt.want.maxReadBps {
+				t.Errorf("parseCgroupQoSParams() maxReadBps = %v, want %v", got.maxReadBps, tt.want.maxReadBps)
+			}
+			if got.maxWriteBps != tt.want.maxWriteBps {
+				t.Errorf("parseCgroupQoSParams() maxWriteBps = %v, want %v", got.maxWriteBps, tt.want.maxWriteBps)
+			}
+		})
+	}
+}
+
+func TestHasCgroupQoSParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		want   bool
+	}{
+		{
+			name: "has maxReadIops",
+			params: map[string]string{
+				maxReadIops: "1000",
+			},
+			want: true,
+		},
+		{
+			name: "has maxWriteIops",
+			params: map[string]string{
+				maxWriteIops: "2000",
+			},
+			want: true,
+		},
+		{
+			name: "has maxReadBps",
+			params: map[string]string{
+				maxReadBps: "10485760",
+			},
+			want: true,
+		},
+		{
+			name: "has maxWriteBps",
+			params: map[string]string{
+				maxWriteBps: "20971520",
+			},
+			want: true,
+		},
+		{
+			name:   "no cgroup QoS params",
+			params: map[string]string{},
+			want:   false,
+		},
+		{
+			name: "empty value",
+			params: map[string]string{
+				maxReadIops: "",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasCgroupQoSParams(tt.params); got != tt.want {
+				t.Errorf("hasCgroupQoSParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatIOMax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		qos  *cgroupQoS
+		want string
+	}{
+		{
+			name: "all limits set",
+			qos: &cgroupQoS{
+				deviceID:     "252:0",
+				maxReadIops:  "1000",
+				maxWriteIops: "2000",
+				maxReadBps:   "10485760",
+				maxWriteBps:  "20971520",
+			},
+			want: "252:0 rbps=10485760 wbps=20971520 riops=1000 wiops=2000",
+		},
+		{
+			name: "only IOPS limits",
+			qos: &cgroupQoS{
+				deviceID:     "252:0",
+				maxReadIops:  "1000",
+				maxWriteIops: "2000",
+				maxReadBps:   "max",
+				maxWriteBps:  "max",
+			},
+			want: "252:0 rbps=max wbps=max riops=1000 wiops=2000",
+		},
+		{
+			name: "only BPS limits",
+			qos: &cgroupQoS{
+				deviceID:     "252:0",
+				maxReadIops:  "max",
+				maxWriteIops: "max",
+				maxReadBps:   "10485760",
+				maxWriteBps:  "20971520",
+			},
+			want: "252:0 rbps=10485760 wbps=20971520 riops=max wiops=max",
+		},
+		{
+			name: "all max",
+			qos: &cgroupQoS{
+				deviceID:     "252:0",
+				maxReadIops:  "max",
+				maxWriteIops: "max",
+				maxReadBps:   "max",
+				maxWriteBps:  "max",
+			},
+			want: "252:0 rbps=max wbps=max riops=max wiops=max",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.qos.formatIOMax(); got != tt.want {
+				t.Errorf("formatIOMax() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCgroupQoSParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+	}{
+		{
+			name: "valid parameters",
+			params: map[string]string{
+				maxReadIops:  "1000",
+				maxWriteIops: "2000",
+				maxReadBps:   "10485760",
+				maxWriteBps:  "20971520",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid maxReadIops",
+			params: map[string]string{
+				maxReadIops: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid maxWriteIops",
+			params: map[string]string{
+				maxWriteIops: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid maxReadBps",
+			params: map[string]string{
+				maxReadBps: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid maxWriteBps",
+			params: map[string]string{
+				maxWriteBps: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero maxReadIops",
+			params: map[string]string{
+				maxReadIops: "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative maxWriteIops",
+			params: map[string]string{
+				maxWriteIops: "-1000",
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero maxReadBps",
+			params: map[string]string{
+				maxReadBps: "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative maxWriteBps",
+			params: map[string]string{
+				maxWriteBps: "-10485760",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty parameters",
+			params:  map[string]string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateCgroupQoSParams(tt.params); (err != nil) != tt.wantErr {
+				t.Errorf("validateCgroupQoSParams() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFindPodCgroupPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		podUID  string
+		wantErr bool
+	}{
+		{
+			name:    "empty pod UID returns error",
+			podUID:  "",
+			wantErr: true,
+		},
+		{
+			name:    "non-existent pod returns error",
+			podUID:  "nonexistent-pod-12345",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := findPodCgroupPath(ctx, tt.podUID)
+
+			if tt.wantErr && err == nil {
+				t.Errorf("findPodCgroupPath() expected error, got nil")
+			}
+
+			if !tt.wantErr && err != nil {
+				t.Errorf("findPodCgroupPath() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestPodCgroupPathConstruction validates the path construction logic
+// without requiring actual filesystem access.
+func TestPodCgroupPathConstruction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		podUID           string
+		qosClass         string
+		expectedSlice    string
+		expectedPodSlice string
+	}{
+		{
+			name:             "guaranteed pod path",
+			podUID:           "abc123-def456",
+			qosClass:         "Guaranteed",
+			expectedSlice:    kubepodsGuaranteedSlice,
+			expectedPodSlice: "kubepods-podabc123_def456.slice",
+		},
+		{
+			name:             "burstable pod path",
+			podUID:           "xyz789-uvw123",
+			qosClass:         "Burstable",
+			expectedSlice:    kubepodsBurstableSlice,
+			expectedPodSlice: "kubepods-burstable-podxyz789_uvw123.slice",
+		},
+		{
+			name:             "besteffort pod path",
+			podUID:           "pod-best-effort",
+			qosClass:         "BestEffort",
+			expectedSlice:    kubepodsBestEffortSlice,
+			expectedPodSlice: "kubepods-besteffort-podpod_best_effort.slice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test UID normalization (hyphens → underscores)
+			normalizedUID := strings.ReplaceAll(tt.podUID, "-", "_")
+
+			// Find matching QoS class info
+			var qos *struct {
+				name      string
+				sliceName string
+				podPrefix string
+			}
+
+			for i := range qosClassInfo {
+				if qosClassInfo[i].name == tt.qosClass {
+					qos = &qosClassInfo[i]
+
+					break
+				}
+			}
+
+			if qos == nil {
+				t.Fatalf("QoS class %s not found in qosClassInfo", tt.qosClass)
+			}
+
+			// Construct expected path using same logic as findPodCgroupPath
+			podSliceName := qos.podPrefix + normalizedUID + ".slice"
+			expectedPath := filepath.Join(cgroupV2BasePath, tt.expectedSlice, tt.expectedPodSlice)
+			constructedPath := filepath.Join(cgroupV2BasePath, qos.sliceName, podSliceName)
+
+			if constructedPath != expectedPath {
+				t.Errorf("path construction mismatch:\ngot:  %s\nwant: %s",
+					constructedPath, expectedPath)
+			}
+		})
+	}
+}
+
+func TestQoSClassOrdering(t *testing.T) {
+	t.Parallel()
+
+	// Verify that qosClassInfo array is ordered as expected (Guaranteed first).
+	// This ordering is critical for performance - most common QoS class checked first.
+	if qosClassInfo[0].name != "Guaranteed" {
+		t.Errorf("qosClassInfo[0] should be Guaranteed for optimal performance, got %s", qosClassInfo[0].name)
+	}
+
+	if qosClassInfo[1].name != "Burstable" {
+		t.Errorf("qosClassInfo[1] should be Burstable, got %s", qosClassInfo[1].name)
+	}
+
+	if qosClassInfo[2].name != "BestEffort" {
+		t.Errorf("qosClassInfo[2] should be BestEffort, got %s", qosClassInfo[2].name)
+	}
+
+	// Verify path prefixes are correctly constructed
+	expectedPrefixes := map[string]string{
+		"Guaranteed": "kubepods-pod",
+		"Burstable":  "kubepods-burstable-pod",
+		"BestEffort": "kubepods-besteffort-pod",
+	}
+
+	for i := range qosClassInfo {
+		expected, ok := expectedPrefixes[qosClassInfo[i].name]
+		if !ok {
+			t.Errorf("unexpected QoS class name: %s", qosClassInfo[i].name)
+
+			continue
+		}
+
+		if qosClassInfo[i].podPrefix != expected {
+			t.Errorf("qosClassInfo[%d].podPrefix = %s, want %s",
+				i, qosClassInfo[i].podPrefix, expected)
+		}
+	}
+}
+
+func TestWriteIOMax(t *testing.T) {
+	t.Parallel()
+
+	ioMaxLine := "252:0 rbps=10485760 wbps=20971520 riops=1000 wiops=2000"
+	tmpFile := filepath.Join(t.TempDir(), "io.max")
+
+	err := writeIOMax(tmpFile, ioMaxLine)
+	if err != nil {
+		t.Fatalf("writeIOMax() error = %v", err)
+	}
+
+	got, err := os.ReadFile(tmpFile) // #nosec:G304, reading test file.
+	if err != nil {
+		t.Fatalf("failed to read result file: %v", err)
+	}
+
+	want := ioMaxLine + "\n"
+	if string(got) != want {
+		t.Errorf("writeIOMax() content mismatch: got %q, want %q", string(got), want)
+	}
+}

--- a/internal/rbd/cgroup_qos_test.go
+++ b/internal/rbd/cgroup_qos_test.go
@@ -379,6 +379,28 @@ func TestPodCgroupPathConstruction(t *testing.T) {
 			expectedSlice:    kubepodsBestEffortSlice,
 			expectedPodSlice: "kubepods-besteffort-podpod_best_effort.slice",
 		},
+		// Real-world examples from actual Kubernetes cluster cgroup paths
+		{
+			name:             "real besteffort pod",
+			podUID:           "d9fd4536-e68d-46a1-954b-2f05da70bd7d",
+			qosClass:         "BestEffort",
+			expectedSlice:    kubepodsBestEffortSlice,
+			expectedPodSlice: "kubepods-besteffort-podd9fd4536_e68d_46a1_954b_2f05da70bd7d.slice",
+		},
+		{
+			name:             "real guaranteed pod",
+			podUID:           "4d237886-32e9-4888-91da-ed1c0f1d4b89",
+			qosClass:         "Guaranteed",
+			expectedSlice:    kubepodsGuaranteedSlice,
+			expectedPodSlice: "kubepods-pod4d237886_32e9_4888_91da_ed1c0f1d4b89.slice",
+		},
+		{
+			name:             "real burstable pod",
+			podUID:           "bd7148ac-95e7-44b7-a285-bb13e225b4f1",
+			qosClass:         "Burstable",
+			expectedSlice:    kubepodsBurstableSlice,
+			expectedPodSlice: "kubepods-burstable-podbd7148ac_95e7_44b7_a285_bb13e225b4f1.slice",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -2022,23 +2022,28 @@ func (cs *ControllerServer) ControllerModifyVolume(
 	}
 	defer cs.OperationLocks.ReleaseModifyLock(volID)
 
-	// QoS parameters only work with rbd-nbd mounter
-	usesNBD, err := rbdVol.UsesNBDMounter(ctx)
+	// Resolve the mounter from image metadata since generateVolumeFromVolumeID
+	// does not populate it. This must happen before QoS parameter validation
+	// so the correct mounter-specific rules are applied.
+	_, err = rbdVol.UsesNBDMounter(ctx)
 	switch {
 	case errors.Is(err, rbderrors.ErrMounterUnknown):
-		// Volume created before mounter tracking - proceed with warning
 		log.WarningLog(ctx, "volume %s has unknown mounter type (created before mounter tracking), "+
 			"proceeding with modification but QoS may not work if volume does not use rbd-nbd", volID)
 	case err != nil:
 		log.ErrorLog(ctx, "failed to check mounter type for volume %s: %v", volID, err)
 
 		return nil, status.Errorf(codes.Internal, "failed to determine volume mounter type: %v", err)
-	case !usesNBD:
-		log.ErrorLog(ctx, "volume %s uses mounter %q, QoS modification requires %q",
-			volID, rbdVol.Mounter, rbdNbdMounter)
+	}
 
+	// Validate QoS parameters based on the resolved mounter type.
+	// The cgroup QoS params (maxReadIops, etc.) overlap with NBD max-limit params,
+	// so the mounter determines which interpretation applies.
+	hasNBDQoS := HasQoSParams(mutableParameters)
+	if rbdVol.Mounter != rbdNbdMounter && hasNBDQoS {
 		return nil, status.Errorf(codes.InvalidArgument,
-			"volume modification requires rbd-nbd mounter, volume uses %q", rbdVol.Mounter)
+			"NBD QoS parameters (baseIops, baseReadIops, etc.) are not supported with %q mounter, "+
+				"use cgroup QoS parameters (maxReadIops, maxWriteIops, maxReadBps, maxWriteBps)", rbdVol.Mounter)
 	}
 
 	// set RequestedVolSize, because calcQosBasedOnCapacity use it.

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -150,6 +150,38 @@ func validateStriping(parameters map[string]string) error {
 	return nil
 }
 
+// validateQoSParameters validates QoS parameters from VolumeAttributesClass
+// based on the configured mounter type. The cgroup QoS params (maxReadIops,
+// maxWriteIops, maxReadBps, maxWriteBps) overlap with NBD max-limit params,
+// so disambiguation must be mounter-based.
+func validateQoSParameters(mutableParams map[string]string, mounter string) error {
+	if mounter == rbdNbdMounter {
+		// NBD mounter: only NBD QoS params are valid.
+		// The shared keys (maxReadIops, etc.) serve as NBD max limits here.
+		if HasQoSParams(mutableParams) {
+			return validateNBDQoSParams(mutableParams)
+		}
+
+		return nil
+	}
+
+	// krbd mounter: only cgroup v2 QoS params are supported.
+	// Reject any NBD-specific params that won't be applied via cgroup.
+	if HasQoSParams(mutableParams) {
+		return fmt.Errorf(
+			"NBD QoS parameters (baseIops, baseReadIops, etc.) are not supported with %q mounter, "+
+				"use cgroup QoS parameters (maxReadIops, maxWriteIops, maxReadBps, maxWriteBps)", mounter)
+	}
+
+	if hasCgroupQoSParams(mutableParams) {
+		if err := validateCgroupQoSParams(mutableParams); err != nil {
+			return fmt.Errorf("invalid cgroup QoS parameters: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // parseVolCreateRequest take create volume `request` argument and make use of the
 // request arguments for subsequent calls.
 func (cs *ControllerServer) parseVolCreateRequest(
@@ -230,10 +262,19 @@ func (cs *ControllerServer) parseVolCreateRequest(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	// parse QOS parameters from mutable parameters
-	err = rbdVol.SetQOS(ctx, req.GetMutableParameters())
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	// Validate QoS parameters from VolumeAttributesClass before creating the image.
+	// This ensures we fail early if parameters are invalid, avoiding orphaned resources.
+	mutableParams := req.GetMutableParameters()
+	if len(mutableParams) > 0 {
+		err = validateQoSParameters(mutableParams, rbdVol.Mounter)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
+		// Store BaseVolSize for capacity-based QoS calculations.
+		if v, ok := mutableParams[baseVolSizeBytes]; ok && v != "" {
+			rbdVol.BaseVolSize = v
+		}
 	}
 
 	err = rbdVol.Connect(cr)
@@ -814,19 +855,18 @@ func (cs *ControllerServer) createBackingImage(
 		return status.Error(codes.Internal, err.Error())
 	}
 
-	// Apply Qos parameters to rbd image.
-	err = rbdVol.ApplyQOS(ctx)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to apply QOS for rbd image: %s with error: %v", rbdVol, err)
+	// Apply QoS parameters from VolumeAttributesClass if present.
+	// This handles both traditional NBD QoS and cgroup v2 QoS.
+	if len(mutableParameters) > 0 {
+		// Set RequestedVolSize for QoS capacity-based calculations.
+		rbdVol.RequestedVolSize = rbdVol.VolSize
 
-		return status.Error(codes.Internal, err.Error())
-	}
-	// Save Qos parameters from mutable parameters in Image metadata, we will use it while resize volume.
-	err = rbdVol.SaveQOS(ctx, mutableParameters)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to save QOS for rbd image: %s with error: %v", rbdVol, err)
+		err = rbdVol.modifyVolumeAttributes(ctx, mutableParameters)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to apply QoS for rbd image: %s with error: %v", rbdVol, err)
 
-		return status.Error(codes.Internal, err.Error())
+			return status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	return nil
@@ -2036,14 +2076,8 @@ func (cs *ControllerServer) ControllerModifyVolume(
 		return nil, status.Errorf(codes.Internal, "failed to determine volume mounter type: %v", err)
 	}
 
-	// Validate QoS parameters based on the resolved mounter type.
-	// The cgroup QoS params (maxReadIops, etc.) overlap with NBD max-limit params,
-	// so the mounter determines which interpretation applies.
-	hasNBDQoS := HasQoSParams(mutableParameters)
-	if rbdVol.Mounter != rbdNbdMounter && hasNBDQoS {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"NBD QoS parameters (baseIops, baseReadIops, etc.) are not supported with %q mounter, "+
-				"use cgroup QoS parameters (maxReadIops, maxWriteIops, maxReadBps, maxWriteBps)", rbdVol.Mounter)
+	if err = validateQoSParameters(mutableParameters, rbdVol.Mounter); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	// set RequestedVolSize, because calcQosBasedOnCapacity use it.

--- a/internal/rbd/controllerserver_test.go
+++ b/internal/rbd/controllerserver_test.go
@@ -165,3 +165,79 @@ func TestToCSIVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateQoSParameters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  map[string]string
+		mounter string
+		wantErr bool
+	}{
+		{
+			name:    "krbd with cgroup params only",
+			params:  map[string]string{maxReadIops: "1000", maxWriteBps: "10485760"},
+			mounter: rbdDefaultMounter,
+			wantErr: false,
+		},
+		{
+			name:    "krbd with NBD-only params",
+			params:  map[string]string{baseIops: "3000"},
+			mounter: rbdDefaultMounter,
+			wantErr: true,
+		},
+		{
+			name:    "krbd with mixed cgroup and NBD params",
+			params:  map[string]string{maxReadIops: "1000", baseReadIops: "500"},
+			mounter: rbdDefaultMounter,
+			wantErr: true,
+		},
+		{
+			name:    "krbd with invalid cgroup param value",
+			params:  map[string]string{maxReadIops: "-1"},
+			mounter: rbdDefaultMounter,
+			wantErr: true,
+		},
+		{
+			name:    "krbd with empty params",
+			params:  map[string]string{},
+			mounter: rbdDefaultMounter,
+			wantErr: false,
+		},
+		{
+			name:    "nbd with NBD params and max limits",
+			params:  map[string]string{baseReadIops: "500", maxReadIops: "1000"},
+			mounter: rbdNbdMounter,
+			wantErr: false,
+		},
+		{
+			name:    "nbd with NBD-only params",
+			params:  map[string]string{baseIops: "3000", iopsPerGiB: "100"},
+			mounter: rbdNbdMounter,
+			wantErr: false,
+		},
+		{
+			name:    "nbd with invalid NBD param value",
+			params:  map[string]string{baseIops: "invalid"},
+			mounter: rbdNbdMounter,
+			wantErr: true,
+		},
+		{
+			name:    "nbd with empty params",
+			params:  map[string]string{},
+			mounter: rbdNbdMounter,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateQoSParameters(tt.params, tt.mounter)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateQoSParameters() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -540,10 +540,8 @@ func (ns *NodeServer) stageTransaction(
 	log.DebugLog(ctx, "rbd image: %s was successfully mapped at %s\n",
 		volOptions, devicePath)
 
-	// userspace mounters like nbd need the device path as a reference while
-	// restarting the userspace processes on a nodeplugin restart. For kernel
-	// mounter(krbd) we don't need it as there won't be any process running
-	// in userspace, hence we don't store the device path for krbd devices.
+	// Store the raw device path for nbd before encryption processing.
+	// The nbd healer uses this path to re-attach the device on restart.
 	if volOptions.Mounter == rbdNbdMounter {
 		err = updateRBDImageMetadataStash(req.GetStagingTargetPath(), devicePath)
 		if err != nil {
@@ -566,6 +564,13 @@ func (ns *NodeServer) stageTransaction(
 	if volOptions.isFileEncrypted() {
 		if err = fscrypt.InitializeNode(ctx); err != nil {
 			return transaction, fmt.Errorf("file encryption setup for %s failed: %w", volOptions.VolID, err)
+		}
+	}
+
+	if volOptions.Mounter != rbdNbdMounter {
+		err = updateRBDImageMetadataStash(req.GetStagingTargetPath(), devicePath)
+		if err != nil {
+			return transaction, err
 		}
 	}
 

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -853,36 +853,178 @@ func (ns *NodeServer) NodePublishVolume(
 	}
 	defer ns.VolumeLocks.Release(targetPath)
 
+	// A single pod can have multiple volumes, each triggering a separate
+	// NodePublishVolume RPC. Serialize operations per pod to prevent
+	// concurrent calls from racing on the pod's cgroup io.max file
+	// during QoS application.
+	podUID := req.GetVolumeContext()[util.VolumeContextPodUIDKey]
+	if podUID != "" {
+		if acquired := ns.VolumeLocks.TryAcquire(podUID); !acquired {
+			log.ErrorLog(ctx, util.PodOperationAlreadyExistsFmt, podUID)
+
+			return nil, status.Errorf(codes.Aborted, util.PodOperationAlreadyExistsFmt, podUID)
+		}
+		defer ns.VolumeLocks.Release(podUID)
+	}
+
 	// Check if that target path exists properly
 	isMnt, err := ns.createTargetMountPath(ctx, targetPath, isBlock)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if isMnt {
-		return &csi.NodePublishVolumeResponse{}, nil
-	}
-
-	fileEncrypted, err := IsFileEncrypted(ctx, req.GetVolumeContext())
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if fileEncrypted {
-		stagingPath = fscrypt.AppendEncyptedSubdirectory(stagingPath)
-		if err = fscrypt.IsDirectoryUnlocked(stagingPath, req.GetVolumeCapability().GetMount().GetFsType()); err != nil {
+	if !isMnt {
+		fileEncrypted, err := IsFileEncrypted(ctx, req.GetVolumeContext())
+		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+		if fileEncrypted {
+			stagingPath = fscrypt.AppendEncyptedSubdirectory(stagingPath)
+			if err = fscrypt.IsDirectoryUnlocked(stagingPath, req.GetVolumeCapability().GetMount().GetFsType()); err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
+		}
+
+		// Publish Path
+		err = ns.mountVolume(ctx, stagingPath, req)
+		if err != nil {
+			return nil, err
+		}
+
+		log.DebugLog(ctx, "rbd: successfully mounted stagingPath %s to targetPath %s", stagingPath, targetPath)
 	}
 
-	// Publish Path
-	err = ns.mountVolume(ctx, stagingPath, req)
+	// Apply cgroup v2 QoS if configured.
+	// This runs even when the volume is already mounted (isMnt == true) to
+	// handle the case where the node server restarted after mounting but
+	// before QoS was applied.
+	err = ns.applyCgroupQoSIfConfigured(ctx, req)
 	if err != nil {
-		return nil, err
+		log.ErrorLog(ctx, "failed to apply cgroup QoS for volume %s: %v", volID, err)
 	}
-
-	log.DebugLog(ctx, "rbd: successfully mounted stagingPath %s to targetPath %s", stagingPath, targetPath)
 
 	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+func (ns *NodeServer) applyCgroupQoSIfConfigured(
+	ctx context.Context,
+	req *csi.NodePublishVolumeRequest,
+) error {
+	// Get pod UID from volume context (requires podInfoOnMount enabled).
+	podUID := req.GetVolumeContext()[util.VolumeContextPodUIDKey]
+	if podUID == "" {
+		log.DebugLog(ctx, "pod UID not available, skipping cgroup QoS")
+
+		return nil
+	}
+
+	volID := req.GetVolumeId()
+
+	// Get device path from staging metadata.
+	// The stash is created at the staging target path (without volumeID) during NodeStageVolume.
+	imgInfo, err := lookupRBDImageMetadataStash(req.GetStagingTargetPath())
+	if err != nil {
+		log.ErrorLog(ctx, "failed to lookup image metadata for cgroup QoS: %v", err)
+
+		return err
+	}
+
+	devicePath := imgInfo.DevicePath
+	if devicePath == "" {
+		log.WarningLog(ctx, "device path not found in metadata, skipping cgroup QoS")
+
+		return nil
+	}
+
+	// Get credentials to access the volume metadata.
+	cr, err := ns.getNodePublishCredentials(ctx, req)
+	if err != nil {
+		log.WarningLog(ctx, "failed to get NodePublish credentials for cgroup QoS, skipping: %v", err)
+
+		return nil
+	}
+
+	// Backward compatibility: QoS requires credentials to read RBD image metadata.
+	// If credentials are not configured, gracefully skip QoS to avoid breaking
+	// existing PVCs that don't have NodePublish secrets configured.
+	if cr == nil {
+		log.WarningLog(ctx, "NodePublish secret not configured, skipping cgroup QoS for volume %s", volID)
+
+		return nil
+	}
+	defer cr.DeleteCredentials()
+
+	// Initialize volume to access metadata.
+	isStaticVol := parseBoolOption(ctx, req.GetVolumeContext(), staticVol, false)
+	var rv *rbdVolume
+	if isStaticVol {
+		rv, err = initStaticVol(ctx, volID, req.GetVolumeContext(), false)
+	} else {
+		rv, err = initDynamicVol(ctx, volID, cr, req.GetSecrets(), req.GetVolumeContext())
+	}
+	if err != nil {
+		log.WarningLog(ctx, "failed to initialize volume for cgroup QoS, skipping: %v", err)
+		// Backward compatibility: If volume initialization fails, skip QoS
+		// rather than failing the mount. This ensures existing volumes continue
+		// to work even if there are issues accessing metadata.
+		return nil
+	}
+	defer rv.Destroy(ctx)
+
+	// Apply cgroup QoS.
+	err = rv.applyCgroupQoSForVolume(ctx, devicePath, podUID)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to apply cgroup QoS for volume %s: %v", volID, err)
+
+		return err
+	}
+
+	log.DebugLog(ctx, "successfully applied cgroup QoS for volume %s", volID)
+
+	return nil
+}
+
+// getNodePublishCredentials retrieves credentials for NodePublishVolume operation.
+// This is required for cgroup QoS to access RBD image metadata.
+// Returns (nil, nil) if no secret is configured to maintain backward compatibility.
+func (ns *NodeServer) getNodePublishCredentials(
+	ctx context.Context,
+	req *csi.NodePublishVolumeRequest,
+) (*util.Credentials, error) {
+	// Try to get secret from req.GetSecrets() first (passed from StorageClass).
+	secrets := req.GetSecrets()
+	if len(secrets) > 0 {
+		return util.NewUserCredentialsWithMigration(secrets)
+	}
+
+	// Fall back to getting secret from CSI ConfigMap (rbd.nodePublishSecretRef).
+	volCtx := req.GetVolumeContext()
+	clusterID, err := util.GetClusterID(volCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster ID: %w", err)
+	}
+
+	secretName, secretNamespace, err := util.GetRBDNodePublishSecretRef(util.CsiConfigFile, clusterID)
+	if err != nil {
+		log.ErrorLog(ctx, "error retrieving NodePublish secret config for cluster %s: %v", clusterID, err)
+
+		return nil, nil
+	}
+
+	if secretName == "" || secretNamespace == "" {
+		log.DebugLog(ctx, "NodePublish secret not configured for cluster %s", clusterID)
+		// Backward compatibility: Return nil credentials to indicate no secret.
+		return nil, nil
+	}
+
+	// Get secret from Kubernetes.
+	secretData, err := k8s.GetSecret(secretName, secretNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get NodePublish secret %s/%s: %w",
+			secretNamespace, secretName, err)
+	}
+
+	return util.NewUserCredentialsWithMigration(secretData)
 }
 
 func (ns *NodeServer) mountVolumeToStagePath(

--- a/internal/rbd/qos.go
+++ b/internal/rbd/qos.go
@@ -19,6 +19,7 @@ package rbd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 
 	librbd "github.com/ceph/go-ceph/rbd"
@@ -117,9 +118,35 @@ func (h *nbdQoSHandler) HasParams(params map[string]string) bool {
 }
 
 // Validate validates traditional NBD QoS parameters.
-// Currently returns nil as NBD QoS validation is done during SetQOS.
 func (h *nbdQoSHandler) Validate(params map[string]string) error {
-	// NBD QoS validation is performed in SetQOS via calcQosBasedOnCapacity.
+	return validateNBDQoSParams(params)
+}
+
+// validateNBDQoSParams validates traditional NBD QoS parameters.
+// Ensures all numeric values are valid and positive.
+func validateNBDQoSParams(params map[string]string) error {
+	// All NBD QoS parameter keys that accept numeric values
+	numericParams := []string{
+		baseIops, maxIops, baseReadIops, maxReadIops, baseWriteIops, maxWriteIops,
+		baseBps, maxBps, baseReadBps, maxReadBps, baseWriteBps, maxWriteBps,
+		iopsPerGiB, readIopsPerGiB, writeIopsPerGiB,
+		bpsPerGiB, readBpsPerGiB, writeBpsPerGiB,
+		baseVolSizeBytes,
+	}
+
+	for _, key := range numericParams {
+		if val, ok := params[key]; ok && val != "" {
+			parsed, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid value for %s: %s, must be a valid integer", key, val)
+			}
+			// Allow zero for base limits (can be omitted), but not negative
+			if parsed < 0 {
+				return fmt.Errorf("invalid value for %s: %s, must be non-negative", key, val)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/rbd/qos.go
+++ b/internal/rbd/qos.go
@@ -101,6 +101,49 @@ func HasQoSParams(params map[string]string) bool {
 	return false
 }
 
+// nbdQoSHandler implements QoSHandler for traditional NBD QoS (rbd-nbd mounter).
+type nbdQoSHandler struct {
+	volume *rbdVolume
+}
+
+// newNBDQoSHandler creates a new NBD QoS handler.
+func newNBDQoSHandler(volume *rbdVolume) QoSHandler {
+	return &nbdQoSHandler{volume: volume}
+}
+
+// HasParams checks if traditional NBD QoS parameters are present in the request.
+func (h *nbdQoSHandler) HasParams(params map[string]string) bool {
+	return HasQoSParams(params)
+}
+
+// Validate validates traditional NBD QoS parameters.
+// Currently returns nil as NBD QoS validation is done during SetQOS.
+func (h *nbdQoSHandler) Validate(params map[string]string) error {
+	// NBD QoS validation is performed in SetQOS via calcQosBasedOnCapacity.
+	return nil
+}
+
+// Apply sets and applies traditional NBD QoS to the rbd-nbd device.
+func (h *nbdQoSHandler) Apply(ctx context.Context, params map[string]string) error {
+	if err := h.volume.SetQOS(ctx, params); err != nil {
+		return err
+	}
+
+	if err := h.volume.ApplyQOS(ctx); err != nil {
+		return err
+	}
+
+	return h.volume.SaveQOS(ctx, params)
+}
+
+// Clear removes all traditional NBD QoS settings.
+func (h *nbdQoSHandler) Clear(ctx context.Context) error {
+	// Pass empty params to clear QoS settings.
+	emptyParams := map[string]string{}
+
+	return h.Apply(ctx, emptyParams)
+}
+
 func parseQosParams(
 	mutableParameters map[string]string,
 ) map[string]*qosSpec {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2500,19 +2500,39 @@ func (rv *rbdVolume) modifyVolumeAttributes(
 	}
 	defer image.Close() //nolint:errcheck // not a critical failure
 
-	err = rv.SetQOS(ctx, newMutableParameters)
-	if err != nil {
-		return err
+	// QoS handlers implement different QoS strategies:
+	// - cgroupQoSHandler: cgroup v2 QoS for krbd mounter
+	// - nbdQoSHandler: traditional NBD QoS for rbd-nbd mounter
+	//
+	// Note: ControllerModifyVolume validates that only one type is set at a time.
+	handlers := []QoSHandler{
+		newCgroupQoSHandler(rv),
+		newNBDQoSHandler(rv),
 	}
 
-	err = rv.ApplyQOS(ctx)
-	if err != nil {
-		return err
+	// Find and apply the QoS type present in the request.
+	for _, handler := range handlers {
+		if handler.HasParams(newMutableParameters) {
+			// Validate parameters before applying.
+			if err := handler.Validate(newMutableParameters); err != nil {
+				return err
+			}
+
+			// Apply the QoS settings.
+			return handler.Apply(ctx, newMutableParameters)
+		}
 	}
 
-	err = rv.SaveQOS(ctx, newMutableParameters)
-	if err != nil {
-		return err
+	// No QoS parameters provided - clear any existing QoS of all types.
+	// This happens when VolumeAttributesClass is removed from the PVC.
+	log.DebugLog(ctx, "no QoS parameters in request, clearing existing QoS for volume %s", rv.VolID)
+
+	for _, handler := range handlers {
+		if err := handler.Clear(ctx); err != nil {
+			log.ErrorLog(ctx, "failed to clear QoS for volume %s: %v", rv.VolID, err)
+
+			return err
+		}
 	}
 
 	return nil

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -267,3 +267,16 @@ func GetCephFSControllerPublishSecretRef(pathToConfig, clusterID string) (string
 
 	return secretRef.Name, secretRef.Namespace, nil
 }
+
+// GetRBDNodePublishSecretRef returns the secret name and namespace used for
+// node publish operations for RBD volumes.
+func GetRBDNodePublishSecretRef(pathToConfig, clusterID string) (string, string, error) {
+	cluster, err := readClusterInfo(pathToConfig, clusterID)
+	if err != nil {
+		return "", "", err
+	}
+
+	secretRef := cluster.RBD.NodePublishSecretRef
+
+	return secretRef.Name, secretRef.Namespace, nil
+}

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -32,6 +32,9 @@ const (
 	// TargetPathOperationAlreadyExistsFmt string format to return for concurrent operation on target path.
 	TargetPathOperationAlreadyExistsFmt = "an operation with the given target path %s already exists"
 
+	// PodOperationAlreadyExistsFmt string format to return for concurrent operation on pod.
+	PodOperationAlreadyExistsFmt = "an operation with the given Pod UUID %s already exists"
+
 	// HostOperationAlreadyExistsFmt is used for reporting an in-progress operation that modifies the
 	// NVMe-oF gateway configuration for a prticular host.
 	HostOperationAlreadyExistsFmt = "an operation that modifies the gateway for Host ID %s already exists"

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -40,6 +40,11 @@ const (
 	// PublishContextServiceAccount is the publish context key for the allowed
 	// service account, set during ControllerPublishVolume.
 	PublishContextServiceAccount = "serviceAccount"
+
+	// VolumeContextPodUIDKey is the key in the volume context that contains
+	// the pod's UID, set by Kubelet when podInfoOnMount is enabled in the
+	// CSIDriver spec.
+	VolumeContextPodUIDKey = "csi.storage.k8s.io/pod.uid"
 )
 
 // A regex to verify the expected format: 0000-0000-arbitrary-number-of-000-and-chars.

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/csi-config-map.go
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/kubernetes/csi-config-map.go
@@ -60,6 +60,9 @@ type RBD struct {
 	// ControllerPublishSecretRef contains the secret reference for controller
 	// publish operations.
 	ControllerPublishSecretRef corev1.SecretReference `json:"controllerPublishSecretRef"`
+	// NodePublishSecretRef contains the secret reference for node publish
+	// operations. Used for retrieving QoS metadata during NodePublishVolume.
+	NodePublishSecretRef corev1.SecretReference `json:"nodePublishSecretRef"`
 }
 
 type NFS struct {


### PR DESCRIPTION
This PR implements cgroup v2 QoS enforcement for RBD volumes using Kubernetes VolumeAttributesClass (VAC). It enables administrators to apply I/O limits (IOPS and bandwidth) to krbd-backed volumes at the pod cgroup level, providing fine-grained I/O control without modifying the underlying RBD image configuration.

