### PR TITLE
cleanup: use CSI Server interfaces (CephFS & NFS)

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -42,9 +42,8 @@ import (
 	rterrors "github.com/ceph/ceph-csi/internal/util/reftracker/errors"
 )
 
-// ControllerServer struct of CEPH CSI driver with supported methods of CSI
-// controller server spec.
-type ControllerServer struct {
+// cephfsControllerServer implements the CSI controller server for the CephFS driver.
+type cephfsControllerServer struct {
 	*csicommon.DefaultControllerServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID/volume name) return an Aborted error
@@ -65,6 +64,12 @@ type ControllerServer struct {
 	ClusterName string
 }
 
+// Assert required implementation of CSI interfaces.
+var (
+	_ csi.ControllerServer      = &cephfsControllerServer{}
+	_ csi.GroupControllerServer = &cephfsControllerServer{}
+)
+
 // subvolumeMetadataHandler holds the metadata handling functions.
 type subvolumeMetadataHandler struct {
 	logSubvolumeName     string
@@ -73,7 +78,7 @@ type subvolumeMetadataHandler struct {
 }
 
 // createBackingVolume creates the backing subvolume and on any error cleans up any created entities.
-func (cs *ControllerServer) createBackingVolume(
+func (cs *cephfsControllerServer) createBackingVolume(
 	ctx context.Context,
 	volOptions,
 	parentVolOpt *store.VolumeOptions,
@@ -112,7 +117,7 @@ func (cs *ControllerServer) createBackingVolume(
 	return nil
 }
 
-func (cs *ControllerServer) createBackingVolumeFromSnapshotSource(
+func (cs *cephfsControllerServer) createBackingVolumeFromSnapshotSource(
 	ctx context.Context,
 	volOptions *store.VolumeOptions,
 	parentVolOpt *store.VolumeOptions,
@@ -156,7 +161,7 @@ func (cs *ControllerServer) createBackingVolumeFromSnapshotSource(
 	return nil
 }
 
-func (cs *ControllerServer) createBackingVolumeFromVolumeSource(
+func (cs *cephfsControllerServer) createBackingVolumeFromVolumeSource(
 	ctx context.Context,
 	parentVolOpt *store.VolumeOptions,
 	volClient core.SubVolumeClient,
@@ -183,7 +188,7 @@ func (cs *ControllerServer) createBackingVolumeFromVolumeSource(
 	return nil
 }
 
-func (cs *ControllerServer) checkContentSource(
+func (cs *cephfsControllerServer) checkContentSource(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
 	cr *util.Credentials,
@@ -289,7 +294,7 @@ func buildCreateVolumeResponse(
 // CreateVolume creates a reservation and the volume in backend, if it is not already present.
 //
 //nolint:gocognit,gocyclo,nestif,cyclop // TODO: reduce complexity
-func (cs *ControllerServer) CreateVolume(
+func (cs *cephfsControllerServer) CreateVolume(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
 ) (*csi.CreateVolumeResponse, error) {
@@ -484,7 +489,7 @@ func (cs *ControllerServer) CreateVolume(
 }
 
 // DeleteVolume deletes the volume in backend and its reservation.
-func (cs *ControllerServer) DeleteVolume(
+func (cs *cephfsControllerServer) DeleteVolume(
 	ctx context.Context,
 	req *csi.DeleteVolumeRequest,
 ) (*csi.DeleteVolumeResponse, error) {
@@ -583,7 +588,7 @@ func (cs *ControllerServer) DeleteVolume(
 	return &csi.DeleteVolumeResponse{}, nil
 }
 
-func (cs *ControllerServer) cleanUpBackingVolume(
+func (cs *cephfsControllerServer) cleanUpBackingVolume(
 	ctx context.Context,
 	volOptions *store.VolumeOptions,
 	volID *store.VolumeIdentifier,
@@ -674,7 +679,7 @@ func (cs *ControllerServer) cleanUpBackingVolume(
 
 // ValidateVolumeCapabilities checks whether the volume capabilities requested
 // are supported.
-func (cs *ControllerServer) ValidateVolumeCapabilities(
+func (cs *cephfsControllerServer) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest,
 ) (*csi.ValidateVolumeCapabilitiesResponse, error) {
@@ -693,7 +698,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 }
 
 // ControllerExpandVolume expands CephFS Volumes on demand based on resizer request.
-func (cs *ControllerServer) ControllerExpandVolume(
+func (cs *cephfsControllerServer) ControllerExpandVolume(
 	ctx context.Context,
 	req *csi.ControllerExpandVolumeRequest,
 ) (*csi.ControllerExpandVolumeResponse, error) {
@@ -755,7 +760,7 @@ func (cs *ControllerServer) ControllerExpandVolume(
 // in store
 //
 //nolint:gocyclo,cyclop // golangci-lint did not catch this earlier, needs to get fixed late
-func (cs *ControllerServer) CreateSnapshot(
+func (cs *cephfsControllerServer) CreateSnapshot(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest,
 ) (*csi.CreateSnapshotResponse, error) {
@@ -916,7 +921,7 @@ func (cs *ControllerServer) CreateSnapshot(
 	}, nil
 }
 
-func (cs *ControllerServer) doSnapshot(
+func (cs *cephfsControllerServer) doSnapshot(
 	ctx context.Context,
 	volOpt *store.VolumeOptions,
 	snapshotName string,
@@ -960,7 +965,7 @@ func (cs *ControllerServer) doSnapshot(
 	return snap, err
 }
 
-func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.CreateSnapshotRequest) error {
+func (cs *cephfsControllerServer) validateSnapshotReq(ctx context.Context, req *csi.CreateSnapshotRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT); err != nil {
 		log.ErrorLog(ctx, "invalid create snapshot req: %v", protosanitizer.StripSecrets(req))
@@ -981,7 +986,7 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 
 // DeleteSnapshot deletes the snapshot in backend and removes the
 // snapshot metadata from store.
-func (cs *ControllerServer) DeleteSnapshot(
+func (cs *cephfsControllerServer) DeleteSnapshot(
 	ctx context.Context,
 	req *csi.DeleteSnapshotRequest,
 ) (*csi.DeleteSnapshotResponse, error) {
@@ -1127,7 +1132,7 @@ func deleteSnapshotAndUndoReservation(
 // ControllerPublishVolume implements the CSI ControllerPublishVolume RPC.
 // It reads the service account restriction metadata from the backing CephFS
 // subvolume and passes it to the node via publish context.
-func (cs *ControllerServer) ControllerPublishVolume(
+func (cs *cephfsControllerServer) ControllerPublishVolume(
 	ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest,
 ) (*csi.ControllerPublishVolumeResponse, error) {
@@ -1150,7 +1155,7 @@ func (cs *ControllerServer) ControllerPublishVolume(
 // getServiceAccountRestriction reads the service account restriction metadata
 // from the CephFS subvolume backing the volume. Returns empty string if no
 // restriction is set.
-func (cs *ControllerServer) getServiceAccountRestriction(
+func (cs *cephfsControllerServer) getServiceAccountRestriction(
 	ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest,
 ) (string, error) {
@@ -1207,7 +1212,7 @@ func (cs *ControllerServer) getServiceAccountRestriction(
 
 // ControllerUnpublishVolume implements the CSI ControllerUnpublishVolume RPC.
 // This function is responsible for fencing a node when a volume is unpublished.
-func (cs *ControllerServer) ControllerUnpublishVolume(
+func (cs *cephfsControllerServer) ControllerUnpublishVolume(
 	ctx context.Context,
 	req *csi.ControllerUnpublishVolumeRequest,
 ) (*csi.ControllerUnpublishVolumeResponse, error) {
@@ -1266,7 +1271,7 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 
 // getSubvolumeMetadataHandler returns the appropriate metadata handler based on whether
 // the volume is a backing snapshot or a regular subvolume.
-func (cs *ControllerServer) getSubvolumeMetadataHandler(
+func (cs *cephfsControllerServer) getSubvolumeMetadataHandler(
 	ctx context.Context,
 	volOptions *store.VolumeOptions,
 	secrets map[string]string,
@@ -1317,7 +1322,7 @@ func (cs *ControllerServer) getSubvolumeMetadataHandler(
 //
 // Behavior:
 //   - Removes the user ID mapping metadata for the specified nodeId from the subvolume.
-func (cs *ControllerServer) removeUserIdMapping(
+func (cs *cephfsControllerServer) removeUserIdMapping(
 	ctx context.Context,
 	volumeId, nodeId string,
 	secrets map[string]string,
@@ -1367,7 +1372,7 @@ func (cs *ControllerServer) removeUserIdMapping(
 //   - Handles missing or empty metadata gracefully and logs appropriate warnings.
 //
 // Returns an error if any step in the fencing process fails.
-func (cs *ControllerServer) fenceNode(
+func (cs *cephfsControllerServer) fenceNode(
 	ctx context.Context,
 	volumeId, nodeId string,
 	secrets map[string]string,

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -39,7 +39,7 @@ import (
 type cephfsDriver struct {
 	cd *csicommon.CSIDriver
 
-	is *IdentityServer
+	is csi.IdentityServer
 	ns csi.NodeServer
 	cs csi.ControllerServer
 	// cas is the CSIAddonsServer where CSI-Addons services are handled
@@ -55,8 +55,8 @@ func NewDriver() driver.Driver {
 }
 
 // NewIdentityServer initialize a identity server for ceph CSI driver.
-func NewIdentityServer(d *csicommon.CSIDriver) *IdentityServer {
-	return &IdentityServer{
+func NewIdentityServer(d *csicommon.CSIDriver) csi.IdentityServer {
+	return &cephfsIdentityServer{
 		DefaultIdentityServer: csicommon.NewDefaultIdentityServer(d),
 	}
 }
@@ -175,8 +175,7 @@ func (fs *cephfsDriver) Run(conf *util.Config) {
 	}
 
 	if conf.IsControllerServer {
-		cs := NewControllerServer(fs.cd, conf.ClusterName)
-		fs.cs = cs
+		fs.cs = NewControllerServer(fs.cd, conf.ClusterName)
 	}
 	if !conf.IsControllerServer && !conf.IsNodeServer {
 		topology, err = util.GetTopologyFromDomainLabels(conf.DomainLabels, conf.NodeID, conf.DriverName)

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -40,8 +40,8 @@ type cephfsDriver struct {
 	cd *csicommon.CSIDriver
 
 	is *IdentityServer
-	ns *NodeServer
-	cs *ControllerServer
+	ns csi.NodeServer
+	cs csi.ControllerServer
 	// cas is the CSIAddonsServer where CSI-Addons services are handled
 	cas *csiaddons.CSIAddonsServer
 }
@@ -62,13 +62,14 @@ func NewIdentityServer(d *csicommon.CSIDriver) *IdentityServer {
 }
 
 // NewControllerServer initialize a controller server for ceph CSI driver.
-func NewControllerServer(d *csicommon.CSIDriver) *ControllerServer {
-	return &ControllerServer{
+func NewControllerServer(d *csicommon.CSIDriver, clusterName string) csi.ControllerServer {
+	return &cephfsControllerServer{
 		DefaultControllerServer: csicommon.NewDefaultControllerServer(d),
 		VolumeLocks:             util.NewIDLocker(),
 		SnapshotLocks:           util.NewIDLocker(),
 		VolumeGroupLocks:        util.NewIDLocker(),
 		OperationLocks:          util.NewOperationLock(),
+		ClusterName:             clusterName,
 	}
 }
 
@@ -79,9 +80,9 @@ func NewNodeServer(
 	kernelMountOptions string,
 	fuseMountOptions string,
 	nodeLabels, topology, crushLocationMap map[string]string,
-) *NodeServer {
+) csi.NodeServer {
 	cliReadAffinityMapOptions := util.ConstructReadAffinityMapOption(crushLocationMap)
-	ns := &NodeServer{
+	ns := &cephfsNodeServer{
 		DefaultNodeServer:  csicommon.NewDefaultNodeServer(d, t, cliReadAffinityMapOptions, topology, nodeLabels),
 		VolumeLocks:        util.NewIDLocker(),
 		kernelMountOptions: kernelMountOptions,
@@ -174,8 +175,8 @@ func (fs *cephfsDriver) Run(conf *util.Config) {
 	}
 
 	if conf.IsControllerServer {
-		fs.cs = NewControllerServer(fs.cd)
-		fs.cs.ClusterName = conf.ClusterName
+		cs := NewControllerServer(fs.cd, conf.ClusterName)
+		fs.cs = cs
 	}
 	if !conf.IsControllerServer && !conf.IsNodeServer {
 		topology, err = util.GetTopologyFromDomainLabels(conf.DomainLabels, conf.NodeID, conf.DriverName)
@@ -187,7 +188,7 @@ func (fs *cephfsDriver) Run(conf *util.Config) {
 			conf.KernelMountOptions, conf.FuseMountOptions,
 			nodeLabels, topology, crushLocationMap,
 		)
-		fs.cs = NewControllerServer(fs.cd)
+		fs.cs = NewControllerServer(fs.cd, "")
 	}
 
 	// configure CSI-Addons server and components
@@ -201,7 +202,7 @@ func (fs *cephfsDriver) Run(conf *util.Config) {
 		IS: fs.is,
 		CS: fs.cs,
 		NS: fs.ns,
-		GS: fs.cs,
+		GS: csicommon.ToGroupControllerServer(fs.cs),
 	}
 	server.Start(conf.Endpoint, srv, csicommon.MiddlewareServerOptionConfig{
 		LogSlowOpInterval: conf.LogSlowOpInterval,

--- a/internal/cephfs/fuserecovery.go
+++ b/internal/cephfs/fuserecovery.go
@@ -46,7 +46,7 @@ func (ms mountState) String() string {
 	}[int(ms)]
 }
 
-func (ns *NodeServer) getMountState(path string) (mountState, error) {
+func (ns *cephfsNodeServer) getMountState(path string) (mountState, error) {
 	isMnt, err := ns.Mounter.IsMountPoint(path)
 	if err != nil {
 		if util.IsCorruptedMountError(err) {
@@ -79,7 +79,7 @@ func (ns *NodeServer) getMountState(path string) (mountState, error) {
 //     * staging target path is unmounted and mounted again using ceph-fuse,
 //     * target path is only unmounted; NodePublishVolume is then expected to
 //     continue normally.
-func (ns *NodeServer) tryRestoreFuseMountsInNodePublish(
+func (ns *cephfsNodeServer) tryRestoreFuseMountsInNodePublish(
 	ctx context.Context,
 	volID fsutil.VolumeID,
 	stagingTargetPath string,
@@ -174,7 +174,7 @@ func (ns *NodeServer) tryRestoreFuseMountsInNodePublish(
 // Try to restore FUSE mount of the staging target path in NodeStageVolume.
 // If corruption is detected, try to only unmount the volume. NodeStageVolume
 // should be able to continue with mounting the volume normally afterwards.
-func (ns *NodeServer) tryRestoreFuseMountInNodeStage(
+func (ns *cephfsNodeServer) tryRestoreFuseMountInNodeStage(
 	ctx context.Context,
 	stagingTargetPath string,
 ) error {

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -40,7 +40,7 @@ import (
 
 // validateCreateVolumeGroupSnapshotRequest validates the request for creating
 // a group snapshot of volumes.
-func (cs *ControllerServer) validateCreateVolumeGroupSnapshotRequest(
+func (cs *cephfsControllerServer) validateCreateVolumeGroupSnapshotRequest(
 	ctx context.Context,
 	req *csi.CreateVolumeGroupSnapshotRequest,
 ) error {
@@ -74,7 +74,7 @@ func (cs *ControllerServer) validateCreateVolumeGroupSnapshotRequest(
 }
 
 // CreateVolumeGroupSnapshot creates a group snapshot of volumes.
-func (cs *ControllerServer) CreateVolumeGroupSnapshot(
+func (cs *cephfsControllerServer) CreateVolumeGroupSnapshot(
 	ctx context.Context,
 	req *csi.CreateVolumeGroupSnapshotRequest) (
 	*csi.CreateVolumeGroupSnapshotResponse,
@@ -188,7 +188,7 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 // queisceFileSystems quiesces the subvolumes and subvolume groups present in
 // the filesystems of the volumeID's present in the
 // CreateVolumeGroupSnapshotRequest.
-func (cs *ControllerServer) queisceFileSystems(ctx context.Context,
+func (cs *cephfsControllerServer) queisceFileSystems(ctx context.Context,
 	vgs *store.VolumeGroupSnapshotIdentifier,
 	fsMap core.FSQuiesceClientMap,
 ) (bool, error) {
@@ -215,7 +215,7 @@ func (cs *ControllerServer) queisceFileSystems(ctx context.Context,
 // releaseQuiesceAndGetVolumeGroupSnapshotResponse releases the quiesce of the
 // subvolumes and subvolume groups in the filesystems for the volumeID's
 // present in the CreateVolumeGroupSnapshotRequest.
-func (cs *ControllerServer) releaseQuiesceAndGetVolumeGroupSnapshotResponse(
+func (cs *cephfsControllerServer) releaseQuiesceAndGetVolumeGroupSnapshotResponse(
 	ctx context.Context,
 	req *csi.CreateVolumeGroupSnapshotRequest,
 	vgs *store.VolumeGroupSnapshotIdentifier,
@@ -306,7 +306,7 @@ func (cs *ControllerServer) releaseQuiesceAndGetVolumeGroupSnapshotResponse(
 // volume and add the snapshotID and volumeID to the volume group journal omap.
 // If any error occurs other than ErrInProgress it will delete the snapshots
 // and undo the reservation and return the error.
-func (cs *ControllerServer) createSnapshotAddToVolumeGroupJournal(
+func (cs *cephfsControllerServer) createSnapshotAddToVolumeGroupJournal(
 	ctx context.Context,
 	req *csi.CreateVolumeGroupSnapshotRequest,
 	vgo *store.VolumeGroupOptions,
@@ -439,7 +439,7 @@ func fsQuiesceWithExpireTimeout(ctx context.Context,
 // createSnapshotAndAddMapping creates the snapshot and adds the snapshotID and
 // volumeID to the volume group journal omap. If any error occurs it will
 // delete the last created snapshot as its still not added to the journal.
-func (cs *ControllerServer) createSnapshotAndAddMapping(
+func (cs *cephfsControllerServer) createSnapshotAndAddMapping(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest,
 	vgo *store.VolumeGroupOptions,
@@ -612,7 +612,7 @@ func matchesSourceVolumeIDs(sourceVolumeIDs, volumeIDsInOMap []string) bool {
 // when fsMap is empty function will skip filesystem quiesce operations and
 // only perform snapshot deletion and reservation cleanup. This is the intended
 // behavior for DeleteVolumeGroupSnapshot operation where filesystem quiesce is not required.
-func (cs *ControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Context,
+func (cs *cephfsControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Context,
 	vgs *store.VolumeGroupSnapshotIdentifier,
 	cr *util.Credentials,
 	fsMap core.FSQuiesceClientMap,
@@ -679,7 +679,7 @@ func (cs *ControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Contex
 
 // validateVolumeGroupSnapshotDeleteRequest validates the request for creating a group
 // snapshot of volumes.
-func (cs *ControllerServer) validateVolumeGroupSnapshotDeleteRequest(
+func (cs *cephfsControllerServer) validateVolumeGroupSnapshotDeleteRequest(
 	ctx context.Context,
 	req *csi.DeleteVolumeGroupSnapshotRequest,
 ) error {
@@ -699,7 +699,7 @@ func (cs *ControllerServer) validateVolumeGroupSnapshotDeleteRequest(
 }
 
 // DeleteVolumeGroupSnapshot deletes a group snapshot of volumes.
-func (cs *ControllerServer) DeleteVolumeGroupSnapshot(ctx context.Context,
+func (cs *cephfsControllerServer) DeleteVolumeGroupSnapshot(ctx context.Context,
 	req *csi.DeleteVolumeGroupSnapshotRequest) (
 	*csi.DeleteVolumeGroupSnapshotResponse,
 	error,

--- a/internal/cephfs/groupcontrollerserver_test.go
+++ b/internal/cephfs/groupcontrollerserver_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestControllerServer_validateCreateVolumeGroupSnapshotRequest(t *testing.T) {
 	t.Parallel()
-	cs := ControllerServer{
+	cs := cephfsControllerServer{
 		DefaultControllerServer: csicommon.NewDefaultControllerServer(
 			csicommon.NewCSIDriver("cephfs.csi.ceph.com", "1.0.0", "test", "default", false)),
 	}

--- a/internal/cephfs/identityserver.go
+++ b/internal/cephfs/identityserver.go
@@ -24,14 +24,16 @@ import (
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 )
 
-// IdentityServer struct of ceph CSI driver with supported methods of CSI
-// identity server spec.
-type IdentityServer struct {
+// cephfsIdentityServer implements the CSI identity server for the CephFS driver.
+type cephfsIdentityServer struct {
 	*csicommon.DefaultIdentityServer
 }
 
+// Assert required implementation of CSI interfaces.
+var _ csi.IdentityServer = &cephfsIdentityServer{}
+
 // GetPluginCapabilities returns available capabilities of the ceph driver.
-func (is *IdentityServer) GetPluginCapabilities(
+func (is *cephfsIdentityServer) GetPluginCapabilities(
 	ctx context.Context,
 	req *csi.GetPluginCapabilitiesRequest,
 ) (*csi.GetPluginCapabilitiesResponse, error) {

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -44,9 +44,8 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
-// NodeServer struct of ceph CSI driver with supported methods of CSI
-// node server spec.
-type NodeServer struct {
+// cephfsNodeServer implements the CSI node server for the CephFS driver.
+type cephfsNodeServer struct {
 	*csicommon.DefaultNodeServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID) return an Aborted error
@@ -55,6 +54,9 @@ type NodeServer struct {
 	fuseMountOptions   string
 	healthChecker      hc.Manager
 }
+
+// Assert required implementation of CSI interfaces.
+var _ csi.NodeServer = &cephfsNodeServer{}
 
 func getCredentialsForVolume(
 	volOptions *store.VolumeOptions,
@@ -84,7 +86,7 @@ func getCredentialsForVolume(
 	return cr, nil
 }
 
-func (ns *NodeServer) getVolumeOptions(
+func (ns *cephfsNodeServer) getVolumeOptions(
 	ctx context.Context,
 	volID fsutil.VolumeID,
 	volContext,
@@ -214,7 +216,7 @@ func maybeInitializeFileEncryption(
 // NodeStageVolume mounts the volume to a staging path on the node.
 //
 //nolint:gocyclo,cyclop // TODO: reduce complexity
-func (ns *NodeServer) NodeStageVolume(
+func (ns *cephfsNodeServer) NodeStageVolume(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest,
 ) (*csi.NodeStageVolumeResponse, error) {
@@ -353,7 +355,7 @@ func (ns *NodeServer) NodeStageVolume(
 // The user ID is the ceph user used for mounting the subvolume.
 // If the volume is a snapshot-backed, the user ID mapping is set on the backing snapshot metadata.
 // If the volume is static it does nothing.
-func (ns *NodeServer) setUserIdMapping(
+func (ns *cephfsNodeServer) setUserIdMapping(
 	ctx context.Context, secrets map[string]string,
 	volumeId string, volOptions *store.VolumeOptions,
 ) error {
@@ -406,7 +408,7 @@ func (ns *NodeServer) setUserIdMapping(
 // We parse this to extract just the IP address portion (e.g., "10.244.0.1") and store in metadata.
 // If the '--enable-fencing' flag is set to false in CSI driver configuration or if the volume is static
 // this function does nothing.
-func (ns *NodeServer) setClientAddress(
+func (ns *cephfsNodeServer) setClientAddress(
 	ctx context.Context,
 	volumeId string,
 	secrets map[string]string,
@@ -472,7 +474,7 @@ func (ns *NodeServer) setClientAddress(
 // This checker can be shared between multiple containers.
 //
 // TODO: start a FileChecker for read-writable volumes that have an app-data subdir.
-func (ns *NodeServer) startSharedHealthChecker(ctx context.Context, volumeID, dir string) {
+func (ns *cephfsNodeServer) startSharedHealthChecker(ctx context.Context, volumeID, dir string) {
 	// The StatChecker works for volumes that do not have a dedicated app-data
 	// subdirectory, or are read-only.
 	err := ns.healthChecker.StartSharedChecker(volumeID, dir, hc.StatCheckerType)
@@ -481,7 +483,7 @@ func (ns *NodeServer) startSharedHealthChecker(ctx context.Context, volumeID, di
 	}
 }
 
-func (ns *NodeServer) mount(
+func (ns *cephfsNodeServer) mount(
 	ctx context.Context,
 	mnt mounter.VolumeMounter,
 	volOptions *store.VolumeOptions,
@@ -625,7 +627,7 @@ func getBackingSnapshotRoot(
 
 // NodePublishVolume mounts the volume mounted to the staging path to the target
 // path.
-func (ns *NodeServer) NodePublishVolume(
+func (ns *cephfsNodeServer) NodePublishVolume(
 	ctx context.Context,
 	req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
@@ -746,7 +748,7 @@ func (ns *NodeServer) NodePublishVolume(
 }
 
 // NodeUnpublishVolume unmounts the volume from the target path.
-func (ns *NodeServer) NodeUnpublishVolume(
+func (ns *cephfsNodeServer) NodeUnpublishVolume(
 	ctx context.Context,
 	req *csi.NodeUnpublishVolumeRequest,
 ) (*csi.NodeUnpublishVolumeResponse, error) {
@@ -811,7 +813,7 @@ func (ns *NodeServer) NodeUnpublishVolume(
 }
 
 // NodeUnstageVolume unstages the volume from the staging path.
-func (ns *NodeServer) NodeUnstageVolume(
+func (ns *cephfsNodeServer) NodeUnstageVolume(
 	ctx context.Context,
 	req *csi.NodeUnstageVolumeRequest,
 ) (*csi.NodeUnstageVolumeResponse, error) {
@@ -875,7 +877,7 @@ func (ns *NodeServer) NodeUnstageVolume(
 }
 
 // NodeGetCapabilities returns the supported capabilities of the node server.
-func (ns *NodeServer) NodeGetCapabilities(
+func (ns *cephfsNodeServer) NodeGetCapabilities(
 	ctx context.Context,
 	req *csi.NodeGetCapabilitiesRequest,
 ) (*csi.NodeGetCapabilitiesResponse, error) {
@@ -914,7 +916,7 @@ func (ns *NodeServer) NodeGetCapabilities(
 }
 
 // NodeGetVolumeStats returns volume stats.
-func (ns *NodeServer) NodeGetVolumeStats(
+func (ns *cephfsNodeServer) NodeGetVolumeStats(
 	ctx context.Context,
 	req *csi.NodeGetVolumeStatsRequest,
 ) (*csi.NodeGetVolumeStatsResponse, error) {
@@ -990,7 +992,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 
 // setMountOptions updates the kernel/fuse mount options from CSI config file if it exists.
 // If not, it falls back to returning the kernelMountOptions/fuseMountOptions from the command line.
-func (ns *NodeServer) setMountOptions(
+func (ns *cephfsNodeServer) setMountOptions(
 	mnt mounter.VolumeMounter,
 	volOptions *store.VolumeOptions,
 	volCap *csi.VolumeCapability,

--- a/internal/cephfs/nodeserver_test.go
+++ b/internal/cephfs/nodeserver_test.go
@@ -69,14 +69,14 @@ func Test_setMountOptions(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		ns         *NodeServer
+		ns         *cephfsNodeServer
 		mnt        mounter.VolumeMounter
 		volOptions *store.VolumeOptions
 		want       string
 	}{
 		{
 			name: "KernelMountOptions set in cluster-1 config and not set in CLI",
-			ns:   &NodeServer{},
+			ns:   &cephfsNodeServer{},
 			mnt:  mounter.VolumeMounter(mounter.NewKernelMounter()),
 			volOptions: &store.VolumeOptions{
 				ClusterID: "cluster-1",
@@ -85,7 +85,7 @@ func Test_setMountOptions(t *testing.T) {
 		},
 		{
 			name: "FuseMountOptions set in cluster-1 config and not set in CLI",
-			ns:   &NodeServer{},
+			ns:   &cephfsNodeServer{},
 			mnt:  mounter.VolumeMounter(&mounter.FuseMounter{}),
 			volOptions: &store.VolumeOptions{
 				ClusterID: "cluster-1",
@@ -94,7 +94,7 @@ func Test_setMountOptions(t *testing.T) {
 		},
 		{
 			name: "KernelMountOptions set in cluster-1 config and set in CLI",
-			ns: &NodeServer{
+			ns: &cephfsNodeServer{
 				kernelMountOptions: cliKernelMountOptions,
 			},
 			mnt: mounter.VolumeMounter(mounter.NewKernelMounter()),
@@ -105,7 +105,7 @@ func Test_setMountOptions(t *testing.T) {
 		},
 		{
 			name: "FuseMountOptions not set in cluster-2 config and set in CLI",
-			ns: &NodeServer{
+			ns: &cephfsNodeServer{
 				fuseMountOptions: cliFuseMountOptions,
 			},
 			mnt: mounter.VolumeMounter(&mounter.FuseMounter{}),
@@ -116,7 +116,7 @@ func Test_setMountOptions(t *testing.T) {
 		},
 		{
 			name: "KernelMountOptions not set in cluster-2 config and set in CLI",
-			ns: &NodeServer{
+			ns: &cephfsNodeServer{
 				kernelMountOptions: cliKernelMountOptions,
 			},
 			mnt: mounter.VolumeMounter(mounter.NewKernelMounter()),
@@ -127,7 +127,7 @@ func Test_setMountOptions(t *testing.T) {
 		},
 		{
 			name: "FuseMountOptions not set in cluster-1 config and set in CLI",
-			ns: &NodeServer{
+			ns: &cephfsNodeServer{
 				fuseMountOptions: cliFuseMountOptions,
 			},
 			mnt: mounter.VolumeMounter(&mounter.FuseMounter{}),

--- a/internal/cephfs/validator.go
+++ b/internal/cephfs/validator.go
@@ -27,7 +27,7 @@ import (
 )
 
 // validateCreateVolumeRequest validates the Controller CreateVolume request.
-func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
+func (cs *cephfsControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		return fmt.Errorf("invalid CreateVolumeRequest: %w", err)
@@ -85,7 +85,7 @@ func (cs *ControllerServer) validateCreateVolumeRequest(req *csi.CreateVolumeReq
 }
 
 // validateDeleteVolumeRequest validates the Controller DeleteVolume request.
-func (cs *ControllerServer) validateDeleteVolumeRequest(req *csi.DeleteVolumeRequest) error {
+func (cs *cephfsControllerServer) validateDeleteVolumeRequest(req *csi.DeleteVolumeRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		return fmt.Errorf("invalid DeleteVolumeRequest: %w", err)
@@ -99,7 +99,7 @@ func (cs *ControllerServer) validateDeleteVolumeRequest(req *csi.DeleteVolumeReq
 }
 
 // validateExpandVolumeRequest validates the Controller ExpandVolume request.
-func (cs *ControllerServer) validateExpandVolumeRequest(req *csi.ControllerExpandVolumeRequest) error {
+func (cs *cephfsControllerServer) validateExpandVolumeRequest(req *csi.ControllerExpandVolumeRequest) error {
 	if err := cs.Driver.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_EXPAND_VOLUME); err != nil {
 		return fmt.Errorf("invalid ExpandVolumeRequest: %w", err)
 	}

--- a/internal/csi-common/controllerserver-default.go
+++ b/internal/csi-common/controllerserver-default.go
@@ -65,3 +65,19 @@ func (cs *DefaultControllerServer) GroupControllerGetCapabilities(
 		Capabilities: cs.Driver.groupCapabilities,
 	}, nil
 }
+
+// ToGroupControllerServer checks if the given ControllerServer implements the
+// GroupControllerServer interface and aborts the execution of the process if
+// it does not.
+func ToGroupControllerServer(cs csi.ControllerServer) csi.GroupControllerServer {
+	if cs == nil {
+		return nil
+	}
+
+	gcs, ok := cs.(csi.GroupControllerServer)
+	if !ok {
+		log.FatalLogMsg("BUG: ControllerServer does not implement GroupControllerServer")
+	}
+
+	return gcs
+}

--- a/internal/csi-common/controllerserver-default_test.go
+++ b/internal/csi-common/controllerserver-default_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csicommon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/require"
+)
+
+// mockControllerServerWithGroup implements both ControllerServer and GroupControllerServer.
+type mockControllerServerWithGroup struct {
+	csi.UnimplementedControllerServer
+	csi.UnimplementedGroupControllerServer
+}
+
+// GroupControllerGetCapabilities implements a basic GroupControllerServer
+// method. This differs from the implementation in
+// csi.UnimplementedGroupControllerServer, which returns an UnimplementedError.
+func (m *mockControllerServerWithGroup) GroupControllerGetCapabilities(
+	ctx context.Context,
+	req *csi.GroupControllerGetCapabilitiesRequest,
+) (*csi.GroupControllerGetCapabilitiesResponse, error) {
+	return &csi.GroupControllerGetCapabilitiesResponse{
+		Capabilities: []*csi.GroupControllerServiceCapability{},
+	}, nil
+}
+
+func TestToGroupControllerServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success - ControllerServer implements GroupControllerServer", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a mock that implements both interfaces
+		cs := &mockControllerServerWithGroup{}
+
+		// This should succeed and return a GroupControllerServer
+		gcs := ToGroupControllerServer(cs)
+		require.NotNil(t, gcs)
+
+		// Verify it's actually a GroupControllerServer by calling a method
+		resp, err := gcs.GroupControllerGetCapabilities(
+			context.Background(),
+			&csi.GroupControllerGetCapabilitiesRequest{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("success - DefaultControllerServer implements GroupControllerServer", func(t *testing.T) {
+		t.Parallel()
+
+		// DefaultControllerServer should implement both interfaces
+		driver := NewCSIDriver("test-driver", "v1.0.0", "test-node", "test-instance", false)
+		require.NotNil(t, driver)
+
+		cs := NewDefaultControllerServer(driver)
+		require.NotNil(t, cs)
+
+		// This should succeed
+		gcs := ToGroupControllerServer(cs)
+		require.NotNil(t, gcs)
+
+		// Verify it works
+		resp, err := gcs.GroupControllerGetCapabilities(
+			context.Background(),
+			&csi.GroupControllerGetCapabilitiesRequest{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	// Note: Testing the failure case (when ControllerServer does not implement
+	// GroupControllerServer) is not practical because ToGroupControllerServer
+	// calls log.FatalLogMsg which calls os.Exit() to terminate the process. In
+	// production code, this is intentional as it indicates a programming error
+	// that should be caught during development/testing, not at runtime.
+}

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -34,29 +34,32 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
-// Server struct of CEPH CSI driver with supported methods of CSI controller
-// server spec.
-type Server struct {
+// nfsControllerServer struct of CEPH CSI driver with supported methods of CSI
+// controller server spec.
+type nfsControllerServer struct {
 	csi.UnimplementedControllerServer
 
 	// backendServer handles the CephFS requests
 	backendServer *cephfs.ControllerServer
 }
 
+// Assert required implementation of CSI interfaces.
+var _ csi.ControllerServer = &nfsControllerServer{}
+
 // NewControllerServer initialize a controller server for ceph CSI driver.
-func NewControllerServer(d *csicommon.CSIDriver) *Server {
+func NewControllerServer(d *csicommon.CSIDriver) csi.ControllerServer {
 	// global instance of the volume journal, yuck
 	store.VolJournal = journal.NewCSIVolumeJournalWithNamespace(d.GetInstanceID(), fsutil.RadosNamespace)
 	store.SnapJournal = journal.NewCSISnapshotJournalWithNamespace(d.GetInstanceID(), fsutil.RadosNamespace)
 
-	return &Server{
+	return &nfsControllerServer{
 		backendServer: cephfs.NewControllerServer(d),
 	}
 }
 
 // ControllerGetCapabilities uses the CephFS backendServer to return the
 // capabilities that were set in the Driver.Run() function.
-func (cs *Server) ControllerGetCapabilities(
+func (cs *nfsControllerServer) ControllerGetCapabilities(
 	ctx context.Context,
 	req *csi.ControllerGetCapabilitiesRequest,
 ) (*csi.ControllerGetCapabilitiesResponse, error) {
@@ -65,7 +68,7 @@ func (cs *Server) ControllerGetCapabilities(
 
 // ValidateVolumeCapabilities checks whether the volume capabilities requested
 // are supported.
-func (cs *Server) ValidateVolumeCapabilities(
+func (cs *nfsControllerServer) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest,
 ) (*csi.ValidateVolumeCapabilitiesResponse, error) {
@@ -74,7 +77,7 @@ func (cs *Server) ValidateVolumeCapabilities(
 
 // CreateVolume creates the backing subvolume and on any error cleans up any
 // created entities.
-func (cs *Server) CreateVolume(
+func (cs *nfsControllerServer) CreateVolume(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
 ) (*csi.CreateVolumeResponse, error) {
@@ -139,7 +142,7 @@ func (cs *Server) CreateVolume(
 }
 
 // DeleteVolume deletes the volume in backend and its reservation.
-func (cs *Server) DeleteVolume(
+func (cs *nfsControllerServer) DeleteVolume(
 	ctx context.Context,
 	req *csi.DeleteVolumeRequest,
 ) (*csi.DeleteVolumeResponse, error) {
@@ -182,7 +185,7 @@ func (cs *Server) DeleteVolume(
 // ControllerPublishVolume delegates to the CephFS backend to read the service
 // account restriction metadata from the backing CephFS subvolume and pass it
 // to the node via publish context.
-func (cs *Server) ControllerPublishVolume(
+func (cs *nfsControllerServer) ControllerPublishVolume(
 	ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest,
 ) (*csi.ControllerPublishVolumeResponse, error) {
@@ -190,7 +193,7 @@ func (cs *Server) ControllerPublishVolume(
 }
 
 // ControllerUnpublishVolume is a no-op for the NFS CSI driver.
-func (cs *Server) ControllerUnpublishVolume(
+func (cs *nfsControllerServer) ControllerUnpublishVolume(
 	ctx context.Context,
 	req *csi.ControllerUnpublishVolumeRequest,
 ) (*csi.ControllerUnpublishVolumeResponse, error) {
@@ -200,7 +203,7 @@ func (cs *Server) ControllerUnpublishVolume(
 // ControllerExpandVolume calls the backend (CephFS) procedure to expand the
 // volume. There is no interaction with the NFS-server needed to publish the
 // new size.
-func (cs *Server) ControllerExpandVolume(
+func (cs *nfsControllerServer) ControllerExpandVolume(
 	ctx context.Context,
 	req *csi.ControllerExpandVolumeRequest,
 ) (*csi.ControllerExpandVolumeResponse, error) {
@@ -209,7 +212,7 @@ func (cs *Server) ControllerExpandVolume(
 
 // CreateSnapshot calls the backend (CephFS) procedure to create snapshot.
 // There is no interaction with the NFS-server needed for snapshot creation.
-func (cs *Server) CreateSnapshot(
+func (cs *nfsControllerServer) CreateSnapshot(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest,
 ) (*csi.CreateSnapshotResponse, error) {
@@ -218,7 +221,7 @@ func (cs *Server) CreateSnapshot(
 
 // DeleteSnapshot calls the backend (CephFS) procedure to delete snapshot.
 // There is no interaction with the NFS-server needed for snapshot creation.
-func (cs *Server) DeleteSnapshot(
+func (cs *nfsControllerServer) DeleteSnapshot(
 	ctx context.Context,
 	req *csi.DeleteSnapshotRequest,
 ) (*csi.DeleteSnapshotResponse, error) {
@@ -228,7 +231,7 @@ func (cs *Server) DeleteSnapshot(
 // ControllerModifyVolume adjusts parameters after a volume has been created.
 // The new parameters from the [mutable_parameters] attribute are stored in
 // the [NFSVolume] object (which stores the parameters in the volumes OMAP).
-func (cs *Server) ControllerModifyVolume(
+func (cs *nfsControllerServer) ControllerModifyVolume(
 	ctx context.Context,
 	req *csi.ControllerModifyVolumeRequest,
 ) (*csi.ControllerModifyVolumeResponse, error) {

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -40,7 +40,7 @@ type nfsControllerServer struct {
 	csi.UnimplementedControllerServer
 
 	// backendServer handles the CephFS requests
-	backendServer *cephfs.ControllerServer
+	backendServer csi.ControllerServer
 }
 
 // Assert required implementation of CSI interfaces.
@@ -53,7 +53,7 @@ func NewControllerServer(d *csicommon.CSIDriver) csi.ControllerServer {
 	store.SnapJournal = journal.NewCSISnapshotJournalWithNamespace(d.GetInstanceID(), fsutil.RadosNamespace)
 
 	return &nfsControllerServer{
-		backendServer: cephfs.NewControllerServer(d),
+		backendServer: cephfs.NewControllerServer(d, ""),
 	}
 }
 

--- a/internal/nfs/identity/identityserver.go
+++ b/internal/nfs/identity/identityserver.go
@@ -24,21 +24,23 @@ import (
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 )
 
-// Server struct of ceph CSI driver with supported methods of CSI identity
-// server spec.
-type Server struct {
+// nfsIdentityServer implements the CSI identity server for the NFS driver.
+type nfsIdentityServer struct {
 	*csicommon.DefaultIdentityServer
 }
 
+// Assert required implementation of CSI interfaces.
+var _ csi.IdentityServer = &nfsIdentityServer{}
+
 // NewIdentityServer initialize a identity server for ceph CSI driver.
-func NewIdentityServer(d *csicommon.CSIDriver) *Server {
-	return &Server{
+func NewIdentityServer(d *csicommon.CSIDriver) csi.IdentityServer {
+	return &nfsIdentityServer{
 		DefaultIdentityServer: csicommon.NewDefaultIdentityServer(d),
 	}
 }
 
 // GetPluginCapabilities returns available capabilities of the ceph driver.
-func (is *Server) GetPluginCapabilities(
+func (is *nfsIdentityServer) GetPluginCapabilities(
 	ctx context.Context,
 	req *csi.GetPluginCapabilitiesRequest,
 ) (*csi.GetPluginCapabilitiesResponse, error) {

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -47,26 +47,28 @@ const (
 
 var errInvalidParameter = errors.New("invalid parameter")
 
-// NodeServer struct of ceph CSI driver with supported methods of CSI
-// node server spec.
-type NodeServer struct {
+// nfsNodeServer implements the CSI node server for the NFS driver.
+type nfsNodeServer struct {
 	csicommon.DefaultNodeServer
 }
+
+// Assert required implementation of CSI interfaces.
+var _ csi.NodeServer = &nfsNodeServer{}
 
 // NewNodeServer initialize a node server for ceph CSI driver.
 func NewNodeServer(
 	d *csicommon.CSIDriver,
 	t string,
-) *NodeServer {
+) csi.NodeServer {
 	store.VolJournal = journal.NewCSIVolumeJournalWithNamespace(d.GetInstanceID(), fsutil.RadosNamespace)
 
-	return &NodeServer{
+	return &nfsNodeServer{
 		DefaultNodeServer: *csicommon.NewDefaultNodeServer(d, t, "", map[string]string{}, map[string]string{}),
 	}
 }
 
 // NodePublishVolume mount the volume.
-func (ns *NodeServer) NodePublishVolume(
+func (ns *nfsNodeServer) NodePublishVolume(
 	ctx context.Context,
 	req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
@@ -133,7 +135,7 @@ func (ns *NodeServer) NodePublishVolume(
 }
 
 // NodeUnpublishVolume unmount the volume.
-func (ns *NodeServer) NodeUnpublishVolume(
+func (ns *nfsNodeServer) NodeUnpublishVolume(
 	ctx context.Context,
 	req *csi.NodeUnpublishVolumeRequest,
 ) (*csi.NodeUnpublishVolumeResponse, error) {
@@ -157,7 +159,7 @@ func (ns *NodeServer) NodeUnpublishVolume(
 }
 
 // NodeGetCapabilities returns the supported capabilities of the node server.
-func (ns *NodeServer) NodeGetCapabilities(
+func (ns *nfsNodeServer) NodeGetCapabilities(
 	ctx context.Context,
 	req *csi.NodeGetCapabilitiesRequest,
 ) (*csi.NodeGetCapabilitiesResponse, error) {
@@ -182,7 +184,7 @@ func (ns *NodeServer) NodeGetCapabilities(
 }
 
 // NodeGetVolumeStats get volume stats.
-func (ns *NodeServer) NodeGetVolumeStats(
+func (ns *nfsNodeServer) NodeGetVolumeStats(
 	ctx context.Context,
 	req *csi.NodeGetVolumeStatsRequest,
 ) (*csi.NodeGetVolumeStatsResponse, error) {
@@ -208,7 +210,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 }
 
 // mountNFS mounts nfs volumes.
-func (ns *NodeServer) mountNFS(
+func (ns *nfsNodeServer) mountNFS(
 	ctx context.Context,
 	volumeID, source, mountPoint, netNamespaceFilePath string,
 	mountOptions []string,


### PR DESCRIPTION
Rename the different gRPC server structs to include a prefix of the storage protocol they use. This makes it easier to understand the code, as having a struct `NodeServer` for each protocol causes confusion.

The `NewNodeServer()` and similar functions now return a CSI interface type, making sure that the implementation of the structs is not available to external consumers.

 - All server types now follow Go naming conventions (unexported, driver-prefixed)
 - All types have compile-time interface assertions
 - All constructors return CSI interface types instead of concrete types 

**Note:** RBD and NVMe-oF changes will be sent in a separate PR.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
