### PR TITLE
util: skip volume ID format check for pre-provisioned volumes

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -580,6 +580,14 @@ var _ = Describe(cephfsType, func() {
 			}
 		})
 
+		It("check static PVC with monitors and provisionVolume=false", func() {
+			scPath := cephFSExamplePath + "secret.yaml"
+			err := validateCephFsMonitorListPV(f, appPath, scPath, fileSystemName)
+			if err != nil {
+				logAndFail("failed to validate CephFS static pv with monitor list: %v", err)
+			}
+		})
+
 		It("create a storageclass with pool and a PVC then bind it to an app", func() {
 			err := createCephfsStorageClass(f.ClientSet, f, true, nil)
 			if err != nil {

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -499,6 +499,181 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath, fsName stri
 	return nil
 }
 
+// validateCephFsMonitorListPV validates that a CephFS PV created with
+// provisionVolume=false and monitors (instead of staticVolume=true and
+// clusterID) can be mounted by an application pod.
+func validateCephFsMonitorListPV(f *framework.Framework, appPath, scPath, fsName string) error {
+	opt := make(map[string]string)
+	var (
+		cephFsVolName = "testSubVol"
+		groupName     = "testGroup"
+		pvName        = "pv-name"
+		pvcName       = "pvc-name"
+		namespace     = f.UniqueName
+		// minikube creates default storage class in cluster, we need to set dummy
+		// storageclass on PV and PVC to avoid storageclass name mismatch
+		sc         = "storage-class"
+		secretName = "cephfs-monlist-pv-sc" // #nosec
+	)
+
+	c := f.ClientSet
+
+	listOpt := metav1.ListOptions{
+		LabelSelector: "app=rook-ceph-tools",
+	}
+
+	mons, err := getMons(rookNamespace, c)
+	if err != nil {
+		return fmt.Errorf("failed to get monitors: %w", err)
+	}
+	monsStr := strings.Join(mons, ",")
+
+	// 4GiB in bytes
+	size := "4294967296"
+
+	// create subvolumegroup, command will work even if group is already present.
+	cmd := fmt.Sprintf("ceph fs subvolumegroup create %s %s", fileSystemName, groupName)
+
+	_, e, err := execCommandInPod(f, cmd, rookNamespace, &listOpt)
+	if err != nil {
+		return err
+	}
+	if e != "" {
+		return fmt.Errorf("failed to create subvolumegroup: %s", e)
+	}
+
+	// create subvolume
+	cmd = fmt.Sprintf("ceph fs subvolume create %s %s %s --size %s", fileSystemName, cephFsVolName, groupName, size)
+	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
+	if err != nil {
+		return err
+	}
+	if e != "" {
+		return fmt.Errorf("failed to create subvolume: %s", e)
+	}
+
+	// get rootpath
+	cmd = fmt.Sprintf("ceph fs subvolume getpath %s %s %s", fileSystemName, cephFsVolName, groupName)
+	rootPath, e, err := execCommandInPod(f, cmd, rookNamespace, &listOpt)
+	if err != nil {
+		return err
+	}
+	if e != "" {
+		return fmt.Errorf("failed to get rootpath %s", e)
+	}
+	// remove new line present in rootPath
+	rootPath = strings.Trim(rootPath, "\n")
+
+	// create secret
+	secret, err := getSecret(scPath)
+	if err != nil {
+		return err
+	}
+	adminKey, e, err := execCommandInPod(f, "ceph auth get-key client.admin", rookNamespace, &listOpt)
+	if err != nil {
+		return err
+	}
+	if e != "" {
+		return fmt.Errorf("failed to get adminKey %s", e)
+	}
+	secret.StringData["userID"] = adminUser
+	secret.StringData["userKey"] = adminKey
+	secret.Name = secretName
+	secret.Namespace = cephCSINamespace
+	_, err = c.CoreV1().Secrets(cephCSINamespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	opt["monitors"] = monsStr
+	opt["provisionVolume"] = strconv.FormatBool(false)
+	opt["rootPath"] = rootPath
+	if fsName != "" {
+		opt["fsName"] = fsName
+	}
+	pv := getStaticPV(
+		pvName,
+		pvName,
+		staticPVSize,
+		secretName,
+		cephCSINamespace,
+		sc,
+		"cephfs.csi.ceph.com",
+		false,
+		opt,
+		nil,
+		retainPolicy)
+	_, err = c.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create PV: %w", err)
+	}
+
+	pvc := getStaticPVC(pvcName, pvName, size, namespace, sc, false)
+	_, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create PVC: %w", err)
+	}
+	// bind pvc to app
+	app, err := loadApp(appPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app: %w", err)
+	}
+
+	app.Namespace = namespace
+	app.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = pvcName
+	err = createApp(f.ClientSet, app, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create pod: %w", err)
+	}
+
+	err = deletePod(app.Name, namespace, f.ClientSet, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete pod: %w", err)
+	}
+
+	err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete pvc: %w", err)
+	}
+
+	err = c.CoreV1().PersistentVolumes().Delete(context.TODO(), pv.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete pv: %w", err)
+	}
+
+	err = waitForPVToBeDeleted(f.ClientSet, pv.Name, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to validate PV %s is deleted: %w", pv.Name, err)
+	}
+
+	err = c.CoreV1().Secrets(cephCSINamespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete secret: %w", err)
+	}
+
+	// delete subvolume
+	cmd = fmt.Sprintf("ceph fs subvolume rm %s %s %s", fileSystemName, cephFsVolName, groupName)
+	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
+	if err != nil {
+		return err
+	}
+	if e != "" {
+		return fmt.Errorf("failed to remove sub-volume %s", e)
+	}
+
+	// delete subvolume group
+	cmd = fmt.Sprintf("ceph fs subvolumegroup rm %s %s", fileSystemName, groupName)
+	_, e, err = execCommandInPod(f, cmd, rookNamespace, &listOpt)
+	if err != nil {
+		return err
+	}
+	if e != "" {
+		return fmt.Errorf("failed to remove subvolume group %s", e)
+	}
+
+	return nil
+}
+
 func validateRBDStaticResize(
 	f *framework.Framework,
 	app *v1.Pod,

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -270,7 +270,7 @@ func (ns *nfsNodeServer) mountNFS(
 
 // validateNodePublishVolumeRequest validates node publish volume request.
 func validateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
-	if err := util.ValidateVolumeID(req.GetVolumeId(), util.IsStaticVol(req.GetVolumeContext())); err != nil {
+	if err := util.ValidateVolumeID(req.GetVolumeId(), util.IsPreProvisionedVol(req.GetVolumeContext())); err != nil {
 		return err
 	}
 

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1154,7 +1154,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest,
 ) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	if err := util.ValidateVolumeID(req.GetVolumeId(), util.IsStaticVol(req.GetVolumeContext())); err != nil {
+	if err := util.ValidateVolumeID(req.GetVolumeId(), util.IsPreProvisionedVol(req.GetVolumeContext())); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/internal/util/validate.go
+++ b/internal/util/validate.go
@@ -53,7 +53,7 @@ var validator = regexp.MustCompile(`^[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[a-zA-Z0-9\-_
 
 // ValidateControllerPublishVolumeRequest validates the controller publish request.
 func ValidateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequest) error {
-	if err := ValidateVolumeID(req.GetVolumeId(), IsStaticVol(req.GetVolumeContext())); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), IsPreProvisionedVol(req.GetVolumeContext())); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -86,7 +86,7 @@ func ValidateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
 		return status.Error(codes.InvalidArgument, "volume capability missing in request")
 	}
 
-	if err := ValidateVolumeID(req.GetVolumeId(), IsStaticVol(req.GetVolumeContext())); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), IsPreProvisionedVol(req.GetVolumeContext())); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -129,7 +129,7 @@ func ValidateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
 		return status.Error(codes.InvalidArgument, "volume capability missing in request")
 	}
 
-	if err := ValidateVolumeID(req.GetVolumeId(), IsStaticVol(req.GetVolumeContext())); err != nil {
+	if err := ValidateVolumeID(req.GetVolumeId(), IsPreProvisionedVol(req.GetVolumeContext())); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -191,7 +191,7 @@ func ValidateVolumeID(volumeID string, skipFormatCheck bool) error {
 	}
 
 	// Should match the expected format: 0000-0000-arbitrary-number-of-000-and-chars.
-	// This is checked only when the volume is not statically provisioned.
+	// This is checked only when the volume is not pre-provisioned.
 	if matches := validator.MatchString(volumeID); !skipFormatCheck && !matches {
 		return fmt.Errorf("the volumeID has an unexpected format: %q", volumeID)
 	}
@@ -200,17 +200,23 @@ func ValidateVolumeID(volumeID string, skipFormatCheck bool) error {
 	return nil
 }
 
-// IsStaticVol checks the volumeAttribute of a volume to determine
-// if it is statically provisioned.
-func IsStaticVol(volAttrs map[string]string) bool {
-	val, ok := volAttrs["staticVolume"]
-	if ok {
-		boolVal, err := strconv.ParseBool(val)
-		if err != nil {
-			return false
+// IsPreProvisionedVol checks the volume context to determine if the volume
+// was provisioned outside of ceph-csi (either as a static volume or via
+// an external provisioner).
+func IsPreProvisionedVol(volAttrs map[string]string) bool {
+	if val, ok := volAttrs["staticVolume"]; ok {
+		if boolVal, err := strconv.ParseBool(val); err == nil && boolVal {
+			return true
 		}
+	}
 
-		return boolVal
+	if val, ok := volAttrs["provisionVolume"]; ok {
+		if boolVal, err := strconv.ParseBool(val); err == nil && !boolVal {
+			log.WarningLogMsg("volumeContext key %q is deprecated, use %q instead",
+				"provisionVolume", "staticVolume=true")
+
+			return true
+		}
 	}
 
 	return false

--- a/internal/util/validate_test.go
+++ b/internal/util/validate_test.go
@@ -79,6 +79,40 @@ func TestValidateVolumeID(t *testing.T) {
 	}
 }
 
+func TestIsPreProvisionedVol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		volAttrs map[string]string
+		want     bool
+	}{
+		{"staticVolume true", map[string]string{"staticVolume": "true"}, true},
+		{"staticVolume false", map[string]string{"staticVolume": "false"}, false},
+		{"provisionVolume false", map[string]string{"provisionVolume": "false"}, true},
+		{"provisionVolume true", map[string]string{"provisionVolume": "true"}, false},
+		{
+			"staticVolume checked first when both keys present",
+			map[string]string{"staticVolume": "true", "provisionVolume": "false"},
+			true,
+		},
+		{"neither set", map[string]string{"foo": "bar"}, false},
+		{"empty map", map[string]string{}, false},
+		{"nil map", nil, false},
+		{"staticVolume invalid", map[string]string{"staticVolume": "notabool"}, false},
+		{"provisionVolume invalid", map[string]string{"provisionVolume": "notabool"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsPreProvisionedVol(tt.volAttrs)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestValidateServiceAccountRestriction(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Some external provisioners pass volume IDs that don't match our expected format. The format validation only skipped the check for `staticVolume=true` but not for `provisionVolume=false`.

Renamed `IsStaticVol` to `IsPreProvisionedVol` and modified it to also recognize `provisionVolume=false` so that the format check is skipped for all volumes that are not dynamically provisioned.

Fixes: #6347

