### PR TITLE
rbd: update cgroup v2 QoS support for krbd

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -6270,6 +6270,18 @@ var _ = Describe("RBD", func() {
 			if err != nil {
 				logAndFail("failed to create app: %v", err)
 			}
+
+			// Validate io.max file content on the node
+			appPod, err := f.ClientSet.CoreV1().Pods(f.UniqueName).Get(
+				context.TODO(), app.Name, metav1.GetOptions{})
+			if err != nil {
+				logAndFail("failed to get app pod: %v", err)
+			}
+			err = validateIOMax(f, appPod, pvc, wantsMedium)
+			if err != nil {
+				logAndFail("failed to validate io.max for RWO filesystem: %v", err)
+			}
+
 			err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 			if err != nil {
 				logAndFail("failed to delete app: %v", err)
@@ -6315,6 +6327,17 @@ var _ = Describe("RBD", func() {
 			err = createApp(f.ClientSet, appBlock, deployTimeout)
 			if err != nil {
 				logAndFail("failed to create raw app: %v", err)
+			}
+
+			// Validate io.max file content on the node
+			appBlockPod, err := f.ClientSet.CoreV1().Pods(f.UniqueName).Get(
+				context.TODO(), appBlock.Name, metav1.GetOptions{})
+			if err != nil {
+				logAndFail("failed to get block app pod: %v", err)
+			}
+			err = validateIOMax(f, appBlockPod, pvcBlock, wantsLow)
+			if err != nil {
+				logAndFail("failed to validate io.max for RWO block: %v", err)
 			}
 
 			// Test I/O enforcement
@@ -6371,6 +6394,18 @@ var _ = Describe("RBD", func() {
 			if err != nil {
 				logAndFail("failed to create RWOP app: %v", err)
 			}
+
+			// Validate io.max file content on the node
+			appRWOPPod, err := f.ClientSet.CoreV1().Pods(f.UniqueName).Get(
+				context.TODO(), appRWOP.Name, metav1.GetOptions{})
+			if err != nil {
+				logAndFail("failed to get RWOP app pod: %v", err)
+			}
+			err = validateIOMax(f, appRWOPPod, pvcRWOP, wantsHigh)
+			if err != nil {
+				logAndFail("failed to validate io.max for RWOP: %v", err)
+			}
+
 			err = deletePod(appRWOP.Name, appRWOP.Namespace, f.ClientSet, deployTimeout)
 			if err != nil {
 				logAndFail("failed to delete RWOP app: %v", err)

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -18,6 +18,8 @@ package e2e
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1984,4 +1986,224 @@ func modifyPVCVolumeAttributesClass(
 
 		return true, nil
 	})
+}
+
+// validateIOMax reads the io.max file from the pod's cgroup on the node
+// and validates that it contains the expected QoS values for the volume's device.
+//
+// The function:
+//  1. Finds the csi-rbdplugin pod on the same node as the app pod.
+//  2. Discovers the RBD device major:minor from the node.
+//  3. Locates the pod's cgroup path (probing systemd and cgroupfs layouts).
+//  4. Reads io.max and verifies the device's line matches the expected QoS values.
+func validateIOMax(
+	f *framework.Framework,
+	appPod *v1.Pod,
+	pvc *v1.PersistentVolumeClaim,
+	wants map[string]string,
+) error {
+	podUID := string(appPod.UID)
+	nodeName := appPod.Spec.NodeName
+
+	pluginPodName, err := getDaemonsetPodOnNode(f, rbdDaemonsetName, nodeName, cephCSINamespace)
+	if err != nil {
+		return fmt.Errorf("failed to find csi-rbdplugin pod on node %s: %w", nodeName, err)
+	}
+
+	// Get the PV to find the volume handle for the staging path.
+	_, pv, err := getPVCAndPV(f.ClientSet, pvc.Name, pvc.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get PV for PVC %s: %w", pvc.Name, err)
+	}
+
+	deviceID, err := getDeviceIDOnNode(f, pluginPodName, pv)
+	if err != nil {
+		return fmt.Errorf("failed to get device ID: %w", err)
+	}
+
+	framework.Logf("device ID for volume %s: %s", pv.Name, deviceID)
+
+	ioMaxContent, err := readPodCgroupIOMax(f, pluginPodName, podUID)
+	if err != nil {
+		return fmt.Errorf("failed to read io.max for pod %s: %w", appPod.Name, err)
+	}
+
+	framework.Logf("io.max content for pod %s:\n%s", appPod.Name, ioMaxContent)
+
+	return verifyIOMaxContent(ioMaxContent, deviceID, wants)
+}
+
+// getDeviceIDOnNode gets the major:minor device ID for the RBD volume on the node
+// by reading the stash file from the staging path in the csi-rbdplugin container.
+func getDeviceIDOnNode(
+	f *framework.Framework,
+	pluginPodName string,
+	pv *v1.PersistentVolume,
+) (string, error) {
+	volumeHandle := pv.Spec.CSI.VolumeHandle
+
+	// The kubelet staging directory layout differs for filesystem and block volumes:
+	//   Filesystem: /var/lib/kubelet/plugins/kubernetes.io/csi/rbd.csi.ceph.com/<sha256>/globalmount/
+	//   Block:      /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/<pv-name>/
+	hash := sha256.Sum256([]byte(volumeHandle))
+	dirName := hex.EncodeToString(hash[:])
+	candidates := []string{
+		fmt.Sprintf(
+			"/var/lib/kubelet/plugins/kubernetes.io/csi/rbd.csi.ceph.com/%s/globalmount/image-meta.json",
+			dirName),
+		fmt.Sprintf(
+			"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/%s/image-meta.json",
+			pv.Name),
+	}
+
+	var stashContent string
+	var stashPath string
+	for _, candidate := range candidates {
+		cmd := "cat " + candidate + " 2>/dev/null"
+		content, _, err := execCommandInContainerByPodName(
+			f, cmd, cephCSINamespace, pluginPodName, rbdContainerName)
+		if err == nil && strings.TrimSpace(content) != "" {
+			stashContent = content
+			stashPath = candidate
+
+			break
+		}
+	}
+
+	if stashContent == "" {
+		return "", fmt.Errorf("stash file not found for volume %s (tried %v)", volumeHandle, candidates)
+	}
+
+	framework.Logf("found stash file at %s", stashPath)
+
+	var stash struct {
+		Device string `json:"device"`
+	}
+	if err := json.Unmarshal([]byte(stashContent), &stash); err != nil {
+		return "", fmt.Errorf("failed to parse stash file: %w", err)
+	}
+
+	if stash.Device == "" {
+		return "", fmt.Errorf("device path not found in stash file %s", stashPath)
+	}
+
+	// stat the device to get major:minor
+	cmd := fmt.Sprintf("stat -c '%%t:%%T' %s", stash.Device)
+	hexID, _, err := execCommandInContainerByPodName(
+		f, cmd, cephCSINamespace, pluginPodName, rbdContainerName)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat device %s: %w", stash.Device, err)
+	}
+
+	hexID = strings.TrimSpace(hexID)
+	parts := strings.SplitN(hexID, ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected stat output for device %s: %q", stash.Device, hexID)
+	}
+
+	major, err := strconv.ParseInt(parts[0], 16, 64)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse major number %q: %w", parts[0], err)
+	}
+
+	minor, err := strconv.ParseInt(parts[1], 16, 64)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse minor number %q: %w", parts[1], err)
+	}
+
+	return fmt.Sprintf("%d:%d", major, minor), nil
+}
+
+// readPodCgroupIOMax reads the io.max file from the pod's cgroup path on the node
+// by probing both systemd and cgroupfs cgroup driver layouts.
+func readPodCgroupIOMax(
+	f *framework.Framework,
+	pluginPodName string,
+	podUID string,
+) (string, error) {
+	uidUnderscore := strings.ReplaceAll(podUID, "-", "_")
+
+	// Candidate cgroup paths matching production code (podCgroupCandidates).
+	candidates := []string{
+		// systemd cgroup driver
+		"/sys/fs/cgroup/kubepods.slice/kubepods-pod" + uidUnderscore + ".slice",
+		"/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod" + uidUnderscore + ".slice",
+		"/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod" + uidUnderscore + ".slice",
+		// cgroupfs cgroup driver
+		"/sys/fs/cgroup/kubepods/pod" + podUID,
+		"/sys/fs/cgroup/kubepods/burstable/pod" + podUID,
+		"/sys/fs/cgroup/kubepods/besteffort/pod" + podUID,
+	}
+
+	for _, candidate := range candidates {
+		ioMaxPath := candidate + "/io.max"
+		cmd := "cat " + ioMaxPath + " 2>/dev/null"
+
+		content, _, err := execCommandInContainerByPodName(
+			f, cmd, cephCSINamespace, pluginPodName, rbdContainerName)
+		if err == nil && strings.TrimSpace(content) != "" {
+			framework.Logf("found io.max at %s", ioMaxPath)
+
+			return strings.TrimSpace(content), nil
+		}
+	}
+
+	return "", fmt.Errorf("io.max not found for pod UID %s in any candidate cgroup path", podUID)
+}
+
+// verifyIOMaxContent parses io.max content and verifies that the line for the
+// given device ID contains the expected QoS values.
+func verifyIOMaxContent(content, deviceID string, wants map[string]string) error {
+	// Map VAC parameter names to io.max field names.
+	paramToField := map[string]string{
+		"maxReadIops":  "riops",
+		"maxWriteIops": "wiops",
+		"maxReadBps":   "rbps",
+		"maxWriteBps":  "wbps",
+	}
+
+	// Find the line for our device.
+	var deviceLine string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, deviceID+" ") || strings.HasPrefix(line, deviceID+"\t") {
+			deviceLine = line
+
+			break
+		}
+	}
+
+	if deviceLine == "" {
+		return fmt.Errorf("device %s not found in io.max content:\n%s", deviceID, content)
+	}
+
+	// Parse key=value pairs from the device line.
+	actual := make(map[string]string)
+	fields := strings.Fields(deviceLine)
+	for _, field := range fields[1:] {
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) == 2 {
+			actual[parts[0]] = parts[1]
+		}
+	}
+
+	// Verify each expected value.
+	for param, expected := range wants {
+		fieldName, ok := paramToField[param]
+		if !ok {
+			continue
+		}
+
+		got, exists := actual[fieldName]
+		if !exists {
+			return fmt.Errorf("io.max field %s (%s) not found for device %s", fieldName, param, deviceID)
+		}
+
+		if got != expected {
+			return fmt.Errorf("io.max %s (%s) for device %s: got %q, want %q",
+				fieldName, param, deviceID, got, expected)
+		}
+	}
+
+	return nil
 }

--- a/internal/rbd/cgroup_qos.go
+++ b/internal/rbd/cgroup_qos.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	librbd "github.com/ceph/go-ceph/rbd"
+	"golang.org/x/sys/unix"
 
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
@@ -198,35 +199,18 @@ func hasCgroupQoSParams(params map[string]string) bool {
 }
 
 // getDeviceID returns the device major:minor number for the given device path.
-func getDeviceID(ctx context.Context, devicePath string) (string, error) {
-	// Get the real path if devicePath is a symlink.
+func getDeviceID(devicePath string) (string, error) {
 	realPath, err := filepath.EvalSymlinks(devicePath)
 	if err != nil {
-		log.ErrorLog(ctx, "failed to resolve symlink for device %s: %v", devicePath, err)
-
-		return "", err
+		return "", fmt.Errorf("failed to resolve symlink for device %s: %w", devicePath, err)
 	}
 
-	// Read /proc/partitions to get major:minor for the device.
-	data, err := os.ReadFile("/proc/partitions")
-	if err != nil {
-		log.ErrorLog(ctx, "failed to read /proc/partitions: %v", err)
-
-		return "", err
+	var st unix.Stat_t
+	if err := unix.Stat(realPath, &st); err != nil {
+		return "", fmt.Errorf("failed to stat device %s: %w", realPath, err)
 	}
 
-	deviceName := filepath.Base(realPath)
-	for line := range strings.SplitSeq(string(data), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) >= 4 && fields[3] == deviceName {
-			major := fields[0]
-			minor := fields[1]
-
-			return fmt.Sprintf("%s:%s", major, minor), nil
-		}
-	}
-
-	return "", fmt.Errorf("device %s not found in /proc/partitions", deviceName)
+	return fmt.Sprintf("%d:%d", unix.Major(st.Rdev), unix.Minor(st.Rdev)), nil
 }
 
 // formatIOMax formats the io.max line for cgroup v2.
@@ -405,7 +389,7 @@ func (rv *rbdVolume) applyCgroupQoSForVolume(ctx context.Context, devicePath, po
 
 	// Get device ID (major:minor).
 	qos := parseCgroupQoSParams(qosParams)
-	qos.deviceID, err = getDeviceID(ctx, devicePath)
+	qos.deviceID, err = getDeviceID(devicePath)
 	if err != nil {
 		return fmt.Errorf("failed to get device ID for %s: %w", devicePath, err)
 	}

--- a/internal/rbd/cgroup_qos.go
+++ b/internal/rbd/cgroup_qos.go
@@ -64,31 +64,13 @@ const (
 	qosMetadataMaxReadBps   = qosMetadataKeyPrefix + "cgroup_qos_max_read_bps"
 	qosMetadataMaxWriteBps  = qosMetadataKeyPrefix + "cgroup_qos_max_write_bps"
 
-	// cgroup v2 base path.
-	cgroupV2BasePath = "/sys/fs/cgroup"
-
-	// Kubernetes cgroup slices based on QoS class.
-	// BestEffort and Burstable are nested under kubepods.slice parent.
-	kubepodsBestEffortSlice = "kubepods.slice/kubepods-besteffort.slice"
-	kubepodsBurstableSlice  = "kubepods.slice/kubepods-burstable.slice"
-	kubepodsGuaranteedSlice = "kubepods.slice"
-
 	// io.max file for cgroup v2.
 	ioMaxFile = "io.max"
-)
 
-// qosClassInfo holds pre-computed cgroup path information for each QoS class.
-// Ordered by most common QoS class in production (Guaranteed > Burstable > BestEffort)
-// to minimize stat() syscalls on average.
-var qosClassInfo = [...]struct {
-	name      string
-	sliceName string
-	podPrefix string
-}{
-	{"Guaranteed", kubepodsGuaranteedSlice, "kubepods-pod"},
-	{"Burstable", kubepodsBurstableSlice, "kubepods-burstable-pod"},
-	{"BestEffort", kubepodsBestEffortSlice, "kubepods-besteffort-pod"},
-}
+	// Cgroup v2 base paths for systemd and cgroupfs drivers.
+	cgroupV2SystemdBase  = "/sys/fs/cgroup/kubepods.slice"
+	cgroupV2CgroupfsBase = "/sys/fs/cgroup/kubepods"
+)
 
 // qosParamToMetadataKey maps VolumeAttributesClass parameter keys to RBD image metadata keys.
 // Metadata keys are prefixed with `.rbd.csi.ceph.com/` to prevent copying during clone/snapshot.
@@ -227,30 +209,43 @@ func writeIOMax(ioMaxPath, ioMaxLine string) error {
 	return os.WriteFile(ioMaxPath, []byte(ioMaxLine+"\n"), 0o600)
 }
 
-// findPodCgroupPath tries to find the pod's cgroup path by attempting all QoS classes.
-// Optimized to minimize allocations and stat() syscalls per lookup.
+// podCgroupCandidates returns candidate cgroup paths for the given pod UID,
+// covering both the systemd and cgroupfs cgroup drivers.
+// Systemd paths use underscores in place of dashes; cgroupfs paths keep the
+// original dashed UUID.
+// Ordered: Guaranteed > Burstable > BestEffort within each driver, systemd first.
+func podCgroupCandidates(podUID string) []string {
+	uid := strings.ReplaceAll(podUID, "-", "_")
+
+	return []string{
+		// systemd cgroup driver
+		filepath.Join(cgroupV2SystemdBase,
+			"kubepods-pod"+uid+".slice"),
+		filepath.Join(cgroupV2SystemdBase, "kubepods-burstable.slice",
+			"kubepods-burstable-pod"+uid+".slice"),
+		filepath.Join(cgroupV2SystemdBase, "kubepods-besteffort.slice",
+			"kubepods-besteffort-pod"+uid+".slice"),
+
+		// cgroupfs cgroup driver
+		filepath.Join(cgroupV2CgroupfsBase, "pod"+podUID),
+		filepath.Join(cgroupV2CgroupfsBase, "burstable", "pod"+podUID),
+		filepath.Join(cgroupV2CgroupfsBase, "besteffort", "pod"+podUID),
+	}
+}
+
+// findPodCgroupPath tries to find the pod's cgroup v2 path by probing
+// candidates for both the systemd and cgroupfs cgroup drivers.
 func findPodCgroupPath(ctx context.Context, podUID string) (string, error) {
 	if podUID == "" {
 		return "", errors.New("pod UID is empty")
 	}
 
-	// Normalize pod UID once: replace hyphens with underscores.
-	normalizedUID := strings.ReplaceAll(podUID, "-", "_")
+	for _, candidate := range podCgroupCandidates(podUID) {
+		ioMaxPath := filepath.Join(candidate, ioMaxFile)
+		if _, err := os.Stat(ioMaxPath); err == nil {
+			log.DebugLog(ctx, "found pod cgroup path: %s", candidate)
 
-	// Try each QoS class path using pre-computed path prefixes.
-	// Ordered by most common in production: Guaranteed → Burstable → BestEffort.
-	// This minimizes average syscalls (1-2 stat() calls instead of always 3).
-	for i := range qosClassInfo {
-		qos := &qosClassInfo[i]
-		// Construct pod slice name directly (e.g., "kubepods-guaranteed-pod<uid>.slice").
-		// Using string concatenation instead of fmt.Sprintf reduces allocations.
-		podSliceName := qos.podPrefix + normalizedUID + ".slice"
-		podPath := filepath.Join(cgroupV2BasePath, qos.sliceName, podSliceName)
-
-		if _, err := os.Stat(podPath); err == nil {
-			log.DebugLog(ctx, "found pod cgroup path: %s for QoS class: %s", podPath, qos.name)
-
-			return podPath, nil
+			return candidate, nil
 		}
 	}
 

--- a/internal/rbd/cgroup_qos_test.go
+++ b/internal/rbd/cgroup_qos_test.go
@@ -346,137 +346,62 @@ func TestFindPodCgroupPath(t *testing.T) {
 	}
 }
 
-// TestPodCgroupPathConstruction validates the path construction logic
-// without requiring actual filesystem access.
-func TestPodCgroupPathConstruction(t *testing.T) {
+// TestPodCgroupCandidates validates the candidate path generation for both
+// systemd and cgroupfs cgroup drivers.
+func TestPodCgroupCandidates(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name             string
-		podUID           string
-		qosClass         string
-		expectedSlice    string
-		expectedPodSlice string
-	}{
-		{
-			name:             "guaranteed pod path",
-			podUID:           "abc123-def456",
-			qosClass:         "Guaranteed",
-			expectedSlice:    kubepodsGuaranteedSlice,
-			expectedPodSlice: "kubepods-podabc123_def456.slice",
-		},
-		{
-			name:             "burstable pod path",
-			podUID:           "xyz789-uvw123",
-			qosClass:         "Burstable",
-			expectedSlice:    kubepodsBurstableSlice,
-			expectedPodSlice: "kubepods-burstable-podxyz789_uvw123.slice",
-		},
-		{
-			name:             "besteffort pod path",
-			podUID:           "pod-best-effort",
-			qosClass:         "BestEffort",
-			expectedSlice:    kubepodsBestEffortSlice,
-			expectedPodSlice: "kubepods-besteffort-podpod_best_effort.slice",
-		},
-		// Real-world examples from actual Kubernetes cluster cgroup paths
-		{
-			name:             "real besteffort pod",
-			podUID:           "d9fd4536-e68d-46a1-954b-2f05da70bd7d",
-			qosClass:         "BestEffort",
-			expectedSlice:    kubepodsBestEffortSlice,
-			expectedPodSlice: "kubepods-besteffort-podd9fd4536_e68d_46a1_954b_2f05da70bd7d.slice",
-		},
-		{
-			name:             "real guaranteed pod",
-			podUID:           "4d237886-32e9-4888-91da-ed1c0f1d4b89",
-			qosClass:         "Guaranteed",
-			expectedSlice:    kubepodsGuaranteedSlice,
-			expectedPodSlice: "kubepods-pod4d237886_32e9_4888_91da_ed1c0f1d4b89.slice",
-		},
-		{
-			name:             "real burstable pod",
-			podUID:           "bd7148ac-95e7-44b7-a285-bb13e225b4f1",
-			qosClass:         "Burstable",
-			expectedSlice:    kubepodsBurstableSlice,
-			expectedPodSlice: "kubepods-burstable-podbd7148ac_95e7_44b7_a285_bb13e225b4f1.slice",
-		},
+	podUID := "d9fd4536-e68d-46a1-954b-2f05da70bd7d"
+	uidUnderscore := "d9fd4536_e68d_46a1_954b_2f05da70bd7d"
+
+	candidates := podCgroupCandidates(podUID)
+
+	expectedPaths := []string{
+		// systemd
+		filepath.Join(cgroupV2SystemdBase,
+			"kubepods-pod"+uidUnderscore+".slice"),
+		filepath.Join(cgroupV2SystemdBase, "kubepods-burstable.slice",
+			"kubepods-burstable-pod"+uidUnderscore+".slice"),
+		filepath.Join(cgroupV2SystemdBase, "kubepods-besteffort.slice",
+			"kubepods-besteffort-pod"+uidUnderscore+".slice"),
+		// cgroupfs
+		filepath.Join(cgroupV2CgroupfsBase, "pod"+podUID),
+		filepath.Join(cgroupV2CgroupfsBase, "burstable", "pod"+podUID),
+		filepath.Join(cgroupV2CgroupfsBase, "besteffort", "pod"+podUID),
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	if len(candidates) != len(expectedPaths) {
+		t.Fatalf("podCgroupCandidates() returned %d candidates, want %d",
+			len(candidates), len(expectedPaths))
+	}
 
-			// Test UID normalization (hyphens → underscores)
-			normalizedUID := strings.ReplaceAll(tt.podUID, "-", "_")
-
-			// Find matching QoS class info
-			var qos *struct {
-				name      string
-				sliceName string
-				podPrefix string
-			}
-
-			for i := range qosClassInfo {
-				if qosClassInfo[i].name == tt.qosClass {
-					qos = &qosClassInfo[i]
-
-					break
-				}
-			}
-
-			if qos == nil {
-				t.Fatalf("QoS class %s not found in qosClassInfo", tt.qosClass)
-			}
-
-			// Construct expected path using same logic as findPodCgroupPath
-			podSliceName := qos.podPrefix + normalizedUID + ".slice"
-			expectedPath := filepath.Join(cgroupV2BasePath, tt.expectedSlice, tt.expectedPodSlice)
-			constructedPath := filepath.Join(cgroupV2BasePath, qos.sliceName, podSliceName)
-
-			if constructedPath != expectedPath {
-				t.Errorf("path construction mismatch:\ngot:  %s\nwant: %s",
-					constructedPath, expectedPath)
-			}
-		})
+	for i, got := range candidates {
+		if got != expectedPaths[i] {
+			t.Errorf("candidate[%d] = %s, want %s", i, got, expectedPaths[i])
+		}
 	}
 }
 
-func TestQoSClassOrdering(t *testing.T) {
+// TestPodCgroupCandidatesUIDNormalization verifies that systemd paths use
+// underscores and cgroupfs paths keep dashes.
+func TestPodCgroupCandidatesUIDNormalization(t *testing.T) {
 	t.Parallel()
 
-	// Verify that qosClassInfo array is ordered as expected (Guaranteed first).
-	// This ordering is critical for performance - most common QoS class checked first.
-	if qosClassInfo[0].name != "Guaranteed" {
-		t.Errorf("qosClassInfo[0] should be Guaranteed for optimal performance, got %s", qosClassInfo[0].name)
-	}
+	podUID := "abc-def-123"
+	candidates := podCgroupCandidates(podUID)
 
-	if qosClassInfo[1].name != "Burstable" {
-		t.Errorf("qosClassInfo[1] should be Burstable, got %s", qosClassInfo[1].name)
-	}
-
-	if qosClassInfo[2].name != "BestEffort" {
-		t.Errorf("qosClassInfo[2] should be BestEffort, got %s", qosClassInfo[2].name)
-	}
-
-	// Verify path prefixes are correctly constructed
-	expectedPrefixes := map[string]string{
-		"Guaranteed": "kubepods-pod",
-		"Burstable":  "kubepods-burstable-pod",
-		"BestEffort": "kubepods-besteffort-pod",
-	}
-
-	for i := range qosClassInfo {
-		expected, ok := expectedPrefixes[qosClassInfo[i].name]
-		if !ok {
-			t.Errorf("unexpected QoS class name: %s", qosClassInfo[i].name)
-
-			continue
+	for _, c := range candidates[:3] {
+		if strings.Contains(c, podUID) {
+			t.Errorf("systemd candidate should not contain dashed UID: %s", c)
 		}
+		if !strings.Contains(c, "abc_def_123") {
+			t.Errorf("systemd candidate should contain underscore UID: %s", c)
+		}
+	}
 
-		if qosClassInfo[i].podPrefix != expected {
-			t.Errorf("qosClassInfo[%d].podPrefix = %s, want %s",
-				i, qosClassInfo[i].podPrefix, expected)
+	for _, c := range candidates[3:] {
+		if !strings.Contains(c, podUID) {
+			t.Errorf("cgroupfs candidate should contain original dashed UID: %s", c)
 		}
 	}
 }

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -2069,7 +2069,7 @@ func (cs *ControllerServer) ControllerModifyVolume(
 	switch {
 	case errors.Is(err, rbderrors.ErrMounterUnknown):
 		log.WarningLog(ctx, "volume %s has unknown mounter type (created before mounter tracking), "+
-			"proceeding with modification but QoS may not work if volume does not use rbd-nbd", volID)
+			"proceeding with modification but QoS will work only if volume uses krbd", volID)
 	case err != nil:
 		log.ErrorLog(ctx, "failed to check mounter type for volume %s: %v", volID, err)
 


### PR DESCRIPTION
- Support both systemd and cgroupfs cgroup drivers by probing candidate  paths across Guaranteed, Burstable, and BestEffort QoS classes
- Use `unix.Stat` syscall to obtain device major:minor instead of parsing  `/proc/partitions`
- update the e2e to validate the io.max file content