### PR TITLE
Prevent concurrent DeleteVolume/DeleteSnapshot during CreateVolume 

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -344,6 +344,24 @@ func (cs *cephfsControllerServer) CreateVolume(
 		defer parentVol.Destroy()
 	}
 
+	// Lock the source volume or snapshot to prevent deletion while creating from it
+	if pvID != nil {
+		if acquired := cs.VolumeLocks.TryAcquire(pvID.VolumeID); !acquired {
+			log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, pvID.VolumeID)
+
+			return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, pvID.VolumeID)
+		}
+		defer cs.VolumeLocks.Release(pvID.VolumeID)
+	}
+	if sID != nil {
+		if acquired := cs.SnapshotLocks.TryAcquire(sID.SnapshotID); !acquired {
+			log.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, sID.SnapshotID)
+
+			return nil, status.Errorf(codes.Aborted, util.SnapshotOperationAlreadyExistsFmt, sID.SnapshotID)
+		}
+		defer cs.SnapshotLocks.Release(sID.SnapshotID)
+	}
+
 	err = checkValidCreateVolumeRequest(volOptions, parentVol, pvID, sID, req)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -394,6 +394,8 @@ func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSna
 }
 
 // CreateVolume creates the volume in backend.
+//
+//nolint:gocyclo,cyclop // TODO: reduce complexity.
 func (cs *ControllerServer) CreateVolume(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest,
@@ -433,6 +435,24 @@ func (cs *ControllerServer) CreateVolume(
 	}
 	if rbdSnap != nil {
 		defer rbdSnap.Destroy(ctx)
+	}
+
+	// Lock the source volume or snapshot to prevent concurrent operations
+	if parentVol != nil {
+		if acquired := cs.VolumeLocks.TryAcquire(parentVol.VolID); !acquired {
+			log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, parentVol.VolID)
+
+			return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, parentVol.VolID)
+		}
+		defer cs.VolumeLocks.Release(parentVol.VolID)
+	}
+	if rbdSnap != nil {
+		if acquired := cs.SnapshotLocks.TryAcquire(rbdSnap.VolID); !acquired {
+			log.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, rbdSnap.VolID)
+
+			return nil, status.Errorf(codes.Aborted, util.SnapshotOperationAlreadyExistsFmt, rbdSnap.VolID)
+		}
+		defer cs.SnapshotLocks.Release(rbdSnap.VolID)
 	}
 
 	err = updateTopologyConstraints(rbdVol, rbdSnap)


### PR DESCRIPTION
# Describe what this PR does #

There is a race condition possible when `CreateVolume` uses a source volume/snapshot and the source is deleted at the same time. The creation of the volume may fail in weird ways. By grabbing a lock for the source volume/snapshot, a concurrent `DeleteVolume` procedure has to wait until the `CreateVolume` procedure has finished.

## Related issues ##

Fixes: #6321

Note: NFS does not use the source volume/snapshot in any way, it forwards the `CreateVolume` call on to the CephFS Controller. There is no need for the added locking in NFS. NVMe-oF only gets the Clone/Restore functionality through the work-in-progress #6277.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
