### PR TITLE
journal: lower omap not found log level in getOMapValuesByKeys

### DIFF
--- a/internal/journal/omap.go
+++ b/internal/journal/omap.go
@@ -61,7 +61,7 @@ func getOMapValuesByKeys(
 			err = opErr.OpError
 		}
 		if errors.Is(err, rados.ErrNotFound) {
-			log.ErrorLog(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v",
+			log.DebugLog(ctx, "omap not found (pool=%q, namespace=%q, name=%q): %v",
 				poolName, namespace, oid, err)
 
 			return nil, fmt.Errorf("%w: %w", util.ErrKeyNotFound, err)


### PR DESCRIPTION
On the first get value attempt, a missing omap object is expected and the caller continues normal processing. Log this case at debug level to avoid reporting expected behavior as an error.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
