### PR TITLE
helm: add PodMonitor support to ceph-csi-rbd Helm chart

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-podmonitor.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-podmonitor.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.nodeplugin.podMonitor.enabled .Values.nodeplugin.httpMetrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "ceph-csi-rbd.nodeplugin.fullname" . }}
+  namespace: {{ .Values.nodeplugin.podMonitor.namespace | default .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.nodeplugin.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.nodeplugin.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "ceph-csi-rbd.name" . }}
+      component: {{ .Values.nodeplugin.name }}
+      release: {{ .Release.Name }}
+  podMetricsEndpoints:
+    - port: metrics
+{{- end }}

--- a/charts/ceph-csi-rbd/templates/provisioner-podmonitor.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-podmonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.provisioner.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "ceph-csi-rbd.provisioner.fullname" . }}
+  namespace: {{ .Values.provisioner.podMonitor.namespace | default .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.provisioner.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.provisioner.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.provisioner.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "ceph-csi-rbd.name" . }}
+      component: {{ .Values.provisioner.name }}
+      release: {{ .Release.Name }}
+  podMetricsEndpoints:
+    {{- if ((.Values.provisioner.provisioner.args).httpEndpointPort) }}
+    - port: provisioner
+    {{- end }}
+    {{- if ((.Values.provisioner.attacher.args).httpEndpointPort) }}
+    - port: attacher
+    {{- end }}
+    {{- if ((.Values.provisioner.resizer.args).httpEndpointPort) }}
+    - port: resizer
+    {{- end }}
+    {{- if ((.Values.provisioner.snapshotter.args).httpEndpointPort) }}
+    - port: snapshotter
+    {{- end }}
+{{- end }}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -135,6 +135,18 @@ nodeplugin:
   imagePullSecrets: []
   # - name: "image-pull-secret"
 
+  podMonitor:
+    # Specifies whether a PodMonitor should be created for the nodeplugin.
+    # Requires the prometheus-operator to be installed.
+    # Requires nodeplugin.httpMetrics.enabled=true.
+    enabled: false
+    # Namespace where the PodMonitor is deployed. Defaults to the release namespace.
+    namespace: ""
+    # Additional labels to add to the PodMonitor.
+    labels: {}
+    # Additional annotations to add to the PodMonitor.
+    annotations: {}
+
   profiling:
     # enable profiling to check for memory leaks
     enabled: false

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -249,6 +249,19 @@ provisioner:
   imagePullSecrets: []
   # - name: "image-pull-secret"
 
+  podMonitor:
+    # Specifies whether a PodMonitor should be created for the provisioner.
+    # Requires the prometheus-operator to be installed.
+    # Each sidecar port is included only when its httpEndpointPort is set under
+    # provisioner.{provisioner,attacher,resizer,snapshotter}.args.httpEndpointPort.
+    enabled: false
+    # Namespace where the PodMonitor is deployed. Defaults to the release namespace.
+    namespace: ""
+    # Additional labels to add to the PodMonitor.
+    labels: {}
+    # Additional annotations to add to the PodMonitor.
+    annotations: {}
+
   profiling:
     # enable profiling to check for memory leaks
     enabled: false


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #
This pull request adds support for monitoring the provisioner component of the Ceph-CSI RBD Helm chart via Prometheus by introducing an optional `PodMonitor` resource.
This enables users to easily integrate metrics collection for the provisioner and its sidecars when Prometheus Operator is installed.

`provisioner.podMonitor.enabled=false`

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
