### PR TITLE
ci: add queued PR rebase workflow

### DIFF
--- a/.github/workflows/queue-rebase-and-label.yaml
+++ b/.github/workflows/queue-rebase-and-label.yaml
@@ -1,0 +1,90 @@
+---
+name: Queue pull request
+
+# yamllint disable-line rule:truthy
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_target:
+    branches:
+      - devel
+      - "release-v*"
+    types:
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  request-rebase:
+    # yamllint disable rule:line-length
+    if: >
+      github.repository == 'ceph/ceph-csi' &&
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/queue' &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    # yamllint enable rule:line-length
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add queued/rebase label
+        # yamllint disable-line rule:line-length
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          github-token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['queued/rebase']
+            })
+
+      - name: Request rebase through Mergify
+        # yamllint disable-line rule:line-length
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
+        with:
+          token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            @mergifyio rebase
+
+  add-ok-to-test-label:
+    if: >
+      github.repository == 'ceph/ceph-csi' &&
+      github.event_name == 'pull_request_target' &&
+      (github.actor == 'ceph-csi-bot' || github.actor == 'mergify[bot]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ok-to-test label after queued rebase push
+        # yamllint disable-line rule:line-length
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          github-token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          script: |
+            const labels = context.payload.pull_request.labels.map(
+              (label) => label.name
+            )
+            if (!labels.includes('queued/rebase')) {
+              core.info(
+                'Skipping ok-to-test label because queued/rebase is not set'
+              )
+
+              return
+            }
+
+            await github.rest.issues.addLabels({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ok-to-test']
+            })
+
+            await github.rest.issues.removeLabel({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'queued/rebase'
+            })

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -278,11 +278,13 @@ need to be met before it will be merged:
   on the PR. The bot will merge the PR if it's having one approval and the
   label `ready-to-merge`.
 
-When the criteria are met, a project maintainer can instruct the Mergify bot to
-queue the PR for merging. This usually is done by leaving two comments:
+When the criteria are met, a project maintainer can instruct the automation to
+queue the PR for merging by commenting `/queue` on the pull request.
 
-* `@mergifyio rebase` to rebase on the latest HEAD of the branch
-* `@mergifyio queue` once the rebasing is done, to add the PR to the merge queue
+The `/queue` command adds the `queued/rebase` label, asks Mergify to rebase the
+pull request on the latest HEAD of the branch, and after the rebase push adds
+the `ok-to-test` label so e2e testing can start before the PR is queued for
+merging.
 
 ### Backport a Fix to a Release Branch
 


### PR DESCRIPTION

Handle /queue PR comments by labeling the pull request as queued,
requesting a Mergify rebase, and adding ok-to-test after the resulting
synchronize event.

This keeps the queue flow explicit and ensures ok-to-test is only
applied to pull requests that were intentionally queued.
