### PR TITLE
ci: commitlint and markdownlint fix

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: commitlint
         # yamllint disable-line rule:line-length
         run: make containerized-test TARGET=commitlint GIT_SINCE="origin/${GITHUB_BASE_REF}"

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -50,7 +50,7 @@ RUN set -x \
 	pylint \
     && dnf -y update \
     && dnf -y clean all \
-    && gem install mdl \
+    && gem install mdl -v 0.15.0 \
     && mkdir -p ${GOROOT} \
     && curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${GOARCH}.tar.gz  \
        | tar xzf - -C ${GOROOT} --strip-components=1 \


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

- commitlint v21 runs git merge-base to find the common ancestor
between origin/devel and HEAD, which requires full history.
The previous shallow checkout worked with v20 but fails with v21
since the merge-base commit is not available in a shallow clone.

- The latest mdl version has issues reporting links longer
than 80 characters. Pin to the last known working version
to unblock CI. This can be revisited later when the issue
is resolved upstream.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
