### PR TITLE
ci: serialize merge queue CI runs to prevent resource contention

### DIFF
--- a/.github/workflows/mergify-copy-labels.yaml
+++ b/.github/workflows/mergify-copy-labels.yaml
@@ -21,5 +21,4 @@ jobs:
       - name: Copying labels
         uses: Mergifyio/gha-mergify-merge-queue-labels-copier@1d2b277f94d52987008ec05b571fb68f2357e63f  # main
         with:
-          additional-labels: 'ok-to-test'
           token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,6 @@ defaults:
 
 merge_protections_settings:
   reporting_method: check-runs
-  auto_merge_conditions: true
 
 queue_rules:
   - name: default
@@ -44,56 +43,57 @@ queue_rules:
                       - "status-success=commitlint"
               # exclude the ci/centos branch from above status checks
               - base=ci/centos
-          - or:
-              # requirenents per branch
-              - and:
-                  # ci/skip/e2e label has no meaning on ci/centos
-                  - base!=ci/centos
-                  - label=ci/skip/e2e
-              - and:
-                  - base~=^(release-.+)$
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.35"
-                  - "status-success=ci/centos/upgrade-tests-cephfs"
-                  - "status-success=ci/centos/upgrade-tests-rbd"
-              - and:
-                  - base=release-v3.16
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.32"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.33"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                  - "status-success=ci/centos/upgrade-tests-cephfs"
-                  - "status-success=ci/centos/upgrade-tests-rbd"
-              - and:
-                  - base=devel
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.36"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
-                  - "status-success=ci/centos/mini-e2e-helm/k8s-1.36"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.35"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.36"
-                  - "status-success=ci/centos/upgrade-tests-cephfs"
-                  - "status-success=ci/centos/upgrade-tests-rbd"
-              - and:
-                  # requirements for ci/centos branch
-                  - base=ci/centos
-                  - "status-success=ci/centos/job-validation"
-                  - "status-success=ci/centos/jjb-validate"
+    merge_conditions:
+      - or:
+          # requirements per branch
+          - and:
+              # ci/skip/e2e label has no meaning on ci/centos
+              - base!=ci/centos
+              - label=ci/skip/e2e
+          - and:
+              - base~=^(release-.+)$
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
+              - "status-success=ci/centos/mini-e2e/k8s-1.33"
+              - "status-success=ci/centos/mini-e2e/k8s-1.34"
+              - "status-success=ci/centos/mini-e2e/k8s-1.35"
+              - "status-success=ci/centos/upgrade-tests-cephfs"
+              - "status-success=ci/centos/upgrade-tests-rbd"
+          - and:
+              - base=release-v3.16
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.32"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.33"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.32"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.33"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
+              - "status-success=ci/centos/mini-e2e/k8s-1.32"
+              - "status-success=ci/centos/mini-e2e/k8s-1.33"
+              - "status-success=ci/centos/mini-e2e/k8s-1.34"
+              - "status-success=ci/centos/upgrade-tests-cephfs"
+              - "status-success=ci/centos/upgrade-tests-rbd"
+          - and:
+              - base=devel
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
+              - "status-success=ci/centos/k8s-e2e-external-storage/1.36"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.34"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.35"
+              - "status-success=ci/centos/mini-e2e-helm/k8s-1.36"
+              - "status-success=ci/centos/mini-e2e/k8s-1.34"
+              - "status-success=ci/centos/mini-e2e/k8s-1.35"
+              - "status-success=ci/centos/mini-e2e/k8s-1.36"
+              - "status-success=ci/centos/upgrade-tests-cephfs"
+              - "status-success=ci/centos/upgrade-tests-rbd"
+          - and:
+              # requirements for ci/centos branch
+              - base=ci/centos
+              - "status-success=ci/centos/job-validation"
+              - "status-success=ci/centos/jjb-validate"
 
 merge_queue:
   max_parallel_checks: 1
@@ -109,12 +109,43 @@ pull_request_rules:
       - not: check-pending~=^ci/centos
       - not: status-success~=^ci/centos
       - or:
-          - queue-position >= 0
+          - queue-position = 0
           - author=mergify[bot]
     actions:
       label:
         add:
           - ok-to-test
+
+  - name: label PRs entering the merge queue
+    conditions:
+      - -closed
+      - queue-position >= 0
+    actions:
+      label:
+        add:
+          - queued
+
+  - name: remove queued label when PR leaves the merge queue
+    conditions:
+      - label=queued
+      - not: queue-position >= 0
+    actions:
+      label:
+        remove:
+          - queued
+
+  - name: prevent concurrent CI for queued PRs not first in line
+    conditions:
+      - label=ok-to-test
+      - queue-position > 0
+      - base~=^(devel)|(release-.+)$
+    actions:
+      label:
+        remove:
+          - ok-to-test
+      comment:
+        # yamllint disable-line rule:line-length
+        message: "The `ok-to-test` label was removed because this PR is waiting in the merge queue. CI will start automatically when the PR reaches the front of the queue."
 
   - name: remove outdated approvals
     conditions:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

- Serialize Jenkins E2E CI runs through the Mergify merge queue by only triggering CI for the PR at queue position 0 (front of queue), preventing concurrent runs that exhaust the 8 Jenkins executors
- Split `queue_conditions` and `merge_conditions` so E2E failures block the queue instead of dequeuing the PR, letting developers retry without losing their queue position
- Add `queued` label for visibility and a guard rule that removes manually-added `ok-to-test` from PRs not first in line
- Remove `ok-to-test` from the merge-queue labels copier to prevent duplicate CI triggers on shadow PRs

## New flow

1. Developer gets approvals + GHA checks pass
2. `@Mergifyio queue` → PR enters queue, gets `queued` label
3. First in queue (position 0) → Mergify rebases, adds `ok-to-test` → CI runs
4. **CI passes** → merge → next PR advances to position 0
5. **CI fails** → PR stays in queue at position 0, **blocking the queue** until one retries (re-add `ok-to-test` or /retest) or dequeues (`@Mergifyio dequeue`)
6. Other queued PRs wait no CI triggered for them

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
