### PR TITLE
nfs: add async health checks to NodeGetVolumeStats

### DIFF
--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/cephfs/store"
 	fsutil "github.com/ceph/ceph-csi/internal/cephfs/util"
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
+	hc "github.com/ceph/ceph-csi/internal/health-checker"
 	"github.com/ceph/ceph-csi/internal/journal"
 	nfs "github.com/ceph/ceph-csi/internal/nfs/types"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -50,6 +51,7 @@ var errInvalidParameter = errors.New("invalid parameter")
 // nfsNodeServer implements the CSI node server for the NFS driver.
 type nfsNodeServer struct {
 	csicommon.DefaultNodeServer
+	healthChecker hc.Manager
 }
 
 // Assert required implementation of CSI interfaces.
@@ -64,6 +66,7 @@ func NewNodeServer(
 
 	return &nfsNodeServer{
 		DefaultNodeServer: *csicommon.NewDefaultNodeServer(d, t, "", map[string]string{}, map[string]string{}),
+		healthChecker:     hc.NewHealthCheckManager(),
 	}
 }
 
@@ -131,6 +134,11 @@ func (ns *nfsNodeServer) NodePublishVolume(
 	log.DebugLog(ctx, "nfs: successfully mounted volume %q mount %q to %q succeeded",
 		volumeID, source, targetPath)
 
+	err = ns.healthChecker.StartChecker(volumeID, targetPath, hc.StatCheckerType)
+	if err != nil {
+		log.WarningLog(ctx, "failed to start healthchecker: %v", err)
+	}
+
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
@@ -147,6 +155,10 @@ func (ns *nfsNodeServer) NodeUnpublishVolume(
 	volumeID := req.GetVolumeId()
 	targetPath := req.GetTargetPath()
 	log.DebugLog(ctx, "nfs: unmounting volume %s on %s", volumeID, targetPath)
+
+	// stop the health-checker that may have been started in NodePublishVolume()
+	ns.healthChecker.StopChecker(volumeID, targetPath)
+
 	err = mount.CleanupMountPoint(targetPath, ns.Mounter, true)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to unmount target %q: %v",
@@ -179,6 +191,13 @@ func (ns *nfsNodeServer) NodeGetCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+					},
+				},
+			},
 		},
 	}, nil
 }
@@ -195,8 +214,46 @@ func (ns *nfsNodeServer) NodeGetVolumeStats(
 			fmt.Sprintf("targetpath %v is empty", targetPath))
 	}
 
+	volumeID := req.GetVolumeId()
+	if err := util.ValidateVolumeID(volumeID, true); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// health check first, return without stats if unhealthy
+	healthy, msg := ns.healthChecker.IsHealthy(volumeID, targetPath)
+
+	// If healthy and an error is returned, it means that the checker was not
+	// started. This could happen when the node-plugin was restarted and the
+	// volume is already published.
+	if healthy && msg != nil {
+		err = ns.healthChecker.StartChecker(volumeID, targetPath, hc.StatCheckerType)
+		if err != nil {
+			log.WarningLog(ctx, "failed to start healthchecker: %v", err)
+		}
+	}
+
+	if !healthy {
+		return &csi.NodeGetVolumeStatsResponse{
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: true,
+				Message:  msg.Error(),
+			},
+		}, nil
+	}
+
 	stat, err := os.Stat(targetPath)
 	if err != nil {
+		if util.IsCorruptedMountError(err) {
+			log.WarningLog(ctx, "corrupted mount detected in %q: %v", targetPath, err)
+
+			return &csi.NodeGetVolumeStatsResponse{
+				VolumeCondition: &csi.VolumeCondition{
+					Abnormal: true,
+					Message:  err.Error(),
+				},
+			}, nil
+		}
+
 		return nil, status.Errorf(codes.InvalidArgument,
 			"failed to get stat for targetpath %q: %v", targetPath, err)
 	}


### PR DESCRIPTION
Use the health-check manager in the NFS node server so NodeGetVolumeStats reports async health state before calling os.Stat(). Avoids stat hangs on an unresponsive NFS mount.
A non shared checker start/stop during publish/unpublish.
Add VOLUME_CONDITION capability in NodeGetCapabilities.

## Testing:

##### Logs of `openshift-storage.nfs.csi.ceph.com-nodeplugin-<HASH>` pod:

```
I0729 08:54:50.666747       1 cephcsi.go:213] Driver version: canary and Git version: 923ffbb79d25779e7da754fe2ce1cfb3c9aab11b
I0729 08:54:50.667361       1 cephcsi.go:315] Initial PID limit is set to -1
I0729 08:54:50.667409       1 cephcsi.go:321] Reconfigured PID limit to -1 (max)
I0729 08:54:50.667588       1 cephcsi.go:267] Starting driver type: nfs with name: openshift-storage.nfs.csi.ceph.com
I0729 08:54:50.669870       1 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
I0729 08:54:50.670245       1 server.go:131] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
I0729 08:54:50.943047       1 utils.go:361] ID: 1 GRPC call: /csi.v1.Identity/GetPluginInfo
I0729 08:54:50.943075       1 utils.go:362] ID: 1 GRPC request: {}
I0729 08:54:50.943091       1 identityserver-default.go:40] ID: 1 Using default GetPluginInfo
I0729 08:54:50.943237       1 utils.go:368] ID: 1 GRPC response: {"name":"openshift-storage.nfs.csi.ceph.com","vendor_version":"canary"}
I0729 08:54:51.522441       1 utils.go:361] ID: 2 GRPC call: /csi.v1.Node/NodeGetInfo
I0729 08:54:51.522465       1 utils.go:362] ID: 2 GRPC request: {}
I0729 08:54:51.522492       1 nodeserver-default.go:46] ID: 2 Using default NodeGetInfo
I0729 08:54:51.522582       1 utils.go:368] ID: 2 GRPC response: {"accessible_topology":{},"node_id":"ip-10-0-46-156.ec2.internal"}
I0729 08:57:18.617477       1 utils.go:361] ID: 3 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0729 08:57:18.617501       1 utils.go:362] ID: 3 GRPC request: {}
I0729 08:57:18.617653       1 utils.go:368] ID: 3 GRPC response: {"capabilities":[{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"VOLUME_CONDITION"}}]}
I0729 08:57:18.622980       1 utils.go:361] ID: 4 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0729 08:57:18.622997       1 utils.go:362] ID: 4 GRPC request: {}
I0729 08:57:18.623036       1 utils.go:368] ID: 4 GRPC response: {"capabilities":[{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"VOLUME_CONDITION"}}]}
I0729 08:57:18.627312       1 utils.go:361] ID: 5 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0729 08:57:18.627346       1 utils.go:362] ID: 5 GRPC request: {}
I0729 08:57:18.627389       1 utils.go:368] ID: 5 GRPC response: {"capabilities":[{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"VOLUME_CONDITION"}}]}
I0729 08:57:18.628145       1 utils.go:361] ID: 6 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0729 08:57:18.628160       1 utils.go:362] ID: 6 GRPC request: {}
I0729 08:57:18.628223       1 utils.go:368] ID: 6 GRPC response: {"capabilities":[{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"VOLUME_CONDITION"}}]}
I0729 08:57:18.629081       1 utils.go:361] ID: 7 Req-ID: 0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323 GRPC call: /csi.v1.Node/NodePublishVolume
I0729 08:57:18.629158       1 utils.go:362] ID: 7 Req-ID: 0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323 GRPC request: {"target_path":"/var/lib/kubelet/pods/bd35c32f-b706-43ca-bbb6-c83fe118bb43/volumes/kubernetes.io~csi/pvc-d5221aa7-9f36-44d2-85d1-e0b689c64596/mount","volume_capability":{"access_mode":{"mode":"MULTI_NODE_MULTI_WRITER"},"mount":{"fs_type":"ext4"}},"volume_context":{"backingSnapshot":"false","clusterID":"openshift-storage","fsName":"ocs-storagecluster-cephfilesystem","nfsCluster":"ocs-storagecluster-cephnfs","server":"ocs-storagecluster-cephnfs-service","share":"/0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323","storage.kubernetes.io/csiProvisionerIdentity":"1785315072464-9814-openshift-storage.nfs.csi.ceph.com","subvolumeName":"nfs-export-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323","subvolumePath":"/volumes/csi/nfs-export-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323/ad899dae-b103-41e3-b4eb-c2a445a43603","volumeNamePrefix":"nfs-export-"},"volume_id":"0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323"}
I0729 08:57:18.629457       1 nodeserver.go:308] nfs: mounting volumeID(0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323) source(ocs-storagecluster-cephnfs-service:/0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323) targetPath(/var/lib/kubelet/pods/bd35c32f-b706-43ca-bbb6-c83fe118bb43/volumes/kubernetes.io~csi/pvc-d5221aa7-9f36-44d2-85d1-e0b689c64596/mount) mountflags([])
I0729 08:57:18.629477       1 mount_linux.go:259] Mounting cmd (mount) with arguments (-t nfs ocs-storagecluster-cephnfs-service:/0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323 /var/lib/kubelet/pods/bd35c32f-b706-43ca-bbb6-c83fe118bb43/volumes/kubernetes.io~csi/pvc-d5221aa7-9f36-44d2-85d1-e0b689c64596/mount)
I0729 08:57:20.129311       1 nodeserver.go:134] ID: 7 Req-ID: 0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323 nfs: successfully mounted volume "0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323" mount "ocs-storagecluster-cephnfs-service:/0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323" to "/var/lib/kubelet/pods/bd35c32f-b706-43ca-bbb6-c83fe118bb43/volumes/kubernetes.io~csi/pvc-d5221aa7-9f36-44d2-85d1-e0b689c64596/mount" succeeded
I0729 08:57:20.129406       1 utils.go:368] ID: 7 Req-ID: 0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323 GRPC response: {}
I0729 08:58:03.886492       1 utils.go:361] ID: 8 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0729 08:58:03.886516       1 utils.go:362] ID: 8 GRPC request: {}
I0729 08:58:03.886564       1 utils.go:368] ID: 8 GRPC response: {"capabilities":[{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}},{"rpc":{"type":"VOLUME_CONDITION"}}]}
I0729 08:58:03.887388       1 utils.go:361] ID: 9 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0729 08:58:03.887419       1 utils.go:362] ID: 9 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-6f00590d-f0fe-4a4b-89fb-b0a91dfb2323","volume_path":"/var/lib/kubelet/pods/bd35c32f-b706-43ca-bbb6-c83fe118bb43/volumes/kubernetes.io~csi/pvc-d5221aa7-9f36-44d2-85d1-e0b689c64596/mount"}
I0729 08:58:03.893486       1 utils.go:368] ID: 9 GRPC response: {"usage":[{"available":1073741824,"total":1073741824,"unit":"BYTES"}],"volume_condition":{"message":"volume is in a healthy condition"}}
```