### PR TITLE
rbd: (filesystem) add async health checks to NodeGetVolumeStats

### DIFF
--- a/internal/health-checker/manager.go
+++ b/internal/health-checker/manager.go
@@ -32,6 +32,8 @@ const (
 	// FileCheckerType writes and reads a timestamp to a file for checking the
 	// volume health.
 	FileCheckerType
+	// NoOpCheckerType is a no-operation checker that always returns healthy.
+	NoOpCheckerType
 )
 
 // Manager provides the API for getting the health status of a volume. The main
@@ -147,9 +149,18 @@ func (hcm *healthCheckManager) createChecker(volumeID, path string, ct CheckerTy
 		return hcm.startFileChecker(volumeID, path, shared)
 	case StatCheckerType:
 		return hcm.startStatChecker(volumeID, path, shared)
+	case NoOpCheckerType:
+		return hcm.startNoOpChecker(volumeID, path, shared)
 	}
 
 	return nil
+}
+
+// startNoOpChecker initializes the noOpChecker and starts it.
+func (hcm *healthCheckManager) startNoOpChecker(volumeID, path string, shared bool) error {
+	cc := newNoOpChecker()
+
+	return hcm.startChecker(cc, volumeID, path, shared)
 }
 
 // startFileChecker initializes the fileChecker and starts it.

--- a/internal/health-checker/noopchecker.go
+++ b/internal/health-checker/noopchecker.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecker
+
+type noOpChecker struct {
+	checker
+}
+
+func newNoOpChecker() ConditionChecker {
+	nc := &noOpChecker{}
+	nc.initDefaults()
+
+	// always healthy, no errors
+	nc.healthy = true
+	nc.err = nil
+
+	nc.checker.runChecker = func() {
+		nc.isRunning = true
+
+		// Wait for stop command
+		<-nc.commands
+		nc.isRunning = false
+	}
+
+	return nc
+}

--- a/internal/health-checker/noopchecker.go
+++ b/internal/health-checker/noopchecker.go
@@ -41,7 +41,7 @@ func newNoOpChecker() ConditionChecker {
 // always healthy, no errors
 // overrides checker.isHealthy() so that the timeout-based
 // staleness check (which compares lastUpdate against interval+timeout)
-// never marks a NoOp checker unhealthy
+// never marks a NoOp checker unhealthy.
 func (nc *noOpChecker) isHealthy() (bool, error) {
 	return true, nil
 }

--- a/internal/health-checker/noopchecker.go
+++ b/internal/health-checker/noopchecker.go
@@ -24,7 +24,6 @@ func newNoOpChecker() ConditionChecker {
 	nc := &noOpChecker{}
 	nc.initDefaults()
 
-	// always healthy, no errors
 	nc.healthy = true
 	nc.err = nil
 
@@ -37,4 +36,12 @@ func newNoOpChecker() ConditionChecker {
 	}
 
 	return nc
+}
+
+// always healthy, no errors
+// overrides checker.isHealthy() so that the timeout-based
+// staleness check (which compares lastUpdate against interval+timeout)
+// never marks a NoOp checker unhealthy
+func (nc *noOpChecker) isHealthy() (bool, error) {
+	return true, nil
 }

--- a/internal/health-checker/noopchecker_test.go
+++ b/internal/health-checker/noopchecker_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNoOpChecker(t *testing.T) {
+	t.Parallel()
+
+	nc := newNoOpChecker()
+	checker, ok := nc.(*noOpChecker)
+	if !ok {
+		t.Errorf("failed to convert nc to *noOpChecker: %v", nc)
+	}
+
+	// start the checker
+	checker.start()
+
+	// wait a second to get the go routine running
+	time.Sleep(time.Second)
+	if !checker.isRunning {
+		t.Error("checker failed to start")
+	}
+
+	// check health, should always be healthy with the expected message
+	healthy, msg := checker.isHealthy()
+	if !healthy {
+		t.Error("NoOpChecker should always return healthy=true")
+	}
+	if msg != nil {
+		t.Error("NoOpChecker should never return an error message")
+	}
+
+	// verify it stays healthy over time
+	for range 5 {
+		healthy, msg = checker.isHealthy()
+		if !healthy {
+			t.Error("NoOpChecker should always return healthy=true")
+		}
+		if msg != nil {
+			t.Errorf("unexpected message: %v", msg)
+		}
+		time.Sleep(time.Second)
+	}
+
+	if !checker.isRunning {
+		t.Error("runChecker() exited already")
+	}
+
+	// stop the checker
+	checker.stop()
+}

--- a/internal/health-checker/noopchecker_test.go
+++ b/internal/health-checker/noopchecker_test.go
@@ -39,13 +39,24 @@ func TestNoOpChecker(t *testing.T) {
 		t.Error("checker failed to start")
 	}
 
-	// check health, should always be healthy with the expected message
+	// check health, should be healthy with the expected message
 	healthy, msg := checker.isHealthy()
 	if !healthy {
 		t.Error("NoOpChecker should always return healthy=true")
 	}
 	if msg != nil {
 		t.Error("NoOpChecker should never return an error message")
+	}
+
+	// verify the isHealthy override
+	// prevents the base checker from marking it unhealthy
+	checker.lastUpdate = checker.lastUpdate.Add(-(checker.interval + checker.timeout + time.Minute))
+	healthy, msg = checker.isHealthy()
+	if !healthy {
+		t.Error("NoOpChecker should stay healthy even after timeout window")
+	}
+	if msg != nil {
+		t.Errorf("unexpected message after timeout window: %v", msg)
 	}
 
 	// verify it stays healthy over time

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -27,6 +27,7 @@ import (
 	csiaddons "github.com/ceph/ceph-csi/internal/csi-addons/server"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	"github.com/ceph/ceph-csi/internal/driver"
+	hc "github.com/ceph/ceph-csi/internal/health-checker"
 	"github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/rbd/features"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -82,6 +83,7 @@ func NewNodeServer(
 		DefaultNodeServer: csicommon.NewDefaultNodeServer(d, t, cliReadAffinityMapOptions, topology, nodeLabels),
 		VolumeLocks:       util.NewIDLocker(),
 	}
+	ns.SetHealthChecker(hc.NewHealthCheckManager())
 
 	return &ns
 }

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -34,6 +34,7 @@ import (
 	utilexec "k8s.io/utils/exec"
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	hc "github.com/ceph/ceph-csi/internal/health-checker"
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/file"
@@ -49,12 +50,18 @@ type NodeServer struct {
 	*csicommon.DefaultNodeServer
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID) return an Aborted error
-	VolumeLocks *util.IDLocker
+	VolumeLocks   *util.IDLocker
+	healthChecker hc.Manager
 
 	// ext4HasPrezeroedSupport indicates whether the ext4 filesystem has support for pre-zeroed blocks.
 	ext4HasPrezeroedSupport featureFlag
 	// xfsHasReflinkSupport indicates whether the xfs filesystem has support for reflink.
 	xfsHasReflinkSupport featureFlag
+}
+
+// SetHealthChecker configures the manager used for volume health checks.
+func (ns *NodeServer) SetHealthChecker(manager hc.Manager) {
+	ns.healthChecker = manager
 }
 
 // stageTransaction struct represents the state a transaction was when it either completed
@@ -367,6 +374,7 @@ func (ns *NodeServer) NodeStageVolume(
 	stagingParentPath := req.GetStagingTargetPath()
 	stagingTargetPath := stagingParentPath + "/" + volID
 
+	isBlock := req.GetVolumeCapability().GetBlock() != nil
 	isHealer := parseBoolOption(ctx, req.GetVolumeContext(), volHealerCtx, false)
 	if !isHealer {
 		var isNotMnt bool
@@ -376,6 +384,8 @@ func (ns *NodeServer) NodeStageVolume(
 			return nil, status.Error(codes.Internal, err.Error())
 		} else if !isNotMnt {
 			log.DebugLog(ctx, "rbd: volume %s is already mounted to %s, skipping", volID, stagingTargetPath)
+
+			ns.startSharedHealthChecker(ctx, volID, stagingTargetPath, isBlock)
 
 			return &csi.NodeStageVolumeResponse{}, nil
 		}
@@ -397,6 +407,8 @@ func (ns *NodeServer) NodeStageVolume(
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+
+		ns.startSharedHealthChecker(ctx, volID, stagingTargetPath, isBlock)
 
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
@@ -435,6 +447,8 @@ func (ns *NodeServer) NodeStageVolume(
 		"rbd: successfully mounted volume %s to stagingTargetPath %s",
 		volID,
 		stagingTargetPath)
+
+	ns.startSharedHealthChecker(ctx, volID, stagingTargetPath, isBlock)
 
 	return &csi.NodeStageVolumeResponse{}, nil
 }
@@ -825,6 +839,21 @@ func (ns *NodeServer) createStageMountPoint(ctx context.Context, mountPath strin
 	return nil
 }
 
+// startSharedHealthChecker starts a health-checker on the stagingTargetPath.
+// This checker can be shared between multiple containers.
+// TODO: Add a real health checker for block-mode volumes.
+func (ns *NodeServer) startSharedHealthChecker(ctx context.Context, volumeID, dir string, isBlock bool) {
+	var checkerType hc.CheckerType = hc.StatCheckerType
+	if isBlock {
+		checkerType = hc.NoOpCheckerType
+	}
+
+	err := ns.healthChecker.StartSharedChecker(volumeID, dir, checkerType)
+	if err != nil {
+		log.WarningLog(ctx, "failed to start healthchecker: %v", err)
+	}
+}
+
 // NodePublishVolume mounts the volume mounted to the device path to the target
 // path.
 func (ns *NodeServer) NodePublishVolume(
@@ -1206,6 +1235,9 @@ func (ns *NodeServer) NodeUnpublishVolume(
 	}
 	defer ns.VolumeLocks.Release(targetPath)
 
+	// stop the health-checker that may have been started in NodeGetVolumeStats()
+	ns.healthChecker.StopChecker(req.GetVolumeId(), targetPath)
+
 	isMnt, err := ns.Mounter.IsMountPoint(targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1262,6 +1294,8 @@ func (ns *NodeServer) NodeUnstageVolume(
 	}
 
 	volID := req.GetVolumeId()
+
+	ns.healthChecker.StopSharedChecker(volID)
 
 	if acquired := ns.VolumeLocks.TryAcquire(volID); !acquired {
 		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
@@ -1665,6 +1699,78 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 	defer ns.VolumeLocks.Release(targetPath)
 
+	// Health check first, return without stats if unhealthy.
+	healthy, msg := ns.healthChecker.IsHealthy(volumeId, targetPath)
+
+	// If healthy and an error is returned, it either means that the checker
+	// was not started or it is running but has not completed its
+	// first health-check cycle yet.
+	// This could happen when the node-plugin was restarted and the
+	// volume is already staged and published.
+	if healthy && msg != nil {
+		// Start a StatChecker for the mounted targetPath, this prevents
+		// writing a file in the user-visible location. Ideally a (shared)
+		// FileChecker is started with the stagingTargetPath, but we can't
+		// get the stagingPath from the request easily.
+		// TODO: resolve the stagingPath like rbd.getStagingPath() does
+		// NOTE: rbd.getStagingPath() uses os.Stat() internally which
+		// if called synchronously, could block indefinitely.
+
+		// Start the background checker and return
+		// immediately instead of calling os.Stat() on this goroutine.
+		// If the mount is unresponsive, os.Stat() would block,
+		// holding the VolumeLock (acquired above) and preventing all future
+		// calls for this path from reaching isHealthy().
+		// The background checker will do the stat(), the next periodic
+		// call will pick up the result (or detect the timeout).
+
+		var checkerType hc.CheckerType = hc.StatCheckerType
+
+		// Known bug for filesystem-mode volumes, still causing
+		// the calling goroutine to block indefinitely on an
+		// unresponsive mount:
+		// when the node-plugin restarts
+		// (healthy = true, msg = "first check not yet completed"),
+		// this block of code is executed and if the mount is already
+		// unresponsive, this call blocks while holding the VolumeLock,
+		// causing all subsequent NodeGetVolumeStats calls for this path
+		// to fail with "Aborted".
+		// TODO: remove synchronous os.Stat() for volume mode detection here.
+		stat, statErr := os.Stat(targetPath)
+		if statErr != nil {
+			log.WarningLog(ctx, "failed to stat targetPath %q: %v",
+				targetPath, statErr)
+		} else if (stat.Mode() & os.ModeDevice) == os.ModeDevice {
+			checkerType = hc.NoOpCheckerType
+		}
+
+		err = ns.healthChecker.StartChecker(volumeId, targetPath, checkerType)
+		if err != nil {
+			log.WarningLog(ctx, "failed to start healthchecker: %v", err)
+		}
+
+		return &csi.NodeGetVolumeStatsResponse{
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: false,
+				Message:  "health checker started, status not yet available",
+			},
+		}, nil
+	}
+
+	// !healthy indicates a problem with the volume.
+	if !healthy {
+		return &csi.NodeGetVolumeStatsResponse{
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: true,
+				Message:  msg.Error(),
+			},
+		}, nil
+	}
+
+	// warning: reaching here should mean that synchronous os.Stat()
+	// call is safe and will not indefinitely block/hang
+	// NOTE: we have a known bug (mentioned above) which still
+	// causes hangs, that needs to be fixed.
 	stat, err := os.Stat(targetPath)
 	if err != nil {
 		if util.IsCorruptedMountError(err) {
@@ -1768,7 +1874,7 @@ func (ns *NodeServer) blockNodeGetVolumeStats(
 		},
 		VolumeCondition: &csi.VolumeCondition{
 			Abnormal: false,
-			Message:  "volume is in a healthy condition",
+			Message:  "block-mode health checking is not supported",
 		},
 	}, nil
 }
@@ -1796,7 +1902,7 @@ func getBlockMetrics(
 		},
 		VolumeCondition: &csi.VolumeCondition{
 			Abnormal: false,
-			Message:  "volume is in a healthy condition",
+			Message:  "block-mode health checking is not supported",
 		},
 	}, nil
 }

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -385,6 +385,10 @@ func (ns *NodeServer) NodeStageVolume(
 		} else if !isNotMnt {
 			log.DebugLog(ctx, "rbd: volume %s is already mounted to %s, skipping", volID, stagingTargetPath)
 
+			if stashErr := stashVolumeInfo(volID, &volumeInfo{IsBlockMode: isBlock}); stashErr != nil {
+				log.WarningLog(ctx, "failed to stash volume info for %s: %v", volID, stashErr)
+			}
+
 			ns.startSharedHealthChecker(ctx, volID, stagingTargetPath, isBlock)
 
 			return &csi.NodeStageVolumeResponse{}, nil
@@ -406,6 +410,10 @@ func (ns *NodeServer) NodeStageVolume(
 		err = healerStageTransaction(ctx, cr, rv, stagingParentPath)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		if stashErr := stashVolumeInfo(volID, &volumeInfo{IsBlockMode: isBlock}); stashErr != nil {
+			log.WarningLog(ctx, "failed to stash volume info for %s: %v", volID, stashErr)
 		}
 
 		ns.startSharedHealthChecker(ctx, volID, stagingTargetPath, isBlock)
@@ -447,6 +455,10 @@ func (ns *NodeServer) NodeStageVolume(
 		"rbd: successfully mounted volume %s to stagingTargetPath %s",
 		volID,
 		stagingTargetPath)
+
+	if stashErr := stashVolumeInfo(volID, &volumeInfo{IsBlockMode: isBlock}); stashErr != nil {
+		log.WarningLog(ctx, "failed to stash volume info for %s: %v", volID, stashErr)
+	}
 
 	ns.startSharedHealthChecker(ctx, volID, stagingTargetPath, isBlock)
 
@@ -1354,6 +1366,11 @@ func (ns *NodeServer) NodeUnstageVolume(
 
 		// It was not mounted and image metadata is also missing, we are done as the last step in
 		// the staging transaction is complete
+		// remove the volume info stash for this volumeID (in case it exists)
+		if err = removeVolumeInfo(volID); err != nil {
+			log.WarningLog(ctx, "failed to remove volume info for %s: %v", volID, err)
+		}
+
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 
@@ -1387,6 +1404,10 @@ func (ns *NodeServer) NodeUnstageVolume(
 		log.ErrorLog(ctx, "failed to cleanup image metadata stash (%v)", err)
 
 		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if err = removeVolumeInfo(volID); err != nil {
+		log.WarningLog(ctx, "failed to remove volume info for %s: %v", volID, err)
 	}
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
@@ -1716,6 +1737,14 @@ func (ns *NodeServer) NodeGetVolumeStats(
 		// NOTE: rbd.getStagingPath() uses os.Stat() internally which
 		// if called synchronously, could block indefinitely.
 
+		var checkerType hc.CheckerType = hc.StatCheckerType
+		info, lookupErr := lookupVolumeInfo(volumeId)
+		if lookupErr == nil && info.IsBlockMode {
+			checkerType = hc.NoOpCheckerType
+		} else if lookupErr != nil {
+			log.DebugLog(ctx, "could not lookup volume info for %s: %v", volumeId, lookupErr)
+		}
+
 		// Start the background checker and return
 		// immediately instead of calling os.Stat() on this goroutine.
 		// If the mount is unresponsive, os.Stat() would block,
@@ -1723,27 +1752,6 @@ func (ns *NodeServer) NodeGetVolumeStats(
 		// calls for this path from reaching isHealthy().
 		// The background checker will do the stat(), the next periodic
 		// call will pick up the result (or detect the timeout).
-
-		var checkerType hc.CheckerType = hc.StatCheckerType
-
-		// Known bug for filesystem-mode volumes, still causing
-		// the calling goroutine to block indefinitely on an
-		// unresponsive mount:
-		// when the node-plugin restarts
-		// (healthy = true, msg = "first check not yet completed"),
-		// this block of code is executed and if the mount is already
-		// unresponsive, this call blocks while holding the VolumeLock,
-		// causing all subsequent NodeGetVolumeStats calls for this path
-		// to fail with "Aborted".
-		// TODO: remove synchronous os.Stat() for volume mode detection here.
-		stat, statErr := os.Stat(targetPath)
-		if statErr != nil {
-			log.WarningLog(ctx, "failed to stat targetPath %q: %v",
-				targetPath, statErr)
-		} else if (stat.Mode() & os.ModeDevice) == os.ModeDevice {
-			checkerType = hc.NoOpCheckerType
-		}
-
 		err = ns.healthChecker.StartChecker(volumeId, targetPath, checkerType)
 		if err != nil {
 			log.WarningLog(ctx, "failed to start healthchecker: %v", err)
@@ -1769,8 +1777,6 @@ func (ns *NodeServer) NodeGetVolumeStats(
 
 	// warning: reaching here should mean that synchronous os.Stat()
 	// call is safe and will not indefinitely block/hang
-	// NOTE: we have a known bug (mentioned above) which still
-	// causes hangs, that needs to be fixed.
 	stat, err := os.Stat(targetPath)
 	if err != nil {
 		if util.IsCorruptedMountError(err) {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2031,6 +2031,63 @@ func cleanupRBDImageMetadataStash(metaDataPath string) error {
 	return nil
 }
 
+// The "/csi" directory inside the container is backed by the
+// host-path volume "socket-dir" (ref rbd-plugin DaemonSet yaml file)
+// which maps to "/var/lib/kubelet/plugins/rbd.csi.ceph.com" on the node.
+const volumeInfoDir = "/csi/volume-info"
+
+// Holds per-volume metadata that needs to persist across
+// node-plugin restarts, indexed by volumeID.
+type volumeInfo struct {
+	IsBlockMode bool `json:"isBlockMode"`
+}
+
+// This function is different from "stashRBDImageMetadata" which stores info at stagingPath.
+// Not all RPCs have access to the stagingPath. For example,
+// NodeGetVolumeStats uses this to determine the volume mode using volumeID as the index.
+func stashVolumeInfo(volumeID string, info *volumeInfo) error {
+	if err := os.MkdirAll(volumeInfoDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create volume-info directory: %w", err)
+	}
+
+	encodedBytes, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("failed to marshal volume info for %s: %w", volumeID, err)
+	}
+
+	fPath := filepath.Join(volumeInfoDir, volumeID+".json")
+	if err = os.WriteFile(fPath, encodedBytes, 0o600); err != nil {
+		return fmt.Errorf("failed to stash volume info for %s: %w", volumeID, err)
+	}
+
+	return nil
+}
+
+func lookupVolumeInfo(volumeID string) (*volumeInfo, error) {
+	fPath := filepath.Join(volumeInfoDir, volumeID+".json")
+
+	encodedBytes, err := os.ReadFile(fPath) // #nosec - intended reading from fPath
+	if err != nil {
+		return nil, err
+	}
+
+	var info volumeInfo
+	if err = json.Unmarshal(encodedBytes, &info); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal volume info for %s: %w", volumeID, err)
+	}
+
+	return &info, nil
+}
+
+func removeVolumeInfo(volumeID string) error {
+	fPath := filepath.Join(volumeInfoDir, volumeID+".json")
+	if err := os.Remove(fPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove volume info for %s: %w", volumeID, err)
+	}
+
+	return nil
+}
+
 // expand checks if the requestedVolume size and the existing image size both
 // are same. If they are same, it returns nil else it resizes the image.
 func (rv *rbdVolume) expand() error {


### PR DESCRIPTION
Pre-requisite PR: https://github.com/ceph/ceph-csi/pull/6418

Use the shared health-check manager in the RBD node server so `NodeGetVolumeStats` reports async health state before calling `os.Stat()`.
Avoids stat hangs and aligns RBD behaviour with CephFS.
Start/Stop shared checkers during stage/unstage and incorporated fallback in NodeGetVolumeStats for node-plugin restart scenarios.
Only supported for filesystem-mode volumes.

## Testing:

##### Logs of `openshift-storage.rbd.csi.ceph.com-nodeplugin-<HASH>` pod:
Returns `"volume_condition":{"message":"block-mode health checking is not supported"}` for RBD block.
Returns `"volume_condition":{"message":"volume is in a healthy condition"}` for RBD filesystem.
```
I0727 13:08:51.304966 1545666 utils.go:368] ID: 3410 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"VOLUME_CONDITION"}},{"rpc":{"type":"EXPAND_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}}]}
I0727 13:08:51.305872 1545666 utils.go:361] ID: 3411 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0727 13:08:51.305900 1545666 utils.go:362] ID: 3411 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000002-dec53106-24a3-4f4d-8ed4-865e614f04ae","volume_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/pvc-1049141e-3ce1-434d-83b3-c10e270a18e3/dev/ca34f0f7-fc11-4552-9dd8-bc91714ef737"}
I0727 13:08:51.312332 1545666 omap.go:87] ID: 3411 got omap values by keys: (pool="ocs-storagecluster-cephblockpool", namespace="", name="csi.volume.dec53106-24a3-4f4d-8ed4-865e614f04ae"): map[csi.imageid:723a5aa4d498 csi.imagename:csi-vol-dec53106-24a3-4f4d-8ed4-865e614f04ae csi.volname:pvc-1049141e-3ce1-434d-83b3-c10e270a18e3 csi.volume.owner:volume-health-test]
I0727 13:08:51.349269 1545666 rbd_util.go:2435] ID: 3411 rbd: running DiffIterate over image ocs-storagecluster-cephblockpool/csi-vol-dec53106-24a3-4f4d-8ed4-865e614f04ae of size 1073741824 bytes
I0727 13:08:51.350479 1545666 rbd_util.go:2456] ID: 3411 DiffIterate on image ocs-storagecluster-cephblockpool/csi-vol-dec53106-24a3-4f4d-8ed4-865e614f04ae of size 1073741824 bytes took 0.00118902 seconds
I0727 13:08:51.350814 1545666 utils.go:368] ID: 3411 GRPC response: {"usage":[{"available":1073741824,"total":1073741824,"unit":"BYTES"}],"volume_condition":{"message":"block-mode health checking is not supported"}}
I0727 13:08:54.234071 1545666 utils.go:361] ID: 3412 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0727 13:08:54.234097 1545666 utils.go:362] ID: 3412 GRPC request: {}
I0727 13:08:54.234192 1545666 utils.go:368] ID: 3412 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"VOLUME_CONDITION"}},{"rpc":{"type":"EXPAND_VOLUME"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}}]}
I0727 13:08:54.234936 1545666 utils.go:361] ID: 3413 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0727 13:08:54.234969 1545666 utils.go:362] ID: 3413 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000002-a52055c9-b783-46b8-8e0f-8972915a7796","volume_path":"/var/lib/kubelet/pods/a765e803-7650-45b5-a73d-7c432b182b1a/volumes/kubernetes.io~csi/pvc-3103d574-581f-4399-92ad-901bebbd1353/mount"}
I0727 13:08:54.235097 1545666 utils.go:368] ID: 3413 GRPC response: {"usage":[{"available":88815403008,"total":98747928576,"unit":"BYTES","used":9915748352},{"available":5475380,"total":6160384,"unit":"INODES","used":685004}],"volume_condition":{"message":"volume is in a healthy condition"}}
```