### PR TITLE
ci: include rockylinux:10 container image in CI registry and pull it during runs

### DIFF
--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -140,7 +140,9 @@ node('cico-workspace') {
 			}
 
 			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
-			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			if (base_image.startsWith("quay.io/")) {
+				podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			}
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 			// rockylinux images are used for building ceph-csi

--- a/k8s-e2e-external-storage.groovy
+++ b/k8s-e2e-external-storage.groovy
@@ -143,6 +143,9 @@ node('cico-workspace') {
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
+			// rockylinux images are used for building ceph-csi
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10")
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
 		}
 		stage('build artifacts') {
 			// build container image
@@ -177,8 +180,6 @@ node('cico-workspace') {
 			// busybox is used in external storage testing
 			podman_pull(ci_registry, "docker.io", "library/busybox:1.29")
 			ssh "./podman2minikube.sh docker.io/library/busybox:1.29"
-			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
-			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('deploy ceph-csi through operator') {
 			def operator_version = sh(

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -145,6 +145,9 @@ node('cico-workspace') {
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
+			// rockylinux images are used for building ceph-csi
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10")
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
 		}
 		stage('build artifacts') {
 			// build container image
@@ -185,8 +188,6 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
-			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
-			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('deploy ceph-csi through helm') {
 			timeout(time: 30, unit: 'MINUTES') {

--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -142,7 +142,9 @@ node('cico-workspace') {
 			}
 
 			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
-			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			if (base_image.startsWith("quay.io/")) {
+				podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			}
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 			// rockylinux images are used for building ceph-csi

--- a/mini-e2e-operator.groovy
+++ b/mini-e2e-operator.groovy
@@ -139,7 +139,9 @@ node('cico-workspace') {
 			}
 
 			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
-			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			if (base_image.startsWith("quay.io/")) {
+				podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			}
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 			// rockylinux images are used for building ceph-csi

--- a/mini-e2e-operator.groovy
+++ b/mini-e2e-operator.groovy
@@ -142,6 +142,9 @@ node('cico-workspace') {
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
+			// rockylinux images are used for building ceph-csi
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10")
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
 		}
 		stage('build artifacts') {
 			// build container image
@@ -182,8 +185,6 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
-			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
-			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('deploy ceph-csi through operator') {
 			def operator_version = sh(

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -139,7 +139,9 @@ node('cico-workspace') {
 			}
 
 			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
-			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			if (base_image.startsWith("quay.io/")) {
+				podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			}
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 			// rockylinux images are used for building ceph-csi

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -142,6 +142,9 @@ node('cico-workspace') {
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
+			// rockylinux images are used for building ceph-csi
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10")
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
 		}
 		stage('build artifacts') {
 			// build container image
@@ -182,8 +185,6 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
-			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
-			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage('run e2e') {
 			timeout(time: 240, unit: 'MINUTES') {

--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -29,4 +29,5 @@ docker.io/library/vault:latest	library/vault:latest
 docker.io/library/vault:1.8.5	library/vault:1.8.5
 
 # Ceph base OS
+docker.io/rockylinux/rockylinux:10		rockylinux/rockylinux:10
 docker.io/rockylinux/rockylinux:10-minimal	rockylinux/rockylinux:10-minimal

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -142,6 +142,9 @@ node('cico-workspace') {
 			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
+			// rockylinux images are used for building ceph-csi
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10")
+			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
 		}
 		stage('build artifacts') {
 			// build container image
@@ -182,8 +185,6 @@ node('cico-workspace') {
 			ssh "./podman2minikube.sh docker.io/library/nginx:latest"
 			podman_pull(ci_registry, "docker.io", "library/vault:1.8.5")
 			ssh "./podman2minikube.sh docker.io/library/vault:1.8.5"
-			podman_pull(ci_registry, "docker.io", "rockylinux/rockylinux:10-minimal")
-			ssh "./podman2minikube.sh docker.io/rockylinux/rockylinux:10-minimal"
 		}
 		stage("set csi-upgrade-version from build.env") {
 			def build_env_csi_upgrade_version = sh(

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -139,7 +139,9 @@ node('cico-workspace') {
 			}
 
 			// base_image is like quay.io/ceph/ceph:v19, strip "quay.io/"
-			podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			if (base_image.startsWith("quay.io/")) {
+				podman_pull(ci_registry, "quay.io", "${base_image}" - q_io_regex)
+			}
 			// cephcsi:devel is used with 'make containerized-build'
 			podman_pull(ci_registry, ci_registry, "ceph-csi:devel")
 			// rockylinux images are used for building ceph-csi


### PR DESCRIPTION
Both `rockylinux:10` and `rockylinux:10-minimal` are used during the build phase of Ceph-CSI (with #6411). These images need to be the in CI container registry to prevent Docker Hub rate limiting causing failed jobs.

Pull both images from the CI registry before building. 

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
