### PR TITLE
rbd: enable WholeObject & IncludeParent in snap diff

### DIFF
--- a/internal/rbd/snap_diff.go
+++ b/internal/rbd/snap_diff.go
@@ -97,9 +97,11 @@ func (rbdSnap *rbdSnapshot) ProcessMetadata(
 		sendResponse,
 	)
 	diffIterateByIDConfig := librbd.DiffIterateByIDConfig{
-		Offset:   uint64(startingOffset),
-		Length:   uint64(rbdSnap.VolSize) - uint64(startingOffset),
-		Callback: cb,
+		Offset:        uint64(startingOffset),
+		Length:        uint64(rbdSnap.VolSize) - uint64(startingOffset),
+		IncludeParent: librbd.IncludeParent,
+		WholeObject:   librbd.EnableWholeObject,
+		Callback:      cb,
 	}
 	if baseSnap != nil {
 		// If a base snapshot is provided, set the FromSnapID to


### PR DESCRIPTION
Enable WholeObject and IncludeParent flags in DiffIterateByIDConfig
used by ProcessMetadata, matching the existing DiffIterate config
in getUsedBytes. WholeObject improves performance by reporting
whole-object granularity diffs instead of byte-level diffs.
IncludeParent ensures diffs against parent snapshots are included.


Assisted-by: Claude <noreply@anthropic.com>
