### PR TITLE
nvmeof: move QoS and host parsing into dedicated types\files.

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/ghodss/yaml"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -348,13 +347,13 @@ func (cs *Server) ControllerModifyVolume(
 
 		return nil, status.Error(codes.InvalidArgument, "cannot set RBD QoS parameters on NVMe-oF volumes")
 	}
-	nvmeofQoS, err := parseQoSParameters(params)
+	nvmeofQoS, err := nvmeof.NewNVMeoFQosVolumeFromParams(params)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to parse NVMe-oF QoS parameters: %v", err)
 
 		return nil, status.Errorf(codes.InvalidArgument, "failed to parse QoS parameters: %v", err)
 	}
-	hostsList, err := parseHostsParameters(params)
+	hostsList, err := nvmeof.NewNVMeoFHostListFromParams(params)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to parse NVMe-oF hosts parameters: %v", err)
 
@@ -471,12 +470,12 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	}
 
 	// It take the mutableParams value from the volumeAttributesClassName in the PersistentVolumeClaim yaml.
-	_, err = parseQoSParameters(mutableParams)
+	_, err = nvmeof.NewNVMeoFQosVolumeFromParams(mutableParams)
 	if err != nil {
 		return fmt.Errorf("invalid NVMe-oF QoS parameters: %w", err)
 	}
 
-	_, err = parseHostsParameters(mutableParams)
+	_, err = nvmeof.NewNVMeoFHostListFromParams(mutableParams)
 	if err != nil {
 		return fmt.Errorf("invalid NVMe-oF hosts parameters (for external clients): %w", err)
 	}
@@ -546,26 +545,6 @@ func validateNetworkMask(networkMask string) error {
 	return nil
 }
 
-// parseHostsParameters parses the hosts yaml list parameter and validates its contents.
-// It returns a slice of hostNQNs or an error if the YAML is invalid.
-// Returns nil if the key is absent (caller should not modify hosts).
-// Returns empty slice if the key is present but empty (caller should remove all hosts).
-func parseHostsParameters(params map[string]string) ([]string, error) {
-	allowHostNQNs, exists := params[AllowHostNQNs]
-	if !exists {
-		return nil, nil // Key absent: don't modify existing hosts
-	}
-	if allowHostNQNs == "" {
-		return []string{}, nil // Key present but empty: remove all hosts
-	}
-	var allowHostsList []string
-	if err := yaml.Unmarshal([]byte(allowHostNQNs), &allowHostsList); err != nil {
-		return nil, fmt.Errorf("invalid %s: must be a YAML list of strings: %w", AllowHostNQNs, err)
-	}
-
-	return allowHostsList, nil
-}
-
 // withGatewayConnection is a helper that manages the common pattern of:
 // 1. Getting secrets (with fallback to k8s secret)
 // 2. Getting NVMe-oF metadata
@@ -624,8 +603,12 @@ func (cs *Server) withGatewayConnection(
 	return fn(ctx, gateway, nvmeofData)
 }
 
-// modifyNVMeoFHosts handles adding or removing hosts from the subsystem based on the provided list of host NQNs.
-func (cs *Server) modifyNVMeoFHosts(ctx context.Context, req *csi.ControllerModifyVolumeRequest, hosts []string) error {
+// modifyNVMeoFHosts handles adding or removing hosts from the subsystem based on the provided host list.
+func (cs *Server) modifyNVMeoFHosts(
+	ctx context.Context,
+	req *csi.ControllerModifyVolumeRequest,
+	hostsList *nvmeof.NVMeoFHostList,
+) error {
 	volumeID := req.GetVolumeId()
 
 	return cs.withGatewayConnection(ctx, req, volumeID, func(
@@ -634,9 +617,9 @@ func (cs *Server) modifyNVMeoFHosts(ctx context.Context, req *csi.ControllerModi
 		nvmeofData *nvmeof.NVMeoFVolumeData,
 	) error {
 		log.DebugLog(ctx, "Modifying hosts for subsystem=%s, nsid=%d: desired hosts=%v",
-			nvmeofData.SubsystemNQN, nvmeofData.NamespaceID, hosts)
+			nvmeofData.SubsystemNQN, nvmeofData.NamespaceID, hostsList)
 
-		err := gateway.UpdateHostsForSubsystem(ctx, nvmeofData.SubsystemNQN, hosts)
+		err := gateway.UpdateHostsForSubsystem(ctx, nvmeofData.SubsystemNQN, hostsList.HostNQNs)
 		if err != nil {
 			log.ErrorLog(ctx, "Failed to update hosts for subsystem: %v", err)
 
@@ -647,44 +630,6 @@ func (cs *Server) modifyNVMeoFHosts(ctx context.Context, req *csi.ControllerModi
 
 		return nil
 	})
-}
-
-// parseQoSParameters extracts and parses QoS parameters from the given map.
-func parseQoSParameters(params map[string]string) (*nvmeof.NVMeoFQosVolume, error) {
-	qos := &nvmeof.NVMeoFQosVolume{}
-	hasAnyQoS := false
-
-	parseParam := func(key, name string, dest **uint64) error {
-		if val, exists := params[key]; exists && val != "" {
-			parsed, err := strconv.ParseUint(val, 10, 64)
-			if err != nil {
-				return fmt.Errorf("invalid %s: %w", name, err)
-			}
-			*dest = &parsed
-			hasAnyQoS = true
-		}
-
-		return nil
-	}
-
-	if err := parseParam(nvmeof.RwIosPerSecond, nvmeof.RwIosPerSecond, &qos.RwIosPerSecond); err != nil {
-		return nil, err
-	}
-	if err := parseParam(nvmeof.RwMbytesPerSecond, nvmeof.RwMbytesPerSecond, &qos.RwMbytesPerSecond); err != nil {
-		return nil, err
-	}
-	if err := parseParam(nvmeof.RMbytesPerSecond, nvmeof.RMbytesPerSecond, &qos.RMbytesPerSecond); err != nil {
-		return nil, err
-	}
-	if err := parseParam(nvmeof.WMbytesPerSecond, nvmeof.WMbytesPerSecond, &qos.WMbytesPerSecond); err != nil {
-		return nil, err
-	}
-
-	if !hasAnyQoS {
-		return nil, nil
-	}
-
-	return qos, nil
 }
 
 // modifyNVMeoFQoS handles NVMe-oF gateway QoS modification.
@@ -835,7 +780,7 @@ func (cs *Server) createNVMeoFResources(
 	mutableParams := req.GetMutableParameters()
 	// It take the mutableParams value from the volumeAttributesClassName in the PersistentVolumeClaim yaml.
 	// We already verified in the validateCreateVolumeRequest that there is no RBD QoS
-	nvmeofQoS, err := parseQoSParameters(mutableParams)
+	nvmeofQoS, err := nvmeof.NewNVMeoFQosVolumeFromParams(mutableParams)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to parse NVMe-oF QoS parameters: %v", err)
 
@@ -844,7 +789,7 @@ func (cs *Server) createNVMeoFResources(
 	// If VAC with hosts list is given (for external client)
 	// We need to parse the hosts list and pass it to the gateway for creating host entries
 	// and adding them to the subsystem.
-	hosts, err := parseHostsParameters(mutableParams)
+	hostsList, err := nvmeof.NewNVMeoFHostListFromParams(mutableParams)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to parse NVMe-oF hosts parameters: %v", err)
 
@@ -897,9 +842,9 @@ func (cs *Server) createNVMeoFResources(
 			return nvmeofData, fmt.Errorf("setting QoS limits failed: %w", err)
 		}
 	}
-	if hosts != nil {
-		log.DebugLog(ctx, "Adding hosts to subsystem: %v", hosts)
-		for _, host := range hosts {
+	if hostsList != nil {
+		log.DebugLog(ctx, "Adding hosts to subsystem: %s", hostsList)
+		for _, host := range hostsList.HostNQNs {
 			// TODO - for now we create host with empty DH-CHAP keys,
 			// in the future we can extend the VAC parameters to allow passing DH-CHAP keys for each host if needed??
 			if err := gateway.AddHost(ctx, nvmeofData.SubsystemNQN, host, nvmeof.DHCHAPKeys{}); err != nil {
@@ -1105,15 +1050,6 @@ func getHostNQNFromNodeID(nodeID string) (string, error) {
 
 	return prefix + nodeID, nil
 }
-
-// AllowHostNQNs is the VolumeAttributesClass mutable parameter key for specifying
-// a YAML list of host NQNs to allow access to a volume. Use "*" to allow any host.
-// Example:
-//
-//	allowHostNQNs: |
-//	  - nqn.2014-08.org.nvmexpress:host1
-//	  - nqn.2014-08.org.nvmexpress:host2
-const AllowHostNQNs = "allowHostNQNs"
 
 // VolumeContext metadata keys.
 const (

--- a/internal/nvmeof/controller/hosts_test.go
+++ b/internal/nvmeof/controller/hosts_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/ceph-csi/internal/nvmeof"
+)
+
+func TestParseHostParameters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		params      map[string]string
+		expected    *nvmeof.NVMeoFHostList
+		expectError bool
+	}{
+		{
+			name:     "no allowHostNQNs parameter",
+			params:   map[string]string{},
+			expected: nil,
+		},
+		{
+			name: "empty allowHostNQNs (remove all hosts)",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: "",
+			},
+			expected: &nvmeof.NVMeoFHostList{HostNQNs: []string{}}, // Empty slice, not nil - signals to remove all hosts
+		},
+		{
+			name: "single host NQN",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: `- nqn.2014-08.org.nvmexpress:host1`,
+			},
+			expected: &nvmeof.NVMeoFHostList{
+				HostNQNs: []string{"nqn.2014-08.org.nvmexpress:host1"},
+			},
+		},
+		{
+			name: "multiple host NQNs",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: `- nqn.2014-08.org.nvmexpress:host1
+- nqn.2014-08.org.nvmexpress:host2
+- nqn.2014-08.org.nvmexpress:host3`,
+			},
+			expected: &nvmeof.NVMeoFHostList{
+				HostNQNs: []string{
+					"nqn.2014-08.org.nvmexpress:host1",
+					"nqn.2014-08.org.nvmexpress:host2",
+					"nqn.2014-08.org.nvmexpress:host3",
+				},
+			},
+		},
+		{
+			name: "wildcard to allow any host",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: `- "*"`,
+			},
+			expected: &nvmeof.NVMeoFHostList{
+				HostNQNs: []string{"*"},
+			},
+		},
+		{
+			name: "YAML list in flow style",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: `["nqn.2014-08.org.nvmexpress:host1", "nqn.2014-08.org.nvmexpress:host2"]`,
+			},
+			expected: &nvmeof.NVMeoFHostList{
+				HostNQNs: []string{
+					"nqn.2014-08.org.nvmexpress:host1",
+					"nqn.2014-08.org.nvmexpress:host2",
+				},
+			},
+		},
+		{
+			name: "invalid YAML - not a list (plain string)",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: `nqn.2014-08.org.nvmexpress:host1`,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid YAML - map instead of list",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: `host1: nqn.2014-08.org.nvmexpress:host1`,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid YAML - unclosed quote",
+			params: map[string]string{
+				nvmeof.AllowHostNQNs: `- "nqn.2014-08.org.nvmexpress:host1`,
+			},
+			expectError: true,
+		},
+		{
+			name: "other parameters present but no allowHostNQNs",
+			params: map[string]string{
+				"someOtherParam":       "value",
+				"nvmeofRWIOsPerSecond": "10000",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := nvmeof.NewNVMeoFHostListFromParams(tt.params)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/nvmeof/controller/qos_test.go
+++ b/internal/nvmeof/controller/qos_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Ceph-CSI Authors.
+Copyright 2026 The Ceph-CSI Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -139,113 +139,7 @@ func TestParseQoSParameters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := parseQoSParameters(tt.params)
-
-			if tt.expectError {
-				require.Error(t, err)
-				assert.Nil(t, result)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestParseHostParameters(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		params      map[string]string
-		expected    []string
-		expectError bool
-	}{
-		{
-			name:     "no allowHostNQNs parameter",
-			params:   map[string]string{},
-			expected: nil,
-		},
-		{
-			name: "empty allowHostNQNs (remove all hosts)",
-			params: map[string]string{
-				AllowHostNQNs: "",
-			},
-			expected: []string{}, // Empty slice, not nil - signals to remove all hosts
-		},
-		{
-			name: "single host NQN",
-			params: map[string]string{
-				AllowHostNQNs: `- nqn.2014-08.org.nvmexpress:host1`,
-			},
-			expected: []string{"nqn.2014-08.org.nvmexpress:host1"},
-		},
-		{
-			name: "multiple host NQNs",
-			params: map[string]string{
-				AllowHostNQNs: `- nqn.2014-08.org.nvmexpress:host1
-- nqn.2014-08.org.nvmexpress:host2
-- nqn.2014-08.org.nvmexpress:host3`,
-			},
-			expected: []string{
-				"nqn.2014-08.org.nvmexpress:host1",
-				"nqn.2014-08.org.nvmexpress:host2",
-				"nqn.2014-08.org.nvmexpress:host3",
-			},
-		},
-		{
-			name: "wildcard to allow any host",
-			params: map[string]string{
-				AllowHostNQNs: `- "*"`,
-			},
-			expected: []string{"*"},
-		},
-		{
-			name: "YAML list in flow style",
-			params: map[string]string{
-				AllowHostNQNs: `["nqn.2014-08.org.nvmexpress:host1", "nqn.2014-08.org.nvmexpress:host2"]`,
-			},
-			expected: []string{
-				"nqn.2014-08.org.nvmexpress:host1",
-				"nqn.2014-08.org.nvmexpress:host2",
-			},
-		},
-		{
-			name: "invalid YAML - not a list (plain string)",
-			params: map[string]string{
-				AllowHostNQNs: `nqn.2014-08.org.nvmexpress:host1`,
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid YAML - map instead of list",
-			params: map[string]string{
-				AllowHostNQNs: `host1: nqn.2014-08.org.nvmexpress:host1`,
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid YAML - unclosed quote",
-			params: map[string]string{
-				AllowHostNQNs: `- "nqn.2014-08.org.nvmexpress:host1`,
-			},
-			expectError: true,
-		},
-		{
-			name: "other parameters present but no allowHostNQNs",
-			params: map[string]string{
-				"someOtherParam":       "value",
-				"nvmeofRWIOsPerSecond": "10000",
-			},
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result, err := parseHostsParameters(tt.params)
+			result, err := nvmeof.NewNVMeoFQosVolumeFromParams(tt.params)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/internal/nvmeof/hosts.go
+++ b/internal/nvmeof/hosts.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nvmeof
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+// NVMeoFHostList holds a list of host NQNs that are allowed to access a volume.
+type NVMeoFHostList struct {
+	HostNQNs []string
+}
+
+// AllowHostNQNs is the VolumeAttributesClass mutable parameter key for specifying
+// a YAML list of host NQNs to allow access to a volume. Use "*" to allow any host.
+// Example:
+//
+//	allowHostNQNs: |
+//	  - nqn.2014-08.org.nvmexpress:host1
+//	  - nqn.2014-08.org.nvmexpress:host2
+const AllowHostNQNs = "allowHostNQNs"
+
+// NewNVMeoFHostListFromParams parses the hosts YAML list parameter and validates its contents.
+// Returns:
+//   - nil if the key is absent (caller should not modify existing hosts)
+//   - *NVMeoFHostList with empty HostNQNs slice if key is present but empty (caller should remove all hosts)
+//   - *NVMeoFHostList with populated HostNQNs slice if hosts are specified
+func NewNVMeoFHostListFromParams(params map[string]string) (*NVMeoFHostList, error) {
+	allowHostNQNs, exists := params[AllowHostNQNs]
+	if !exists {
+		return nil, nil // Key absent: don't modify existing hosts
+	}
+	if allowHostNQNs == "" {
+		return &NVMeoFHostList{HostNQNs: []string{}}, nil // Key present but empty: remove all hosts
+	}
+
+	var allowHostsList []string
+	if err := yaml.Unmarshal([]byte(allowHostNQNs), &allowHostsList); err != nil {
+		return nil, fmt.Errorf("invalid %s: must be a YAML list of strings: %w", AllowHostNQNs, err)
+	}
+
+	return &NVMeoFHostList{HostNQNs: allowHostsList}, nil
+}
+
+// String returns a string representation of the host list.
+func (h *NVMeoFHostList) String() string {
+	if h == nil {
+		return "nil"
+	}
+	if len(h.HostNQNs) == 0 {
+		return "no hosts"
+	}
+	if len(h.HostNQNs) == 1 && h.HostNQNs[0] == "*" {
+		return "all hosts (*)"
+	}
+
+	return fmt.Sprintf("%d host(s): %s", len(h.HostNQNs), strings.Join(h.HostNQNs, ", "))
+}

--- a/internal/nvmeof/qos.go
+++ b/internal/nvmeof/qos.go
@@ -17,6 +17,7 @@ package nvmeof
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -37,6 +38,45 @@ const (
 	RMbytesPerSecond  = "rMbytesPerSecond"
 	WMbytesPerSecond  = "wMbytesPerSecond"
 )
+
+// NewNVMeoFQosVolumeFromParams extracts and parses QoS parameters from the given map
+// and returns a new NVMeoFQosVolume instance. Returns nil if no QoS parameters are found.
+func NewNVMeoFQosVolumeFromParams(params map[string]string) (*NVMeoFQosVolume, error) {
+	qos := &NVMeoFQosVolume{}
+	hasAnyQoS := false
+
+	parseParam := func(key, name string, dest **uint64) error {
+		if val, exists := params[key]; exists && val != "" {
+			parsed, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid %s: %w", name, err)
+			}
+			*dest = &parsed
+			hasAnyQoS = true
+		}
+
+		return nil
+	}
+
+	if err := parseParam(RwIosPerSecond, RwIosPerSecond, &qos.RwIosPerSecond); err != nil {
+		return nil, err
+	}
+	if err := parseParam(RwMbytesPerSecond, RwMbytesPerSecond, &qos.RwMbytesPerSecond); err != nil {
+		return nil, err
+	}
+	if err := parseParam(RMbytesPerSecond, RMbytesPerSecond, &qos.RMbytesPerSecond); err != nil {
+		return nil, err
+	}
+	if err := parseParam(WMbytesPerSecond, WMbytesPerSecond, &qos.WMbytesPerSecond); err != nil {
+		return nil, err
+	}
+
+	if !hasAnyQoS {
+		return nil, nil
+	}
+
+	return qos, nil
+}
 
 // String returns a string representation of the NVMeoFQosVolume.
 func (q *NVMeoFQosVolume) String() string {


### PR DESCRIPTION
Move NVMe-oF QoS and host-list parsing out of the controller into dedicated package types,
and split the related tests into focused files.
fix issue: https://github.com/ceph/ceph-csi/issues/6302

the issue is actually this comment from [discussion_r3318503744](https://github.com/ceph/ceph-csi/pull/6251#discussion_r3318503744)

> nixpanic
> on May 28
> You could consider moving all QoS related structs/functions to qos.go to keep is a little better organized.


