### PR TITLE
[WIP] nvmeof/add tls psk

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -418,6 +418,16 @@ func validateDHCHAPParameter(dhchapMode string) error {
 	return nil
 }
 
+// validateTLSPSKParameter helper function to validate the TLS-PSK parameters.
+func validateTLSPSKParameter(tlsPskMode string) error {
+	if tlsPskMode != nvmeof.TLSPSKEmpty && tlsPskMode != nvmeof.TLSPSKNone &&
+		tlsPskMode != nvmeof.TLSPSKEnabled {
+		return fmt.Errorf("invalid tlsPskMode: %s (must be empty, 'none', or 'enabled')", tlsPskMode)
+	}
+
+	return nil
+}
+
 // validateCreateVolumeRequest validates the incoming request for nvmeof.
 // the rest of the parameters are validated by RBD.
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
@@ -466,6 +476,10 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 		return fmt.Errorf("invalid NVMe-oF QoS parameters: %w", err)
 	}
 	err = validateDHCHAPParameter(params["dhchapMode"])
+	if err != nil {
+		return err
+	}
+	err = validateTLSPSKParameter(params["tlsPskMode"])
 	if err != nil {
 		return err
 	}
@@ -656,6 +670,7 @@ func ensureSubsystem(
 	subsystemNQN,
 	networkMask string,
 	listeners []nvmeof.ListenerDetails,
+	securedListener bool,
 ) error {
 	exists, err := gateway.SubsystemExists(ctx, subsystemNQN)
 	if err != nil {
@@ -663,7 +678,7 @@ func ensureSubsystem(
 	}
 	if !exists {
 		// Create if it doesn't exist (controller decision)
-		err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask)
+		err = gateway.CreateSubsystem(ctx, subsystemNQN, networkMask, securedListener)
 		if err != nil {
 			return err
 		}
@@ -676,7 +691,7 @@ func ensureSubsystem(
 		// Create all listeners
 		for i, listener := range listeners {
 			log.DebugLog(ctx, "Creating listener %d: %s", i, listener.String())
-			if err := gateway.CreateListener(ctx, subsystemNQN, listener); err != nil {
+			if err := gateway.CreateListener(ctx, subsystemNQN, listener, securedListener); err != nil {
 				return fmt.Errorf("failed to create listener %d (%s): %w", i, listener.String(), err)
 			}
 		}
@@ -751,7 +766,7 @@ func (cs *Server) createNVMeoFResources(
 	networkMask := params["networkMask"]
 	nvmeofData := &nvmeof.NVMeoFVolumeData{}
 
-	if err := nvmeofData.SetFromParameters(params); err != nil {
+	if err := nvmeofData.SetFromParameters(ctx, params); err != nil {
 		return nil, fmt.Errorf("failed to set NVMe-oF volume data: %w", err)
 	}
 
@@ -790,7 +805,10 @@ func (cs *Server) createNVMeoFResources(
 	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
 
 	// Step 3: Ensure subsystem exists (and listener)
-	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, networkMask, nvmeofData.ListenerInfo); err != nil {
+	// Determine if TLS-PSK is enabled for secure listeners
+	secure := nvmeofData.Security.TlsPskMode == nvmeof.TLSPSKEnabled
+	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, networkMask,
+		nvmeofData.ListenerInfo, secure); err != nil {
 		return nvmeofData, fmt.Errorf("subsystem setup failed: %w", err)
 	}
 
@@ -926,8 +944,16 @@ func (cs *Server) publishResources(ctx context.Context,
 		return "", err
 	}
 
+	// Get TLS-PSK configuration from volume context
+	tlsPskMode := volumeContext[vcTLSPSKMode] // "none", "enabled", or empty
+	var pskKey string
+	pskKey, err = cs.setupTLSPSKKey(ctx, req, nodeID, subsystemNQN, tlsPskMode)
+	if err != nil {
+		return "", err
+	}
+
 	// Add host to subsystem
-	if err := gateway.AddHost(ctx, subsystemNQN, hostNQN, dhchapKeys); err != nil {
+	if err := gateway.AddHost(ctx, subsystemNQN, hostNQN, dhchapKeys, pskKey); err != nil {
 		return "", fmt.Errorf("failed to add host %s: %w", hostNQN, err)
 	}
 
@@ -996,6 +1022,15 @@ func (cs *Server) unpublishResources(ctx context.Context,
 		}
 	}
 
+	// Cleanup TLS-PSK key from KMS
+	if data.Security.TlsPskMode == nvmeof.TLSPSKEnabled {
+		err = cs.cleanupTLSPSKKey(ctx, secrets, nodeID, volumeID, subsystemNQN,
+			data.Security.TlsPskMode, data.Security.AuthenticationKMSID)
+		if err != nil {
+			return fmt.Errorf("failed to cleanup TLS-PSK key for host %s: %w", hostNQN, err)
+		}
+	}
+
 	return nil
 }
 
@@ -1033,6 +1068,9 @@ const (
 
 	// DH-CHAP mode for authentication.
 	vcDHCHAPMode = "dhchapMode"
+
+	// TLS-PSK mode for secure transport (authentication + encryption).
+	vcTLSPSKMode = "tlsPskMode"
 )
 
 // toRBDMetadataKey converts clean volume context key to prefixed RBD metadata key.
@@ -1063,6 +1101,7 @@ func populateVolumeContext(volume *csi.Volume, data *nvmeof.NVMeoFVolumeData) er
 	// Store Security info
 	volume.VolumeContext[vcAuthenticationKMSID] = data.Security.AuthenticationKMSID
 	volume.VolumeContext[vcDHCHAPMode] = data.Security.DhchapMode
+	volume.VolumeContext[vcTLSPSKMode] = data.Security.TlsPskMode
 
 	return nil
 }
@@ -1116,8 +1155,9 @@ func (cs *Server) storeNVMeoFMetadata(
 		toRBDMetadataKey(vcGatewayAddress): nvmeofData.GatewayManagementInfo.Address,
 		toRBDMetadataKey(vcGatewayPort):    gatewayManagementInfoPortStr,
 
-		// DH-CHAP mode
+		// Security config
 		toRBDMetadataKey(vcDHCHAPMode):          nvmeofData.Security.DhchapMode,
+		toRBDMetadataKey(vcTLSPSKMode):          nvmeofData.Security.TlsPskMode,
 		toRBDMetadataKey(vcAuthenticationKMSID): nvmeofData.Security.AuthenticationKMSID,
 	}
 
@@ -1173,6 +1213,7 @@ func (cs *Server) getNVMeoFMetadata(
 	}
 	optionalKeys := []string{
 		toRBDMetadataKey(vcDHCHAPMode),
+		toRBDMetadataKey(vcTLSPSKMode),
 		toRBDMetadataKey(vcAuthenticationKMSID),
 	}
 
@@ -1239,6 +1280,7 @@ func (cs *Server) getNVMeoFMetadata(
 		},
 		Security: nvmeof.NVMeoFSecurityConfig{
 			DhchapMode:          metadata[toRBDMetadataKey(vcDHCHAPMode)],
+			TlsPskMode:          metadata[toRBDMetadataKey(vcTLSPSKMode)],
 			AuthenticationKMSID: metadata[toRBDMetadataKey(vcAuthenticationKMSID)],
 		},
 	}

--- a/internal/nvmeof/controller/security.go
+++ b/internal/nvmeof/controller/security.go
@@ -176,3 +176,106 @@ func (cs *Server) cleanupDHCHAPKeys(
 
 	return nil
 }
+
+// setupTLSPSKKey configures TLS-PSK secure transport and returns the PSK.
+// TLS-PSK provides both authentication and encryption.
+// Returns empty string if TLS-PSK is disabled.
+func (cs *Server) setupTLSPSKKey(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest,
+	nodeID,
+	subsystemNQN,
+	tlsPskMode string,
+) (string, error) {
+	// Only proceed if TLS-PSK is explicitly enabled (validated at request time)
+	if tlsPskMode != nvmeof.TLSPSKEnabled {
+		return "", nil
+	}
+
+	log.DebugLog(ctx, "TLS-PSK mode: %s - setting up secure transport for node %s", tlsPskMode, nodeID)
+	// Get authentication KMS ID from volume context
+	volumeContext := req.GetVolumeContext()
+	authKMSID := volumeContext[vcAuthenticationKMSID]
+	secrets := req.GetSecrets()
+
+	// Initialize security key manager
+	securityKeysManager, err := cs.getOrInitSecurityKeys(ctx, authKMSID, secrets)
+
+	// Setup DEK store if needed (for metadata KMS)
+	// (just for test, not for production!! for production, use external KMS like Vault)
+	if errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		volumeID := req.GetVolumeId()
+		mgr := rbdutil.NewManager(cs.backendServer.Driver.GetInstanceID(), nil, secrets)
+		defer mgr.Destroy(ctx)
+
+		rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+		if err != nil {
+			return "", fmt.Errorf("failed to find volume with ID %q: %w", volumeID, err)
+		}
+		defer rbdVol.Destroy(ctx)
+
+		dekStore := nvmeof.NewRBDVolumeDEKStore(rbdVol)
+		securityKeysManager.SetDEKStore(dekStore)
+	} else if err != nil {
+		return "", fmt.Errorf("failed to initialize security key manager: %w", err)
+	}
+
+	// Get or create TLS-PSK key
+	pskKey, err := nvmeof.GetOrCreateTLSPSKKey(ctx, securityKeysManager, nodeID, subsystemNQN)
+	if err != nil {
+		return "", fmt.Errorf("failed to get/create TLS-PSK key: %w", err)
+	}
+
+	log.DebugLog(ctx, "TLS-PSK key retrieved for node %s, subsystem %s", nodeID, subsystemNQN)
+
+	return pskKey, nil
+}
+
+// cleanupTLSPSKKey removes TLS-PSK keys for the unpublished host.
+func (cs *Server) cleanupTLSPSKKey(
+	ctx context.Context,
+	secrets map[string]string,
+	nodeID,
+	volumeID,
+	subsystemNQN,
+	tlsPskMode,
+	authKMSID string,
+) error {
+	// Return if TLS-PSK is disabled
+	if tlsPskMode == nvmeof.TLSPSKEmpty || tlsPskMode == nvmeof.TLSPSKNone {
+		return nil
+	}
+	log.DebugLog(ctx, "Cleaning up TLS-PSK keys for node %s, subsystem %s", nodeID, subsystemNQN)
+
+	log.DebugLog(ctx, "TLS-PSK mode: %s - cleaning up secure transport for node %s", tlsPskMode, nodeID)
+
+	// Initialize security key manager
+	securityKeysManager, err := cs.getOrInitSecurityKeys(ctx, authKMSID, secrets)
+
+	// Setup DEK store if needed (for metadata KMS)
+	// (just for test, not for production!! for production, use external KMS like Vault)
+	if errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		mgr := rbdutil.NewManager(cs.backendServer.Driver.GetInstanceID(), nil, secrets)
+		defer mgr.Destroy(ctx)
+
+		rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+		if err != nil {
+			return fmt.Errorf("failed to find volume with ID %q: %w", volumeID, err)
+		}
+		defer rbdVol.Destroy(ctx)
+
+		dekStore := nvmeof.NewRBDVolumeDEKStore(rbdVol)
+		securityKeysManager.SetDEKStore(dekStore)
+	} else if err != nil {
+		return fmt.Errorf("failed to initialize security key manager: %w", err)
+	}
+
+	// Remove PSK key
+	if err := nvmeof.RemoveTLSPSKKey(ctx, securityKeysManager, nodeID, subsystemNQN); err != nil {
+		log.ErrorLog(ctx, "Failed to remove TLS-PSK key: %v", err)
+	} else {
+		log.DebugLog(ctx, "TLS-PSK key removed for node %s", nodeID)
+	}
+
+	return nil
+}

--- a/internal/nvmeof/crypto.go
+++ b/internal/nvmeof/crypto.go
@@ -43,6 +43,12 @@ const (
 	// NVMeOFSecurityOwner is the identifier used when requesting KMS instances
 	// for NVMe-oF authentication key management.
 	NVMeOFSecurityOwner = "nvmeof-system"
+
+	// RBDMetadataKMS is the KMS identifier for the metadata-based KMS implementation.
+	// This KMS stores encrypted keys in RBD image metadata and is intended for testing
+	// and environments without an external KMS. It requires the caller to provide a DEKStore.
+	// In production, a more robust KMS like Vault should be used instead.
+	RBDMetadataKMS = "metadata"
 )
 
 // SecurityKeyManager defines the interface for managing NVMe-oF security keys.
@@ -87,7 +93,7 @@ func InitSecurityKeyManager(
 ) (SecurityKeyManager, error) {
 	if kmsID == "" {
 		// Use metadata KMS for testing (stores in RBD metadata)
-		kmsID = "metadata"
+		kmsID = RBDMetadataKMS
 	}
 	kmsInstance, err := kms.GetKMS(NVMeOFSecurityOwner, kmsID, credentials)
 	if err != nil {

--- a/internal/nvmeof/nodeserver/nodeserver.go
+++ b/internal/nvmeof/nodeserver/nodeserver.go
@@ -76,6 +76,7 @@ type NvmeConnectionInfo struct {
 	HostNQN       string                   `json:"hostNQN,omitempty"`
 	Transport     string                   `json:"transport"`
 	DhchapMode    string                   `json:"dhchapMode,omitempty"`
+	TlsPskMode    string                   `json:"tlsPskMode,omitempty"`
 }
 
 // stageTransaction struct represents the state a transaction was when it either completed
@@ -98,6 +99,7 @@ const (
 	nvmeofHostNQN       = "HostNQN"
 	defaultTransport    = "tcp"
 	nvmeofdhchapMode    = "dhchapMode"
+	nvmeoftlsPskMode    = "tlsPskMode"
 	authenticationKMSID = "authenticationKMSID"
 )
 
@@ -687,6 +689,10 @@ func (ns *NodeServer) getNvmeConnection(volumeContext, publishContext map[string
 	if !ok || dhchapMode == "" || dhchapMode == "none" {
 		dhchapMode = ""
 	}
+	tlsPskMode, ok := volumeContext[nvmeoftlsPskMode]
+	if !ok || tlsPskMode == "" || tlsPskMode == "none" {
+		tlsPskMode = ""
+	}
 
 	return &NvmeConnectionInfo{
 		SubsystemNQN:  subsystemNQN,
@@ -696,6 +702,7 @@ func (ns *NodeServer) getNvmeConnection(volumeContext, publishContext map[string
 		HostNQN:       hostNQN,
 		Transport:     defaultTransport,
 		DhchapMode:    dhchapMode,
+		TlsPskMode:    tlsPskMode,
 	}, nil
 }
 
@@ -717,6 +724,13 @@ func (ns *NodeServer) connectToSubsystem(
 	// Setup DH-CHAP authentication if required
 	if info.DhchapMode != nvmeof.DHCHAPEmpty && info.DhchapMode != nvmeof.DHCHAPModeNone {
 		if err := ns.setupDHCHAPAuth(ctx, volumeID, info, secrets, authKMSID, connectReq); err != nil {
+			return "", err
+		}
+	}
+
+	// Setup TLS-PSK secure transport if required
+	if info.TlsPskMode == nvmeof.TLSPSKEnabled {
+		if err := ns.setupTLSPSKAuth(ctx, volumeID, info, secrets, authKMSID, connectReq); err != nil {
 			return "", err
 		}
 	}

--- a/internal/nvmeof/nodeserver/security.go
+++ b/internal/nvmeof/nodeserver/security.go
@@ -99,3 +99,55 @@ func (ns *NodeServer) setupDHCHAPAuth(
 
 	return nil
 }
+
+// setupTLSPSKAuth configures TLS-PSK secure transport for the connection.
+// TLS-PSK provides both authentication and encryption.
+func (ns *NodeServer) setupTLSPSKAuth(
+	ctx context.Context,
+	volumeID string,
+	info *NvmeConnectionInfo,
+	secrets map[string]string,
+	authKMSID string,
+	connectReq *nvmeof.ConnectRequest,
+) error {
+	// Initialize security key manager
+	securityKeys, err := ns.getOrInitSecurityKeys(ctx, authKMSID, secrets)
+
+	// Setup DEK store if needed (for metadata KMS)
+	if errors.Is(err, nvmeof.ErrDEKStoreNeeded) {
+		cr, err := util.NewUserCredentialsWithMigration(secrets)
+		if err != nil {
+			return fmt.Errorf("failed to get user credentials: %w", err)
+		}
+		defer cr.DeleteCredentials()
+
+		rbdVol, err := rbdutil.GenVolFromVolID(ctx, volumeID, cr, secrets)
+		if err != nil {
+			return fmt.Errorf("failed to get volume: %w", err)
+		}
+		defer rbdVol.Destroy(ctx)
+
+		dekStore := nvmeof.NewRBDVolumeDEKStore(rbdVol)
+		securityKeys.SetDEKStore(dekStore)
+	} else if err != nil {
+		return fmt.Errorf("failed to initialize security key manager: %w", err)
+	}
+
+	// Get TLS-PSK key (get-only, no creation)
+	// Node-side must NOT create PSK keys to prevent mismatches with gateway.
+	// The controller creates the PSK during ControllerPublishVolume.
+	pskKey, err := nvmeof.GetTLSPSKKey(ctx, securityKeys, ns.nodeID, info.SubsystemNQN)
+	if err != nil {
+		if errors.Is(err, nvmeof.ErrKeyNotFound) {
+			return fmt.Errorf(
+				"TLS-PSK key not found in KMS for node %s and subsystem %s: "+
+					"ensure ControllerPublishVolume completed successfully before NodeStageVolume",
+				ns.nodeID, info.SubsystemNQN)
+		}
+
+		return fmt.Errorf("failed to retrieve TLS-PSK key: %w", err)
+	}
+	connectReq.PSKKey = pskKey
+
+	return nil
+}

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -357,7 +357,9 @@ func (gw *GatewayRpcClient) GetUUIDBySubsystemAndNameSpaceID(
 }
 
 // CreateSubsystem creates an NVMe-oF subsystem on the gateway.
-func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN, networkMask string) error {
+func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN, networkMask string,
+	securedListener bool,
+) error {
 	log.DebugLog(ctx, "Creating NVMe subsystem: %s on gateway %s",
 		subsystemNQN, gw.config)
 
@@ -382,6 +384,9 @@ func (gw *GatewayRpcClient) CreateSubsystem(ctx context.Context, subsystemNQN, n
 	if networkMask != "" {
 		listNetworkMask = append(listNetworkMask, networkMask)
 		req.NetworkMask = listNetworkMask
+		if securedListener {
+			req.SecureListeners = &securedListener
+		}
 	}
 	status, err := gw.client.CreateSubsystem(ctx, req)
 	switch {
@@ -453,7 +458,9 @@ func (gw *GatewayRpcClient) SubsystemExists(ctx context.Context, subsystemNQN st
 }
 
 // AddHost adds a host to a subsystem (allows access).
-func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN string, dhchapKeys DHCHAPKeys) error {
+func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN string,
+	dhchapKeys DHCHAPKeys, pskKey string,
+) error {
 	log.DebugLog(ctx, "Adding host %s to subsystem %s on gateway %s",
 		hostNQN, subsystemNQN, gw.config)
 
@@ -462,11 +469,14 @@ func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN s
 	req := &pb.AddHostReq{
 		SubsystemNqn: subsystemNQN,
 		HostNqn:      hostNQN,
-		// Psk: nil,          // No pre-shared key
-		// DhchapKey: nil,    // No DH-CHAP authentication
 		// PskEncrypted: nil, // No PSK encryption
 		// KeyEncrypted: nil, // No key encryption
 		// CtrlrKeyEncrypted: nil, // No controller key encryption
+	}
+
+	// Add TLS-PSK key if provided
+	if pskKey != "" {
+		req.Psk = &pskKey
 	}
 
 	// Add DH-CHAP key if provided
@@ -496,6 +506,7 @@ func (gw *GatewayRpcClient) AddHost(ctx context.Context, subsystemNQN, hostNQN s
 }
 
 func (gw *GatewayRpcClient) CreateListener(ctx context.Context, subsystemNQN string, listenerInfo ListenerDetails,
+	securedListener bool,
 ) error {
 	log.DebugLog(ctx, "Adding listener %s to subsystem %s", listenerInfo.Address, subsystemNQN)
 	adrfam := pb.AddressFamily_ipv4
@@ -505,8 +516,12 @@ func (gw *GatewayRpcClient) CreateListener(ctx context.Context, subsystemNQN str
 		Traddr:   listenerInfo.Address,
 		Trsvcid:  &listenerInfo.Port,
 		Adrfam:   &adrfam, // Assuming IPv4, can be configurable // TODO - make it configurable
-		// Secure  // false, // Assuming no security for now   // TODO - make it configurable?
 		// VerifyHostName // false, // Assuming no hostname verification for now // TODO - make it configurable
+	}
+
+	// Set secure flag for TLS if enabled
+	if securedListener {
+		req.Secure = &securedListener
 	}
 
 	resp, err := gw.client.CreateListener(ctx, req)

--- a/internal/nvmeof/nvmeof_initiator.go
+++ b/internal/nvmeof/nvmeof_initiator.go
@@ -19,6 +19,7 @@ package nvmeof
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -74,6 +75,8 @@ type ConnectRequest struct {
 	SubsystemDhchapKey string
 	// Optional - In-band authentication secret for uni-directional authentication
 	HostDhchapKey string
+	// Optional - TLS-PSK pre-shared key for secure transport (authentication + encryption)
+	PSKKey string
 }
 
 // nvmeInitiator implements NVMeInitiator interface.
@@ -196,6 +199,20 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 	}
 	// Try connecting to each address until one succeeds
 	var success bool
+	if req.PSKKey != "" {
+		// Verify tlshd daemon is running (required for TLS-PSK keyring support)
+		if err := verifyTLSHandshakeDaemon(ctx); err != nil {
+			log.ErrorLog(ctx, "TLS handshake daemon verification failed for TLS-PSK connection: %v", err)
+
+			return false, err
+		}
+		// Insert PSK into kernel keyring using nvme check-tls-key
+		if err := insertPSKIntoKeyring(ctx, req.PSKKey, req.HostNQN, req.SubsystemNQN); err != nil {
+			log.ErrorLog(ctx, "Failed to insert TLS-PSK into keyring for %s: %v", req.SubsystemNQN, err)
+
+			return false, err
+		}
+	}
 	for _, listener := range req.Listeners {
 		portStr := strconv.FormatUint(uint64(listener.Port), 10)
 
@@ -235,6 +252,10 @@ func (ni *nvmeInitiator) ConnectSubsystem(ctx context.Context, req *ConnectReque
 		// if Subsystem DH-CHAP key is provided, add it to the command (for bi-directional auth)
 		if req.SubsystemDhchapKey != "" {
 			args = append(args, "--dhchap-ctrl-secret", req.SubsystemDhchapKey)
+		}
+		// if PSK key is provided, connect with --tls (key already inserted into keyring above)
+		if req.PSKKey != "" {
+			args = append(args, "--tls")
 		}
 		stdout, stderr, err := util.ExecCommandWithTimeout(ctx, connectTimeout, "nvme", args...)
 		// Execute connection
@@ -548,4 +569,46 @@ func getNamespacesForController(ctx context.Context, controllerName string) ([]i
 	}
 
 	return nsids, nil
+}
+
+// verifyTLSHandshakeDaemon checks if the tlshd daemon is running.
+// tlshd must be pre-installed and running on the host node as a prerequisite for TLS-PSK.
+// This function is called only when TLS-PSK is actually requested.
+func verifyTLSHandshakeDaemon(ctx context.Context) error {
+	// Use pgrep which searches host process table (works since hostPID=true)
+	// systemctl is not reliable from within a container
+	_, _, err := util.ExecCommandWithTimeout(ctx, 5*time.Second, "pgrep", "-x", "tlshd")
+	if err != nil {
+		return errors.New("tlshd daemon is not running (required for TLS-PSK). " +
+			"Install ktls-utils and start tlshd on the host.")
+	}
+
+	log.DebugLog(ctx, "tlshd daemon is running and available for TLS-PSK")
+
+	return nil
+}
+
+// insertPSKIntoKeyring inserts a TLS-PSK into the kernel keyring.
+// This must be done before connecting with --tls flag.
+// The keyring is managed by tlshd daemon and uses identity version 0 for SPDK/Ceph compatibility.
+func insertPSKIntoKeyring(ctx context.Context, pskKey, hostNQN, subsystemNQN string) error {
+	args := []string{
+		"check-tls-key",
+		"--keydata", pskKey,
+		"--hostnqn", hostNQN,
+		"--subsysnqn", subsystemNQN,
+		"--identity", "0", // Use identity version 0 for SPDK/Ceph compatibility
+		"--insert", // Insert into kernel keyring
+	}
+
+	stdout, stderr, err := util.ExecCommandWithTimeout(ctx, connectTimeout, "nvme", args...)
+	if err != nil {
+		return fmt.Errorf("nvme check-tls-key --insert failed (stdout: %s, stderr: %s): %w",
+			stdout, stderr, err)
+	}
+
+	// Output format: "Inserted TLS key 156b1745"
+	log.DebugLog(ctx, "Inserted TLS-PSK into keyring: %s", strings.TrimSpace(stdout))
+
+	return nil
 }

--- a/internal/nvmeof/tests/nvmeof_test.go
+++ b/internal/nvmeof/tests/nvmeof_test.go
@@ -119,13 +119,15 @@ func TestRealGateway(t *testing.T) {
 
 	// Test create subsystem
 	networkMask := "" // No auto-listeners
-	err = client.CreateSubsystem(ctx, nvmeofData.SubsystemNQN, networkMask)
+	securedListener := false
+	err = client.CreateSubsystem(ctx, nvmeofData.SubsystemNQN, networkMask, securedListener)
 	require.NoError(t, err)
 	t.Logf("✓ Subsystem created: %s", nvmeofData.SubsystemNQN)
 
 	// Test add host
 	noneDhchapKeys := nvmeof.DHCHAPKeys{} // No DH-CHAP authentication
-	err = client.AddHost(ctx, nvmeofData.SubsystemNQN, hostNQN, noneDhchapKeys)
+	noTLSPSKKey := ""                     // No TLS-PSK key
+	err = client.AddHost(ctx, nvmeofData.SubsystemNQN, hostNQN, noneDhchapKeys, noTLSPSKKey)
 	require.NoError(t, err)
 	t.Logf("✓ Host added: %s to subsystem %s", hostNQN, nvmeofData.SubsystemNQN)
 
@@ -136,7 +138,7 @@ func TestRealGateway(t *testing.T) {
 	t.Logf("✓ Subsystem exists: %s", nvmeofData.SubsystemNQN)
 
 	// Test create listener
-	err = client.CreateListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo[0])
+	err = client.CreateListener(ctx, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo[0], false)
 	require.NoError(t, err)
 	t.Logf("✓ Listener created for subsystem %s at %s", testNQN, config)
 

--- a/internal/nvmeof/tls_psk.go
+++ b/internal/nvmeof/tls_psk.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvmeof
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ceph/ceph-csi/internal/util"
+)
+
+// TLS-PSK Key Storage Architecture
+//
+// TLS-PSK keys are stored in a DEKStore (Data Encryption Key Store) using a structured key ID format.
+// The DEKStore can be backed by different storage systems:
+//   - RBD metadata (for testing) - stored as RBD image metadata key-value pairs
+//   - External KMS like Vault (for production) - stored in the KMS system
+//
+// Key ID Format:
+//   <prefix>-<nodeID>-<subsystemHash>
+//
+// Components:
+//   prefix:         "nvmeof-tls-psk"
+//   nodeID:         Kubernetes node name (e.g., "worker-node-1")
+//   subsystemHash:  First 16 characters of SHA-256 hash of subsystem NQN
+//
+// Examples:
+//   TLS-PSK key:    nvmeof-tls-psk-worker-node-1-a1b2c3d4e5f6g7h8
+//
+// Key Value Format:
+//   The value stored is the TLS-PSK in NVMe PSK Interchange format:
+//   NVMeTLSkey-1:<hash_type>:<base64_encoded_key_with_crc>:
+//
+//   Example: NVMeTLSkey-1:01:lLyldXckJcsT8tGnxG00BsR2kHsK/92ygXcRbYXTC8jekqdm:
+//
+// Storage Flow:
+//   1. Generate PSK using nvme gen-tls-key command
+//   2. Encrypt key using KMS (EncryptDEK)
+//   3. Store encrypted key in DEKStore with key ID
+//
+// Retrieval Flow:
+//   1. Fetch encrypted key from DEKStore using key ID
+//   2. Decrypt key using KMS (DecryptDEK)
+//   3. Return plaintext TLS-PSK for nvme connect
+//
+
+// TLS-PSK modes.
+const (
+	TLSPSKEmpty   = ""        // when no TLS-PSK is provided
+	TLSPSKNone    = "none"    // when TLS-PSK is explicitly disabled
+	TLSPSKEnabled = "enabled" // when TLS-PSK is enabled
+)
+
+// TLS-PSK specific constants.
+const (
+	// Key prefix for DEKStore key IDs.
+	keyPrefixTLSPSK = "nvmeof-tls-psk"
+)
+
+// GetOrCreateTLSPSKKey retrieves existing PSK or creates new one if not found.
+// This function follows the same pattern as GetOrCreateDHCHAPHostKey.
+func GetOrCreateTLSPSKKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID,
+	subsystemNQN string,
+) (string, error) {
+	// Try to get existing key
+	pskKey, err := GetTLSPSKKey(ctx, skm, nodeID, subsystemNQN)
+	if err == nil {
+		// Key exists, return it
+		return pskKey, nil
+	}
+
+	// TODO: When another KMS implementation is added, check what kind of error it
+	// returns when a key is not found and handle that here instead of relying on
+	// ErrKeyNotFound. For now, since we only have the RBD DEKStore, we can check
+	// for ErrKeyNotFound, which is returned by the RBD DEKStore when a key is not found.
+
+	// Only create if truly not found - not on any other error.
+	if !errors.Is(err, ErrKeyNotFound) {
+		// Real error (KMS down, network issue etc) - don't generate new key
+		return "", fmt.Errorf("failed to check existing TLS-PSK key: %w", err)
+	}
+
+	// Key doesn't exist, generate new one
+	pskKey, err = generateAndStoreTLSPSKKey(ctx, skm, nodeID, subsystemNQN)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate TLS-PSK key: %w", err)
+	}
+
+	return pskKey, nil
+}
+
+// RemoveTLSPSKKey removes the TLS-PSK key for the given node and subsystem connection.
+func RemoveTLSPSKKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID string,
+	subsystemNQN string,
+) error {
+	keyID := buildTLSPSKKeyID(nodeID, subsystemNQN)
+
+	return skm.RemoveKey(ctx, keyID)
+}
+
+// generateAndStoreTLSPSKKey generates a new TLS-PSK key and stores it in the DEKStore.
+//
+// Key generation and storage flow:
+//  1. Build key ID: nvmeof-tls-psk-<nodeID>-<subsystemHash>
+//  2. Generate TLS-PSK using nvme gen-tls-key command
+//  3. Encrypt key using KMS
+//  4. Store encrypted key in DEKStore with key ID
+//
+// Example key ID: nvmeof-tls-psk-worker-node-1-a1b2c3d4e5f6g7h8.
+func generateAndStoreTLSPSKKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID,
+	subsystemNQN string,
+) (string, error) {
+	keyID := buildTLSPSKKeyID(nodeID, subsystemNQN)
+	pskKey, err := generateTLSPSKKey(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate TLS-PSK key for %s: %w", keyID, err)
+	}
+	err = skm.StoreKey(ctx, keyID, pskKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to store TLS-PSK key for %s: %w", keyID, err)
+	}
+
+	return pskKey, nil
+}
+
+// generateTLSPSKKey generates a TLS-PSK key using nvme-cli gen-tls-key command.
+// This generates a TLS-PSK in NVMe PSK Interchange format:
+// NVMeTLSkey-1:<hash_type>:<base64_encoded_key_with_crc>:
+//
+// The format includes:
+//   - NVMeTLSkey-1: Protocol identifier
+//   - hash_type: 01 (SHA-256), 02 (SHA-384)
+//   - base64_encoded_key_with_crc: Base64 of (key_bytes + crc_checksum)
+//
+// Example output: NVMeTLSkey-1:01:lLyldXckJcsT8tGnxG00BsR2kHsK/92ygXcRbYXTC8jekqdm: .
+func generateTLSPSKKey(ctx context.Context) (string, error) {
+	args := []string{
+		"gen-tls-key",
+	}
+
+	stdout, stderr, err := util.ExecCommandWithTimeout(ctx, connectTimeout, "nvme", args...)
+	if err != nil {
+		// Command doesn't exist or failed
+		return "", fmt.Errorf("nvme gen-tls-key command failed: %w (stderr: %s)", err, stderr)
+	}
+
+	// Parse output - nvme gen-tls-key outputs the key in format:
+	// NVMeTLSkey-1:01:base64key:
+	key := strings.TrimSpace(stdout)
+	if key == "" {
+		return "", errors.New("generated TLS-PSK key is empty")
+	}
+
+	return key, nil
+}
+
+// buildTLSPSKKeyID constructs a unique key ID for DEKStore storage.
+//
+// Format: nvmeof-tls-psk-<nodeID>-<subsystemHash>
+//
+// Components:
+//   - prefix: "nvmeof-tls-psk"
+//   - nodeID: Kubernetes node name
+//   - subsystemHash: First 16 chars of SHA-256 hash of subsystem NQN
+//
+// Examples:
+//
+//	buildTLSPSKKeyID("worker-1", "nqn.2016-06.io.spdk:cnode1")
+//	 "nvmeof-tls-psk-worker-1-a1b2c3d4e5f6g7h8"
+func buildTLSPSKKeyID(
+	nodeID string,
+	subsystemNQN string,
+) string {
+	subsystemHash := hashSubsystemNQN(subsystemNQN)
+
+	return fmt.Sprintf("%s-%s-%s", keyPrefixTLSPSK, nodeID, subsystemHash)
+}
+
+// GetTLSPSKKey retrieves the TLS-PSK key from the DEKStore (get-only, no creation).
+// Returns ErrKeyNotFound if the key doesn't exist.
+// This should be used on the node side to prevent PSK regeneration mismatches.
+func GetTLSPSKKey(
+	ctx context.Context,
+	skm SecurityKeyManager,
+	nodeID string,
+	subsystemNQN string,
+) (string, error) {
+	keyID := buildTLSPSKKeyID(nodeID, subsystemNQN)
+
+	return skm.GetKey(ctx, keyID)
+}

--- a/internal/nvmeof/volume.go
+++ b/internal/nvmeof/volume.go
@@ -108,7 +108,7 @@ func (v *NVMeoFVolumeData) SetFromParameters(parameters map[string]string) error
 	if v.Security.DhchapMode != DHCHAPEmpty &&
 		v.Security.DhchapMode != DHCHAPModeNone &&
 		v.Security.AuthenticationKMSID == "" {
-		v.Security.AuthenticationKMSID = "metadata"
+		v.Security.AuthenticationKMSID = RBDMetadataKMS
 	}
 
 	// set listeners

--- a/internal/nvmeof/volume.go
+++ b/internal/nvmeof/volume.go
@@ -17,10 +17,13 @@ limitations under the License.
 package nvmeof
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // NVMeoFVolumeData holds the data required for an NVMe-oF volume.
@@ -35,6 +38,7 @@ type NVMeoFVolumeData struct {
 
 type NVMeoFSecurityConfig struct {
 	DhchapMode          string
+	TlsPskMode          string
 	AuthenticationKMSID string
 }
 
@@ -84,7 +88,7 @@ func SetupListeners(listenersJSON string) ([]ListenerDetails, error) {
 // It extracts the subsystem NQN, gateway management info, security config, and
 // listener info from the parameters.
 // It also applies default values to listeners if necessary.
-func (v *NVMeoFVolumeData) SetFromParameters(parameters map[string]string) error {
+func (v *NVMeoFVolumeData) SetFromParameters(ctx context.Context, parameters map[string]string) error {
 	// set subsystem NQN
 	v.SubsystemNQN = parameters["subsystemNQN"]
 
@@ -100,6 +104,7 @@ func (v *NVMeoFVolumeData) SetFromParameters(parameters map[string]string) error
 
 	// set security config
 	v.Security.DhchapMode = parameters["dhchapMode"]
+	v.Security.TlsPskMode = parameters["tlsPskMode"]
 	v.Security.AuthenticationKMSID = parameters["authenticationKMSID"]
 
 	// If dhchapMode was explicitly provided and is not "none", and authenticationKMSID is empty,
@@ -109,6 +114,18 @@ func (v *NVMeoFVolumeData) SetFromParameters(parameters map[string]string) error
 		v.Security.DhchapMode != DHCHAPModeNone &&
 		v.Security.AuthenticationKMSID == "" {
 		v.Security.AuthenticationKMSID = RBDMetadataKMS
+	}
+
+	// If tlsPskMode was explicitly provided and is not "none", and authenticationKMSID is empty,
+	// use a default KMS ID - RBD metadata KMS.
+	// In production, users should always provide a KMS ID when using TLS-PSK.
+	if v.Security.TlsPskMode != TLSPSKEmpty &&
+		v.Security.TlsPskMode != TLSPSKNone &&
+		v.Security.AuthenticationKMSID == "" {
+		v.Security.AuthenticationKMSID = RBDMetadataKMS
+		log.WarningLog(ctx,
+			"using default KMS ID for TLS-PSK: %s, it is strongly recommended to provide a KMS ID in production",
+			RBDMetadataKMS)
 	}
 
 	// set listeners

--- a/internal/nvmeof/volume_test.go
+++ b/internal/nvmeof/volume_test.go
@@ -177,7 +177,7 @@ func TestSetFromParameters(t *testing.T) {
 				},
 				Security: NVMeoFSecurityConfig{
 					DhchapMode:          "bidirectional",
-					AuthenticationKMSID: "metadata",
+					AuthenticationKMSID: RBDMetadataKMS,
 				},
 				ListenerInfo: []ListenerDetails{
 					{Hostname: "nvmeof-gw-b", GatewayAddress: GatewayAddress{Port: 4420, Address: "10.92.3.13"}},

--- a/internal/nvmeof/volume_test.go
+++ b/internal/nvmeof/volume_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nvmeof
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -209,7 +210,7 @@ func TestSetFromParameters(t *testing.T) {
 	}
 	for _, test := range tests {
 		vol := &NVMeoFVolumeData{}
-		err := vol.SetFromParameters(test.params)
+		err := vol.SetFromParameters(context.Background(), test.params)
 		if test.expectError {
 			require.Error(t, err)
 		} else {


### PR DESCRIPTION
# Add TLS-PSK support for NVMe-oF volumes

This PR adds TLS-PSK (Pre-Shared Key) to encrypt NVMe-oF connections between nodes and Ceph gateways.
It is very similar implementation like DH-CHAP feature. (Both use KMS and dek-store for encrypting and saving the key inside). 
 DH-CHAP is for authentication, TLS-PSK for secure communication. 

## What changed

Added `tlsPskMode` StorageClass parameter that enables TLS encryption for volumes. When enabled:

1. **Controller generates PSK** when publishing volume to a node
   - Creates 256-bit random key using `nvme gen-tls-key`
   - Encrypts and stores key in KMS/DEKStore (same pattern as DH-CHAP)
   - Configures gateway with PSK via `AddHost()` call
   - Creates listeners with `secure=true` flag

2. **Node retrieves PSK** when staging volume
   - Fetches same key from KMS using node ID + subsystem NQN
   - Connects with `nvme connect --tls --tls-key <PSK>`

3. **Controller cleanup** when unpublishing
   - Removes PSK from KMS after host is removed from subsystem

## Key design choices

- **PSK scope**: Per host-subsystem pair). Multiple volumes on same node connecting to same subsystem share one key.
- **Storage**: Uses existing DEKStore pattern - RBD metadata for testing, Vault/external KMS for production. 
- **Key retrieval**: Node independently fetches key from KMS, controller doesn't pass it through volume context.
- **Key format**: `nvmeof-tls-psk-<nodeID>-<subsystemHash>` where subsystemHash is first 16 chars of SHA-256(subsystemNQN)

## Usage

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ceph-nvmeof-tls
provisioner: nvmeof.csi.ceph.com
parameters:
  tlsPskMode: "enabled"
  authenticationKMSID: "metadata"  # or vault/aws-kms/etc
```

## Testing 
I did not test it yet.

fix issue : https://github.com/ceph/ceph-csi/issues/5717

## UPDATE
TLS-PSK requires `tlshd` (TLS Handshake Daemon) to be installed and running on each node where the CSI node plugin is deployed. The Linux kernel's NVMe-TCP driver cannot perform TLS handshakes directly in kernel space, so it delegates this to `tlshd`, a user-space daemon from the ktls-utils package. When `nvme connect --tls` is issued, the kernel sends a handshake request via netlink socket to tlshd, which uses the GnuTLS library to perform the TLS 1.3 negotiation with the gateway. The resulting session keys are passed back to the kernel's kTLS layer, which then handles all subsequent I/O encryption transparently. The PSK key must be pre-inserted into the kernel's .nvme keyring (via `nvme check-tls-key --insert --identity 0`) before connecting, and tlshd must be configured with `keyrings=.nvme` in `/etc/tlshd.conf` so it can locate the key during the handshake. Without tlshd running, all TLS-PSK connection attempts will fail with a handshake error regardless of whether the key is correctly configured on both sides.

**We need to figure out how to handle it.** 


**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
