### PR TITLE
ci: add jobs for Kubernetes 1.37

### DIFF
--- a/jobs/k8s-e2e-external-storage.yaml
+++ b/jobs/k8s-e2e-external-storage.yaml
@@ -12,6 +12,8 @@
           only_run_on_request: true
       - '1.36':
           only_run_on_request: true
+      - '1.37':
+          only_run_on_request: true
     jobs:
       - 'k8s-e2e-external-storage-{k8s_version}'
 

--- a/jobs/mini-e2e.yaml
+++ b/jobs/mini-e2e.yaml
@@ -12,6 +12,8 @@
           only_run_on_request: true
       - '1.36':
           only_run_on_request: true
+      - '1.37':
+          only_run_on_request: true
     test_type:
       - 'cephfs'
       - 'nfs'


### PR DESCRIPTION
Kubernetes 1.37 is available as ALPHA release, it can be used for early testing.

See-also: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.37.md

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
