### PR TITLE
docs: improve linking of the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ attaching them to workloads.
 Independent CSI plugins are provided to support RBD and CephFS backed volumes,
 
 - For details about configuration and deployment of RBD plugin, please refer
-  [rbd doc](https://github.com/ceph/ceph-csi/blob/devel/docs/rbd/deploy.md) and
+  [rbd doc](https://ceph.github.io/ceph-csi/rbd/deploy/) and
   for CephFS plugin configuration and deployment please
-  refer [cephFS doc](https://github.com/ceph/ceph-csi/blob/devel/docs/cephfs/deploy.md).
+  refer [cephFS doc](https://ceph.github.io/ceph-csi/cephfs/deploy/).
 - For example usage of the RBD and CephFS CSI plugins, see examples in `examples/`.
-- Stale resource cleanup, please refer [cleanup doc](docs/resource-cleanup.md).
+- Stale resource cleanup, please refer [cleanup doc](https://ceph.github.io/ceph-csi/resource-cleanup/).
 
 NOTE:
 
@@ -204,8 +204,8 @@ in the Kubernetes documentation.
 
 ## Contributing to this repo
 
-Please follow [development-guide](<https://github.com/ceph/ceph-csi/tree/devel/docs/development-guide.md>)
-and [coding style guidelines](<https://github.com/ceph/ceph-csi/tree/devel/docs/coding.md>)
+Please follow [development-guide](https://ceph.github.io/ceph-csi/development-guide/)
+and [coding style guidelines](https://ceph.github.io/ceph-csi/coding/)
 if you are interested to contribute to this repo.
 
 ## Troubleshooting

--- a/docs/cephfs/deploy.md
+++ b/docs/cephfs/deploy.md
@@ -84,7 +84,7 @@ you're running it inside a k8s cluster and find the config itself).
 | `extraDeploy` | no | array of extra objects to deploy with the release |
 
 **NOTE:** An accompanying CSI configuration file, needs to be provided to the
-running pods. Refer to [Creating CSI configuration](../../examples/README.md#creating-csi-configuration)
+running pods. Refer to [Creating CSI configuration](https://github.com/ceph/ceph-csi/blob/devel/examples/README.md#creating-csi-configuration)
 for more information.
 
 **NOTE:** A suggested way to populate and retain uniqueness of the clusterID is
@@ -141,7 +141,7 @@ kubectl create -f csi-config-map.yaml
 
 The configmap deploys an empty CSI configuration that is mounted as a volume
 within the Ceph CSI plugin pods. To add a specific Ceph clusters configuration
-details, refer to [Creating CSI configuration](../../examples/README.md#creating-csi-configuration)
+details, refer to [Creating CSI configuration](https://github.com/ceph/ceph-csi/blob/devel/examples/README.md#creating-csi-configuration)
 for more information.
 
 **Deploy Ceph configuration ConfigMap for CSI pods:**
@@ -203,7 +203,9 @@ service/csi-cephfsplugin-provisioner   ClusterIP   10.101.78.75     <none>      
 
 Once the CSI plugin configuration is updated with details from a Ceph cluster of
 choice, you can try deploying a demo pod from examples/cephfs using the
-instructions [provided](../../examples/README.md#deploying-the-storage-class) to
+instructions
+[provided](https://github.com/ceph/ceph-csi/blob/devel/examples/README.md#deploying-the-storage-class)
+to
 test the deployment further.
 
 ### Notes on volume deletion

--- a/docs/csi-addons/disaster-recovery.md
+++ b/docs/csi-addons/disaster-recovery.md
@@ -197,7 +197,7 @@ status:
    * Create storageclass on the secondary cluster
 
   ```bash
-    kubectl create -f examples/rbd/storageclass.yaml --context=cluster-2
+    kubectl create -f https://raw.githubusercontent.com/ceph/ceph-csi/devel/examples/rbd/storageclass.yaml --context=cluster-2
 
    storageclass.storage.k8s.io/csi-rbd-sc created
   ```

--- a/docs/design/proposals/encryption-with-vault-sa.md
+++ b/docs/design/proposals/encryption-with-vault-sa.md
@@ -14,7 +14,7 @@ KMS implementation. Or, if changes would be minimal, a configuration option to
 one of the implementations can be added.
 
 Different KMS implementations and their configurable options can be found at
-[`csi-kms-connection-details.yaml`](../../../examples/kms/vault/csi-kms-connection-details.yaml)
+[`csi-kms-connection-details.yaml`](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/csi-kms-connection-details.yaml)
 .
 
 ### VaultTokensKMS
@@ -24,17 +24,18 @@ Different KMS implementations and their configurable options can be found at
 - fetches a Secret from the Tenants (volume owner) namespace
 
 An example of the per Tenant configuration options are in
-[`tenant-config.yaml`](../../../examples/kms/vault/tenant-config.yaml) and
-[`tenant-token.yaml`](../../../examples/kms/vault/tenant-token.yaml).
+[`tenant-config.yaml`](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/tenant-config.yaml)
+and
+[`tenant-token.yaml`](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/tenant-token.yaml).
 
-Implementation is in [`vault_tokens.go`](../../../internal/kms/vault_tokens.go)
+Implementation is in [`vault_tokens.go`](https://github.com/ceph/ceph-csi/blob/devel/internal/kms/vault_tokens.go)
 .
 
 ### Vault
 
 - uses Kubernetes Auth with single service account (aka storage admin account)
 
-Implementation is in [`vault.go`](../../../internal/kms/vault.go).
+Implementation is in [`vault.go`](https://github.com/ceph/ceph-csi/blob/devel/internal/kms/vault.go).
 
 ## Extension or New KMS implementation
 
@@ -67,7 +68,7 @@ read the contents of the ServiceAccount(s) in the Tenants namespace.
    parameter
 1. a ConfigMap in the namespace of the Ceph-CSI deployment contains the KMS
    configuration for the `kmsID`
-   ([`csi-kms-connection-details.yaml`](../../../examples/kms/vault/csi-kms-connection-details.yaml))
+([`csi-kms-connection-details.yaml`](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/csi-kms-connection-details.yaml))
 
 When Ceph-CSI receives a `CreateVolume` request, the parameters from the
 StorageClass and details about the requested Volume are available. The Ceph-CSI

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -100,7 +100,7 @@ make image-cephcsi
 | `extraDeploy` | no | array of extra objects to deploy with the release |
 
 **NOTE:** An accompanying CSI configuration file, needs to be provided to the
-running pods. Refer to [Creating CSI configuration](../../examples/README.md#creating-csi-configuration)
+running pods. Refer to [Creating CSI configuration](https://github.com/ceph/ceph-csi/blob/devel/examples/README.md#creating-csi-configuration)
 for more information.
 
 **NOTE:** A suggested way to populate and retain uniqueness of the clusterID is
@@ -152,7 +152,7 @@ kubectl create -f csi-config-map.yaml
 The configmap deploys an empty CSI configuration that is mounted as a volume
 within the Ceph CSI plugin pods. To add a specific Ceph clusters configuration
 details, refer to [Creating CSI configuration for RBD based
-provisioning](../../examples/README.md#creating-csi-configuration)
+provisioning](https://github.com/ceph/ceph-csi/blob/devel/examples/README.md#creating-csi-configuration)
 for more information.
 
 **Deploy Ceph configuration ConfigMap for CSI pods:**
@@ -214,8 +214,9 @@ service/csi-rbdplugin-provisioner   ClusterIP   10.104.2.130   <none>        808
 
 Once the CSI plugin configuration is updated with details from a Ceph cluster of
 choice, you can try deploying a demo pod from examples/rbd using the
-instructions [provided](../../examples/README.md#deploying-the-storage-class) to
-test the deployment further.
+instructions
+[provided](https://github.com/ceph/ceph-csi/blob/devel/examples/README.md#deploying-the-storage-class)
+to test the deployment further.
 
 ## Deployment with Helm
 
@@ -318,7 +319,7 @@ of the volume.
 To encrypt rbd volumes with `metadata` encryption, users need to set
 `encrypted: "true"` and `encryptionKMSID` to a unique identifier in storageclass.
 This unique identifier should be similar to the
-[examples](../../examples/kms/vault/csi-kms-connection-details.yaml).
+[examples](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/csi-kms-connection-details.yaml).
 The configuration must include `"encryptionKMSType": "metadata"`. The
 `encryptionPassphrase` is fetched based on the following conditions:
 
@@ -345,7 +346,8 @@ There are two options to use Hashicorp Vault as a KMS:
 
 To use Vault as KMS set `encryptionKMSID` to a unique identifier for Vault
 configuration. You will also need to create vault configuration similar to the
-[example](../../examples/kms/vault/kms-config.yaml) and use same
+[example](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml)
+and use same
 `encryptionKMSID`.
 
 To use the Kubernetes ServiceAccount to access Vault, the configuration must
@@ -366,7 +368,7 @@ client can be instantiated to delete passphrase on volume delete)
 When the Tenants need to provide their own Vault Token, they will need to place
 it in a Kubernetes Secret (by default) called `ceph-csi-kms-token`, where the
 Vault Token is stored in the `token` key as shown in [the
-example](../../examples/kms/vault/tenant-token.yaml).
+example](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/tenant-token.yaml).
 
 #### Configuring HashiCorp Vault with a single Kubernetes ServiceAccount
 
@@ -376,7 +378,8 @@ documentation](https://www.vaultproject.io/docs/auth/kubernetes.html).
 
 If token reviewer is used, you will need to configure service account for
 that also like in
-[example](../../examples/kms/vault/csi-vaulttokenreview-rbac.yaml) to be able to
+[example](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/csi-vaulttokenreview-rbac.yaml)
+to be able to
 review jwt tokens.
 
 Configure a role(s) for service accounts used for ceph-csi:
@@ -396,7 +399,8 @@ ServiceAccount is expected to be called `ceph-csi-vault-sa` by default. This
 can be changed by setting the `tenantSAName` option to a different value. An
 example of the global configuration that can be done in the Kubernetes
 Namespace where Ceph-CSI is deployed can be found in
-[`kms-config.yaml`](../../examples/kms/vault/kms-config.yaml) where the
+[`kms-config.yaml`](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml)
+where the
 `encryptionKMSType` is set to `vaulttenantsa`.
 
 Most notably, the Vault Tokens KMS configuration can be used, without the Token
@@ -406,13 +410,15 @@ Tenants do have the ability to reconfigure parts of the connection details to
 the Vault service. It will often be required to set the backend path to a
 location where the Tenant can manage the secrets. These changes can be done by
 placing a ConfigMap called `ceph-csi-kms-config` in the Tenants Namespace, an
-[example](../../examples/kms/vault/tenant-sa.yaml) is available.
+[example](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/tenant-sa.yaml)
+is available.
 
 As each ServiceAccount needs to be added to the Vault configuration, the
 administrator of the service will need to apply the permissions by creating a
 Vault Policy that allows a ServiceAccount to access a key-value store in the
 KMS. In the Ceph-CSI automated testing, there is [a Kubernetes Job that sets
-this up](../../examples/kms/vault/tenant-token.yaml) for a single Tenant that uses
+this up](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/tenant-token.yaml)
+for a single Tenant that uses
 the Kubernetes Namespace `tenant`.
 
 #### Configuring Amazon KMS
@@ -425,7 +431,7 @@ passphrase, after which it can be used to open the device with `cryptsetup` and
 provide access to it for the Pod.
 
 There are a few settings that need to be included in the [KMS configuration
-file](../../examples/kms/vault/kms-config.yaml):
+file](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kms-config.yaml):
 
 1. `KMS_PROVIDER`: should be set to `aws-metadata`.
 1. `KMS_SECRET_NAME`: name of the Kubernetes Secret (in the Namespace where
@@ -433,7 +439,9 @@ file](../../examples/kms/vault/kms-config.yaml):
    AWS. This defaults to `ceph-csi-aws-credentials`.
 1. `AWS_REGION`: the region where the AWS KMS service is available.
 
-The [Secret with credentials](../../examples/kms/vault/aws-credentials.yaml) for
+The
+[Secret with credentials](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/aws-credentials.yaml)
+for
 the AWS KMS is expected to contain:
 
 1. `AWS_ACCESS_KEY_ID`: ID of the key to use for encrypting/decrypting
@@ -462,7 +470,8 @@ file](../../examples/kms/vault/kms-config.yaml):
    AWS. This defaults to `ceph-csi-aws-credentials`.
 
 The [Secret with
-credentials](../../examples/kms/vault/aws-sts-credentials.yaml) for the AWS KMS
+credentials](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/aws-sts-credentials.yaml)
+for the AWS KMS
 is expected to contain:
 
 1. `awsRoleARN`: Role which will be used access credentials from AWS STS
@@ -492,7 +501,9 @@ file](../../examples/kms/vault/kms-config.yaml):
    created in Azure Active Directory that serves as the username.
 1. `AZURE_TENANT_ID`: Tenant ID of the service principal.
 
-The [Secret with credentials](../../examples/kms/vault/azure-credentials.yaml) for
+The
+[Secret with credentials](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/azure-credentials.yaml)
+for
 the Azure KMS is expected to contain:
 
 1. `CLIENT_CERT`: The client certificate used for authentication
@@ -529,7 +540,9 @@ file](../../examples/kms/vault/kms-config.yaml):
 1. `WRITE_TIMEOUT`(optional): Network write timeout, in seconds. The default
    value is 10.
 
-The [Secret with credentials](../../examples/kms/vault/kmip-credentials.yaml) for
+The
+[Secret with credentials](https://github.com/ceph/ceph-csi/blob/devel/examples/kms/vault/kmip-credentials.yaml)
+for
 the KMIP KMS is expected to contain:
 
 1. `CA_CERT`: CA certificate that will be used to connect to KMIP server.

--- a/docs/snap-clone.md
+++ b/docs/snap-clone.md
@@ -47,7 +47,7 @@
 ### Create CephFS SnapshotClass
 
 ```console
-kubectl create -f ../examples/cephfs/snapshotclass.yaml
+kubectl create -f https://raw.githubusercontent.com/ceph/ceph-csi/devel/examples/cephfs/snapshotclass.yaml
 ```
 
 ### Create CephFS Snapshot
@@ -70,7 +70,7 @@ csi-cephfs-pvc    Bound         pvc-1ea51547-a88b-4ab0-8b4a-812caeaf025d   1Gi  
 - Create snapshot of the bound PVC
 
 ```console
-$ kubectl create -f ../examples/cephfs/snapshot.yaml
+$ kubectl create -f https://raw.githubusercontent.com/ceph/ceph-csi/devel/examples/cephfs/snapshot.yaml
 volumesnapshot.snapshot.storage.k8s.io/cephfs-pvc-snapshot created
 ```
 
@@ -95,7 +95,7 @@ snapcontent-881cb74a-9dff-4989-a83d-eece5ed079af   true         1073741824    De
 ### Restore CephFS Snapshot
 
 ```console
-kubectl create -f ../examples/cephfs/pvc-restore.yaml
+kubectl create -f https://raw.githubusercontent.com/ceph/ceph-csi/devel/examples/cephfs/pvc-restore.yaml
 ```
 
 ```console
@@ -108,7 +108,7 @@ cephfs-pvc-restore   Bound    pvc-95308c75-6c93-4928-a551-6b5137192209   1Gi    
 ### Clone CephFS PVC
 
 ```console
-kubectl create -f ../examples/cephfs/pvc-clone.yaml
+kubectl create -f https://raw.githubusercontent.com/ceph/ceph-csi/devel/examples/cephfs/pvc-clone.yaml
 ```
 
 ```console
@@ -122,8 +122,8 @@ cephfs-pvc-restore   Bound    pvc-95308c75-6c93-4928-a551-6b5137192209   1Gi    
 ## Create RBD Snapshot and Clone Volume
 
 In the `examples/rbd` directory you will find two files related to snapshots:
-[snapshotclass.yaml](../examples/rbd/snapshotclass.yaml)
-and [snapshot.yaml](../examples/rbd/snapshot.yaml)
+[snapshotclass.yaml](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/snapshotclass.yaml)
+and [snapshot.yaml](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/snapshot.yaml)
 
 Once you created RBD PVC, you'll need to customize `snapshotclass.yaml` and
 make sure the `clusterid` parameter matches `clusterid` mentioned in the
@@ -165,8 +165,8 @@ rbd-pvc-snapshot   true         rbd-pvc                             1Gi         
 ### Restore RBD Snapshot
 
 To restore the snapshot to a new PVC, create
-[pvc-restore.yaml](../examples/rbd/pvc-restore.yaml)
-and a testing pod [pod-restore.yaml](../examples/rbd/pod-restore.yaml)
+[pvc-restore.yaml](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/pvc-restore.yaml)
+and a testing pod [pod-restore.yaml](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/pod-restore.yaml)
 
 ```bash
 kubectl create -f pvc-restore.yaml
@@ -176,7 +176,7 @@ kubectl create -f pod-restore.yaml
 ### Clone RBD PVC
 
 ```console
-$ kubectl create -f ../examples/rbd/pvc-clone.yaml
+$ kubectl create -f https://raw.githubusercontent.com/ceph/ceph-csi/devel/examples/rbd/pvc-clone.yaml
 $ kubectl get pvc
 NAME              STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
 rbd-pvc           Bound     pvc-c2ffdc98-3abe-4b07-838c-35a2a8067771   1Gi        RWO            rook-ceph-block   41m


### PR DESCRIPTION

Update README.md with references to published documentation on
https://ceph.github.io/ceph-csi/

Replace relative paths to examples with direct GitHub URLs pointing to the
devel branch. The links were broken as the examples are not included in the
documentation directory.
