### PR TITLE
rbd: remove snapshot lock from restore path

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -724,13 +724,6 @@ func (cs *ControllerServer) createVolumeFromSnapshot(
 	rbdVol *rbdVolume,
 	snapshotID string,
 ) error {
-	if acquired := cs.SnapshotLocks.TryAcquire(snapshotID); !acquired {
-		log.ErrorLog(ctx, util.SnapshotOperationAlreadyExistsFmt, snapshotID)
-
-		return status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, snapshotID)
-	}
-	defer cs.SnapshotLocks.Release(snapshotID)
-
 	rbdSnap, err := genSnapFromSnapID(ctx, snapshotID, cr, secrets)
 	if err != nil {
 		if errors.Is(err, util.ErrPoolNotFound) {


### PR DESCRIPTION
Drop the SnapshotLocks guard from createVolumeFromSnapshot() and rely on the existing restore operation lock for snapshot-based restore requests.

Ceph RBD supports concurrent clones from the same snapshot. The snapshot lock in createVolumeFromSnapshot() unnecessarily serialized restore requests for the same snapshot and reduced restore performance.

Under concurrent restore workloads, the lock also caused requests to fail with Aborted, which triggered large numbers of retries from csi-provisioner and increased overall system load.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
