### PR TITLE
cephfs: support MDS pinning via ControllerModifyVolume

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-clusterrole.yaml
@@ -41,6 +41,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list","watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
 {{- if .Values.provisioner.snapshotter.args.enableVolumeGroupSnapshots }}
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]

--- a/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-rbac.yaml
@@ -80,6 +80,9 @@ rules:
   - apiGroups: ["replication.storage.openshift.io"]
     resources: ["volumegroupreplicationclasses"]
     verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/docs/cephfs/deploy.md
+++ b/docs/cephfs/deploy.md
@@ -358,3 +358,45 @@ ceph fs subvolume metadata rm <filesystem> <subvolume> --group_name=<group> \
 
 All the Pods using the PVC should be scaled down completely and then scaled up for
 removing the restriction after removing metadata from the subvolume.
+
+## MDS pinning using VolumeAttributesClass
+
+CephFS subvolumes can be pinned to MDS ranks to control how their metadata is
+distributed across the MDS daemons of the filesystem. Ceph-CSI exposes this
+through the `VolumeAttributesClass` (VAC) mutable parameters, which are applied
+to an existing volume via the CSI `ControllerModifyVolume` RPC.
+
+This maps directly to:
+
+```bash
+ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting>
+```
+
+See the upstream documentation for the semantics of each pin type:
+<https://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning>
+
+### Supported parameters
+
+The following parameters are supported. They are **mutually exclusive**: at most
+one may be set on a single `VolumeAttributesClass`.
+
+| Parameter             | Pin type      | Value                                     |
+| --------------------- | ------------- | ----------------------------------------- |
+| `mds-pin-export`      | `export`      | MDS rank, an integer `>= -1` (`-1` unpins)|
+| `mds-pin-distributed` | `distributed` | `"1"` to enable, `"0"` to disable         |
+| `mds-pin-random`      | `random`      | float in the range `0.0`-`1.0`            |
+
+### Example
+
+An example `VolumeAttributesClass` is available at
+[volumeattributesclass.yaml][cephfs-vac-example].
+
+[cephfs-vac-example]: ../../examples/cephfs/volumeattributesclass.yaml
+
+Create the `VolumeAttributesClass` and reference it from a PVC using the
+`volumeAttributesClassName` field. The driver applies the pin when the PVC is
+associated with the class, and re-applies it when the class is changed.
+
+```bash
+kubectl create -f ../examples/cephfs/volumeattributesclass.yaml
+```

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -2740,6 +2740,99 @@ var _ = Describe(cephfsType, func() {
 			validateOmapCount(f, 0, cephfsType, metadataPool, snapsType)
 		})
 
+		It("create a PVC with a VolumeAttributesClass for MDS pinning and modify it", func() {
+			// VolumeAttributesClass support requires Kubernetes 1.34+.
+			if !k8sVersionGreaterEquals(f.ClientSet, 1, 34) {
+				framework.Logf("skipping VolumeAttributesClass test, needs Kubernetes >= 1.34")
+
+				return
+			}
+
+			// This test validates VolumeAttributesClass (VAC) support for
+			// CephFS subvolumes via MDS pinning, exercising both the
+			// CreateVolume and ControllerModifyVolume code paths:
+			//   1. Create a StorageClass.
+			//   2. Create two VACs with different mds-pin-export ranks.
+			//   3. Create a PVC referencing the first VAC and verify the PV
+			//      gets the VAC applied at creation time.
+			//   4. Update the PVC to reference the second VAC and verify the
+			//      change is applied via ControllerModifyVolume.
+			//   5. Clean up.
+			err := createCephfsStorageClass(f.ClientSet, f, true, nil)
+			if err != nil {
+				logAndFail("failed to create CephFS storageclass: %v", err)
+			}
+			defer func() {
+				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					logAndFail("failed to delete CephFS storageclass: %v", err)
+				}
+			}()
+
+			vacName1 := "e2e-" + f.UniqueName + "-cephfs-vac1"
+			vacName2 := "e2e-" + f.UniqueName + "-cephfs-vac2"
+
+			err = createCephFSVolumeAttributesClass(f.ClientSet, vacName1,
+				map[string]string{"mds-pin-export": "0"})
+			if err != nil {
+				logAndFail("failed to create VolumeAttributesClass: %v", err)
+			}
+			defer func() {
+				if err = deleteCephFSVolumeAttributesClass(f.ClientSet, vacName1); err != nil {
+					logAndFail("failed to delete VolumeAttributesClass: %v", err)
+				}
+			}()
+
+			err = createCephFSVolumeAttributesClass(f.ClientSet, vacName2,
+				map[string]string{"mds-pin-export": "1"})
+			if err != nil {
+				logAndFail("failed to create VolumeAttributesClass: %v", err)
+			}
+			defer func() {
+				if err = deleteCephFSVolumeAttributesClass(f.ClientSet, vacName2); err != nil {
+					logAndFail("failed to delete VolumeAttributesClass: %v", err)
+				}
+			}()
+
+			// create a PVC referencing the first VAC; this exercises the
+			// CreateVolume path applying the mutable parameters.
+			pvc, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC: %v", err)
+			}
+			pvc.Namespace = f.UniqueName
+			pvc.Spec.VolumeAttributesClassName = &vacName1
+
+			err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC: %v", err)
+			}
+
+			pv, err := getBoundPV(f.ClientSet, pvc)
+			if err != nil {
+				logAndFail("failed to get bound PV: %v", err)
+			}
+			if pv.Spec.VolumeAttributesClassName == nil ||
+				*pv.Spec.VolumeAttributesClassName != vacName1 {
+				logAndFail("PV %s does not reference the expected VolumeAttributesClass %q",
+					pv.Name, vacName1)
+			}
+			validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
+
+			// update the PVC to reference the second VAC; this exercises the
+			// ControllerModifyVolume path.
+			err = modifyPVCVolumeAttributesClass(f.ClientSet, pvc, vacName2)
+			if err != nil {
+				logAndFail("failed to modify VolumeAttributesClass: %v", err)
+			}
+
+			err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC: %v", err)
+			}
+			validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+		})
+
 		// Make sure this should be last testcase in
 		// this file, because it deletes pool
 		It("Create a PVC and delete PVC when backend pool deleted", func() {

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -27,6 +27,7 @@ import (
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	v1 "k8s.io/api/core/v1"
 	scv1 "k8s.io/api/storage/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -985,4 +986,66 @@ func verifyUserIdMappingMetadataSnapshotBacked(
 	}
 
 	return nil
+}
+
+// createCephFSVolumeAttributesClass creates a VolumeAttributesClass for CephFS
+// from the example manifest, optionally overriding its name and parameters.
+func createCephFSVolumeAttributesClass(
+	c kubernetes.Interface,
+	name string,
+	params map[string]string,
+) error {
+	vac, err := getVolumeAttributesClass(cephFSExamplePath + "volumeattributesclass.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to get vac: %w", err)
+	}
+	if name != "" {
+		vac.Name = name
+	}
+
+	// override with the parameters passed by the caller, so that a test can
+	// exercise a specific MDS pin type.
+	if params != nil {
+		vac.Parameters = params
+	}
+
+	timeout := time.Duration(deployTimeout) * time.Minute
+
+	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err = c.StorageV1().VolumeAttributesClasses().Create(ctx, &vac, metav1.CreateOptions{})
+		if err != nil {
+			if apierrs.IsAlreadyExists(err) {
+				return true, nil
+			}
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to create VolumeAttributesClass %q: %w", vac.Name, err)
+		}
+
+		return true, nil
+	})
+}
+
+// deleteCephFSVolumeAttributesClass deletes the named CephFS
+// VolumeAttributesClass.
+func deleteCephFSVolumeAttributesClass(c kubernetes.Interface, name string) error {
+	timeout := time.Duration(deployTimeout) * time.Minute
+
+	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(ctx context.Context) (bool, error) {
+		err := c.StorageV1().VolumeAttributesClasses().Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil {
+			if apierrs.IsNotFound(err) {
+				return true, nil
+			}
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to delete VolumeAttributesClass %q: %w", name, err)
+		}
+
+		return true, nil
+	})
 }

--- a/examples/cephfs/volumeattributesclass.yaml
+++ b/examples/cephfs/volumeattributesclass.yaml
@@ -1,0 +1,31 @@
+---
+# VolumeAttributesClass for CephFS volumes
+# This example demonstrates the mutable parameters supported by the CephFS
+# driver to control MDS pinning of a subvolume at runtime.
+#
+# The three MDS pinning parameters are MUTUALLY EXCLUSIVE: at most one of them
+# may be set. They map to "ceph fs subvolume pin <vol> <sub> <type> <setting>".
+# See: https://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: cephfs-vac
+driverName: cephfs.csi.ceph.com
+parameters:
+  # Export pinning: pin the subvolume to a specific MDS rank.
+  # Value is an MDS rank (integer >= -1). Use "-1" to remove the pin.
+  mds-pin-export: "2"
+
+  # Alternative: Distributed ephemeral pinning.
+  # Value is "1" to enable or "0" to disable.
+  # mds-pin-distributed: "1"
+
+  # Alternative: Random ephemeral pinning.
+  # Value is a float in the range 0.0-1.0 (fraction of directories pinned).
+  # mds-pin-random: "0.5"
+
+# Notes:
+# - Only one of mds-pin-export, mds-pin-distributed or mds-pin-random may
+#   be set.
+# - VolumeAttributesClass can be modified at runtime using kubectl.
+# - Changes are applied dynamically via ControllerModifyVolume.

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -412,6 +412,16 @@ func (cs *cephfsControllerServer) CreateVolume(
 			}
 		}
 
+		// apply MutableParameters (e.g. MDS pinning) from a
+		// VolumeAttributesClass, if any were requested. The subvolume already
+		// existed before this request, so it must not be purged on failure.
+		if len(req.GetMutableParameters()) != 0 {
+			if err = applyMutableParameters(ctx, volClient, vID.FsSubvolName,
+				req.GetMutableParameters()); err != nil {
+				return nil, err
+			}
+		}
+
 		return buildCreateVolumeResponse(req, volOptions, vID), nil
 	}
 
@@ -485,6 +495,22 @@ func (cs *cephfsControllerServer) CreateVolume(
 
 	log.DebugLog(ctx, "cephfs: successfully created backing volume named %s for request name %s",
 		vID.FsSubvolName, requestName)
+
+	// apply MutableParameters (e.g. MDS pinning) from a VolumeAttributesClass,
+	// if any were requested. On failure the freshly created subvolume must be
+	// purged to avoid leaving an orphaned subvolume behind (the deferred
+	// UndoVolReservation only cleans up the reservation/OMAP entry).
+	if len(req.GetMutableParameters()) != 0 {
+		if err = applyMutableParameters(ctx, volClient, vID.FsSubvolName,
+			req.GetMutableParameters()); err != nil {
+			if purgeErr := volClient.PurgeVolume(ctx, true); purgeErr != nil {
+				log.ErrorLog(ctx, "failed to purge subvolume %s after applying mutable "+
+					"parameters failed: %v", vID.FsSubvolName, purgeErr)
+			}
+
+			return nil, err
+		}
+	}
 
 	return buildCreateVolumeResponse(req, volOptions, vID), nil
 }
@@ -1567,8 +1593,12 @@ func validateMDSPinSetting(key, setting string) error {
 	return nil
 }
 
-// ControllerModifyVolume modifies mutable attributes of a CephFS subvolume
-// based on parameters from a VolumeAttributesClass.
+// applyMutableParameters applies the mutable VolumeAttributesClass parameters
+// to an already resolved subvolume. It performs no locking and does not resolve
+// the volume; the caller is expected to have taken the required locks and to
+// provide a ready-to-use SubVolumeClient. This lets both CreateVolume and
+// ControllerModifyVolume share the same logic without duplicating locking or
+// volume resolution steps.
 //
 // Currently supported parameters (mutually exclusive, at most one may be set):
 //   - mds-pin-export:      pin to a specific MDS rank (e.g. "2")
@@ -1578,6 +1608,34 @@ func validateMDSPinSetting(key, setting string) error {
 // Similar To:
 //
 //	ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting>
+func applyMutableParameters(
+	ctx context.Context,
+	volClient core.SubVolumeClient,
+	volID string,
+	mutableParams map[string]string,
+) error {
+	pinType, pinSetting, err := validateMDSPinParameters(mutableParams)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if pinType != "" {
+		if err = volClient.PinVolume(ctx, pinType, pinSetting); err != nil {
+			log.ErrorLog(ctx, "failed to pin subvolume %s: %v", volID, err)
+
+			return status.Error(codes.Internal, err.Error())
+		}
+		log.DebugLog(ctx, "cephfs: subvolume %s pinned with type=%s setting=%s",
+			volID, pinType, pinSetting)
+	}
+
+	return nil
+}
+
+// ControllerModifyVolume modifies mutable attributes of a CephFS subvolume
+// based on parameters from a VolumeAttributesClass. It acquires the required
+// locks, resolves the volume and delegates the actual work to
+// applyMutableParameters.
 func (cs *cephfsControllerServer) ControllerModifyVolume(
 	ctx context.Context,
 	req *csi.ControllerModifyVolumeRequest,
@@ -1631,21 +1689,10 @@ func (cs *cephfsControllerServer) ControllerModifyVolume(
 	}
 	defer volOptions.Destroy()
 
-	pinType, pinSetting, err := validateMDSPinParameters(mutableParams)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
-	if pinType != "" {
-		volClient := core.NewSubVolume(volOptions.GetConnection(),
-			&volOptions.SubVolume, volOptions.ClusterID, cs.ClusterName)
-		if err = volClient.PinVolume(ctx, pinType, pinSetting); err != nil {
-			log.ErrorLog(ctx, "failed to pin subvolume %s: %v", volID, err)
-
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		log.DebugLog(ctx, "cephfs: subvolume %s pinned with type=%s setting=%s",
-			volID, pinType, pinSetting)
+	volClient := core.NewSubVolume(volOptions.GetConnection(),
+		&volOptions.SubVolume, volOptions.ClusterID, cs.ClusterName)
+	if err = applyMutableParameters(ctx, volClient, volID, mutableParams); err != nil {
+		return nil, err
 	}
 
 	return &csi.ControllerModifyVolumeResponse{}, nil

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"syscall"
 
 	osdAdmin "github.com/ceph/go-ceph/common/admin/osd"
@@ -1463,4 +1464,189 @@ func (cs *cephfsControllerServer) fenceNode(
 	}
 
 	return nil
+}
+
+const (
+	// paramMDSPinExport is the VolumeAttributesClass mutable parameter key for
+	// pinning the subvolume to a specific MDS rank (e.g. "2").
+	paramMDSPinExport = "mds-pin-export"
+	// paramMDSPinDistributed is the VolumeAttributesClass mutable parameter
+	// key for distributed ephemeral pinning ("1" to enable, "0" to disable).
+	paramMDSPinDistributed = "mds-pin-distributed"
+	// paramMDSPinRandom is the VolumeAttributesClass mutable parameter key for
+	// random ephemeral pinning, a float in the range 0.0–1.0 (e.g. "0.5").
+	paramMDSPinRandom = "mds-pin-random"
+)
+
+// mdsPinParamToType maps a VolumeAttributesClass MDS pin parameter key to the
+// CephFS pin type it represents, as per:
+// https://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning
+var mdsPinParamToType = map[string]string{
+	paramMDSPinExport:      "export",
+	paramMDSPinDistributed: "distributed",
+	paramMDSPinRandom:      "random",
+}
+
+// mdsPinParams is the ordered list of MDS pin parameter keys recognized on a
+// VolumeAttributesClass. The order is only relevant for deterministic error
+// messages.
+var mdsPinParams = []string{paramMDSPinExport, paramMDSPinDistributed, paramMDSPinRandom}
+
+// validateMDSPinParameters inspects the MDS pin parameters in params and
+// returns the CephFS pin type and setting to apply.
+//
+// The three pin parameters (mds-pin-export, mds-pin-distributed,
+// mds-pin-random) are mutually exclusive: at most one may be set. Any parameter
+// key that is not a recognized MDS pin parameter is rejected, as recommended by
+// the CSI spec for unsupported mutable parameters. It returns:
+//   - ("", "", nil)               when no MDS pin parameter is present
+//   - (pinType, pinSetting, nil)  when exactly one is present with a valid value
+//   - ("", "", err)               when an unknown parameter is present, more
+//     than one is present, or the value is invalid for the given pin type
+func validateMDSPinParameters(params map[string]string) (string, string, error) {
+	var (
+		selected string
+		setting  string
+	)
+
+	for key := range params {
+		if _, ok := mdsPinParamToType[key]; !ok {
+			return "", "", fmt.Errorf("unsupported mutable parameter %q", key)
+		}
+	}
+
+	for _, key := range mdsPinParams {
+		value, ok := params[key]
+		if !ok {
+			continue
+		}
+		if selected != "" {
+			return "", "", fmt.Errorf("%q and %q are mutually exclusive: only one may be set",
+				selected, key)
+		}
+		selected = key
+		setting = value
+	}
+
+	if selected == "" {
+		return "", "", nil
+	}
+
+	if err := validateMDSPinSetting(selected, setting); err != nil {
+		return "", "", err
+	}
+
+	return mdsPinParamToType[selected], setting, nil
+}
+
+// validateMDSPinSetting validates that setting is a valid value for the given
+// MDS pin parameter key.
+func validateMDSPinSetting(key, setting string) error {
+	switch key {
+	case paramMDSPinExport:
+		// MDS rank: a non-negative integer, or "-1" to unset the pin.
+		rank, err := strconv.Atoi(setting)
+		if err != nil || rank < -1 {
+			return fmt.Errorf("invalid %q value %q: must be an MDS rank integer >= -1",
+				key, setting)
+		}
+	case paramMDSPinDistributed:
+		// Distributed ephemeral pinning is a boolean-like "1"/"0".
+		if setting != "0" && setting != "1" {
+			return fmt.Errorf("invalid %q value %q: must be \"0\" or \"1\"", key, setting)
+		}
+	case paramMDSPinRandom:
+		// Random ephemeral pinning is a float in the range 0.0–1.0.
+		ratio, err := strconv.ParseFloat(setting, 64)
+		if err != nil || ratio < 0.0 || ratio > 1.0 {
+			return fmt.Errorf("invalid %q value %q: must be a float in the range 0.0-1.0",
+				key, setting)
+		}
+	}
+
+	return nil
+}
+
+// ControllerModifyVolume modifies mutable attributes of a CephFS subvolume
+// based on parameters from a VolumeAttributesClass.
+//
+// Currently supported parameters (mutually exclusive, at most one may be set):
+//   - mds-pin-export:      pin to a specific MDS rank (e.g. "2")
+//   - mds-pin-distributed: distributed ephemeral pinning ("1" or "0")
+//   - mds-pin-random:      random ephemeral pinning, a float 0.0–1.0
+//
+// Similar To:
+//
+//	ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting>
+func (cs *cephfsControllerServer) ControllerModifyVolume(
+	ctx context.Context,
+	req *csi.ControllerModifyVolumeRequest,
+) (*csi.ControllerModifyVolumeResponse, error) {
+	if err := cs.Driver.ValidateControllerServiceRequest(
+		csi.ControllerServiceCapability_RPC_MODIFY_VOLUME); err != nil {
+		log.ErrorLog(ctx, "invalid modify volume req: %v", protosanitizer.StripSecrets(req))
+
+		return nil, err
+	}
+
+	volID := req.GetVolumeId()
+	if err := util.ValidateVolumeID(volID, true); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	mutableParams := req.GetMutableParameters()
+	if len(mutableParams) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "mutable parameters cannot be empty")
+	}
+
+	// lock out parallel operations against the same volume ID
+	if acquired := cs.VolumeLocks.TryAcquire(volID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volID)
+
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volID)
+	}
+	defer cs.VolumeLocks.Release(volID)
+
+	if err := cs.OperationLocks.GetModifyLock(volID); err != nil {
+		log.ErrorLog(ctx, err.Error())
+
+		return nil, status.Error(codes.Aborted, err.Error())
+	}
+	defer cs.OperationLocks.ReleaseModifyLock(volID)
+
+	// resolve volume options — FsName, SubvolumeGroup and VolID are populated
+	// automatically from the cluster config, no extra input required.
+	volOptions, _, err := store.NewVolumeOptionsFromVolID(ctx, volID, nil, req.GetSecrets(),
+		cs.ClusterName)
+	if err != nil {
+		log.ErrorLog(ctx, "validation and extraction of volume options failed: %v", err)
+
+		// the volume backing the given ID could not be found.
+		if errors.Is(err, cerrors.ErrVolumeNotFound) || errors.Is(err, util.ErrKeyNotFound) ||
+			errors.Is(err, util.ErrPoolNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	defer volOptions.Destroy()
+
+	pinType, pinSetting, err := validateMDSPinParameters(mutableParams)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if pinType != "" {
+		volClient := core.NewSubVolume(volOptions.GetConnection(),
+			&volOptions.SubVolume, volOptions.ClusterID, cs.ClusterName)
+		if err = volClient.PinVolume(ctx, pinType, pinSetting); err != nil {
+			log.ErrorLog(ctx, "failed to pin subvolume %s: %v", volID, err)
+
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		log.DebugLog(ctx, "cephfs: subvolume %s pinned with type=%s setting=%s",
+			volID, pinType, pinSetting)
+	}
+
+	return &csi.ControllerModifyVolumeResponse{}, nil
 }

--- a/internal/cephfs/controllerserver_test.go
+++ b/internal/cephfs/controllerserver_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cephfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMDSPinParameters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		params      map[string]string
+		wantType    string
+		wantSetting string
+		wantErr     bool
+	}{
+		{
+			name:        "no pin parameters",
+			params:      map[string]string{},
+			wantType:    "",
+			wantSetting: "",
+			wantErr:     false,
+		},
+		{
+			name:    "unrelated parameters only",
+			params:  map[string]string{"foo": "bar"},
+			wantErr: true,
+		},
+		{
+			name: "unknown parameter mixed with a valid pin",
+			params: map[string]string{
+				paramMDSPinExport: "1",
+				"foo":             "bar",
+			},
+			wantErr: true,
+		},
+		{
+			name:        "export pin with valid rank",
+			params:      map[string]string{paramMDSPinExport: "2"},
+			wantType:    "export",
+			wantSetting: "2",
+			wantErr:     false,
+		},
+		{
+			name:        "export pin with unpin value -1",
+			params:      map[string]string{paramMDSPinExport: "-1"},
+			wantType:    "export",
+			wantSetting: "-1",
+			wantErr:     false,
+		},
+		{
+			name:    "export pin with invalid non-integer value",
+			params:  map[string]string{paramMDSPinExport: "abc"},
+			wantErr: true,
+		},
+		{
+			name:    "export pin with value below -1",
+			params:  map[string]string{paramMDSPinExport: "-2"},
+			wantErr: true,
+		},
+		{
+			name:        "distributed pin enabled",
+			params:      map[string]string{paramMDSPinDistributed: "1"},
+			wantType:    "distributed",
+			wantSetting: "1",
+			wantErr:     false,
+		},
+		{
+			name:        "distributed pin disabled",
+			params:      map[string]string{paramMDSPinDistributed: "0"},
+			wantType:    "distributed",
+			wantSetting: "0",
+			wantErr:     false,
+		},
+		{
+			name:    "distributed pin with invalid value",
+			params:  map[string]string{paramMDSPinDistributed: "2"},
+			wantErr: true,
+		},
+		{
+			name:        "random pin with valid ratio",
+			params:      map[string]string{paramMDSPinRandom: "0.5"},
+			wantType:    "random",
+			wantSetting: "0.5",
+			wantErr:     false,
+		},
+		{
+			name:        "random pin at lower bound",
+			params:      map[string]string{paramMDSPinRandom: "0.0"},
+			wantType:    "random",
+			wantSetting: "0.0",
+			wantErr:     false,
+		},
+		{
+			name:        "random pin at upper bound",
+			params:      map[string]string{paramMDSPinRandom: "1.0"},
+			wantType:    "random",
+			wantSetting: "1.0",
+			wantErr:     false,
+		},
+		{
+			name:    "random pin above upper bound",
+			params:  map[string]string{paramMDSPinRandom: "1.5"},
+			wantErr: true,
+		},
+		{
+			name:    "random pin with negative ratio",
+			params:  map[string]string{paramMDSPinRandom: "-0.1"},
+			wantErr: true,
+		},
+		{
+			name:    "random pin with non-float value",
+			params:  map[string]string{paramMDSPinRandom: "half"},
+			wantErr: true,
+		},
+		{
+			name: "mutually exclusive export and distributed",
+			params: map[string]string{
+				paramMDSPinExport:      "1",
+				paramMDSPinDistributed: "1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "mutually exclusive export and random",
+			params: map[string]string{
+				paramMDSPinExport: "1",
+				paramMDSPinRandom: "0.5",
+			},
+			wantErr: true,
+		},
+		{
+			name: "mutually exclusive distributed and random",
+			params: map[string]string{
+				paramMDSPinDistributed: "1",
+				paramMDSPinRandom:      "0.5",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotType, gotSetting, err := validateMDSPinParameters(tt.params)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, gotType)
+			require.Equal(t, tt.wantSetting, gotSetting)
+		})
+	}
+}
+
+func TestValidateMDSPinSetting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		setting string
+		wantErr bool
+	}{
+		{name: "export valid rank", key: paramMDSPinExport, setting: "3", wantErr: false},
+		{name: "export unpin", key: paramMDSPinExport, setting: "-1", wantErr: false},
+		{name: "export invalid string", key: paramMDSPinExport, setting: "x", wantErr: true},
+		{name: "export below -1", key: paramMDSPinExport, setting: "-5", wantErr: true},
+		{name: "distributed enable", key: paramMDSPinDistributed, setting: "1", wantErr: false},
+		{name: "distributed disable", key: paramMDSPinDistributed, setting: "0", wantErr: false},
+		{name: "distributed invalid", key: paramMDSPinDistributed, setting: "true", wantErr: true},
+		{name: "random valid", key: paramMDSPinRandom, setting: "0.25", wantErr: false},
+		{name: "random out of range", key: paramMDSPinRandom, setting: "2.0", wantErr: true},
+		{name: "random invalid", key: paramMDSPinRandom, setting: "abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateMDSPinSetting(tt.key, tt.setting)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -336,25 +337,39 @@ func checkSubvolumeHasFeature(feature string, subVolFeatures []string) bool {
 // pinType can be "export", "distributed" or "random".
 // pinSetting is the value for the pin (e.g. MDS rank "2", "true"/"false").
 //
-// NOTE: go-ceph's PinSubVolume does not accept a subvolume group argument
-// (only PinSubVolumeGroup does, and that pins the group, not an individual
-// subvolume). As a result the pin is applied against Ceph's default subvolume
-// group. A subvolume group can be configured per StorageClass in ceph-csi
-// (parameter "subvolumeGroup"), so this is a known limitation until go-ceph
-// exposes a PinSubVolume variant that accepts the group.
+// go-ceph's typed PinSubVolume helper does not accept a subvolume group, so it
+// would always target Ceph's default group and fail for subvolumes created in
+// a non-default group (as ceph-csi does). To support any group, the "fs
+// subvolume pin" manager command is issued directly with the group_name set.
 //
 // Similar To:
 //
-//	ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting>
+//	ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting> \
+//	  --group_name=<group>
 func (s *subVolumeClient) PinVolume(ctx context.Context, pinType, pinSetting string) error {
-	fsa, err := s.conn.GetFSAdmin()
-	if err != nil {
-		return fmt.Errorf("could not get FSAdmin to pin subvolume %s: %w", s.VolID, err)
+	cmd := map[string]string{
+		"prefix":      "fs subvolume pin",
+		"format":      "json",
+		"vol_name":    s.FsName,
+		"sub_name":    s.VolID,
+		"group_name":  s.SubvolumeGroup,
+		"pin_type":    pinType,
+		"pin_setting": pinSetting,
 	}
-	_, err = fsa.PinSubVolume(s.FsName, s.VolID, pinType, pinSetting)
+
+	buf, err := json.Marshal(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to pin subvolume %s in fs %s: %w", s.VolID, s.FsName, err)
+		return fmt.Errorf("failed to marshal pin command for subvolume %s: %w", s.VolID, err)
 	}
+
+	out, status, err := s.conn.MgrCommand([][]byte{buf})
+	if err != nil {
+		return fmt.Errorf("failed to pin subvolume %s in fs %s (group %s): %w",
+			s.VolID, s.FsName, s.SubvolumeGroup, err)
+	}
+
+	log.DebugLog(ctx, "cephfs: pinned subvolume %s in fs %s (group %s), type=%s setting=%s: status=%q output=%q",
+		s.VolID, s.FsName, s.SubvolumeGroup, pinType, pinSetting, status, string(out))
 
 	return nil
 }

--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -88,6 +88,14 @@ type SubVolumeClient interface {
 	UnsetAllMetadata(keys []string) error
 	// ListMetadata gets the metadata for the subvolume.
 	ListMetadata() (map[string]string, error)
+
+	// PinVolume sets an MDS pinning policy on the subvolume.
+	// pinType is one of "export", "distributed" or "random".
+	// pinSetting is the value for the pin, its meaning depends on pinType:
+	//   - export:      MDS rank as an integer (e.g. "2"), or "-1" to unpin
+	//   - distributed: "1" to enable or "0" to disable
+	//   - random:      a float in the range 0.0-1.0
+	PinVolume(ctx context.Context, pinType, pinSetting string) error
 }
 
 // subVolumeClient implements SubVolumeClient interface.
@@ -322,4 +330,31 @@ func checkSubvolumeHasFeature(feature string, subVolFeatures []string) bool {
 	// The subvolume "features" are based on the internal version of the subvolume.
 	// Verify if subvolume supports the required feature.
 	return slices.Contains(subVolFeatures, feature)
+}
+
+// PinVolume sets an MDS pinning policy on the subvolume.
+// pinType can be "export", "distributed" or "random".
+// pinSetting is the value for the pin (e.g. MDS rank "2", "true"/"false").
+//
+// NOTE: go-ceph's PinSubVolume does not accept a subvolume group argument
+// (only PinSubVolumeGroup does, and that pins the group, not an individual
+// subvolume). As a result the pin is applied against Ceph's default subvolume
+// group. A subvolume group can be configured per StorageClass in ceph-csi
+// (parameter "subvolumeGroup"), so this is a known limitation until go-ceph
+// exposes a PinSubVolume variant that accepts the group.
+//
+// Similar To:
+//
+//	ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting>
+func (s *subVolumeClient) PinVolume(ctx context.Context, pinType, pinSetting string) error {
+	fsa, err := s.conn.GetFSAdmin()
+	if err != nil {
+		return fmt.Errorf("could not get FSAdmin to pin subvolume %s: %w", s.VolID, err)
+	}
+	_, err = fsa.PinSubVolume(s.FsName, s.VolID, pinType, pinSetting)
+	if err != nil {
+		return fmt.Errorf("failed to pin subvolume %s in fs %s: %w", s.VolID, s.FsName, err)
+	}
+
+	return nil
 }

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -146,6 +146,7 @@ func (fs *cephfsDriver) Run(conf *util.Config) {
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+			csi.ControllerServiceCapability_RPC_MODIFY_VOLUME,
 		})
 		fs.cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
 			csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -170,3 +170,14 @@ func (cc *ClusterConnection) GetAddrs() (string, error) {
 
 	return cc.conn.GetAddrs()
 }
+
+// MgrCommand sends a raw JSON-encoded command to the Ceph manager and returns
+// its output. It is used for manager commands that are not (yet) exposed by a
+// typed go-ceph helper.
+func (cc *ClusterConnection) MgrCommand(args [][]byte) ([]byte, string, error) {
+	if cc.conn == nil {
+		return nil, "", errors.New("cluster is not connected yet")
+	}
+
+	return cc.conn.MgrCommand(args)
+}


### PR DESCRIPTION
Expose the RPC_MODIFY_VOLUME capability on the CephFS controller and map the mutable VolumeAttributesClass parameters mds-pin-export, mds-pin-distributed and mds-pin-random to "ceph fs subvolume pin". This lets administrators change the MDS distribution policy of an existing subvolume at runtime without recreating the volume.

The three pin parameters are mutually exclusive and validated before being applied. A new PinVolume method on the SubVolumeClient wraps go-ceph's PinSubVolume; since go-ceph does not expose a subvolume-group aware variant, the pin is applied against Ceph's default subvolume group, which is documented as a known limitation.

Adds unit tests for the parameter validation, an example VolumeAttributesClass and documentation in the CephFS deployment guide.


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Fixes: #6378
Depends-on: #6458

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
