### PR TITLE
build: rebase cephcsi container image to Rocky Linux 10

### DIFF
--- a/build.env
+++ b/build.env
@@ -24,7 +24,7 @@ CSI_UPGRADE_VERSION=v3.16.2
 CEPH_CSI_OPERATOR_VERSION=latest
 
 # Ceph version to use
-BASE_IMAGE=docker.io/rockylinux/rockylinux:10
+BASE_IMAGE=quay.io/rockylinux/rockylinux:10
 CEPH_VERSION=tentacle
 
 # standard Golang options

--- a/build.env
+++ b/build.env
@@ -24,7 +24,7 @@ CSI_UPGRADE_VERSION=v3.16.2
 CEPH_CSI_OPERATOR_VERSION=latest
 
 # Ceph version to use
-BASE_IMAGE=quay.io/ceph/ceph:v20
+BASE_IMAGE=docker.io/rockylinux/rockylinux:10
 CEPH_VERSION=tentacle
 
 # standard Golang options

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,7 +1,7 @@
 ARG SRC_DIR="/go/src/github.com/ceph/ceph-csi/"
 ARG GO_ARCH
 ARG BASE_IMAGE
-ARG FINAL_BASE_IMAGE="docker.io/rockylinux/rockylinux:10-minimal"
+ARG FINAL_BASE_IMAGE="quay.io/rockylinux/rockylinux:10-minimal"
 
 FROM ${BASE_IMAGE} as updated_base
 

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -1,24 +1,18 @@
 ARG SRC_DIR="/go/src/github.com/ceph/ceph-csi/"
 ARG GO_ARCH
 ARG BASE_IMAGE
-ARG FINAL_BASE_IMAGE="quay.io/centos/centos:stream9-minimal"
+ARG FINAL_BASE_IMAGE="docker.io/rockylinux/rockylinux:10-minimal"
 
 FROM ${BASE_IMAGE} as updated_base
 
-# TODO: remove the following cmd, when issues
-# https://github.com/ceph/ceph-container/issues/2034
-# https://github.com/ceph/ceph-container/issues/2141 are fixed.
-RUN true \
-    && dnf -y reinstall https://download.ceph.com/rpm-${CEPH_VERSION}/el9/noarch/ceph-release-1-1.el9.noarch.rpm \
-    && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
-    && true
+ARG CEPH_VERSION
 
-RUN mkdir -p /etc/selinux && touch /etc/selinux/config
-
-RUN dnf -y update --nobest \
-       && dnf -y install nfs-utils \
-       && dnf clean all \
-       && rm -rf /var/cache/yum
+RUN rpm -ivh https://download.ceph.com/rpm-${CEPH_VERSION}/el10/noarch/ceph-release-1-0.el10.noarch.rpm \
+    && dnf -y install epel-release \
+    && dnf -y update --nobest \
+    && dnf -y install --enablerepo=crb --setopt=install_weak_deps=False nfs-utils \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf /var/cache/yum
 
 FROM updated_base as builder
 
@@ -45,7 +39,7 @@ RUN ${GOROOT}/bin/go version && ${GOROOT}/bin/go env
 # other/conflicting versions of protobuf get installed as dependency
 RUN dnf -y remove protobuf
 
-RUN dnf -y install --nodocs \
+RUN dnf -y install --enablerepo=crb --nodocs \
 	librados-devel librbd-devel libcephfs-devel \
 	/usr/bin/cc \
 	make \
@@ -85,9 +79,9 @@ LABEL maintainers="Ceph-CSI Authors" \
 COPY --from=builder ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi
 
 RUN true \
-  && rpm -ivh https://download.ceph.com/rpm-${CEPH_VERSION}/el9/noarch/ceph-release-1-1.el9.noarch.rpm \
+  && rpm -ivh https://download.ceph.com/rpm-${CEPH_VERSION}/el10/noarch/ceph-release-1-0.el10.noarch.rpm \
   && microdnf -y install kmod nfs-utils nvme-cli epel-release psmisc e2fsprogs xfsprogs cryptsetup attr --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
-  && microdnf -y install thrift librados2 librbd1 libcephfs2 ceph-common ceph-fuse rbd-nbd --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
+  && microdnf -y install --enablerepo=crb thrift librados2 librbd1 libcephfs2 ceph-common ceph-fuse rbd-nbd --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
   && microdnf clean all \
   && true
 

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -19,32 +19,24 @@ RUN source /build.env \
     && go version \
     && true
 
-# TODO: remove the following cmd, when issues
-# https://github.com/ceph/ceph-container/issues/2034
-# https://github.com/ceph/ceph-container/issues/2141 are fixed.
-RUN true \
-    && dnf -y reinstall https://download.ceph.com/rpm-${CEPH_VERSION}/el9/noarch/ceph-release-1-1.el9.noarch.rpm \
-    && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
-    && true
-
-RUN mkdir -p /etc/selinux && touch /etc/selinux/config
-
 # other/conflicting versions of protobuf get installed as dependency
 RUN dnf -y remove protobuf
 
 RUN source /build.env \
-    && dnf -y install \
+    && rpm -ivh https://download.ceph.com/rpm-${CEPH_VERSION}/el10/noarch/ceph-release-1-0.el10.noarch.rpm \
+    && dnf -y install epel-release \
+    && dnf -y --nobest update \
+    && dnf -y install --enablerepo=crb \
 	git \
 	make \
 	gcc \
 	librados-devel \
-        libcephfs-devel \
+	libcephfs-devel \
 	librbd-devel \
 	python3-pip \
-    && dnf -y --nobest update \
     && pip install mkdocs-material==${MKDOCS_MATERIAL} \
     && dnf clean all \
-    && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/dnf /var/cache/yum \
     && true
 
 WORKDIR "/go/src/github.com/ceph/ceph-csi"


### PR DESCRIPTION
The cephcsi image still built on CentOS Stream 9 packages while upstream Ceph has moved to Rocky Linux 10.

This change moves the builder and final stage to Rocky Linux 10, install Tentacle client RPMs from the el10 ceph-release repo, and enable CRB repo.

This drops the el9 ceph:v20 builder base and the stream9-minimal final image in favour of rockylinux:10 and rockylinux:10-minimal.

Fixes #6411

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
