### PR TITLE
nvmeof: make node DH-CHAP auth get-only

### DIFF
--- a/internal/nvmeof/dhchap.go
+++ b/internal/nvmeof/dhchap.go
@@ -110,7 +110,7 @@ func GetOrCreateDHCHAPHostKey(
 	hostNQN string,
 ) (string, error) {
 	// Try to get existing key
-	hostKey, err := getDHCHAPHostKey(ctx, skm, nodeID, subsystemNQN)
+	hostKey, err := GetDHCHAPHostKey(ctx, skm, nodeID, subsystemNQN)
 	if err == nil {
 		// Key exists, return it
 		return hostKey, nil
@@ -146,7 +146,7 @@ func GetOrCreateDHCHAPSubsystemKey(
 	hostNQN string,
 ) (string, error) {
 	// Try to get existing key
-	subsystemKey, err := getDHCHAPSubsystemKey(ctx, skm, nodeID, subsystemNQN)
+	subsystemKey, err := GetDHCHAPSubsystemKey(ctx, skm, nodeID, subsystemNQN)
 	if err == nil {
 		// Key exists, return it
 		return subsystemKey, nil
@@ -327,7 +327,7 @@ func buildDHCHAPKeyID(
 	return fmt.Sprintf("%s-%s-%s", prefix, nodeID, subsystemHash)
 }
 
-func getDHCHAPHostKey(
+func GetDHCHAPHostKey(
 	ctx context.Context,
 	skm SecurityKeyManager,
 	nodeID string,
@@ -339,7 +339,7 @@ func getDHCHAPHostKey(
 	return skm.GetKey(ctx, keyID)
 }
 
-func getDHCHAPSubsystemKey(
+func GetDHCHAPSubsystemKey(
 	ctx context.Context,
 	skm SecurityKeyManager,
 	nodeID string,

--- a/internal/nvmeof/nodeserver/security.go
+++ b/internal/nvmeof/nodeserver/security.go
@@ -81,7 +81,7 @@ func (ns *NodeServer) setupDHCHAPAuth(
 	}
 
 	// Get host key
-	hostKey, err := nvmeof.GetOrCreateDHCHAPHostKey(ctx, securityKeys, ns.nodeID, info.SubsystemNQN, connectReq.HostNQN)
+	hostKey, err := nvmeof.GetDHCHAPHostKey(ctx, securityKeys, ns.nodeID, info.SubsystemNQN)
 	if err != nil {
 		return fmt.Errorf("failed to get DHCHAP host key: %w", err)
 	}
@@ -89,8 +89,7 @@ func (ns *NodeServer) setupDHCHAPAuth(
 
 	// Get subsystem key for bidirectional mode
 	if info.DhchapMode == nvmeof.DHCHAPModeBiDirectional {
-		subsystemKey, err := nvmeof.GetOrCreateDHCHAPSubsystemKey(ctx, securityKeys, ns.nodeID,
-			info.SubsystemNQN, connectReq.HostNQN)
+		subsystemKey, err := nvmeof.GetDHCHAPSubsystemKey(ctx, securityKeys, ns.nodeID, info.SubsystemNQN)
 		if err != nil {
 			return fmt.Errorf("failed to get DH-CHAP subsystem key: %w", err)
 		}


### PR DESCRIPTION
Avoid generating DH-CHAP keys on node stage.
controller remains the key creator to prevent gateway/KMS key drift.

Fixes: #6288