### PR TITLE
csi: watch VGRC metadata to reduce memory usage

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -85,6 +85,7 @@ func Start(config Config) error {
 				DisableFor: []client.Object{
 					&corev1.PersistentVolume{},
 					&corev1.Secret{},
+					&replicationv1alpha1.VolumeGroupReplicationContent{},
 				},
 			},
 		},

--- a/internal/controller/volumegroup/volumegroupreplicationcontent.go
+++ b/internal/controller/volumegroup/volumegroupreplicationcontent.go
@@ -28,12 +28,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	ctrl "github.com/ceph/ceph-csi/internal/controller"
 	"github.com/ceph/ceph-csi/internal/rbd"
@@ -128,26 +130,24 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return nil
 	}
 
-	// Create a new controller
-	c, err := controller.New(
-		"vgrcontent-controller",
-		mgr,
-		controller.Options{MaxConcurrentReconciles: 1, Reconciler: r})
-	if err != nil {
-		return err
+	eventFilterPredicate := predicate.Funcs{
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
 	}
 
-	// Watch for changes to VolumeGroupReplicationContent
-	err = c.Watch(source.Kind(
-		mgr.GetCache(),
+	build := builder.ControllerManagedBy(mgr).Named(
+		"vgrcontent-controller").WithOptions(
+		controller.Options{MaxConcurrentReconciles: 1})
+
+	// Watch for changes to VolumeGroupReplicationContent metadata.
+	// This will only cache the metadata not the complete spec and status in cache.
+	err = build.WatchesMetadata(
 		&replicationv1alpha1.VolumeGroupReplicationContent{},
-		&handler.TypedEnqueueRequestForObject[*replicationv1alpha1.VolumeGroupReplicationContent]{}),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to watch the changes: %w", err)
-	}
+		&handler.EnqueueRequestForObject{}).
+		WithEventFilter(eventFilterPredicate).Complete(r)
 
-	return nil
+	return err
 }
 
 // Reconcile reconciles the VolumeGroupReplicationContent object and creates a new omap entries


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Use WatchesMetadata instead of caching full VolumeGroupReplicationContent objects in the informer cache. This reduces memory consumption in clusters with many VGRC objects by only caching object metadata.

Also adds a delete event predicate filter to skip unnecessary reconciliation for objects being deleted.

Fixes: #5414

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
