### PR TITLE
rbd: open image as read-only for snapshot metadata operations

### DIFF
--- a/internal/rbd/snap_diff.go
+++ b/internal/rbd/snap_diff.go
@@ -42,7 +42,7 @@ func (rbdSnap *rbdSnapshot) ProcessMetadata(
 ) error {
 	var fromSnapID uint64
 
-	image, err := rbdSnap.open()
+	image, err := rbdSnap.openReadOnly()
 	if err != nil {
 		return fmt.Errorf("failed to open image %q: %w", rbdSnap, err)
 	}


### PR DESCRIPTION
## Summary
- `ProcessMetadata` only reads block diffs via `DiffIterateByID` — never writes
- Currently opens image read-write via `open()`, acquiring exclusive lock unnecessarily
- Switch to `openReadOnly()` (`librbd.OpenImageReadOnly`) to avoid lock contention when volume is mounted

## Test plan
- [x] Built custom ceph-csi image with change
- [x] Deployed on ODF 4.23 cluster
- [x] Tested `GetMetadataAllocated` — returns correct allocated blocks
- [x] Tested `GetMetadataDelta` — returns correct changed blocks between snapshots
- [x] Block-mode PVC: exact 1:1 block correlation confirmed