### PR TITLE
ci: disable ExtendWebSocketsToKubelet for K8s >= 1.36

### DIFF
--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -217,6 +217,17 @@ CSI_IMAGE_VERSION=${CSI_IMAGE_VERSION:-"canary"}
 #feature-gates for kube
 K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-""}
 
+# cri-dockerd does not support WebSocket v5 streaming, which is enabled by
+# default in K8s >= 1.36 via ExtendWebSocketsToKubelet (beta). This causes
+# "kubectl exec" to fail with "http: server gave HTTP response to HTTPS client".
+if [[ $(kube_version 2) -ge 36 ]]; then
+    if [[ -n "${K8S_FEATURE_GATES}" ]]; then
+        K8S_FEATURE_GATES="${K8S_FEATURE_GATES},ExtendWebSocketsToKubelet=false"
+    else
+        K8S_FEATURE_GATES="ExtendWebSocketsToKubelet=false"
+    fi
+fi
+
 # kubelet.resolv-conf needs to point to a file, not a symlink
 # the default minikube VM has /etc/resolv.conf -> /run/systemd/resolve/resolv.conf
 RESOLV_CONF="${RESOLV_CONF:-/run/systemd/resolve/resolv.conf}"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

cri-dockerd does not support WebSocket v5 streaming protocol, which became enabled by default (beta) in Kubernetes 1.36 via the ExtendWebSocketsToKubelet feature gate. This causes "kubectl exec" to fail with "http: server gave HTTP response to HTTPS client" because the kubelet now proxies WebSocket exec requests directly to cri-dockerd's streaming server, which only serves plain HTTP.

Disable this feature gate when running K8s >= 1.36 to fall back to the previous behavior where the API server handles the SPDY translation.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
