### PR TITLE
ci: set e2e timeout to 240 minutes

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -197,7 +197,7 @@ node('cico-workspace') {
 			}
 		}
 		stage('run e2e') {
-			timeout(time: 210, unit: 'MINUTES') {
+			timeout(time: 240, unit: 'MINUTES') {
 				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
 					t_type = '--test-cephfs=true --test-rbd=false --test-nfs=false'

--- a/mini-e2e-operator.groovy
+++ b/mini-e2e-operator.groovy
@@ -197,7 +197,7 @@ node('cico-workspace') {
 			}
 		}
 		stage('run e2e') {
-			timeout(time: 210, unit: 'MINUTES') {
+			timeout(time: 240, unit: 'MINUTES') {
 				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
 					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -184,7 +184,7 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
 		}
 		stage('run e2e') {
-			timeout(time: 210, unit: 'MINUTES') {
+			timeout(time: 240, unit: 'MINUTES') {
 				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
 					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"


### PR DESCRIPTION
The e2e runs take very close to 3 and a half hours, and sometimes even
longer. Set it to 4 hours so that there is less need to re-run jobs.

Example: https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/organizations/jenkins/mini-e2e_k8s-1.36/detail/mini-e2e_k8s-1.36/69/pipeline/90

Longest Running Steps:

 1. Cgroup QoS Testing Suite (~11.5 minutes) - LONGEST
    - Time: 11:58:09 to 12:09:34
    - Includes multiple sub-tests for RWO/RWOP volumes, VAC modifications, encrypted volumes, etc.

 2. CephFS Test Suite Transition (~9 minutes)
    - Time: 09:09:53 to 09:18:50
    - Between destroying namespace "cephfs-6235" and "cephfs-4176"

 3. RBD Topology Testing (~7.5 minutes)
    - Time: 10:56:24 to 11:04:00
    - Testing CSI topology with delayed binding mode and topology-specific pools
