### PR TITLE
Add ceph-csi NetworkPolicy manifest and CI deployment

### DIFF
--- a/deploy/ceph-csi-networkpolicy.yaml
+++ b/deploy/ceph-csi-networkpolicy.yaml
@@ -1,0 +1,120 @@
+######################################################################
+# NetworkPolicy definitions for the Ceph-CSI driver pods.
+# These policies control ingress traffic for each CSI plugin
+# type (CephFS and RBD).
+#
+# Controller plugins expose metrics and CSI-Addons ports,
+# node plugins expose CSI-Addons ports. Monitoring ingress
+# is restricted to the monitoring namespace; CSI-Addons
+# ingress is restricted to the csi-addons-controller-manager
+# pod.
+######################################################################
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ceph-csi-cephfs-ctrlplugin
+  namespace: default # namespace:csi
+spec:
+  podSelector:
+    matchLabels:
+      app: openshift-storage.cephfs.csi.ceph.com-ctrlplugin
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring # namespace:monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8681
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default # namespace:csi
+          podSelector:
+            matchLabels:
+              app: csi-addons-controller-manager
+      ports:
+        - protocol: TCP
+          port: 9080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ceph-csi-cephfs-nodeplugin-csi-addons
+  namespace: default # namespace:csi
+spec:
+  podSelector:
+    matchLabels:
+      app: openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default # namespace:csi
+          podSelector:
+            matchLabels:
+              app: csi-addons-controller-manager
+      ports:
+        - protocol: TCP
+          port: 9071
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ceph-csi-rbd-ctrlplugin
+  namespace: default # namespace:csi
+spec:
+  podSelector:
+    matchLabels:
+      app: openshift-storage.rbd.csi.ceph.com-ctrlplugin
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring # namespace:monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8680
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default # namespace:csi
+          podSelector:
+            matchLabels:
+              app: csi-addons-controller-manager
+      ports:
+        - protocol: TCP
+          port: 9070
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ceph-csi-rbd-nodeplugin-csi-addons
+  namespace: default # namespace:csi
+spec:
+  podSelector:
+    matchLabels:
+      app: openshift-storage.rbd.csi.ceph.com-nodeplugin-csi-addons
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default # namespace:csi
+          podSelector:
+            matchLabels:
+              app: csi-addons-controller-manager
+      ports:
+        - protocol: TCP
+          port: 9071

--- a/scripts/minikube.sh
+++ b/scripts/minikube.sh
@@ -337,6 +337,16 @@ teardown-rook)
     ${minikube} ssh "sudo rm -rf /mnt/${DISK}/var/lib/rook; sudo rm -rf /var/lib/rook"
     ${minikube} ssh "sudo mkdir -p /mnt/${DISK}/var/lib/rook; sudo ln -s /mnt/${DISK}/var/lib/rook /var/lib/rook"
     ;;
+deploy-networkpolicy)
+    echo "deploy ceph-csi network policies"
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    "$DIR"/rook.sh deploy-networkpolicy
+    ;;
+teardown-networkpolicy)
+    echo "teardown ceph-csi network policies"
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    "$DIR"/rook.sh teardown-networkpolicy
+    ;;
 cephcsi)
     echo "copying the cephcsi image"
     copy_image_to_cluster "${CEPHCSI_IMAGE_REPO}"/cephcsi:"${CSI_IMAGE_VERSION}" "${CEPHCSI_IMAGE_REPO}"/cephcsi:"${CSI_IMAGE_VERSION}"
@@ -367,10 +377,12 @@ Available Commands:
   delete-block-pool    Deletes a rook block pool (named $ROOK_BLOCK_POOL_NAME)
   create-block-ec-pool Creates a rook erasure coded block pool (named $ROOK_BLOCK_EC_POOL_NAME)
   delete-block-ec-pool Creates a rook erasure coded block pool (named $ROOK_BLOCK_EC_POOL_NAME)
-  cleanup-snapshotter  Cleanup snapshot controller
-  teardown-rook        Teardown rook from minikube
-  cephcsi              Copy built docker images to kubernetes cluster
-  k8s-sidecar          Copy kubernetes sidecar docker images to kubernetes cluster
+  cleanup-snapshotter      Cleanup snapshot controller
+  teardown-rook            Teardown rook from minikube
+  deploy-networkpolicy     Deploy ceph-csi network policies
+  teardown-networkpolicy   Remove ceph-csi network policies
+  cephcsi                  Copy built docker images to kubernetes cluster
+  k8s-sidecar              Copy kubernetes sidecar docker images to kubernetes cluster
 " >&2
     ;;
 esac

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -6,6 +6,7 @@ ROOK_URL="https://raw.githubusercontent.com/rook/rook/${ROOK_VERSION}/deploy/exa
 ROOK_BLOCK_POOL_NAME=${ROOK_BLOCK_POOL_NAME:-"newrbdpool"}
 ROOK_BLOCK_EC_POOL_NAME=${ROOK_BLOCK_EC_POOL_NAME:-"ec-pool"}
 ROOK_SUBVOLUMEGROUP_NAME=${ROOK_SUBVOLUMEGROUP_NAME:-"csi"}
+CEPHCSI_NAMESPACE=${CEPHCSI_NAMESPACE:-"default"}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck disable=SC1091
@@ -30,9 +31,42 @@ function log_errors() {
 	exit 1
 }
 
+function deploy_networkpolicy() {
+	local np_file="${SCRIPT_DIR}/../deploy/ceph-csi-networkpolicy.yaml"
+	if [ ! -f "${np_file}" ]; then
+		echo "NetworkPolicy file not found at ${np_file}, skipping"
+		return 0
+	fi
+
+	local temp_dir
+	temp_dir="$(mktemp -d)"
+	cp "${np_file}" "${temp_dir}/ceph-csi-networkpolicy.yaml"
+	sed -i "s|namespace: default # namespace:csi|namespace: ${CEPHCSI_NAMESPACE} # namespace:csi|g" "${temp_dir}/ceph-csi-networkpolicy.yaml"
+	sed -i "s|kubernetes.io/metadata.name: default # namespace:csi|kubernetes.io/metadata.name: ${CEPHCSI_NAMESPACE} # namespace:csi|g" "${temp_dir}/ceph-csi-networkpolicy.yaml"
+	kubectl_retry create -f "${temp_dir}/ceph-csi-networkpolicy.yaml"
+	rm -rf "${temp_dir}"
+	echo "NetworkPolicy resources created in namespace ${CEPHCSI_NAMESPACE}"
+}
+
+function teardown_networkpolicy() {
+	local np_file="${SCRIPT_DIR}/../deploy/ceph-csi-networkpolicy.yaml"
+	if [ ! -f "${np_file}" ]; then
+		return 0
+	fi
+
+	local temp_dir
+	temp_dir="$(mktemp -d)"
+	cp "${np_file}" "${temp_dir}/ceph-csi-networkpolicy.yaml"
+	sed -i "s|namespace: default # namespace:csi|namespace: ${CEPHCSI_NAMESPACE} # namespace:csi|g" "${temp_dir}/ceph-csi-networkpolicy.yaml"
+	sed -i "s|kubernetes.io/metadata.name: default # namespace:csi|kubernetes.io/metadata.name: ${CEPHCSI_NAMESPACE} # namespace:csi|g" "${temp_dir}/ceph-csi-networkpolicy.yaml"
+	kubectl delete -f "${temp_dir}/ceph-csi-networkpolicy.yaml" --ignore-not-found
+	rm -rf "${temp_dir}"
+}
+
 function deploy_rook() {
 	kubectl_retry create -f "${ROOK_URL}/common.yaml"
 	kubectl_retry create -f "${ROOK_URL}/crds.yaml"
+	deploy_networkpolicy
 
 	TEMP_DIR="$(mktemp -d)"
 	curl -o "${TEMP_DIR}/operator.yaml" "${ROOK_URL}/operator.yaml"
@@ -84,6 +118,7 @@ function deploy_rook() {
 }
 
 function teardown_rook() {
+	teardown_networkpolicy
 	create_or_delete_subvolumegroup "delete"
 	kubectl delete -f "${ROOK_URL}/pool-test.yaml"
 	kubectl delete -f "${ROOK_URL}/filesystem-test.yaml"
@@ -266,15 +301,23 @@ create-block-ec-pool)
 delete-block-ec-pool)
 	delete_block_ec_pool
 	;;
+deploy-networkpolicy)
+	deploy_networkpolicy
+	;;
+teardown-networkpolicy)
+	teardown_networkpolicy
+	;;
 *)
 	echo " $0 [command]
 Available Commands:
-  deploy             Deploy a rook
-  teardown           Teardown a rook
-  create-block-pool  Create a rook block pool
-  delete-block-pool  Delete a rook block pool
-  create-block-ec-pool Creates a rook erasure coded block pool
-  delete-block-ec-pool Deletes a rook erasure coded block pool
+  deploy                Deploy a rook
+  teardown              Teardown a rook
+  create-block-pool     Create a rook block pool
+  delete-block-pool     Delete a rook block pool
+  create-block-ec-pool  Creates a rook erasure coded block pool
+  delete-block-ec-pool  Deletes a rook erasure coded block pool
+  deploy-networkpolicy  Deploy ceph-csi network policies
+  teardown-networkpolicy Remove ceph-csi network policies
 " >&2
 	;;
 esac


### PR DESCRIPTION
**This PR is just a prototype for exploration and will be closed shortly.**

This PR is just a prototype for exploration and will be closed shortly."

Add deploy/ceph-csi-networkpolicy.yaml with ingress policies for CephFS and RBD CSI plugins. Apply it
automatically during rook.sh cluster setup and
teardown. Expose standalone deploy/teardown commands in rook.sh and minikube.sh. Target namespace is
configurable via CEPHCSI_NAMESPACE (default: "default").


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
