### PR TITLE
rbd: open image read-only for DiffIterate in getUsedBytes

### DIFF
--- a/e2e/configmap.go
+++ b/e2e/configmap.go
@@ -59,6 +59,10 @@ func createConfigMap(pluginPath string, c kubernetes.Interface, f *framework.Fra
 		Monitors:  mons,
 		RBD: cephcsi.RBD{
 			RadosNamespace: radosNamespace,
+			ControllerPublishSecretRef: v1.SecretReference{
+				Name:      rbdProvisionerSecretName,
+				Namespace: cephCSINamespace,
+			},
 		},
 		CephFS: cephcsi.CephFS{
 			RadosNamespace: radosNamespace,

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -413,6 +414,8 @@ func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t i
 		return err
 	}
 
+	isBlock := pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock
+
 	// kubelet needs to be started with --read-only-port=10255
 	cmd := fmt.Sprintf("curl --silent 'http://%s:10255/metrics'", kubelet)
 
@@ -432,25 +435,104 @@ func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t i
 			return false, nil
 		}
 
-		namespace := fmt.Sprintf("namespace=%q", pvc.Namespace)
-		name := fmt.Sprintf("persistentvolumeclaim=%q", pvc.Name)
+		metrics := parseVolumeStatsMetrics(stdOut, pvc.Namespace, pvc.Name)
+		if len(metrics) == 0 {
+			framework.Logf("no metrics found for pvc %s/%s", pvc.Namespace, pvc.Name)
 
-		for _, line := range strings.Split(stdOut, "\n") {
-			if !strings.HasPrefix(line, "kubelet_volume_stats_") {
-				continue
-			}
-			if strings.Contains(line, namespace) && strings.Contains(line, name) {
-				// TODO: validate metrics if possible
-				framework.Logf("found metrics for pvc %s/%s: %s", pvc.Namespace, pvc.Name, line)
-
-				return true, nil
-			}
+			return false, nil
 		}
 
-		framework.Logf("no metrics found for pvc %s/%s", pvc.Namespace, pvc.Name)
+		for name, value := range metrics {
+			framework.Logf("found metric for pvc %s/%s: %s = %f", pvc.Namespace, pvc.Name, name, value)
+		}
 
-		return false, nil
+		return validateVolumeStatsMetrics(metrics, isBlock)
 	})
+}
+
+// parseVolumeStatsMetrics extracts kubelet_volume_stats_* metric values for a
+// specific PVC from the kubelet metrics output.
+func parseVolumeStatsMetrics(metricsOutput, namespace, pvcName string) map[string]float64 {
+	metrics := make(map[string]float64)
+	nsFilter := fmt.Sprintf("namespace=%q", namespace)
+	nameFilter := fmt.Sprintf("persistentvolumeclaim=%q", pvcName)
+
+	for _, line := range strings.Split(metricsOutput, "\n") {
+		if !strings.HasPrefix(line, "kubelet_volume_stats_") {
+			continue
+		}
+		if !strings.Contains(line, nsFilter) || !strings.Contains(line, nameFilter) {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+
+		metricName := parts[0]
+		if idx := strings.Index(metricName, "{"); idx != -1 {
+			metricName = metricName[:idx]
+		}
+
+		value, err := strconv.ParseFloat(parts[len(parts)-1], 64)
+		if err != nil {
+			continue
+		}
+
+		metrics[metricName] = value
+	}
+
+	return metrics
+}
+
+// validateVolumeStatsMetrics checks that the collected metrics are consistent.
+// For filesystem volumes: capacity > 0, used >= 0, used <= capacity.
+// For block volumes: capacity > 0 is required; used and available may not be
+// present when secrets are unavailable for DiffIterate.
+func validateVolumeStatsMetrics(metrics map[string]float64, isBlock bool) (bool, error) {
+	capacity, hasCapacity := metrics["kubelet_volume_stats_capacity_bytes"]
+	if !hasCapacity {
+		return false, fmt.Errorf("missing kubelet_volume_stats_capacity_bytes metric")
+	}
+
+	if capacity <= 0 {
+		return false, fmt.Errorf("capacity_bytes must be > 0, got %f", capacity)
+	}
+
+	used, hasUsed := metrics["kubelet_volume_stats_used_bytes"]
+	available, hasAvailable := metrics["kubelet_volume_stats_available_bytes"]
+
+	if !isBlock {
+		if !hasUsed {
+			return false, fmt.Errorf("missing kubelet_volume_stats_used_bytes for filesystem volume")
+		}
+		if !hasAvailable {
+			return false, fmt.Errorf("missing kubelet_volume_stats_available_bytes for filesystem volume")
+		}
+		if used < 0 {
+			return false, fmt.Errorf("used_bytes must be >= 0, got %f", used)
+		}
+		if used > capacity {
+			return false, fmt.Errorf("used_bytes (%f) > capacity_bytes (%f)", used, capacity)
+		}
+
+		inodes, hasInodes := metrics["kubelet_volume_stats_inodes"]
+		if !hasInodes {
+			return false, fmt.Errorf("missing kubelet_volume_stats_inodes for filesystem volume")
+		}
+		if inodes < 0 {
+			return false, fmt.Errorf("inodes must be >= 0, got %f", inodes)
+		}
+	}
+
+	if hasUsed && hasAvailable {
+		if used+available > capacity {
+			return false, fmt.Errorf("used (%f) + available (%f) > capacity (%f)", used, available, capacity)
+		}
+	}
+
+	return true, nil
 }
 
 func waitForPVToBeDeleted(c kubernetes.Interface, pvName string, t int) error {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -740,12 +740,7 @@ func validateNormalUserPVCAccessFunc(
 		return fmt.Errorf("failed to run validation function: %w", err)
 	}
 
-	// metrics for BlockMode was added in Kubernetes 1.22
-	isBlockMode := false
-	if pvc.Spec.VolumeMode != nil {
-		isBlockMode = (*pvc.Spec.VolumeMode == v1.PersistentVolumeBlock)
-	}
-	if !isBlockMode && !isOpenShift {
+	if !isOpenShift {
 		err = getMetricsForPVC(f, pvc, deployTimeout)
 		if err != nil {
 			return err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -604,6 +604,27 @@ func (ri *rbdImage) open() (*librbd.Image, error) {
 	return image, nil
 }
 
+// openReadOnly opens the rbdImage in read-only mode. This should be used when
+// the caller only needs to read from the image (e.g. DiffIterate for usage
+// statistics), as it avoids any interaction with the exclusive lock on the image.
+func (ri *rbdImage) openReadOnly() (*librbd.Image, error) {
+	err := ri.openIoctx()
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := librbd.OpenImageReadOnly(ri.ioctx, ri.RbdImageName, librbd.NoSnapshot)
+	if err != nil {
+		if errors.Is(err, librbd.ErrNotFound) {
+			err = fmt.Errorf("Failed as %w (internal %w)", rbderrors.ErrImageNotFound, err)
+		}
+
+		return nil, err
+	}
+
+	return image, nil
+}
+
 // isInUse checks if there is a watcher on the image. It returns true if there
 // is a watcher on the image, otherwise returns false.
 // In case of mirroring, the image should be primary to check watchers if the
@@ -2405,7 +2426,7 @@ func (rv *rbdVolume) PrepareVolumeForSnapshot(ctx context.Context, cr *util.Cred
 // getUsedBytes returns the logical used bytes of the rbd image by iterating over
 // the image using DiffIterate API.
 func (rv *rbdVolume) getUsedBytes(ctx context.Context) (uint64, error) {
-	img, err := rv.open()
+	img, err := rv.openReadOnly()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
getUsedBytes() only reads from the RBD image via DiffIterate to calculate volume usage statistics for NodeGetVolumeStats. Opening the image in read-write mode unnecessarily acquires the exclusive lock, causing contention when the image is mapped by a workload.

Switch to OpenImageReadOnly which avoids the exclusive lock and allows stats collection even when the image is actively mapped elsewhere.

Assisted-by: Claude <noreply@anthropic.com>
