### PR TITLE
journal: add multi-shard support for csiDirectory

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,6 +2,13 @@
 
 ## Breaking changes
 
+- Journal metadata now uses sharded `csiDirectory` objects for new CSI name
+  mappings. This is a forward-only upgrade for journal metadata: newer
+  ceph-csi versions can read legacy `csiDirectory` entries, but older versions
+  only read the legacy unsharded object and cannot see mappings written to
+  shard oids after the upgrade. Downgrading after new entries have been written
+  in the upgraded version can break idempotent lookups for those entries.
+
 ## Features
 
 ## NOTE

--- a/docs/resource-cleanup.md
+++ b/docs/resource-cleanup.md
@@ -6,6 +6,13 @@ Manual deletion of PV will result in stale omap keys, values,
 cephFS subvolume and rbd image.
 It is required to cleanup metadata and image separately.
 
+New CSI journal request-name mappings are stored in sharded `csiDirectory`
+objects. For volume journals this means new entries are written to
+`csi.volumes.<instance_id>.<shard>` where `<shard>` is in the range `0..10`.
+During upgrades, older mappings may still exist in the legacy unsharded
+`csi.volumes.<instance_id>` object. Manual cleanup should check the shard oids
+first and also clean the legacy oid when applicable.
+
 ## Steps
 
 ### 1. Get PV name from PVC
@@ -27,26 +34,50 @@ a. get pv_name
 
 ### 2. Get omap key/value
 
-a. get omapkey (suffix of csi.volumes.default is value used for the CLI option
-   [--instanceid](rbd/deploy.md#configuration) in the provisioner deployment.)
+a. get omapkey (suffix of `csi.volumes.<instance_id>` is value used for the CLI
+   option [--instanceid](rbd/deploy.md#configuration) in the provisioner
+   deployment). New entries are stored in one of the 11 shard oids
+   `csi.volumes.<instance_id>.0` ... `csi.volumes.<instance_id>.10`, while
+   upgraded clusters may still have older entries in the legacy unsharded
+   `csi.volumes.<instance_id>` oid.
 
   ```
-  rados listomapkeys csi.volumes.default -p pool_name | grep pv_name
+  pv_name="pvc-bc537af8-67fc-4963-99c4-f40b3401686a"
+  instance_id="default"
+  key="csi.volume.${pv_name}"
+  csi_directory_oid=""
+
+  for shard in $(seq 0 10); do
+    oid="csi.volumes.${instance_id}.${shard}"
+    if rados listomapkeys "${oid}" -p pool_name 2>/dev/null | grep -Fx "${key}" >/dev/null; then
+      csi_directory_oid="${oid}"
+      break
+    fi
+  done
+
+  if [ -z "${csi_directory_oid}" ]; then
+    legacy_oid="csi.volumes.${instance_id}"
+    if rados listomapkeys "${legacy_oid}" -p pool_name 2>/dev/null | grep -Fx "${key}" >/dev/null; then
+      csi_directory_oid="${legacy_oid}"
+    fi
+  fi
+
+  echo "${csi_directory_oid}"
   ```
 
   ```bash
-  $ rados listomapkeys csi.volumes.default -p kube_csi | grep pvc-bc537af8-67fc-4963-99c4-f40b3401686a
-  csi.volume.pvc-bc537af8-67fc-4963-99c4-f40b3401686a
+  $ echo "${csi_directory_oid}"
+  csi.volumes.default.3
   ```
 
 b. get omapval
 
   ```
-  rados getomapval csi.volumes.default omapkey -p pool_name
+  rados getomapval csi_directory_oid omapkey -p pool_name
   ```
 
   ```bash
-  $ rados getomapval csi.volumes.default csi.volume.pvc-bc537af8-67fc-4963-99c4-f40b3401686a -p kube_csi
+  $ rados getomapval "${csi_directory_oid}" "${key}" -p kube_csi
   value (36 bytes) :
   00000000  64 64 32 34 37 33 64 30  2d 36 61 38 63 2d 31 31  |dd2473d0-6a8c-11|
   00000010  65 61 2d 39 31 31 33 2d  30 61 64 35 39 64 39 39  |ea-9113-0ad59d99|
@@ -89,14 +120,16 @@ a. delete omap object
   rados rm csi.volume.dd2473d0-6a8c-11ea-9113-0ad59d995ce7 -p kube_csi
   ```
 
-b. delete omapkey
-
-  ```
-  rados rmomapkey csi.volumes.default csi.volume.omapkey -p pool_name
-  ```
+b. delete omapkey from the found oid. If the key was found in a shard oid, also
+   try to delete it from the legacy unsharded oid to cleanup upgraded clusters.
 
   ```bash
-  rados rmomapkey csi.volumes.default csi.volume.pvc-bc537af8-67fc-4963-99c4-f40b3401686a -p kube_csi
+  rados rmomapkey "${csi_directory_oid}" "${key}" -p pool_name
+
+  legacy_oid="csi.volumes.${instance_id}"
+  if [ "${csi_directory_oid}" != "${legacy_oid}" ]; then
+    rados rmomapkey "${legacy_oid}" "${key}" -p pool_name || true
+  fi
   ```
 
 ### 5. Delete PV

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1124,12 +1124,15 @@ func checkPVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeCl
 		return err
 	}
 
+	key := "csi.volume." + imageData.pvName
+	shardOid := getCsiDirectoryShard(key)
 	_, stdErr, err := execCommandInToolBoxPod(
 		f,
 		fmt.Sprintf(
-			"rados getomapval %s csi.volumes.default csi.volume.%s",
+			"rados getomapval %s %s %s",
 			rbdOptions(pool),
-			imageData.pvName,
+			shardOid,
+			key,
 		),
 		rookNamespace,
 	)
@@ -1137,17 +1140,18 @@ func checkPVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeCl
 		return err
 	}
 	if stdErr != "" {
-		return fmt.Errorf("error getting fsid %v", stdErr)
+		return fmt.Errorf("failed to getomapval from %s: %s", shardOid, stdErr)
 	}
 
 	if radosNamespace != "" {
 		framework.Logf(
-			"found CSI journal entry %s in pool %s namespace %s",
-			"csi.volume."+imageData.pvName,
+			"found CSI journal entry %s in pool %s namespace %s oid %s",
+			key,
 			pool,
-			radosNamespace)
+			radosNamespace,
+			shardOid)
 	} else {
-		framework.Logf("found CSI journal entry %s in pool %s", "csi.volume."+imageData.pvName, pool)
+		framework.Logf("found CSI journal entry %s in pool %s oid %s", key, pool, shardOid)
 	}
 
 	return nil
@@ -1190,22 +1194,28 @@ func deletePVCCSIJournalInPool(f *framework.Framework, pvc *v1.PersistentVolumeC
 		return err
 	}
 
+	key := "csi.volume." + imageData.pvName
+	shardOid := getCsiDirectoryShard(key)
 	_, stdErr, err := execCommandInToolBoxPod(
 		f,
 		fmt.Sprintf(
-			"rados rmomapkey %s csi.volumes.default csi.volume.%s",
+			"rados rmomapkey %s %s %s",
 			rbdOptions(pool),
-			imageData.pvName),
-		rookNamespace)
+			shardOid,
+			key,
+		),
+		rookNamespace,
+	)
 	if err != nil {
 		return err
 	}
 	if stdErr != "" {
 		return fmt.Errorf(
-			"failed to remove %s csi.volumes.default csi.volume.%s: %v",
-			rbdOptions(pool),
-			imageData.imageID,
-			stdErr)
+			"failed to remove %s %s: %s",
+			shardOid,
+			key,
+			stdErr,
+		)
 	}
 
 	return nil

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"os"
 	"regexp"
@@ -73,6 +74,8 @@ const (
 	// cluster Name, set by user.
 	clusterNameKey     = "csi.ceph.com/cluster/name"
 	defaultClusterName = "k8s-cluster-1"
+
+	defaultCSIDirectoryShards = 11
 )
 
 var (
@@ -218,14 +221,81 @@ func compareStdoutWithCount(stdOut string, count int) error {
 	return nil
 }
 
+func getCsiDirectoryShard(key string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+
+	return fmt.Sprintf("%s.%d", "csi.volumes.default", h.Sum32()%defaultCSIDirectoryShards)
+}
+
+func getCSIJournalBaseOID(mode string) string {
+	switch mode {
+	case volumesType:
+		return "csi.volumes.default"
+	case snapsType:
+		return "csi.snaps.default"
+	case groupSnapsType:
+		return "csi.groups.default"
+	default:
+		return ""
+	}
+}
+
+// filterNonEmptyLines normalizes rados output and keeps only non-empty lines.
+func filterNonEmptyLines(stdOut string) []string {
+	lines := strings.Split(stdOut, "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			filtered = append(filtered, line)
+		}
+	}
+
+	return filtered
+}
+
+// getCSIJournalKeyCount sums the omap keys across all CSI journal shards for the mode.
+func getCSIJournalKeyCount(f *framework.Framework, driver, pool, mode string) (int, error) {
+	baseOID := getCSIJournalBaseOID(mode)
+	if baseOID == "" {
+		return 0, fmt.Errorf("unsupported csi journal mode %q", mode)
+	}
+
+	total := 0
+	for i := 0; i < defaultCSIDirectoryShards; i++ {
+		oid := fmt.Sprintf("%s.%d", baseOID, i)
+		var cmd string
+		if strings.EqualFold(driver, cephfsType) {
+			cmd = "rados listomapkeys " + oid + " " + cephfsOptions(pool)
+		} else {
+			cmd = "rados listomapkeys " + oid + " " + rbdOptions(pool)
+		}
+
+		stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+		if err != nil {
+			if strings.Contains(err.Error(), exitOneErr) {
+				continue
+			}
+
+			return 0, err
+		}
+		if stdErr != "" {
+			return 0, fmt.Errorf("failed to list omap keys for %s: %s", oid, stdErr)
+		}
+		total += len(filterNonEmptyLines(stdOut))
+	}
+
+	return total, nil
+}
+
 // validateOmapCount validates no of OMAP entries on the given pool.
-// Works with Cephfs and RBD drivers and mode can be snapsType or volumesType.
+// Works with Cephfs and RBD drivers and mode can be volumesType, snapsType, or groupSnapsType.
 func validateOmapCount(f *framework.Framework, count int, driver, pool, mode string) {
 	type radosListCommand struct {
-		volumeMode                           string
-		driverType                           string
-		radosLsCmd, radosLsCmdFilter         string
-		radosLsKeysCmd, radosLsKeysCmdFilter string
+		volumeMode                   string
+		driverType                   string
+		radosLsCmd, radosLsCmdFilter string
 	}
 
 	radosListCommands := []radosListCommand{
@@ -235,8 +305,6 @@ func validateOmapCount(f *framework.Framework, count int, driver, pool, mode str
 			radosLsCmd: "rados ls " + cephfsOptions(pool),
 			radosLsCmdFilter: fmt.Sprintf("rados ls %s | grep -v default | grep -v csi.volume.group. | grep -c ^csi.volume.",
 				cephfsOptions(pool)),
-			radosLsKeysCmd:       "rados listomapkeys csi.volumes.default " + cephfsOptions(pool),
-			radosLsKeysCmdFilter: fmt.Sprintf("rados listomapkeys csi.volumes.default %s | wc -l", cephfsOptions(pool)),
 		},
 		{
 			volumeMode: volumesType,
@@ -245,40 +313,30 @@ func validateOmapCount(f *framework.Framework, count int, driver, pool, mode str
 			radosLsCmdFilter: fmt.Sprintf(
 				"rados ls %s | grep -v default | grep -v csi.volume.group. |  grep -c ^csi.volume.",
 				rbdOptions(pool)),
-			radosLsKeysCmd:       "rados listomapkeys csi.volumes.default " + rbdOptions(pool),
-			radosLsKeysCmdFilter: fmt.Sprintf("rados listomapkeys csi.volumes.default %s | wc -l", rbdOptions(pool)),
 		},
 		{
-			volumeMode:           snapsType,
-			driverType:           cephfsType,
-			radosLsCmd:           "rados ls " + cephfsOptions(pool),
-			radosLsCmdFilter:     fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.snap.", cephfsOptions(pool)),
-			radosLsKeysCmd:       "rados listomapkeys csi.snaps.default " + cephfsOptions(pool),
-			radosLsKeysCmdFilter: fmt.Sprintf("rados listomapkeys csi.snaps.default %s | wc -l", cephfsOptions(pool)),
+			volumeMode:       snapsType,
+			driverType:       cephfsType,
+			radosLsCmd:       "rados ls " + cephfsOptions(pool),
+			radosLsCmdFilter: fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.snap.", cephfsOptions(pool)),
 		},
 		{
-			volumeMode:           snapsType,
-			driverType:           rbdType,
-			radosLsCmd:           "rados ls " + rbdOptions(pool),
-			radosLsCmdFilter:     fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.snap.", rbdOptions(pool)),
-			radosLsKeysCmd:       "rados listomapkeys csi.snaps.default " + rbdOptions(pool),
-			radosLsKeysCmdFilter: fmt.Sprintf("rados listomapkeys csi.snaps.default %s | wc -l", rbdOptions(pool)),
+			volumeMode:       snapsType,
+			driverType:       rbdType,
+			radosLsCmd:       "rados ls " + rbdOptions(pool),
+			radosLsCmdFilter: fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.snap.", rbdOptions(pool)),
 		},
 		{
-			volumeMode:           groupSnapsType,
-			driverType:           cephfsType,
-			radosLsCmd:           "rados ls" + cephfsOptions(pool),
-			radosLsCmdFilter:     fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.volume.group.", cephfsOptions(pool)),
-			radosLsKeysCmd:       "rados listomapkeys csi.groups.default " + cephfsOptions(pool),
-			radosLsKeysCmdFilter: fmt.Sprintf("rados listomapkeys csi.groups.default %s | wc -l", cephfsOptions(pool)),
+			volumeMode:       groupSnapsType,
+			driverType:       cephfsType,
+			radosLsCmd:       "rados ls" + cephfsOptions(pool),
+			radosLsCmdFilter: fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.volume.group.", cephfsOptions(pool)),
 		},
 		{
-			volumeMode:           groupSnapsType,
-			driverType:           rbdType,
-			radosLsCmd:           "rados ls" + rbdOptions(pool),
-			radosLsCmdFilter:     fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.volume.group.", rbdOptions(pool)),
-			radosLsKeysCmd:       "rados listomapkeys csi.groups.default " + rbdOptions(pool),
-			radosLsKeysCmdFilter: fmt.Sprintf("rados listomapkeys csi.groups.default %s | wc -l", rbdOptions(pool)),
+			volumeMode:       groupSnapsType,
+			driverType:       rbdType,
+			radosLsCmd:       "rados ls" + rbdOptions(pool),
+			radosLsCmdFilter: fmt.Sprintf("rados ls %s | grep -v default | grep -c ^csi.volume.group.", rbdOptions(pool)),
 		},
 	}
 
@@ -286,30 +344,38 @@ func validateOmapCount(f *framework.Framework, count int, driver, pool, mode str
 		if !strings.EqualFold(cmds.volumeMode, mode) || !strings.EqualFold(cmds.driverType, driver) {
 			continue
 		}
-		filterCmds := []string{cmds.radosLsCmdFilter, cmds.radosLsKeysCmdFilter}
-		filterLessCmds := []string{cmds.radosLsCmd, cmds.radosLsKeysCmd}
-		for i, cmd := range filterCmds {
-			stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
-			if err != nil {
-				if !strings.Contains(err.Error(), exitOneErr) {
-					logAndFail("failed to execute rados command '%s' : err=%v stdErr=%s", cmd, err, stdErr)
-				}
+		stdOut, stdErr, err := execCommandInToolBoxPod(f, cmds.radosLsCmdFilter, rookNamespace)
+		if err != nil {
+			if !strings.Contains(err.Error(), exitOneErr) {
+				logAndFail("failed to execute rados command '%s' : err=%v stdErr=%s", cmds.radosLsCmdFilter, err, stdErr)
 			}
-			if stdErr != "" {
-				logAndFail("failed to execute rados command '%s' : stdErr=%s", cmd, stdErr)
-			}
-			err = compareStdoutWithCount(stdOut, count)
-			if err == nil {
-				continue
-			}
-			saveErr := fmt.Errorf("failed to validate omap count for %s: %w", cmd, err)
+		}
+		if stdErr != "" {
+			logAndFail("failed to execute rados command '%s' : stdErr=%s", cmds.radosLsCmdFilter, stdErr)
+		}
+		err = compareStdoutWithCount(stdOut, count)
+		if err != nil {
+			saveErr := fmt.Errorf("failed to validate omap count for %s: %w", cmds.radosLsCmdFilter, err)
 			if strings.Contains(err.Error(), "expected omap object count") {
-				stdOut, stdErr, err = execCommandInToolBoxPod(f, filterLessCmds[i], rookNamespace)
+				stdOut, stdErr, err = execCommandInToolBoxPod(f, cmds.radosLsCmd, rookNamespace)
 				if err == nil {
 					framework.Logf("additional debug info: rados ls command output: %s, stdErr: %s", stdOut, stdErr)
 				}
 			}
 			framework.Fail(saveErr.Error())
+		}
+
+		if mode == volumesType || mode == snapsType || mode == groupSnapsType {
+			keyCount, err := getCSIJournalKeyCount(f, driver, pool, mode)
+			if err != nil {
+				logAndFail("failed to count CSI journal keys: %v", err)
+			}
+			err = compareStdoutWithCount(strconv.Itoa(keyCount), count)
+			if err != nil {
+				framework.Fail(fmt.Errorf("failed to validate journal key count for %s: %w", mode, err).Error())
+			}
+
+			return
 		}
 	}
 }

--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -64,7 +64,7 @@ func getOMapValuesByKeys(
 			log.ErrorLog(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v",
 				poolName, namespace, oid, err)
 
-			return nil, fmt.Errorf("%w: %w", util.ErrKeyNotFound, err)
+			return nil, errors.Join(util.ErrObjectNotFound, util.ErrKeyNotFound, err)
 		}
 
 		return nil, err

--- a/internal/journal/voljournal.go
+++ b/internal/journal/voljournal.go
@@ -22,7 +22,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 
@@ -110,13 +112,18 @@ single entity modifying the related omaps for a given VolName.
 const (
 	defaultVolumeNamingPrefix   string = "csi-vol-"
 	defaultSnapshotNamingPrefix string = "csi-snap-"
+	defaultCSIDirectoryShards   uint32 = 11
 )
 
 // CSIJournal defines the interface and the required key names for the above RADOS based OMaps.
 type Config struct {
-	// csiDirectory is the name of the CSI volumes object map that contains CSI volume-name (or
-	// snapshot name) based keys
+	// csiDirectory is the legacy base name of the CSI volumes object map that contains CSI
+	// volume-name (or snapshot name) based keys.
 	csiDirectory string
+
+	// csiDirectoryShards is the number of sharded directory objects used for new CSI name lookups.
+	// The legacy csiDirectory object remains as a compatibility fallback during upgrades.
+	csiDirectoryShards uint32
 
 	// CSI volume-name keyname prefix, for key in csiDirectory, suffix is the CSI passed volume name
 	csiNameKeyPrefix string
@@ -165,12 +172,18 @@ type Config struct {
 
 	// commonPrefix is the prefix common to all omap keys for this Config
 	commonPrefix string
+
+	// legacyDirectoryAbsent tracks csiDirectory oids that have been confirmed
+	// absent for this controller instance, so later connections can skip legacy
+	// fallback for the same journal directory.
+	legacyDirectoryAbsent *sync.Map
 }
 
 // NewCSIVolumeJournal returns an instance of CSIJournal for volumes.
 func NewCSIVolumeJournal(suffix string) *Config {
 	return &Config{
 		csiDirectory:            "csi.volumes." + suffix,
+		csiDirectoryShards:      defaultCSIDirectoryShards,
 		csiNameKeyPrefix:        "csi.volume.",
 		cephUUIDDirectoryPrefix: "csi.volume.",
 		csiNameKey:              "csi.volname",
@@ -185,6 +198,7 @@ func NewCSIVolumeJournal(suffix string) *Config {
 		ownerKey:                "csi.volume.owner",
 		backingSnapshotIDKey:    "csi.volume.backingsnapshotid",
 		commonPrefix:            "csi.",
+		legacyDirectoryAbsent:   &sync.Map{},
 	}
 }
 
@@ -192,6 +206,7 @@ func NewCSIVolumeJournal(suffix string) *Config {
 func NewCSISnapshotJournal(suffix string) *Config {
 	return &Config{
 		csiDirectory:            "csi.snaps." + suffix,
+		csiDirectoryShards:      defaultCSIDirectoryShards,
 		csiNameKeyPrefix:        "csi.snap.",
 		cephUUIDDirectoryPrefix: "csi.snap.",
 		csiNameKey:              "csi.snapname",
@@ -205,6 +220,7 @@ func NewCSISnapshotJournal(suffix string) *Config {
 		encryptionType:          "csi.volume.encryptionType",
 		ownerKey:                "csi.volume.owner",
 		commonPrefix:            "csi.",
+		legacyDirectoryAbsent:   &sync.Map{},
 	}
 }
 
@@ -275,6 +291,102 @@ func (cj *Config) Connect(monitors, namespace string, cr *util.Credentials) (*Co
 	return conn, nil
 }
 
+// getCsiDirectoryShard returns the shard oid for key based on the csiDirectory hash layout.
+func (cj *Config) getCsiDirectoryShard(key string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+
+	return fmt.Sprintf("%s.%d", cj.csiDirectory, h.Sum32()%cj.csiDirectoryShards)
+}
+
+func legacyCsiDirectoryKey(journalPool, namespace, csiDirectory string) string {
+	return fmt.Sprintf("%s/%s/%s", journalPool, namespace, csiDirectory)
+}
+
+func (cj *Config) isLegacyDirectoryAbsent(journalPool, namespace, csiDirectory string) bool {
+	if cj.legacyDirectoryAbsent == nil {
+		return false
+	}
+
+	_, found := cj.legacyDirectoryAbsent.Load(legacyCsiDirectoryKey(journalPool, namespace, csiDirectory))
+
+	return found
+}
+
+func (cj *Config) markLegacyDirectoryAbsent(journalPool, namespace, csiDirectory string) {
+	if cj.legacyDirectoryAbsent == nil {
+		cj.legacyDirectoryAbsent = &sync.Map{}
+	}
+
+	cj.legacyDirectoryAbsent.Store(legacyCsiDirectoryKey(journalPool, namespace, csiDirectory), struct{}{})
+}
+
+/*
+lookupCsiDirectoryValue looks up key in the sharded csiDirectory layout and
+falls back to the legacy unsharded csiDirectory oid when needed.
+
+New mappings including volume, snapshot, and volume group request
+names, are stored in shard oids selected by getCsiDirectoryShard(). During
+upgrades, existing mappings may still exist only in the legacy csiDirectory
+oid. This helper preserves compatibility by checking the shard oid first and
+retrying the lookup against the legacy oid when the shard object is missing
+or when the requested key is not found in the shard result.
+
+Once the controller confirms that a legacy csiDirectory oid is absent for a
+given pool and namespace, subsequent lookups skip the legacy fallback and
+return the shard result directly.
+
+It returns the mapped value, whether the key was found after shard and
+legacy lookup, and any error returned while reading the omap objects.
+*/
+func lookupCsiDirectoryValue(
+	ctx context.Context,
+	conn *Connection,
+	journalPool, key string,
+) (string, bool, error) {
+	cj := conn.config
+	shardOID := cj.getCsiDirectoryShard(key)
+	values, err := getOMapValuesByKeys(ctx, conn, journalPool, cj.namespace, shardOID, []string{key})
+	switch {
+	case err == nil:
+		if value, found := values[key]; found {
+			return value, true, nil
+		}
+	case errors.Is(err, util.ErrKeyNotFound):
+		log.DebugLog(ctx, "failed reading shard csiDirectory %q with ErrKeyNotFound", shardOID)
+	default:
+		return "", false, err
+	}
+
+	if cj.isLegacyDirectoryAbsent(journalPool, cj.namespace, cj.csiDirectory) {
+		log.DebugLog(ctx, "skipping legacy csiDirectory lookup for %q after confirming the oid is absent",
+			cj.csiDirectory)
+
+		return "", false, nil
+	}
+
+	log.DebugLog(ctx, "key %q not found in shard csiDirectory %q; falling back to legacy oid %q",
+		key, shardOID, cj.csiDirectory)
+
+	values, err = getOMapValuesByKeys(ctx, conn, journalPool, cj.namespace, cj.csiDirectory, []string{key})
+	if err != nil {
+		if errors.Is(err, util.ErrObjectNotFound) {
+			cj.markLegacyDirectoryAbsent(journalPool, cj.namespace, cj.csiDirectory)
+
+			log.DebugLog(ctx, "legacy csiDirectory %q is absent; future lookups will skip the fallback",
+				cj.csiDirectory)
+
+			return "", false, nil
+		}
+
+		return "", false, err
+	}
+
+	value, found := values[key]
+
+	return value, found, nil
+}
+
 /*
 CheckReservation checks if given request name contains a valid reservation
 - If there is a valid reservation, then the corresponding ImageData for the volume/snapshot is returned
@@ -312,12 +424,8 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 	}
 
 	// check if request name is already part of the directory omap
-	fetchKeys := []string{
-		cj.csiNameKeyPrefix + reqName,
-	}
-	values, err := getOMapValuesByKeys(
-		ctx, conn, journalPool, cj.namespace, cj.csiDirectory,
-		fetchKeys)
+	key := cj.csiNameKeyPrefix + reqName
+	objUUIDAndPool, found, err := lookupCsiDirectoryValue(ctx, conn, journalPool, key)
 	if err != nil {
 		if errors.Is(err, util.ErrKeyNotFound) || errors.Is(err, util.ErrPoolNotFound) {
 			// pool or omap (oid) was not present
@@ -327,7 +435,6 @@ func (conn *Connection) CheckReservation(ctx context.Context,
 
 		return nil, err
 	}
-	objUUIDAndPool, found := values[cj.csiNameKeyPrefix+reqName]
 	if !found {
 		// omap was read but was missing the desired key-value pair
 		// stop processing but without an error for no reservation exists
@@ -475,8 +582,14 @@ func (conn *Connection) UndoReservation(ctx context.Context,
 	}
 
 	// delete the request name key (last, inverse of create order)
-	err := removeMapKeys(ctx, conn, csiJournalPool, cj.namespace, cj.csiDirectory,
-		[]string{cj.csiNameKeyPrefix + reqName})
+	key := cj.csiNameKeyPrefix + reqName
+	shardOid := cj.getCsiDirectoryShard(key)
+	err := removeMapKeys(ctx, conn, csiJournalPool, cj.namespace, shardOid, []string{key})
+	if err == nil {
+		// Always delete from the legacy oid as well, to ensure metadata for
+		// already existing volumes gets cleaned up.
+		err = removeMapKeys(ctx, conn, csiJournalPool, cj.namespace, cj.csiDirectory, []string{key})
+	}
 	if err != nil {
 		log.ErrorLog(ctx, "failed removing oMap key %s (%s)", cj.csiNameKeyPrefix+reqName, err)
 
@@ -619,8 +732,9 @@ func (conn *Connection) ReserveName(ctx context.Context,
 	// After generating the UUID Directory omap, we populate the csiDirectory
 	// omap with a key-value entry to map the request to the backend volume:
 	// `csiNameKeyPrefix + reqName: nameKeyVal`
-	err = setOMapKeys(ctx, conn, journalPool, cj.namespace, cj.csiDirectory,
-		map[string]string{cj.csiNameKeyPrefix + reqName: nameKeyVal})
+	key := cj.csiNameKeyPrefix + reqName
+	err = setOMapKeys(ctx, conn, journalPool, cj.namespace, cj.getCsiDirectoryShard(key),
+		map[string]string{key: nameKeyVal})
 	if err != nil {
 		return "", "", err
 	}
@@ -849,12 +963,8 @@ func (conn *Connection) CheckNewUUIDMapping(ctx context.Context,
 	cj := conn.config
 
 	// check if request name is already part of the directory omap
-	fetchKeys := []string{
-		cj.csiNameKeyPrefix + volumeHandle,
-	}
-	values, err := getOMapValuesByKeys(
-		ctx, conn, journalPool, cj.namespace, cj.csiDirectory,
-		fetchKeys)
+	key := cj.csiNameKeyPrefix + volumeHandle
+	value, _, err := lookupCsiDirectoryValue(ctx, conn, journalPool, key)
 	if err != nil {
 		if errors.Is(err, util.ErrKeyNotFound) || errors.Is(err, util.ErrPoolNotFound) {
 			// pool or omap (oid) was not present
@@ -865,7 +975,7 @@ func (conn *Connection) CheckNewUUIDMapping(ctx context.Context,
 		return "", err
 	}
 
-	return values[cj.csiNameKeyPrefix+volumeHandle], nil
+	return value, nil
 }
 
 // ReserveNewUUIDMapping creates the omap mapping between the oldVolumeHandle
@@ -878,12 +988,10 @@ func (conn *Connection) ReserveNewUUIDMapping(ctx context.Context,
 	journalPool, oldVolumeHandle, newVolumeHandle string,
 ) error {
 	cj := conn.config
+	key := cj.csiNameKeyPrefix + oldVolumeHandle
 
-	setKeys := map[string]string{
-		cj.csiNameKeyPrefix + oldVolumeHandle: newVolumeHandle,
-	}
-
-	return setOMapKeys(ctx, conn, journalPool, cj.namespace, cj.csiDirectory, setKeys)
+	return setOMapKeys(ctx, conn, journalPool, cj.namespace, cj.getCsiDirectoryShard(key),
+		map[string]string{key: newVolumeHandle})
 }
 
 // ResetVolumeOwner updates the owner in the rados object.

--- a/internal/journal/volumegroupjournal.go
+++ b/internal/journal/volumegroupjournal.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -100,11 +101,13 @@ func NewCSIVolumeGroupJournal(suffix string) VolumeGroupJournalConfig {
 	return VolumeGroupJournalConfig{
 		Config: Config{
 			csiDirectory:            "csi.groups." + suffix,
+			csiDirectoryShards:      defaultCSIDirectoryShards,
 			csiNameKeyPrefix:        "csi.volume.group.",
 			cephUUIDDirectoryPrefix: "csi.volume.group.",
 			csiImageKey:             "csi.groupname",
 			csiNameKey:              "csi.volname",
 			namespace:               "",
+			legacyDirectoryAbsent:   &sync.Map{},
 		},
 		csiCreationTimeKey: "csi.creationtime",
 	}
@@ -216,12 +219,8 @@ func (vgjc *volumeGroupJournalConnection) CheckReservation(ctx context.Context,
 	)
 
 	// check if request name is already part of the directory omap
-	fetchKeys := []string{
-		cj.csiNameKeyPrefix + reqName,
-	}
-	values, err := getOMapValuesByKeys(
-		ctx, vgjc.connection, journalPool, cj.namespace, cj.csiDirectory,
-		fetchKeys)
+	key := cj.csiNameKeyPrefix + reqName
+	objUUID, found, err := lookupCsiDirectoryValue(ctx, vgjc.connection, journalPool, key)
 	if err != nil {
 		if errors.Is(err, util.ErrKeyNotFound) || errors.Is(err, util.ErrPoolNotFound) {
 			// pool or omap (oid) was not present
@@ -231,8 +230,6 @@ func (vgjc *volumeGroupJournalConnection) CheckReservation(ctx context.Context,
 
 		return nil, err
 	}
-
-	objUUID, found := values[cj.csiNameKeyPrefix+reqName]
 	if !found {
 		// omap was read but was missing the desired key-value pair
 		// stop processing but without an error for no reservation exists
@@ -317,8 +314,14 @@ func (vgjc *volumeGroupJournalConnection) UndoReservation(ctx context.Context,
 	}
 
 	// delete the request name key (last, inverse of create order)
-	err := removeMapKeys(ctx, vgjc.connection, csiJournalPool, cj.namespace, cj.csiDirectory,
-		[]string{cj.csiNameKeyPrefix + reqName})
+	key := cj.csiNameKeyPrefix + reqName
+	shardOID := cj.getCsiDirectoryShard(key)
+	err := removeMapKeys(ctx, vgjc.connection, csiJournalPool, cj.namespace, shardOID, []string{key})
+	if err == nil {
+		// Always delete from the legacy oid as well, to ensure metadata for
+		// already existing volume groups gets cleaned up.
+		err = removeMapKeys(ctx, vgjc.connection, csiJournalPool, cj.namespace, cj.csiDirectory, []string{key})
+	}
 	if err != nil {
 		log.ErrorLog(ctx, "failed removing oMap key %s (%s)", cj.csiNameKeyPrefix+reqName, err)
 	}
@@ -370,8 +373,9 @@ func (vgjc *volumeGroupJournalConnection) ReserveName(ctx context.Context,
 	// After generating the UUID Directory omap, we populate the csiDirectory
 	// omap with a key-value entry to map the request to the backend volume group:
 	// `csiNameKeyPrefix + reqName: nameKeyVal`
-	err = setOMapKeys(ctx, vgjc.connection, journalPool, cj.namespace, cj.csiDirectory,
-		map[string]string{cj.csiNameKeyPrefix + reqName: nameKeyVal})
+	key := cj.csiNameKeyPrefix + reqName
+	err = setOMapKeys(ctx, vgjc.connection, journalPool, cj.namespace, cj.getCsiDirectoryShard(key),
+		map[string]string{key: nameKeyVal})
 	if err != nil {
 		return "", "", err
 	}

--- a/troubleshooting/tools/tracevol.py
+++ b/troubleshooting/tools/tracevol.py
@@ -43,6 +43,7 @@ import re
 import prettytable
 PARSER = argparse.ArgumentParser()
 ARGS=None # just so that the linter is happy, ARGS is global already.
+DEFAULT_CSI_DIRECTORY_SHARDS = 11
 
 # -p pvc-test -k /home/.kube/config -n default -rn rook-ceph
 PARSER.add_argument("-p", "--pvcname", default="", help="PVC name")
@@ -66,6 +67,8 @@ PARSER.add_argument("-cm", "--configmap", default="ceph-csi-config",
                     help="configmap name which holds the cephcsi configuration")
 PARSER.add_argument("-cmn", "--configmapnamespace", default="default",
                     help="namespace where configmap exists")
+PARSER.add_argument("--instanceid", default="default",
+                    help="ceph-csi instance ID")
 
 
 def list_pvc_vol_name_mapping(arg):
@@ -187,34 +190,11 @@ def check_pv_name_in_rados(arg, image_id, pvc_name, pool_name, is_rbd):
     validate pvc information in rados
     """
     omapkey = f'csi.volume.{pvc_name}'
-    cmd = ['rados', 'getomapval', 'csi.volumes.default',
-           omapkey, "--pool", pool_name]
-    if not arg.userkey:
-        cmd += ["--id", arg.userid, "--key", arg.userkey]
-    if not is_rbd:
-        cmd += ["--namespace", "csi"]
-    if arg.toolboxdeployed is True:
-        kube = get_cmd_prefix(arg)
-        cmd = kube + cmd
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as out:
-        stdout, stderr = out.communicate()
-
-    if stderr is not None:
-        return False
-    name = b''
-    lines = [x.strip() for x in stdout.split(b"\n")]
-    for line in lines:
-        if b' ' not in line:
-            continue
-        if b'value' in line and b'bytes' in line:
-            continue
-        part = re.findall(br'[A-Za-z0-9\-]+', line)
-        if part:
-            name += part[-1]
-    if name.decode() != image_id:
+    omapobj = f'csi.volumes.{arg.instanceid}'
+    name = get_val_from_csi_directory(omapobj, omapkey, pool_name, is_rbd)
+    if name != image_id:
         if arg.debug:
-            decoded_name = name.decode()
-            print(f"expected image Id {image_id} found Id in rados {decoded_name}")
+            print(f"expected image Id {image_id} found Id in rados {name}")
         return False
     return True
 
@@ -643,15 +623,45 @@ def get_val_from_omap(obj, key, pool, is_rbd, regex=br'[A-Za-z0-9\-]+'):
 
     return result.decode()
 
+def fnv32a(key):
+    """
+    Returns the 32-bit FNV-1a hash for a string.
+    """
+    hval = 0x811c9dc5
+    for byte in key.encode():
+        hval ^= byte
+        hval = (hval * 0x01000193) & 0xffffffff
+    return hval
+
+def get_csi_directory_shard(base_oid, key):
+    """
+    Returns the sharded csiDirectory object for a key.
+    """
+    shard = fnv32a(key) % DEFAULT_CSI_DIRECTORY_SHARDS
+    return f"{base_oid}.{shard}"
+
+def get_val_from_csi_directory(base_oid, key, pool, is_rbd):
+    """
+    Retrieve a value from sharded csiDirectory with legacy oid fallback.
+    """
+    shard_oid = get_csi_directory_shard(base_oid, key)
+    val = get_val_from_omap(shard_oid, key, pool, is_rbd)
+    if val:
+        return val
+
+    return get_val_from_omap(base_oid, key, pool, is_rbd)
+
 def check_snap_content_name_in_rados(snap_uuid, snap_content_name, pool, is_rbd):
     """
-    Validates if snapshot content name is listed in csi.snaps.default omap
+    Validates if the snapshot content name is listed in the sharded
+    `csi.snaps.<instanceid>.<shard>` journal omap, with fallback to the
+    legacy unsharded `csi.snaps.<instanceid>` oid.
     """
     snap_content_name = snap_content_name.replace("snapcontent", "snapshot")
-    omap_obj = "csi.snaps.default"
+    omap_obj = f"csi.snaps.{ARGS.instanceid}"
     omap_key = f'csi.snap.{snap_content_name}'
 
-    val = get_val_from_omap(omap_obj, omap_key, pool, is_rbd)
+    val = get_val_from_csi_directory(omap_obj, omap_key, pool, is_rbd)
     if val != snap_uuid:
         if ARGS.debug:
             print(f"expected image Id {snap_uuid} found Id in rados {val}")


### PR DESCRIPTION
CSI request-name mappings for volume and snapshot journals are currently stored in a single csiDirectory omap object. In Ceph, the osd_deep_scrub_large_omap_object_key_threshold setting triggers a ceph cluster-side warning when a single object contains more than 200,000 omap keys. With the current business growth supported by ceph-csi, clusters with more than 200,000 RBD volumes have already appeared, which means the existing single-object layout is no longer sufficient. Concentrating all lookups, updates, and cleanup operations on one oid also creates a metadata hotspot and makes the directory harder to scale.

This change introduces a hash-based multi-shard layout for csiDirectory so that new request-name mappings are distributed across multiple shard oids. The existing request-name to UUID mapping model remains unchanged, while omap operations are spread by key.

Compatibility with the legacy csiDirectory layout is preserved to support upgrades:
- CheckReservation and CheckNewUUIDMapping read from the shard oid first and fall back to the legacy oid on lookup miss
- ReserveName and ReserveNewUUIDMapping write new mappings to the shard oid
- UndoReservation removes mappings from the shard oid and also cleans up the legacy oid so that pre-upgrade metadata can still be reclaimed correctly

This enables sharded csiDirectory metadata for new entries without breaking existing volume and snapshot journal data during rolling upgrades.

Currently, the default number of shards is set to 11 and cannot be dynamically modified. This is sufficient for future use.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
