### PR TITLE
doc: enable emoji images in the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,9 @@ theme:
 markdown_extensions:
   - admonition
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.superfences
   - pymdownx.highlight:
       anchor_linenums: true


### PR DESCRIPTION
`csi-addons/disaster-recovery.md` (and maybe others) use emoji's like
:bulb: for information notes. These were not rendered in the
documentation, but with these plugins the are.
