### PR TITLE
update k8s 1.36

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -19,8 +19,14 @@ jobs:
     strategy:
       matrix:
         branch: [release-v3.16, release-v3.17, devel]
-        k8s: ["1.32", "1.33", "1.34", "1.35"]
+        k8s: ["1.32", "1.33", "1.34", "1.35", "1.36"]
         exclude:
+          - k8s: "1.36"
+            branch: "release-v3.16"
+
+          - k8s: "1.36"
+            branch: "release-v3.17"
+
           - k8s: "1.35"
             branch: "release-v3.16"
 
@@ -28,6 +34,9 @@ jobs:
             branch: "release-v3.17"
 
           - k8s: "1.32"
+            branch: "devel"
+
+          - k8s: "1.33"
             branch: "devel"
 
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -78,15 +78,15 @@ queue_rules:
                   - "status-success=ci/centos/upgrade-tests-rbd"
               - and:
                   - base=devel
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
                   - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
                   - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.36"
                   - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
                   - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.33"
+                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.36"
                   - "status-success=ci/centos/mini-e2e/k8s-1.34"
                   - "status-success=ci/centos/mini-e2e/k8s-1.35"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.36"
                   - "status-success=ci/centos/upgrade-tests-cephfs"
                   - "status-success=ci/centos/upgrade-tests-rbd"
               - and:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ environments.
 
 | Ceph CSI Version | Container Orchestrator Name | Version Tested      |
 | -----------------| --------------------------- | ------------------- |
+| devel (v3.18.0)  | Kubernetes                  | v1.34, v1.35, v1.36 |
 | v3.17.0          | Kubernetes                  | v1.33, v1.34, v1.35 |
 | v3.16.2          | Kubernetes                  | v1.32, v1.33, v1.34 |
 | v3.16.1          | Kubernetes                  | v1.32, v1.33, v1.34 |


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

- Add Kubernetes 1.36 CI testing for the devel branch and drop Kubernetes 1.33
- Update Mergify merge requirements to require K8s 1.36 jobs (replacing 1.33) for devel
- Document Kubernetes 1.36 support for the upcoming v3.18.0 release in README

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
