### PR TITLE
fence: fix IPv6 address handling in blocklist operations

### DIFF
--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -521,7 +521,9 @@ func matchEntry(actual, expected string) bool {
 		actual = strings.TrimSuffix(actual, ":0/32")
 	} else {
 		// for ipv6 address, strip the :0/128 suffix if present
+		// Ceph returns IPv6 blocklist entries in bracket format: [fd98::9]:0/128
 		actual = strings.TrimSuffix(actual, ":0/128")
+		actual = strings.Trim(actual, "[]")
 	}
 
 	actualIP := net.ParseIP(actual)

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -232,11 +232,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(1 * time.Hour),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(1 * time.Hour),
 					},
 				},
@@ -250,11 +250,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 				},
@@ -268,11 +268,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 				},
@@ -286,11 +286,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 				},
@@ -336,11 +336,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now(),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now(),
 					},
 				},
@@ -354,11 +354,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::3:0/128",
+						Addr:  "[2001:db8::3]:0/128",
 						Until: time.Now(),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now(),
 					},
 				},
@@ -372,7 +372,7 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.MaxBlocklistTime),
 					},
 				},
@@ -426,25 +426,25 @@ func Test_matchEntry(t *testing.T) {
 		},
 		{
 			name:     "IPv6 match with /128 suffix",
-			actual:   "2001:db8::1:0/128",
+			actual:   "[2001:db8::1]:0/128",
 			expected: "2001:db8::1",
 			want:     true,
 		},
 		{
 			name:     "IPv6 match without /128 suffix",
-			actual:   "2001:db8::1:0/123213",
+			actual:   "[2001:db8::1]:0/123213",
 			expected: "2001:db8::1",
 			want:     false,
 		},
 		{
 			name:     "IPv6 no match different IPs",
-			actual:   "2001:db8::2:0/128",
+			actual:   "[2001:db8::2]:0/128",
 			expected: "2001:db8::1",
 			want:     false,
 		},
 		{
 			name:     "IPv6 compressed notation match",
-			actual:   "fd4a:ecbc:cafd:4e49::1:0/128",
+			actual:   "[fd4a:ecbc:cafd:4e49::1]:0/128",
 			expected: "fd4a:ecbc:cafd:4e49::1",
 			want:     true,
 		},

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"time"
@@ -355,14 +356,20 @@ func RemoveCephBlocklist(ctx context.Context, monitors string, cr *Credentials, 
 	}
 
 	var clientAddr string
+	//nolint:nestif // straightforward IPv4/IPv6 formatting with nonce
 	if useRange {
-		// When useRange is true, ip is already in CIDR format
 		clientAddr = ip
 	} else {
-		// If nonce is not empty and we are not using
-		// range based blocks, we need to add the nonce
 		if nonce != "" {
-			clientAddr = fmt.Sprintf("%s:0/%s", ip, nonce)
+			parsedIP := net.ParseIP(ip)
+			if parsedIP == nil {
+				return fmt.Errorf("failed to parse IP address %q", ip)
+			}
+			if parsedIP.To4() != nil {
+				clientAddr = fmt.Sprintf("%s:0/%s", ip, nonce)
+			} else {
+				clientAddr = fmt.Sprintf("[%s]:0/%s", ip, nonce)
+			}
 		} else {
 			clientAddr = ip
 		}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Ceph returns IPv6 blocklist entries in bracket format (e.g. [fd98::9]:0/128), but matchEntry did not strip brackets after removing the :0/128 suffix, causing net.ParseIP to fail and auto-unfence to silently skip all IPv6 entries.

Similarly, RemoveCephBlocklist formatted IPv6 addresses without brackets (fd98::9:0/0 instead of [fd98::9]:0/0), producing malformed addresses rejected by Ceph.

Fix matchEntry to strip brackets for IPv6, fix RemoveCephBlocklist to wrap IPv6 in brackets, and update test data to use real Ceph bracket format.

---
Test:

After taint added
```
CIDR entry added:
  cidr:[fd98::7]:0/128   2029-06-03T22:23:00+0000   (~3 year expiry)
```

After taint removed
```
I0604 05:03:42.543807       1 utils.go:350] ID: 7 GRPC call: /fence.FenceController/GetFenceClients
I0604 05:03:42.543893       1 utils.go:351] ID: 7 GRPC request: {"parameters":{"clusterID":"openshift-storage"},"secrets":"***stripped***"}
I0604 05:03:42.576659       1 fencing.go:466] ID: 7 auto-unfencing client with address "fd98::7"
I0604 05:03:43.804489       1 utils.go:357] ID: 7 GRPC response: {"clients":[{"addresses":[{"cidr":"fd98::7/128"}],"id":"c834967c-32a0-4ed7-923d-6df9e0365b13"}]}
```

The cidr:[fd98::7]:0/128 entry has been automatically removed after the taint was taken off

---

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
