### PR TITLE
journal: use omap get-by-keys for direct lookups

### DIFF
--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -32,10 +32,10 @@ import (
 // over and over.
 const chunkSize int64 = 512
 
-func getOMapValues(
+func getOMapValuesByKeys(
 	ctx context.Context,
 	conn *Connection,
-	poolName, namespace, oid, prefix string, keys []string,
+	poolName, namespace, oid string, keys []string,
 ) (map[string]string, error) {
 	// fetch and configure the rados ioctx
 	ioctx, err := conn.conn.GetIoctx(poolName)
@@ -49,33 +49,17 @@ func getOMapValues(
 	}
 
 	results := map[string]string{}
-	// want is our "lookup map" that ensures O(1) checks for keys
-	// while iterating, without needing to complicate the caller.
-	want := make(map[string]bool, len(keys))
-	for i := range keys {
-		want[keys[i]] = true
-	}
-	numKeys := uint64(0)
-	startAfter := ""
-	for {
-		prevNumKeys := numKeys
-		err = ioctx.ListOmapValues(
-			oid, startAfter, prefix, chunkSize,
-			func(key string, value []byte) {
-				numKeys++
-				startAfter = key
-				if want[key] {
-					results[key] = string(value)
-				}
-			},
-		)
-		// if we hit an error, or no new keys were seen, exit the loop
-		if err != nil || numKeys == prevNumKeys {
-			break
-		}
-	}
 
+	op := rados.CreateReadOp()
+	defer op.Release()
+
+	step := op.GetOmapValuesByKeys(keys)
+	err = op.Operate(ioctx, oid, rados.OperationNoFlag)
 	if err != nil {
+		var opErr rados.OperationError
+		if errors.As(err, &opErr) {
+			err = opErr.OpError
+		}
 		if errors.Is(err, rados.ErrNotFound) {
 			log.ErrorLog(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v",
 				poolName, namespace, oid, err)
@@ -86,7 +70,21 @@ func getOMapValues(
 		return nil, err
 	}
 
-	log.DebugLog(ctx, "got omap values: (pool=%q, namespace=%q, name=%q): %+v",
+	for {
+		kv, err := step.Next()
+		if err != nil {
+			log.ErrorLog(ctx, "failed reading omap values by keys (pool=%q, namespace=%q, name=%q, keys=%+v): %v",
+				poolName, namespace, oid, keys, err)
+
+			return nil, err
+		}
+		if kv == nil {
+			break
+		}
+		results[kv.Key] = string(kv.Value)
+	}
+
+	log.DebugLog(ctx, "got omap values by keys: (pool=%q, namespace=%q, name=%q): %+v",
 		poolName, namespace, oid, results)
 
 	return results, nil

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -315,9 +315,9 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 	fetchKeys := []string{
 		cj.csiNameKeyPrefix + reqName,
 	}
-	values, err := getOMapValues(
+	values, err := getOMapValuesByKeys(
 		ctx, conn, journalPool, cj.namespace, cj.csiDirectory,
-		cj.commonPrefix, fetchKeys)
+		fetchKeys)
 	if err != nil {
 		if errors.Is(err, util.ErrKeyNotFound) || errors.Is(err, util.ErrPoolNotFound) {
 			// pool or omap (oid) was not present
@@ -728,9 +728,9 @@ func (conn *Connection) GetImageAttributes(
 		cj.backingSnapshotIDKey,
 		cj.csiGroupIDKey,
 	}
-	values, err := getOMapValues(
+	values, err := getOMapValuesByKeys(
 		ctx, conn, pool, cj.namespace, cj.cephUUIDDirectoryPrefix+objectUUID,
-		cj.commonPrefix, fetchKeys)
+		fetchKeys)
 	if err != nil {
 		if !errors.Is(err, util.ErrKeyNotFound) && !errors.Is(err, util.ErrPoolNotFound) {
 			return nil, err
@@ -819,9 +819,9 @@ func (conn *Connection) StoreGroupID(ctx context.Context, pool, reservedUUID, gr
 // FetchAttribute fetches an attribute (key) in omap.
 func (conn *Connection) FetchAttribute(ctx context.Context, pool, reservedUUID, attribute string) (string, error) {
 	key := conn.config.commonPrefix + attribute
-	values, err := getOMapValues(
+	values, err := getOMapValuesByKeys(
 		ctx, conn, pool, conn.config.namespace, conn.config.cephUUIDDirectoryPrefix+reservedUUID,
-		conn.config.commonPrefix, []string{key})
+		[]string{key})
 	if err != nil {
 		return "", fmt.Errorf("failed to get values for key %q from OMAP: %w", key, err)
 	}
@@ -852,9 +852,9 @@ func (conn *Connection) CheckNewUUIDMapping(ctx context.Context,
 	fetchKeys := []string{
 		cj.csiNameKeyPrefix + volumeHandle,
 	}
-	values, err := getOMapValues(
+	values, err := getOMapValuesByKeys(
 		ctx, conn, journalPool, cj.namespace, cj.csiDirectory,
-		cj.commonPrefix, fetchKeys)
+		fetchKeys)
 	if err != nil {
 		if errors.Is(err, util.ErrKeyNotFound) || errors.Is(err, util.ErrPoolNotFound) {
 			// pool or omap (oid) was not present

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -219,9 +219,9 @@ func (vgjc *volumeGroupJournalConnection) CheckReservation(ctx context.Context,
 	fetchKeys := []string{
 		cj.csiNameKeyPrefix + reqName,
 	}
-	values, err := getOMapValues(
+	values, err := getOMapValuesByKeys(
 		ctx, vgjc.connection, journalPool, cj.namespace, cj.csiDirectory,
-		cj.commonPrefix, fetchKeys)
+		fetchKeys)
 	if err != nil {
 		if errors.Is(err, util.ErrKeyNotFound) || errors.Is(err, util.ErrPoolNotFound) {
 			// pool or omap (oid) was not present


### PR DESCRIPTION
Add a getOMapValuesByKeys() helper in the journal layer and switch known-key OMAP reads in volume and volume group journal paths from prefix-based iteration to direct key lookups.

This avoids scanning large csiDirectory omaps for single-key lookups and significantly improves performance when the csiDirectory stores many entries.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
