### PR TITLE
util: improve static PV handling

### DIFF
--- a/docs/static-pvc.md
+++ b/docs/static-pvc.md
@@ -83,6 +83,9 @@ spec:
   volumeMode: Filesystem
 ```
 
+> [!note]
+> `controllerPublishSecretRef` must not be specified for static RBD PVs.
+
 ### RBD Volume Attributes in PV
 
 Below table explains the list of volume attributes can be set when creating a
@@ -277,6 +280,9 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
 ```
+
+> [!note]
+> `controllerPublishSecretRef` must not be specified for static CephFS PVs.
 
 ### Node stage secret ref in CephFS PV
 

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -1187,21 +1187,12 @@ func (cs *cephfsControllerServer) getServiceAccountRestriction(
 	req *csi.ControllerPublishVolumeRequest,
 ) (string, error) {
 	volumeID := req.GetVolumeId()
-	secrets := req.GetSecrets()
-
-	if secrets == nil {
-		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeID, util.CephFsType)
-		if err != nil {
-			log.WarningLog(ctx, "controller publish secret not found: %v", err)
-
-			return "", nil
-		}
-
-		secrets, err = k8s.GetSecret(secretName, secretNamespace)
-		if err != nil {
-			return "", status.Errorf(codes.Internal,
-				"failed to get controller publish secret from k8s: %v", err)
-		}
+	secrets, skip, err := util.GetControllerPublishSecrets(ctx, req.GetSecrets(), volumeID, util.CephFsType)
+	if skip {
+		return "", nil
+	}
+	if err != nil {
+		return "", status.Error(codes.Internal, err.Error())
 	}
 
 	volOptions, _, err := store.NewVolumeOptionsFromVolID(ctx, volumeID, nil, secrets, cs.ClusterName)
@@ -1260,21 +1251,12 @@ func (cs *cephfsControllerServer) ControllerUnpublishVolume(
 	}
 	defer cs.VolumeLocks.Release(volumeId)
 
-	secrets := req.GetSecrets()
-	if secrets == nil {
-		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeId, util.CephFsType)
-		if err != nil {
-			log.WarningLog(ctx, "controller publish secret not found: %v", err)
-
-			// If the secret is not found, return success to not break for older PVs
-			// without controller-publish secrets.
-			return &csi.ControllerUnpublishVolumeResponse{}, nil
-		}
-
-		secrets, err = k8s.GetSecret(secretName, secretNamespace)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get controller publish secret from k8s: %w", err)
-		}
+	secrets, skip, err := util.GetControllerPublishSecrets(ctx, req.GetSecrets(), volumeId, util.CephFsType)
+	if skip {
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	volOptions, _, err := store.NewVolumeOptionsFromVolID(ctx, volumeId, nil, secrets, cs.ClusterName)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1792,21 +1792,12 @@ func (cs *ControllerServer) getServiceAccountRestriction(
 	req *csi.ControllerPublishVolumeRequest,
 ) (string, error) {
 	volumeID := req.GetVolumeId()
-	secrets := req.GetSecrets()
-
-	if secrets == nil {
-		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeID, util.RBDType)
-		if err != nil {
-			log.WarningLog(ctx, "controller publish secret not found: %v", err)
-
-			return "", nil
-		}
-
-		secrets, err = k8s.GetSecret(secretName, secretNamespace)
-		if err != nil {
-			return "", status.Errorf(codes.Internal,
-				"failed to get controller publish secret from k8s: %v", err)
-		}
+	secrets, skip, err := util.GetControllerPublishSecrets(ctx, req.GetSecrets(), volumeID, util.RBDType)
+	if skip {
+		return "", nil
+	}
+	if err != nil {
+		return "", status.Error(codes.Internal, err.Error())
 	}
 
 	cr, err := util.NewUserCredentials(secrets)
@@ -1864,21 +1855,12 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 	}
 	defer cs.VolumeLocks.Release(volumeId)
 
-	secrets := req.GetSecrets()
-	if secrets == nil {
-		secretName, secretNamespace, err := util.GetControllerPublishSecretRef(volumeId, util.RBDType)
-		if err != nil {
-			log.WarningLog(ctx, "controller publish secret not found: %v", err)
-
-			// If the secret is not found, return success to not break for older PVs
-			// without controller-publish secrets.
-			return &csi.ControllerUnpublishVolumeResponse{}, nil
-		}
-
-		secrets, err = k8s.GetSecret(secretName, secretNamespace)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get controller publish secret from k8s: %w", err)
-		}
+	secrets, skip, err := util.GetControllerPublishSecrets(ctx, req.GetSecrets(), volumeId, util.RBDType)
+	if skip {
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	credentials, err := util.NewAdminCredentials(secrets)

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -36,4 +36,6 @@ var (
 	ErrMissingConfigForMonitor = errors.New("missing configuration of cluster ID for monitor")
 	// ErrConfigNotFound is returned when no configuration is found for a cluster ID.
 	ErrConfigNotFound = errors.New("missing configuration for cluster ID")
+	// ErrInvalidVolID is returned when the volume ID cannot be decomposed into a CSI identifier.
+	ErrInvalidVolID = errors.New("invalid volume ID")
 )

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -34,6 +34,7 @@ import (
 	mount "k8s.io/mount-utils"
 
 	"github.com/ceph/ceph-csi/internal/util/k8s"
+	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
 // Driver types to identify type of driver running.
@@ -349,7 +350,8 @@ func GetControllerPublishSecretRef(volumeId, driverType string) (string, string,
 	)
 	err := vi.DecomposeCSIID(volumeId)
 	if err != nil {
-		return secretName, secretNamespace, fmt.Errorf("failed to decode volume ID (%s): %w", volumeId, err)
+		return secretName, secretNamespace,
+			fmt.Errorf("failed to decode volume ID (%s): %w: %w", volumeId, ErrInvalidVolID, err)
 	}
 
 	secretName, secretNamespace, err = getControllerPublishSecretRef(vi.ClusterID, driverType)
@@ -393,6 +395,37 @@ func GetControllerPublishSecretRef(volumeId, driverType string) (string, string,
 	}
 
 	return secretName, secretNamespace, nil
+}
+
+// GetControllerPublishSecrets resolves secrets for a controller publish/unpublish operation.
+// If reqSecrets is non-nil, return it. Otherwise secrets are fetched from the CSI config.
+// When the second return value is true the caller should return early with no error.
+func GetControllerPublishSecrets(
+	ctx context.Context,
+	reqSecrets map[string]string,
+	volumeID, driverType string,
+) (map[string]string, bool, error) {
+	if reqSecrets != nil {
+		return reqSecrets, false, nil
+	}
+	secretName, secretNamespace, err := GetControllerPublishSecretRef(volumeID, driverType)
+	if errors.Is(err, ErrInvalidVolID) || errors.Is(err, ErrConfigNotFound) {
+		// Possibly the volume is a static/older volume. In this case, we have nothing to do.
+		// Even if it's not a static/older volume, we should skip handling it because
+		// we have no way to process handling anyway.
+		log.WarningLog(ctx, "should skip handling this volume: %v", err)
+
+		return nil, true, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get controller publish secret ref: %w", err)
+	}
+	secrets, err := k8s.GetSecret(secretName, secretNamespace)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get controller publish secret from k8s: %w", err)
+	}
+
+	return secrets, false, nil
 }
 
 func getControllerPublishSecretRef(clusterId, driverType string) (string, string, error) {


### PR DESCRIPTION
# Describe what this PR does #

- Clarify static PV must not specify controllerPublishSecretRef.
- Improve handling volumeHandle validation error. This error is harmless for static volume and is a real error for other volumes.

The related discussion:
https://github.com/ceph/ceph-csi/discussions/6290

## Is there anything that requires special attention ##

This PR hardens the spec of static PVs. However, I believe it's not such a big problem since admins have already suffered from troubles if `controllerPublishSecretRef` is specified on static volumes. For instance, `ControllerUnpublishVolume` fails forever in  [`GenVolFromVolID`](https://github.com/satoru-takeuchi/ceph-csi/blob/214d462fe33cf00f19fa2896955e5967ba9e9f63/internal/rbd/controllerserver.go#L1813) unless volumeHandle validation succeeds by accident.

## Related issues ##

Nothing.

## Future concerns ##

Nothing.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---