### PR TITLE
ci: update CI for Kubernetes 1.32-1.36 support

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -2,12 +2,6 @@
 - project:
     name: k8s-e2e-external-storage
     k8s_version:
-      - '1.29':
-          only_run_on_request: true
-      - '1.30':
-          only_run_on_request: true
-      - '1.31':
-          only_run_on_request: true
       - '1.32':
           only_run_on_request: true
       - '1.33':

--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -16,6 +16,8 @@
           only_run_on_request: true
       - '1.35':
           only_run_on_request: true
+      - '1.36':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -2,12 +2,6 @@
 - project:
     name: mini-e2e
     k8s_version:
-      - '1.29':
-          only_run_on_request: true
-      - '1.30':
-          only_run_on_request: true
-      - '1.31':
-          only_run_on_request: true
       - '1.32':
           only_run_on_request: true
       - '1.33':

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -16,6 +16,8 @@
           only_run_on_request: true
       - '1.35':
           only_run_on_request: true
+      - '1.36':
+          only_run_on_request: true
     test_type:
       - 'cephfs'
       - 'nfs'

--- a/jobs/upgrade-tests.yaml
+++ b/jobs/upgrade-tests.yaml
@@ -1,7 +1,7 @@
 ---
 - project:
     name: upgrade-tests
-    k8s_version: '1.34'
+    k8s_version: '1.36'
     only_run_on_request: true
     test_type:
       - 'cephfs'


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

  - Add Jenkins CI job definitions for Kubernetes 1.36
  - Remove unmaintained Kubernetes versions (1.29, 1.30, 1.31) from CI

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
