### PR TITLE
cephfs: avoid hanging os.Stat() in NodeGetVolumeStats after restart

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -941,8 +941,10 @@ func (ns *cephfsNodeServer) NodeGetVolumeStats(
 	// health check first, return without stats if unhealthy
 	healthy, msg := ns.healthChecker.IsHealthy(volumeID, targetPath)
 
-	// If healthy and an error is returned, it means that the checker was not
-	// started. This could happen when the node-plugin was restarted and the
+	// If healthy and an error is returned, it either means that the checker
+	// was not started or it is running but has not completed its
+	// first health-check cycle yet.
+	// This could happen when the node-plugin was restarted and the
 	// volume is already staged and published.
 	if healthy && msg != nil {
 		// Start a StatChecker for the mounted targetPath, this prevents
@@ -950,10 +952,27 @@ func (ns *cephfsNodeServer) NodeGetVolumeStats(
 		// FileChecker is started with the stagingTargetPath, but we can't
 		// get the stagingPath from the request easily.
 		// TODO: resolve the stagingPath like rbd.getStagingPath() does
+		// NOTE: rbd.getStagingPath() uses os.Stat() internally which
+		// if called synchronously, could block indefinitely.
+
+		// Start the background checker but return
+		// immediately instead of calling os.Stat() on this goroutine.
+		// If the mount is unresponsive, os.Stat() would block,
+		// holding the VolumeLock (acquired above) and preventing all future
+		// calls for this path from reaching isHealthy().
+		// The background checker will do the stat(), the next periodic
+		// call will pick up the result (or detect the timeout).
 		err = ns.healthChecker.StartChecker(req.GetVolumeId(), targetPath, hc.StatCheckerType)
 		if err != nil {
 			log.WarningLog(ctx, "failed to start healthchecker: %v", err)
 		}
+
+		return &csi.NodeGetVolumeStatsResponse{
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: false,
+				Message:  "health checker started, status not yet available",
+			},
+		}, nil
 	}
 
 	// !healthy indicates a problem with the volume
@@ -966,7 +985,8 @@ func (ns *cephfsNodeServer) NodeGetVolumeStats(
 		}, nil
 	}
 
-	// warning: stat() may hang on an unhealthy volume
+	// warning: reaching here should mean that synchronous os.Stat()
+	// call is safe and will not indefinitely block/hang
 	stat, err := os.Stat(targetPath)
 	if err != nil {
 		if util.IsCorruptedMountError(err) {

--- a/internal/health-checker/checker.go
+++ b/internal/health-checker/checker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package healthchecker
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -37,8 +38,8 @@ type checker struct {
 	// timeout contains the delay (interval + timeout)
 	timeout time.Duration
 
-	// mutex protects against concurrent access to healthy, err and
-	// lastUpdate
+	// mutex protects against concurrent access to healthy, err,
+	// lastUpdate and checked
 	mutex *sync.RWMutex
 
 	// current status
@@ -46,6 +47,12 @@ type checker struct {
 	healthy    bool
 	err        error
 	lastUpdate time.Time
+
+	// checked is set to true once runChecker() has completed its first
+	// health-check cycle (successful or not). This matters for
+	// checker (re)start scenarios, e.g. following a node-plugin restart
+	// where the volume was already mounted.
+	checked bool
 
 	// commands is the channel to read commands from; when to stop.
 	commands chan command
@@ -60,6 +67,7 @@ func (c *checker) initDefaults() {
 	c.isRunning = false
 	c.err = nil
 	c.healthy = true
+	c.checked = false
 	c.lastUpdate = time.Now()
 	c.commands = make(chan command)
 
@@ -91,12 +99,25 @@ func (c *checker) isHealthy() (bool, error) {
 	// It is required to check, in case the write or read in the go routine
 	// is blocked.
 
-	delay := time.Since(c.lastUpdate)
-	if delay > (c.interval + c.timeout) {
+	c.mutex.RLock()
+	checked := c.checked
+	lastUpdate := c.lastUpdate
+	c.mutex.RUnlock()
+
+	delay := time.Since(lastUpdate)
+	switch {
+	case delay > (c.interval + c.timeout):
 		c.mutex.Lock()
 		c.healthy = false
 		c.err = fmt.Errorf("health-check has not responded for %f seconds", delay.Seconds())
 		c.mutex.Unlock()
+	case !checked:
+		// The first health-check cycle has not completed yet.
+		// Report this explicitly so that callers do
+		// not mistake this for a confirmed healthy volume and fall
+		// through to a fallback that could itself block (e.g. a
+		// synchronous os.Stat() on an unresponsive mount).
+		return true, errors.New("health-check has not completed its first check yet")
 	}
 
 	// read lock to get consistency between the return values

--- a/internal/health-checker/checker_test.go
+++ b/internal/health-checker/checker_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 ceph-csi authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCheckerNotYetChecked(t *testing.T) {
+	t.Parallel()
+
+	c := &checker{}
+	c.initDefaults()
+
+	healthy, err := c.isHealthy()
+	if !healthy || err == nil {
+		t.Errorf("expected (true, error) for a checker that has not completed its first check, got (%t, %v)",
+			healthy, err)
+	}
+}
+
+func TestCheckerStuckFirstCheckEventuallyTimesOut(t *testing.T) {
+	t.Parallel()
+
+	c := &checker{}
+	c.initDefaults()
+	c.interval = time.Millisecond
+	c.timeout = time.Millisecond
+
+	c.mutex.Lock()
+	c.lastUpdate = time.Now().Add(-time.Hour)
+	c.mutex.Unlock()
+
+	healthy, err := c.isHealthy()
+	if healthy || err == nil {
+		t.Errorf("expected (false, error) for a checker whose first check is stuck and overdue, got (%t, %v)",
+			healthy, err)
+	}
+}
+
+func TestCheckerConfirmedHealthyStillExpires(t *testing.T) {
+	t.Parallel()
+
+	c := &checker{}
+	c.initDefaults()
+	c.interval = time.Millisecond
+	c.timeout = time.Millisecond
+
+	c.mutex.Lock()
+	c.checked = true
+	c.healthy = true
+	c.err = nil
+	c.lastUpdate = time.Now().Add(-time.Hour)
+	c.mutex.Unlock()
+
+	healthy, err := c.isHealthy()
+	if healthy || err == nil {
+		t.Errorf("expected (false, error) for a checker that stopped reporting, got (%t, %v)", healthy, err)
+	}
+}

--- a/internal/health-checker/filechecker.go
+++ b/internal/health-checker/filechecker.go
@@ -52,6 +52,7 @@ func newFileChecker(dir string) ConditionChecker {
 				err := fc.writeTimestamp(now)
 				if err != nil {
 					fc.mutex.Lock()
+					fc.checked = true
 					fc.healthy = false
 					fc.err = err
 					fc.mutex.Unlock()
@@ -62,6 +63,7 @@ func newFileChecker(dir string) ConditionChecker {
 				ts, err := fc.readTimestamp()
 				if err != nil {
 					fc.mutex.Lock()
+					fc.checked = true
 					fc.healthy = false
 					fc.err = err
 					fc.mutex.Unlock()
@@ -72,6 +74,7 @@ func newFileChecker(dir string) ConditionChecker {
 				// verify that the written timestamp is read back
 				if now.Compare(ts) != 0 {
 					fc.mutex.Lock()
+					fc.checked = true
 					fc.healthy = false
 					fc.err = errors.New("timestamp read from file does not match what was written")
 					fc.mutex.Unlock()
@@ -81,6 +84,7 @@ func newFileChecker(dir string) ConditionChecker {
 
 				// run health check, write a timestamp to a file, read it back
 				fc.mutex.Lock()
+				fc.checked = true
 				fc.healthy = true
 				fc.err = nil
 				fc.lastUpdate = ts

--- a/internal/health-checker/filechecker_test.go
+++ b/internal/health-checker/filechecker_test.go
@@ -30,7 +30,7 @@ func TestFileChecker(t *testing.T) {
 	if !ok {
 		t.Errorf("failed to convert fc to *fileChecker: %v", fc)
 	}
-	checker.interval = time.Second * 5
+	checker.interval = time.Second * 3
 
 	// start the checker
 	checker.start()
@@ -41,9 +41,18 @@ func TestFileChecker(t *testing.T) {
 		t.Error("checker failed to start")
 	}
 
+	// before the checker has completed its first check cycle
+	healthy, msg := checker.isHealthy()
+	if !healthy || msg == nil {
+		t.Errorf("expected (true, error) before the first tick, got (%t, %v)", healthy, msg)
+	}
+
+	// wait well past the first tick, so the first check has completed.
+	time.Sleep(checker.interval + time.Second)
+
 	for range 10 {
 		// check health, should be healthy
-		healthy, msg := checker.isHealthy()
+		healthy, msg = checker.isHealthy()
 		if !healthy || msg != nil {
 			t.Error("volume is unhealthy")
 		}

--- a/internal/health-checker/statchecker.go
+++ b/internal/health-checker/statchecker.go
@@ -47,20 +47,18 @@ func newStatChecker(dir string) ConditionChecker {
 
 				return
 			case now := <-ticker.C:
-				_, err := os.Stat(sc.dirname)
-				if err != nil {
-					sc.mutex.Lock()
-					sc.healthy = false
-					sc.err = err
-					sc.mutex.Unlock()
-
-					continue
-				}
+				_, statErr := os.Stat(sc.dirname)
 
 				sc.mutex.Lock()
-				sc.healthy = true
-				sc.err = nil
-				sc.lastUpdate = now
+				sc.checked = true
+				if statErr != nil {
+					sc.healthy = false
+					sc.err = statErr
+				} else {
+					sc.healthy = true
+					sc.err = nil
+					sc.lastUpdate = now
+				}
 				sc.mutex.Unlock()
 			}
 		}

--- a/internal/health-checker/statchecker_test.go
+++ b/internal/health-checker/statchecker_test.go
@@ -30,7 +30,7 @@ func TestStatChecker(t *testing.T) {
 	if !ok {
 		t.Errorf("failed to convert fc to *fileChecker: %v", sc)
 	}
-	checker.interval = time.Second * 5
+	checker.interval = time.Second * 3
 
 	// start the checker
 	checker.start()
@@ -41,9 +41,18 @@ func TestStatChecker(t *testing.T) {
 		t.Error("checker failed to start")
 	}
 
+	// before the checker has completed its first check cycle
+	healthy, msg := checker.isHealthy()
+	if !healthy || msg == nil {
+		t.Errorf("expected (true, error) before the first tick, got (%t, %v)", healthy, msg)
+	}
+
+	// wait well past the first tick, so the first check has completed.
+	time.Sleep(checker.interval + time.Second)
+
 	for i := range 10 {
 		// check health, should be healthy
-		healthy, msg := checker.isHealthy()
+		healthy, msg = checker.isHealthy()
 		if !healthy || msg != nil {
 			t.Errorf("volume is unhealthy after %d tries", i+1)
 		}


### PR DESCRIPTION
If a node-plugin pod restarts while the backend (e.g. MDS) is down, NodeGetVolumeStats used to call os.Stat() on the target path immediately after (re)starting the health checker, before the checker had a chance to detect the outage. Since os.Stat() blocks in the kernel on an unresponsive mount, this held the VolumeLock forever and made every later call for that path fail with Aborted.

Return early with an "not yet available" condition instead of calling os.Stat() when the checker was just (re)started, for CephFS.

## Issue:

Slow GRPC calls and connection refused errors when nodeplugin pod restarts while MDS is down. 
##### Logs of `openshift-storage.cephfs.csi.ceph.com-nodeplugin-<HASH>` pod:
```
I0727 13:34:49.967224       1 cephcsi.go:213] Driver version: canary and Git version: a9058c2e1cb4f4c1e0b35a1c6525adc2d74edef8
I0727 13:34:49.967411       1 cephcsi.go:315] Initial PID limit is set to -1
I0727 13:34:49.967460       1 cephcsi.go:321] Reconfigured PID limit to -1 (max)
I0727 13:34:49.967652       1 cephcsi.go:267] Starting driver type: cephfs with name: openshift-storage.cephfs.csi.ceph.com
I0727 13:34:49.982637       1 volumemounter.go:81] loaded mounter: kernel
I0727 13:34:49.997980       1 volumemounter.go:92] loaded mounter: fuse
I0727 13:34:50.013335       1 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
I0727 13:34:50.013624       1 server.go:123] listening for CSI-Addons requests on address: &net.UnixAddr{Name:"/csi/csi-addons.sock", Net:"unix"}
I0727 13:34:50.013671       1 server.go:131] Listening for connections on address: &net.UnixAddr{Name:"//csi/csi.sock", Net:"unix"}
I0727 13:35:17.235671       1 utils.go:361] ID: 1 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0727 13:35:17.235701       1 utils.go:362] ID: 1 GRPC request: {}
I0727 13:35:17.235916       1 utils.go:368] ID: 1 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"VOLUME_CONDITION"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}}]}
I0727 13:35:17.236688       1 utils.go:361] ID: 2 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0727 13:35:17.236717       1 utils.go:362] ID: 2 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd","volume_path":"/var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount"}
I0727 13:35:20.717444       1 utils.go:361] ID: 3 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0727 13:35:20.717497       1 utils.go:362] ID: 3 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e","volume_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/openshift-storage.cephfs.csi.ceph.com/5c6d82102a843b63051ee6ec16343f5fc0fa5f1cedf5999667e1c9171981cdbe/globalmount"}
I0727 13:35:51.828972       1 utils.go:361] ID: 4 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0727 13:35:51.828996       1 utils.go:362] ID: 4 GRPC request: {}
I0727 13:35:51.829059       1 utils.go:368] ID: 4 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"VOLUME_CONDITION"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}}]}
I0727 13:35:51.829782       1 utils.go:361] ID: 5 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0727 13:35:51.829816       1 utils.go:362] ID: 5 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e","volume_path":"/var/lib/kubelet/pods/feaa0cb3-0142-4768-8d2b-77809a508db4/volumes/kubernetes.io~csi/pvc-85f15e58-94ce-4858-9842-19b97a76f042/mount"}
I0727 13:37:47.237573       1 utils.go:394] ID: 2 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (2m29s)
I0727 13:37:47.237626       1 utils.go:396] ID: 2 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd","volume_path":"/var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount"}
I0727 13:38:17.235439       1 utils.go:394] ID: 2 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (2m59s)
I0727 13:38:17.235488       1 utils.go:396] ID: 2 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd","volume_path":"/var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount"}
I0727 13:38:21.830237       1 utils.go:394] ID: 5 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (2m29s)
I0727 13:38:21.830287       1 utils.go:396] ID: 5 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e","volume_path":"/var/lib/kubelet/pods/feaa0cb3-0142-4768-8d2b-77809a508db4/volumes/kubernetes.io~csi/pvc-85f15e58-94ce-4858-9842-19b97a76f042/mount"}
I0727 13:38:40.220107       1 utils.go:361] ID: 6 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0727 13:38:40.220136       1 utils.go:362] ID: 6 GRPC request: {}
I0727 13:38:40.220233       1 utils.go:368] ID: 6 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"VOLUME_CONDITION"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}}]}
I0727 13:38:40.221030       1 utils.go:361] ID: 7 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0727 13:38:40.221060       1 utils.go:362] ID: 7 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd","volume_path":"/var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount"}
E0727 13:38:40.221086       1 utils.go:366] ID: 7 GRPC error: rpc error: code = Aborted desc = an operation with the given target path /var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount already exists
I0727 13:38:47.237391       1 utils.go:394] ID: 2 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (3m29s)
I0727 13:38:47.237448       1 utils.go:396] ID: 2 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd","volume_path":"/var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount"}
I0727 13:38:51.829778       1 utils.go:394] ID: 5 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (2m59s)
I0727 13:38:51.829830       1 utils.go:396] ID: 5 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e","volume_path":"/var/lib/kubelet/pods/feaa0cb3-0142-4768-8d2b-77809a508db4/volumes/kubernetes.io~csi/pvc-85f15e58-94ce-4858-9842-19b97a76f042/mount"}
I0727 13:38:56.411916       1 utils.go:361] ID: 8 GRPC call: /csi.v1.Node/NodeGetCapabilities
I0727 13:38:56.411941       1 utils.go:362] ID: 8 GRPC request: {}
I0727 13:38:56.411997       1 utils.go:368] ID: 8 GRPC response: {"capabilities":[{"rpc":{"type":"STAGE_UNSTAGE_VOLUME"}},{"rpc":{"type":"GET_VOLUME_STATS"}},{"rpc":{"type":"VOLUME_CONDITION"}},{"rpc":{"type":"SINGLE_NODE_MULTI_WRITER"}}]}
I0727 13:38:56.412680       1 utils.go:361] ID: 9 GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0727 13:38:56.412708       1 utils.go:362] ID: 9 GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e","volume_path":"/var/lib/kubelet/pods/feaa0cb3-0142-4768-8d2b-77809a508db4/volumes/kubernetes.io~csi/pvc-85f15e58-94ce-4858-9842-19b97a76f042/mount"}
E0727 13:38:56.412730       1 utils.go:366] ID: 9 GRPC error: rpc error: code = Aborted desc = an operation with the given target path /var/lib/kubelet/pods/feaa0cb3-0142-4768-8d2b-77809a508db4/volumes/kubernetes.io~csi/pvc-85f15e58-94ce-4858-9842-19b97a76f042/mount already exists
I0727 13:39:17.236578       1 utils.go:394] ID: 2 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (3m59s)
I0727 13:39:17.236621       1 utils.go:396] ID: 2 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd","volume_path":"/var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount"}
I0727 13:39:21.830771       1 utils.go:394] ID: 5 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (3m29s)
I0727 13:39:21.830817       1 utils.go:396] ID: 5 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e","volume_path":"/var/lib/kubelet/pods/feaa0cb3-0142-4768-8d2b-77809a508db4/volumes/kubernetes.io~csi/pvc-85f15e58-94ce-4858-9842-19b97a76f042/mount"}
I0727 13:39:47.236887       1 utils.go:394] ID: 2 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (4m29s)
I0727 13:39:47.236932       1 utils.go:396] ID: 2 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd","volume_path":"/var/lib/kubelet/pods/ca8be956-d2a4-47ed-a4dd-1167af26ebbc/volumes/kubernetes.io~csi/pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2/mount"}
I0727 13:39:51.830219       1 utils.go:394] ID: 5 Slow GRPC call /csi.v1.Node/NodeGetVolumeStats (3m59s)
I0727 13:39:51.830271       1 utils.go:396] ID: 5 Slow GRPC request: {"volume_id":"0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e","volume_path":"/var/lib/kubelet/pods/feaa0cb3-0142-4768-8d2b-77809a508db4/volumes/kubernetes.io~csi/pvc-85f15e58-94ce-4858-9842-19b97a76f042/mount"}
```

##### openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addonft2qx logs:
```
2026-07-27T11:52:20.520Z	INFO	client	Probing CSI driver for readiness
2026-07-27T11:52:20.524Z	INFO	setup	The CSI-plugin does not have the CSI-Addons CONTROLLER_SERVICE capability, not running leader election
2026-07-27T11:52:20.708Z	INFO	setup	Starting volume condition reporter	{"driver": "openshift-storage.cephfs.csi.ceph.com"}
2026-07-27T11:52:20.916Z	INFO	csiaddonsnode	Starting watcher for CSIAddonsNode	{"name": "ip-10-0-63-53.ec2.internal-openshift-storage-daemonset-openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons"}
2026-07-27T11:52:21.508Z	INFO	server	Listening for CSI-Addons requests	{"address": "[::]:9071"}
2026-07-27T12:30:20.743Z	INFO	volume-condition	Persistent volume is healthy	{"pvName": "pvc-85f15e58-94ce-4858-9842-19b97a76f042", "message": "volume is in a healthy condition"}
2026-07-27T12:30:20.770Z	INFO	volume-condition	Persistent volume is healthy	{"pvName": "pvc-444f47a0-f2c2-4801-acbc-d12e632bb4c2", "message": "volume is in a healthy condition"}
2026-07-27T13:22:41.170Z	INFO	csiaddonsnode	Watcher exited gracefully, will be restarted soon	{"name": "ip-10-0-63-53.ec2.internal-openshift-storage-daemonset-openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons"}
2026-07-27T13:22:41.199Z	INFO	csiaddonsnode	Starting watcher for CSIAddonsNode	{"name": "ip-10-0-63-53.ec2.internal-openshift-storage-daemonset-openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons"}
2026-07-27T13:34:49.488Z	ERROR	volume-condition	Failed to check if volume is healthy	{"volumeID": "0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e", "error": "failed to call NodeGetVolumeStats: rpc error: code = Unavailable desc = error reading from server: EOF"}
github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition.(*volumeConditionReporter).Run
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/reporter.go:126
main.main.func3
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/main.go:241
2026-07-27T13:34:49.490Z	ERROR	volume-condition	Failed to check if volume is healthy	{"volumeID": "0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd", "error": "failed to call NodeGetVolumeStats: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial unix /var/lib/kubelet/plugins/openshift-storage.cephfs.csi.ceph.com/csi.sock: connect: connection refused\""}
github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition.(*volumeConditionReporter).Run
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/reporter.go:126
main.main.func3
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/main.go:241
2026-07-27T13:34:49.499Z	ERROR	volume-condition	Failed to check if volume is healthy	{"volumeID": "0001-0011-openshift-storage-0000000000000001-71e26d97-9597-47b6-8c22-f7856ad8032e", "error": "failed to call NodeGetVolumeStats: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial unix /var/lib/kubelet/plugins/openshift-storage.cephfs.csi.ceph.com/csi.sock: connect: connection refused\""}
github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition.(*volumeConditionReporter).Run
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/reporter.go:126
main.main.func3
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/main.go:241
2026-07-27T13:34:49.500Z	ERROR	volume-condition	Failed to check if volume is healthy	{"volumeID": "0001-0011-openshift-storage-0000000000000001-2e3d08cb-9516-40d5-822f-de3dfe9cbdbd", "error": "failed to call NodeGetVolumeStats: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial unix /var/lib/kubelet/plugins/openshift-storage.cephfs.csi.ceph.com/csi.sock: connect: connection refused\""}
github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition.(*volumeConditionReporter).Run
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/reporter.go:126
main.main.func3
	/workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/sidecar/main.go:241
```