### PR TITLE
ci: mirror+pull Rocky Linux 10 container images

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -177,6 +177,8 @@ node('cico-workspace') {
 			// busybox is used in external storage testing
 			podman_pull(ci_registry, "docker.io", "library/busybox:1.29")
 			ssh "./podman2minikube.sh docker.io/library/busybox:1.29"
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
+			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('deploy ceph-csi through operator') {
 			def operator_version = sh(

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -185,6 +185,8 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
+			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('deploy ceph-csi through helm') {
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e-operator.groovy
+++ b/mini-e2e-operator.groovy
@@ -182,6 +182,8 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
+			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('deploy ceph-csi through operator') {
 			def operator_version = sh(

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -182,6 +182,8 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
+			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('run e2e') {
 			timeout(time: 240, unit: 'MINUTES') {

--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -27,3 +27,6 @@ docker.io/library/busybox:1.29	library/busybox:1.29
 docker.io/library/nginx:latest	library/nginx:latest
 docker.io/library/vault:latest	library/vault:latest
 docker.io/library/vault:1.8.5	library/vault:1.8.5
+
+# Ceph base OS
+docker.io/rockylinux/rockylinux:10-minimal	rockylinux/rockylinux:10-minimal

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -182,6 +182,8 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
+			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage("set csi-upgrade-version from build.env") {
 			def build_env_csi_upgrade_version = sh(


### PR DESCRIPTION
The next Ceph Tentacle update uses Rocky Linux 10 as a base image.
Ceph-CSI should do so too.

See-also: #6411
