### PR TITLE
rbd: add fatal error handling for ReclaimSpace operations

### DIFF
--- a/internal/csi-addons/rbd/fstrim.go
+++ b/internal/csi-addons/rbd/fstrim.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+/*
+#include <linux/fs.h>
+#include <sys/ioctl.h>
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+// errTrimNotSupported indicates the filesystem does not support FITRIM.
+var errTrimNotSupported = errors.New("trim operation not supported by filesystem")
+
+// fsTrim performs filesystem trim operation on the given path using FITRIM ioctl.
+// This is equivalent to running 'fstrim' command but uses direct ioctl call.
+// Returns ErrTrimNotSupported if the filesystem does not support trim operations.
+func fsTrim(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open path %q: %w", path, err)
+	}
+	defer func() {
+		if file.Close() == nil {
+			// nothing to do
+			return
+		}
+
+		log.ErrorLogMsg("failed to close open filedescriptor for %q, unmounting may fail", path)
+	}()
+
+	trimRange := C.struct_fstrim_range{
+		start:  0,           // 0 (trim from beginning)
+		len:    ^C.__u64(0), // ~0ULL (trim entire filesystem)
+		minlen: 0,           // 0 (no minimum extent length)
+	}
+
+	_, _, err = syscall.Syscall(
+		syscall.SYS_IOCTL,
+		file.Fd(),
+		C.FITRIM,
+		uintptr(unsafe.Pointer(&trimRange)),
+	)
+	if err != nil {
+		// Check for fatal errors that indicate the operation is not supported
+		if errors.Is(err, syscall.EOPNOTSUPP) || errors.Is(err, syscall.ENOTTY) {
+			return fmt.Errorf("%w: %w", errTrimNotSupported, err)
+		}
+
+		return fmt.Errorf("FITRIM ioctl failed: %w", err)
+	}
+
+	return nil
+}

--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -163,16 +163,22 @@ func (rsns *ReclaimSpaceNodeServer) NodeReclaimSpace(
 		return nil, status.Error(codes.Unimplemented, "block-mode space reclaim is not supported")
 	}
 
-	cmd := "fstrim"
-	_, stderr, err := util.ExecCommand(ctx, cmd, path)
+	err := fsTrim(path)
 	if err != nil {
+		// Check if the error is due to unsupported operation
+		if errors.Is(err, errTrimNotSupported) {
+			return nil, status.Errorf(
+				codes.Unimplemented,
+				"trim operation not supported for filesystem at %q: %s",
+				path,
+				err.Error())
+		}
+
 		return nil, status.Errorf(
 			codes.Internal,
-			"failed to execute %q on %q (%s): %s",
-			cmd,
+			"failed to trim filesystem at %q: %s",
 			path,
-			err.Error(),
-			stderr)
+			err.Error())
 	}
 
 	return &rs.NodeReclaimSpaceResponse{}, nil


### PR DESCRIPTION
Replace calling `fstrim` with the underlaying syscall. This makes it possible
to detect different failures. Certain failures indicate that either the
filesystem or block-device does not support the fstrim operation. If this is
the case, CSI-Addons should not try again unless the volume was re-attached or
components were restarted.

One particular case is that the Ceph pool is configured in such a way (with
certain erasure encoding settings) that fstrim is not possible (yet?).
CSI-Addons should not retry the failing operation in this case.

See-also: csi-addons/spec#81 (kubernetes-csi-addons already supports it)
