### PR TITLE
cephfs: add namespace isolated subvolume creation

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,4 +4,10 @@
 
 ## Features
 
+### CephFS
+
+* **Namespace isolated subvolumes:** Added an optional StorageClass parameter
+  (`namespaceIsolated`, default disabled) that allows creating new subvolumes
+  in a unique, isolated RADOS namespace
+
 ## NOTE

--- a/docs/cephfs/deploy.md
+++ b/docs/cephfs/deploy.md
@@ -82,6 +82,7 @@ you're running it inside a k8s cluster and find the config itself).
 | `encrypted`                                                                                         | no             | disabled by default, use `"true"` to enable fscrypt encryption on PVC and `"false"` to disable it. **Do not change for existing storageclasses**                                                                          |
 | `encryptionKMSID`                                                                                   | no             | required if encryption is enabled and a kms is used to store passphrases                                                                                                                                                |
 | `extraDeploy` | no | array of extra objects to deploy with the release |
+| `namespaceIsolated` | no | Boolean value (truthy/falsy string), disabled by default - set to `"true"` in your Kubernetes CephFS StorageClass to create each new subvolume in a unique, isolated RADOS namespace. |
 
 **NOTE:** An accompanying CSI configuration file, needs to be provided to the
 running pods. Refer to [Creating CSI configuration](../../examples/README.md#creating-csi-configuration)

--- a/examples/cephfs/storageclass.yaml
+++ b/examples/cephfs/storageclass.yaml
@@ -64,6 +64,14 @@ parameters:
   # correlation to configmap entry.
   # encryptionKMSID: <kms-config-id>
 
+  # (optional) Enable RADOS namespace isolation for new CephFS subvolumes
+  #   Type: Boolean (as String), defaults to "false"
+  #   If enabled, each new subvolume created on the associated Ceph FS/volume
+  #   will get a unique RADOS namespace created for, and permanently assigned,
+  #   to it. This differs from file/directory layouts, as it is immutable. The
+  #   name of the new NS is not configurable, as it is automatically derived
+  #   from the subvolume name with an "fsvolumens_" prefix.
+  # namespaceIsolated: "true"
 
 reclaimPolicy: Delete
 allowVolumeExpansion: true

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -274,6 +274,9 @@ func buildCreateVolumeResponse(
 	volumeContext := util.GetVolumeContext(req.GetParameters())
 	volumeContext["subvolumeName"] = vID.FsSubvolName
 	volumeContext["subvolumePath"] = volOptions.RootPath
+	if volOptions.PoolNamespace != "" {
+		volumeContext["radosNamespace"] = volOptions.PoolNamespace
+	}
 	volume := &csi.Volume{
 		VolumeId:      vID.VolumeID,
 		CapacityBytes: volOptions.Size,
@@ -468,6 +471,16 @@ func (cs *cephfsControllerServer) CreateVolume(
 			log.ErrorLog(ctx, "failed to get subvolume path %s: %v", vID.FsSubvolName, err)
 
 			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		if volOptions.NamespaceIsolated {
+			svInfo, err := volClient.GetSubVolumeInfo(ctx)
+			if err != nil {
+				log.WarningLog(ctx, "failed to get subvolume info for pool namespace %s: %v",
+					vID.FsSubvolName, err)
+			} else {
+				volOptions.PoolNamespace = svInfo.PoolNamespace
+			}
 		}
 
 		// Set Metadata on PV Create

--- a/internal/cephfs/controllerserver_test.go
+++ b/internal/cephfs/controllerserver_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/ceph-csi/internal/cephfs/store"
+)
+
+func TestBuildCreateVolumeResponse_WithRadosNamespace(t *testing.T) {
+	t.Parallel()
+	const ns = "csi-vol-4c742621-090a-484d-a33b"
+	req := &csi.CreateVolumeRequest{Parameters: map[string]string{}}
+	volOptions := &store.VolumeOptions{
+		PoolNamespace: ns,
+		RootPath:      "/volumes/csi/csi-vol-test/uuid",
+	}
+	vID := &store.VolumeIdentifier{FsSubvolName: "csi-vol-test", VolumeID: "vol-0001"}
+
+	resp := buildCreateVolumeResponse(req, volOptions, vID)
+
+	require.Equal(t, ns, resp.GetVolume().GetVolumeContext()["radosNamespace"])
+}
+
+func TestBuildCreateVolumeResponse_WithoutRadosNamespace(t *testing.T) {
+	t.Parallel()
+	req := &csi.CreateVolumeRequest{Parameters: map[string]string{}}
+	volOptions := &store.VolumeOptions{
+		RootPath: "/volumes/csi/csi-vol-test/uuid",
+	}
+	vID := &store.VolumeIdentifier{FsSubvolName: "csi-vol-test", VolumeID: "vol-0001"}
+
+	resp := buildCreateVolumeResponse(req, volOptions, vID)
+
+	_, present := resp.GetVolume().GetVolumeContext()["radosNamespace"]
+	require.False(t, present, "radosNamespace must be absent when PoolNamespace is empty")
+}
+
+func TestBuildCreateVolumeResponse_SubvolNameAndPath(t *testing.T) {
+	t.Parallel()
+	req := &csi.CreateVolumeRequest{Parameters: map[string]string{}}
+	volOptions := &store.VolumeOptions{
+		RootPath: "/volumes/csi/csi-vol-test/uuid",
+	}
+	vID := &store.VolumeIdentifier{FsSubvolName: "csi-vol-test", VolumeID: "vol-0001"}
+
+	resp := buildCreateVolumeResponse(req, volOptions, vID)
+
+	vc := resp.GetVolume().GetVolumeContext()
+	require.Equal(t, "csi-vol-test", vc["subvolumeName"])
+	require.Equal(t, "/volumes/csi/csi-vol-test/uuid", vc["subvolumePath"])
+}

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -52,6 +52,8 @@ type Subvolume struct {
 	BytesQuota int64
 	Path       string
 	Features   []string
+	// RADOS namespace assigned by Ceph when created with namespace_isolated=true. Empty for standard subvolumes.
+	PoolNamespace string
 }
 
 // SubVolumeClient is the interface that holds the signature of subvolume methods
@@ -107,6 +109,8 @@ type SubVolume struct {
 	Pool           string   // pool name where subvolume will be created.
 	Features       []string // subvolume features.
 	Size           int64    // subvolume size.
+	// Set to true to create the subvolume with a dedicated RADOS namespace.
+	NamespaceIsolated bool
 }
 
 // NewSubVolume returns a new subvolume client.
@@ -174,10 +178,17 @@ func (s *subVolumeClient) GetSubVolumeInfo(ctx context.Context) (*Subvolume, err
 		return nil, err
 	}
 
+	return subvolumeFromInfo(info, s.VolID)
+}
+
+// subvolumeFromInfo converts an fsAdmin.SubVolumeInfo to a Subvolume,
+// handling the polymorphic BytesQuota field.
+func subvolumeFromInfo(info *fsAdmin.SubVolumeInfo, volID string) (*Subvolume, error) {
 	subvol := Subvolume{
 		// only set BytesQuota when it is of type ByteCount
-		Path:     info.Path,
-		Features: make([]string, len(info.Features)),
+		Path:          info.Path,
+		PoolNamespace: info.PoolNamespace,
+		Features:      make([]string, len(info.Features)),
 	}
 	bc, ok := info.BytesQuota.(fsAdmin.ByteCount)
 	if !ok {
@@ -185,7 +196,7 @@ func (s *subVolumeClient) GetSubVolumeInfo(ctx context.Context) (*Subvolume, err
 		// or nil (in case the subvolume is in snapshot-retained state),
 		// just continue without returning quota information.
 		if !(info.BytesQuota == fsAdmin.Infinite || info.State == fsAdmin.StateSnapRetained) {
-			return nil, fmt.Errorf("subvolume %s has unsupported quota: %v", s.VolID, info.BytesQuota)
+			return nil, fmt.Errorf("subvolume %s has unsupported quota: %v", volID, info.BytesQuota)
 		}
 	} else {
 		subvol.BytesQuota = int64(bc)
@@ -221,6 +232,21 @@ func newLocalClusterState(clusterID string) {
 	}
 }
 
+// buildSubVolumeCreateOpts constructs the SubVolumeOptions from the SubVolume fields.
+func buildSubVolumeCreateOpts(sv *SubVolume) fsAdmin.SubVolumeOptions {
+	opts := fsAdmin.SubVolumeOptions{
+		Size: fsAdmin.ByteCount(sv.Size),
+	}
+	if sv.Pool != "" {
+		opts.PoolLayout = sv.Pool
+	}
+	if sv.NamespaceIsolated {
+		opts.NamespaceIsolated = true
+	}
+
+	return opts
+}
+
 // CreateVolume creates a subvolume.
 func (s *subVolumeClient) CreateVolume(ctx context.Context) error {
 	newLocalClusterState(s.clusterID)
@@ -232,12 +258,7 @@ func (s *subVolumeClient) CreateVolume(ctx context.Context) error {
 		return err
 	}
 
-	opts := fsAdmin.SubVolumeOptions{
-		Size: fsAdmin.ByteCount(s.Size),
-	}
-	if s.Pool != "" {
-		opts.PoolLayout = s.Pool
-	}
+	opts := buildSubVolumeCreateOpts(s.SubVolume)
 
 	// FIXME: check if the right credentials are used ("-n", cephEntityClientPrefix + cr.ID)
 	err = ca.CreateSubVolume(s.FsName, s.SubvolumeGroup, s.VolID, &opts)

--- a/internal/cephfs/core/volume_test.go
+++ b/internal/cephfs/core/volume_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"testing"
+
+	fsAdmin "github.com/ceph/go-ceph/cephfs/admin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateVolume_NamespaceIsolated_True(t *testing.T) {
+	t.Parallel()
+	sv := &SubVolume{NamespaceIsolated: true}
+	opts := buildSubVolumeCreateOpts(sv)
+	require.True(t, opts.NamespaceIsolated)
+}
+
+func TestCreateVolume_NamespaceIsolated_False(t *testing.T) {
+	t.Parallel()
+	sv := &SubVolume{}
+	opts := buildSubVolumeCreateOpts(sv)
+	require.False(t, opts.NamespaceIsolated)
+}
+
+func TestGetSubVolumeInfo_PoolNamespace_Populated(t *testing.T) {
+	t.Parallel()
+	const ns = "csi-vol-4c742621-090a-484d-a33b"
+	info := &fsAdmin.SubVolumeInfo{
+		PoolNamespace: ns,
+		BytesQuota:    fsAdmin.Infinite,
+	}
+	sv, err := subvolumeFromInfo(info, "test-vol")
+	require.NoError(t, err)
+	require.Equal(t, ns, sv.PoolNamespace)
+}
+
+func TestGetSubVolumeInfo_PoolNamespace_Empty(t *testing.T) {
+	t.Parallel()
+	info := &fsAdmin.SubVolumeInfo{
+		BytesQuota: fsAdmin.Infinite,
+	}
+	sv, err := subvolumeFromInfo(info, "test-vol")
+	require.NoError(t, err)
+	require.Empty(t, sv.PoolNamespace)
+}

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -49,6 +49,8 @@ type VolumeOptions struct {
 	NamePrefix   string
 	ClusterID    string
 	MetadataPool string
+	// RADOS namespace assigned by Ceph for namespace-isolated subvolumes.
+	PoolNamespace string
 	// ReservedID represents the ID reserved for a subvolume
 	ReservedID           string
 	Monitors             string `json:"monitors"`
@@ -168,6 +170,14 @@ func validateMounter(m string) error {
 
 func (v *VolumeOptions) DetectMounter(options map[string]string) error {
 	return extractMounter(&v.Mounter, options)
+}
+
+// parseNamespaceIsolated returns true only when options contains
+// "namespaceIsolated" with value "true" (case-insensitive).
+func parseNamespaceIsolated(options map[string]string) bool {
+	v, ok := options["namespaceIsolated"]
+
+	return ok && strings.EqualFold(v, "true")
 }
 
 func extractMounter(dest *string, options map[string]string) error {
@@ -304,6 +314,8 @@ func NewVolumeOptions(
 	if err = extractOptionalOption(&opts.NamePrefix, "volumeNamePrefix", volOptions); err != nil {
 		return nil, err
 	}
+
+	opts.NamespaceIsolated = parseNamespaceIsolated(volOptions)
 
 	if err = extractOptionalOption(&backingSnapshotBool, "backingSnapshot", volOptions); err != nil {
 		return nil, err
@@ -537,6 +549,7 @@ func (vo *VolumeOptions) populateVolumeOptionsFromSubvolume(
 		vo.RootPath = info.Path
 		vo.Features = info.Features
 		vo.Size = info.BytesQuota
+		vo.PoolNamespace = info.PoolNamespace
 	}
 
 	if errors.Is(err, cerrors.ErrInvalidCommand) {

--- a/internal/cephfs/store/volumeoptions_test.go
+++ b/internal/cephfs/store/volumeoptions_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsVolumeCreateRO(t *testing.T) {
@@ -217,4 +218,28 @@ func TestIsShallowVolumeSupported(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewVolumeOptions_NamespaceIsolated_True(t *testing.T) {
+	t.Parallel()
+	vo := map[string]string{"namespaceIsolated": "true"}
+	require.True(t, parseNamespaceIsolated(vo))
+}
+
+func TestNewVolumeOptions_NamespaceIsolated_False(t *testing.T) {
+	t.Parallel()
+	vo := map[string]string{"namespaceIsolated": "false"}
+	require.False(t, parseNamespaceIsolated(vo))
+}
+
+func TestNewVolumeOptions_NamespaceIsolated_Absent(t *testing.T) {
+	t.Parallel()
+	vo := map[string]string{}
+	require.False(t, parseNamespaceIsolated(vo))
+}
+
+func TestNewVolumeOptions_NamespaceIsolated_Invalid(t *testing.T) {
+	t.Parallel()
+	vo := map[string]string{"namespaceIsolated": "yes"}
+	require.False(t, parseNamespaceIsolated(vo))
 }


### PR DESCRIPTION
# Describe what this PR does #

Adding support for creating CephFS subvolumes with `go-ceph`'s `namespace_isolated` flag enabled at creation time (configured using the new `namespaceIsolated` parameter in the StorageClass), which will create each new subvolume within its own unique, isolated RADOS namespace.

## Is there anything that requires special attention ##

> Do you have any questions?

None at the moment.

> Is the change backward compatible?

Yes. Tested heavily against Ceph 18.x+ and Ceph-CSI versions even older than the supported ones.

> Are there concerns around backward compatibility?

None from my side.

> Provide any external context for the change, if any.

This flag has been supported [in Ceph](https://github.com/ceph/ceph/pull/34776/changes) and [in `go-ceph`](https://github.com/ceph/go-ceph/pull/342/changes#diff-57b7fbe7bf4be97ff70b2f611837613c3b964cb23a4d4df97e0a628fe056c069R20) for quite a while (since Ceph `v16.1.0` and `go-ceph` `v0.6.0` it looks like), so it's a relatively simple wiring job, and it should be fully backwards compatible across all supported Ceph/Ceph-CSI releases.


## Related issues ##

Fixes: #6267

## Future concerns ##

None that I'm aware of.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
