### PR TITLE
kms: add client certificate support to the vault KMS type

### DIFF
--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -46,6 +46,12 @@ csiConfig: []
 #     vaultPassphraseRoot: /v1/secret
 #     vaultPassphrasePath: ceph-csi/
 #     vaultCAVerify: "true"
+#     # Optional mTLS: all three values are Kubernetes Secret names in the
+#     # CSI pod namespace. The CA cert is read from the "cert" field of the
+#     # named Secret; the client cert from "cert" and the key from "key".
+#     vaultCAFromSecret: vault-ca-secret
+#     vaultClientCertFromSecret: vault-client-tls-secret
+#     vaultClientCertKeyFromSecret: vault-client-tls-secret
 encryptionKMSConfig: {}
 
 # Labels to apply to all resources

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -56,7 +56,13 @@ csiMapping: []
 #     vaultRole: csi-kubernetes
 #     vaultPassphraseRoot: /v1/secret
 #     vaultPassphrasePath: ceph-csi/
-#     vaultCAVerify: "false"
+#     vaultCAVerify: "true"
+#     # Optional mTLS: all three values are Kubernetes Secret names in the
+#     # CSI pod namespace. The CA cert is read from the "cert" field of the
+#     # named Secret; the client cert from "cert" and the key from "key".
+#     vaultCAFromSecret: vault-ca-secret
+#     vaultClientCertFromSecret: vault-client-tls-secret
+#     vaultClientCertKeyFromSecret: vault-client-tls-secret
 encryptionKMSConfig: {}
 
 # Labels to apply to all resources

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -386,6 +386,58 @@ Configure a role(s) for service accounts used for ceph-csi:
 * nodeplugin service account (`rbd-csi-nodeplugin`) requires **create** and
   **read** permissions to save new keys and retrieve existing
 
+##### TLS and mTLS options for `encryptionKMSType: vault`
+
+The following optional TLS configuration keys are supported. All `*FromSecret`
+values are **Kubernetes Secret names** in the CSI pod namespace (the namespace
+where ceph-csi is deployed, typically identified by the `POD_NAMESPACE`
+environment variable).
+
+| Key | Description |
+| --- | --- |
+| `vaultCAVerify` | Verify the Vault server TLS certificate (default: `"true"`) |
+| `vaultTLSServerName` | Override the TLS SNI server name |
+| `vaultCAFromSecret` | Name of a Kubernetes Secret containing the CA certificate in the `cert` field |
+| `vaultClientCertFromSecret` | Name of a Kubernetes Secret containing the client certificate in the `cert` field |
+| `vaultClientCertKeyFromSecret` | Name of a Kubernetes Secret containing the client private key in the `key` field |
+
+The client cert and key may be in the same Secret or in separate Secrets.
+
+Example Secret for the CA certificate:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-ca-secret
+  namespace: <ceph-csi-namespace>
+type: Opaque
+data:
+  cert: <base64-encoded PEM>
+```
+
+Example Secret for the client certificate and key (combined):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-client-tls-secret
+  namespace: <ceph-csi-namespace>
+type: Opaque
+data:
+  cert: <base64-encoded client cert PEM>
+  key: <base64-encoded client key PEM>
+```
+
+> **Note:** `vaultCAFromSecret` behaviour changed in ceph-csi v3.14. Previously
+> the value was treated as a field name within the node-stage secret map
+> (the Secret referenced by `spec.csi.nodeStageSecretRef` on the PV).
+> It is now a Kubernetes Secret name, consistent with `vaulttokens`.
+> **Migration:** create a standalone Kubernetes Secret in the CSI pod namespace
+> with the CA PEM under the `cert` key, and set `vaultCAFromSecret` to that
+> Secret's name.
+
 #### Configuring Hashicorp Vault with a ServiceAccount per Tenant
 
 For deployments where a single ServiceAccount for accessing Hashicorp Vault is

--- a/examples/kms/vault/csi-kms-connection-details.yaml
+++ b/examples/kms/vault/csi-kms-connection-details.yaml
@@ -24,6 +24,19 @@ data:
       "vaultPassphrasePath": "ceph-csi/",
       "vaultCAVerify": "false"
     }
+  vault-mtls-test: |-
+    {
+      "encryptionKMSType": "vault",
+      "vaultAddress": "https://vault.default.svc.cluster.local:8200",
+      "vaultAuthPath": "/v1/auth/kubernetes/login",
+      "vaultRole": "csi-kubernetes",
+      "vaultPassphraseRoot": "/v1/secret",
+      "vaultPassphrasePath": "ceph-csi/",
+      "vaultCAVerify": "true",
+      "vaultCAFromSecret": "vault-ca-secret",
+      "vaultClientCertFromSecret": "vault-client-tls-secret",
+      "vaultClientCertKeyFromSecret": "vault-client-tls-secret"
+    }
   vault-tokens-test: |-
     {
       "KMS_PROVIDER": "vaulttokens",

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -15,6 +15,20 @@ data:
         "vaultPassphrasePath": "ceph-csi/",
         "vaultCAVerify": "false"
       },
+      "vault-mtls-test": {
+        "encryptionKMSType": "vault",
+        "vaultAddress": "https://vault.default.svc.cluster.local:8200",
+        "vaultAuthPath": "/v1/auth/kubernetes/login",
+        "vaultRole": "csi-kubernetes",
+        "vaultBackend": "kv-v2",
+        "vaultDestroyKeys": "true",
+        "vaultPassphraseRoot": "/v1/secret",
+        "vaultPassphrasePath": "ceph-csi/",
+        "vaultCAVerify": "true",
+        "vaultCAFromSecret": "vault-ca-secret",
+        "vaultClientCertFromSecret": "vault-client-tls-secret",
+        "vaultClientCertKeyFromSecret": "vault-client-tls-secret"
+      },
       "vault-tokens-test": {
           "encryptionKMSType": "vaulttokens",
           "vaultAddress": "http://vault.default.svc.cluster.local:8200",

--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -31,6 +31,7 @@ import (
 	"github.com/libopenstorage/secrets/vault"
 
 	"github.com/ceph/ceph-csi/internal/util/file"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 )
 
 const (
@@ -69,10 +70,18 @@ Example JSON structure in the KMS config is,
 		"vaultPassphraseRoot": "/v1/secret",
 		"vaultPassphrasePath": "",
 		"vaultCAVerify": true,
-		"vaultCAFromSecret": "vault-ca"
+		"vaultCAFromSecret": "vault-ca-secret",
+		"vaultClientCertFromSecret": "vault-client-cert-secret",
+		"vaultClientCertKeyFromSecret": "vault-client-cert-secret"
 	},
 	...
 }.
+
+"vaultCAFromSecret", "vaultClientCertFromSecret", and "vaultClientCertKeyFromSecret"
+are Kubernetes Secret names in the CSI pod namespace. The CA cert is read from
+the "cert" field of the named Secret; the client cert from the "cert" field and
+the client key from the "key" field of their respective Secrets (cert and key
+may be in the same Secret or different Secrets).
 */
 
 type vaultConnection struct {
@@ -156,10 +165,11 @@ func setConfigBoolean(option *bool, config map[string]any, key string) error {
 // Destroy frees allocated resources. For a vaultConnection that means removing
 // the created temporary files.
 func (vc *vaultConnection) Destroy() {
-	if vc.vaultConfig != nil {
-		tmpFile, ok := vc.vaultConfig[api.EnvVaultCACert]
-		if ok {
-			// ignore error on failure to remove tmpfile (gosec complains)
+	if vc.vaultConfig == nil {
+		return
+	}
+	for _, key := range []string{api.EnvVaultCACert, api.EnvVaultClientCert, api.EnvVaultClientKey} {
+		if tmpFile, ok := vc.vaultConfig[key]; ok {
 			//nolint:forcetypeassert,errcheck // ignore error on failure to remove tmpfile
 			_ = os.Remove(tmpFile.(string))
 		}
@@ -298,6 +308,13 @@ func (vc *vaultConnection) initConnection(config map[string]any) error {
 // vc.connectVault().
 func (vc *vaultConnection) initCertificates(config map[string]any, secrets map[string]string) error {
 	vaultConfig := make(map[string]any)
+	csiNamespace := os.Getenv("POD_NAMESPACE")
+
+	// Merge vaultConfig into vc.vaultConfig eagerly on return so that any temp
+	// files created before a partial failure are tracked and cleaned up by Destroy().
+	defer func() {
+		maps.Copy(vc.vaultConfig, vaultConfig)
+	}()
 
 	vaultCAFromSecret := "" // optional
 	err := setConfigString(&vaultCAFromSecret, config, "vaultCAFromSecret")
@@ -306,19 +323,61 @@ func (vc *vaultConnection) initCertificates(config map[string]any, secrets map[s
 	}
 	// ignore errConfigOptionMissing, no default was set
 	if vaultCAFromSecret != "" {
-		caPEM, ok := secrets[vaultCAFromSecret]
-		if !ok {
-			return fmt.Errorf("missing vault CA in secret %s", vaultCAFromSecret)
+		cert, err := k8s.GetSecret(vaultCAFromSecret, csiNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to get CA certificate from secret %s: %w", vaultCAFromSecret, err)
 		}
-
+		caPEM, ok := cert["cert"]
+		if !ok {
+			return fmt.Errorf("missing \"cert\" field in secret %s", vaultCAFromSecret)
+		}
 		tf, err := file.CreateTempFile("vault-ca-cert", caPEM)
 		if err != nil {
 			return fmt.Errorf("failed to create temporary file for Vault CA: %w", err)
 		}
 		vaultConfig[api.EnvVaultCACert] = tf.Name()
+	}
 
-		// update the existing config
-		maps.Copy(vc.vaultConfig, vaultConfig)
+	vaultClientCertFromSecret := "" // optional
+	err = setConfigString(&vaultClientCertFromSecret, config, "vaultClientCertFromSecret")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+	if vaultClientCertFromSecret != "" {
+		certSecret, err := k8s.GetSecret(vaultClientCertFromSecret, csiNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to get client certificate from secret %s: %w", vaultClientCertFromSecret, err)
+		}
+		certPEM, ok := certSecret["cert"]
+		if !ok {
+			return fmt.Errorf("missing \"cert\" field in secret %s", vaultClientCertFromSecret)
+		}
+		tf, err := file.CreateTempFile("vault-client-cert", certPEM)
+		if err != nil {
+			return fmt.Errorf("failed to create temporary file for Vault client certificate: %w", err)
+		}
+		vaultConfig[api.EnvVaultClientCert] = tf.Name()
+	}
+
+	vaultClientCertKeyFromSecret := "" // optional
+	err = setConfigString(&vaultClientCertKeyFromSecret, config, "vaultClientCertKeyFromSecret")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+	if vaultClientCertKeyFromSecret != "" {
+		keySecret, err := k8s.GetSecret(vaultClientCertKeyFromSecret, csiNamespace)
+		if err != nil {
+			return fmt.Errorf("failed to get client certificate key from secret %s: %w", vaultClientCertKeyFromSecret, err)
+		}
+		keyPEM, ok := keySecret["key"]
+		if !ok {
+			return fmt.Errorf("missing \"key\" field in secret %s", vaultClientCertKeyFromSecret)
+		}
+		tf, err := file.CreateTempFile("vault-client-cert-key", keyPEM)
+		if err != nil {
+			return fmt.Errorf("failed to create temporary file for Vault client certificate key: %w", err)
+		}
+		vaultConfig[api.EnvVaultClientKey] = tf.Name()
 	}
 
 	return nil

--- a/internal/kms/vault_test.go
+++ b/internal/kms/vault_test.go
@@ -18,10 +18,14 @@ package kms
 
 import (
 	"errors"
+	"os"
 	"testing"
 
+	"github.com/hashicorp/vault/api"
 	loss "github.com/libopenstorage/secrets"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/ceph-csi/internal/util/file"
 )
 
 func TestDetectAuthMountPath(t *testing.T) {
@@ -110,4 +114,57 @@ func TestVaultKMSRegistered(t *testing.T) {
 	t.Parallel()
 	_, ok := kmsManager.providers[kmsTypeVault]
 	require.True(t, ok)
+}
+
+func TestInitCertificatesConfigParsing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid config type returns error", func(t *testing.T) {
+		t.Parallel()
+		vc := &vaultConnection{vaultConfig: make(map[string]any)}
+		config := map[string]any{"vaultCAFromSecret": 12345} // wrong type
+		err := vc.initCertificates(config, nil)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errConfigOptionInvalid))
+	})
+
+	t.Run("empty config is a no-op", func(t *testing.T) {
+		t.Parallel()
+		vc := &vaultConnection{vaultConfig: make(map[string]any)}
+		err := vc.initCertificates(map[string]any{}, nil)
+		require.NoError(t, err)
+		_, hasCA := vc.vaultConfig[api.EnvVaultCACert]
+		require.False(t, hasCA)
+		_, hasCert := vc.vaultConfig[api.EnvVaultClientCert]
+		require.False(t, hasCert)
+		_, hasKey := vc.vaultConfig[api.EnvVaultClientKey]
+		require.False(t, hasKey)
+	})
+}
+
+func TestDestroyRemovesAllTempFiles(t *testing.T) {
+	t.Parallel()
+
+	caFile, err := file.CreateTempFile("vault-ca-cert", "fake-ca")
+	require.NoError(t, err)
+	certFile, err := file.CreateTempFile("vault-client-cert", "fake-cert")
+	require.NoError(t, err)
+	keyFile, err := file.CreateTempFile("vault-client-cert-key", "fake-key")
+	require.NoError(t, err)
+
+	vc := &vaultConnection{
+		vaultConfig: map[string]any{
+			api.EnvVaultCACert:     caFile.Name(),
+			api.EnvVaultClientCert: certFile.Name(),
+			api.EnvVaultClientKey:  keyFile.Name(),
+		},
+	}
+	vc.Destroy()
+
+	_, err = os.Stat(caFile.Name())
+	require.True(t, os.IsNotExist(err), "CA cert temp file should be removed")
+	_, err = os.Stat(certFile.Name())
+	require.True(t, os.IsNotExist(err), "client cert temp file should be removed")
+	_, err = os.Stat(keyFile.Name())
+	require.True(t, os.IsNotExist(err), "client key temp file should be removed")
 }


### PR DESCRIPTION
## What this PR does / why we need it

The `vault` KMS type supports Kubernetes SA token authentication (no
per-namespace Secrets required) but previously had no way to present a
client certificate to Vault, making mTLS impossible.

This PR adds `vaultClientCertFromSecret` and `vaultClientCertKeyFromSecret`
config options to `vaultConnection.initCertificates()`, closing a symmetric
gap with the `vaulttokens` type which already has full mTLS support.

**Before:** `vault` could verify the server cert (`vaultCAFromSecret`) but
could not present a client cert.

**After:** `vault` supports all three TLS config options, all using the same
`k8s.GetSecret` mechanism as `vaulttokens`:
- `vaultCAFromSecret` — Kubernetes Secret name for the CA cert (field: `cert`)
- `vaultClientCertFromSecret` — **New**: Kubernetes Secret name for the client cert (field: `cert`)
- `vaultClientCertKeyFromSecret` — **New**: Kubernetes Secret name for the client key (field: `key`)

All three Secrets are looked up in the CSI pod namespace (`POD_NAMESPACE`).

`Destroy()` is also extended to clean up temp files for the client cert and
key alongside the existing CA cert cleanup.

## ⚠️ Breaking change

`vaultCAFromSecret` behaviour in the `vault` KMS type has changed.

**Before:** the config value was treated as a **key name** within the
node-stage secret map (`args.Secrets`), i.e. a field name in the Kubernetes
Secret referenced by `spec.csi.nodeStageSecretRef` on the PV. The CA PEM
was expected to be stored directly as a value in that Secret.

**After:** the config value is a **Kubernetes Secret name**, consistent with
how `vaulttokens` has always handled `vaultCAFromSecret`. The CA PEM is read
from the `"cert"` field of that named Secret via the Kubernetes API.

**Migration:** users who had `vaultCAFromSecret` configured in a `vault` KMS
config must:
1. Create a standalone Kubernetes Secret in the CSI pod namespace containing
   the CA PEM under the key `"cert"`
2. Update `vaultCAFromSecret` in their KMS config to name that Secret

## Which issue(s) this PR fixes

Fixes a gap where users needing Kubernetes SA auth + mTLS to Vault had no
supported path. The `vaulttokens` type requires a per-tenant Secret (one per
PVC namespace), which is impractical at scale. The `vault` type with mTLS
support is the correct solution for large deployments.

## Special notes for your reviewer

The `secrets map[string]string` parameter is intentionally kept in the
`initCertificates` signature (though now unused after the `vaultCAFromSecret`
migration) to avoid touching the call site in `initVaultKMS`. Happy to remove
it and update the call site if preferred.

## How to test

```bash
go test -v github.com/ceph/ceph-csi/internal/kms
```

New unit tests added:
- `TestInitCertificatesConfigParsing` — config parsing error paths (no cluster needed)
- `TestDestroyRemovesAllTempFiles` — verifies all three temp files are removed on Destroy()