### PR TITLE
nvmeof: add VolumeGroupSnapshot support

### DIFF
--- a/deploy/nvmeof/kubernetes/csi-nvmeofplugin-provisioner.yaml
+++ b/deploy/nvmeof/kubernetes/csi-nvmeofplugin-provisioner.yaml
@@ -133,6 +133,31 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=1"
+            - "--timeout=150s"
+            - "--leader-election=true"
+            - "--extra-create-metadata=true"
+            - "--feature-gates=CSIVolumeGroupSnapshot=true"
+            - "--http-endpoint=$(POD_IP):8092"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi-provisioner.sock
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 8092
+              name: snapshotter
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: csi-attacher
           image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
           args:

--- a/e2e/nvmeof.go
+++ b/e2e/nvmeof.go
@@ -498,5 +498,18 @@ var _ = ginkgo.Describe("nvmeof", func() {
 			validateRBDImageCount(f, 0, nvmeofPool)
 			validateOmapCount(f, 0, rbdType, nvmeofPool, volumesType)
 		})
+
+		ginkgo.It("test volumeGroupSnapshot", func() {
+			scName := nvmeofStorageClass
+			snapshotter, err := newNVMeOFVolumeGroupSnapshot(
+				f, f.UniqueName, scName, false, deployTimeout, 3, 0)
+			if err != nil {
+				logAndFail("failed to create volumeGroupSnapshot Base: %v", err)
+			}
+			err = snapshotter.TestVolumeGroupSnapshot()
+			if err != nil {
+				logAndFail("failed to test volumeGroupSnapshot: %v", err)
+			}
+		})
 	})
 })

--- a/e2e/volumegroupsnapshot.go
+++ b/e2e/volumegroupsnapshot.go
@@ -322,3 +322,86 @@ func (rvgs *rbdVolumeGroupSnapshot) ValidateResourcesForDelete() error {
 
 	return nil
 }
+
+type nvmeofVolumeGroupSnapshot struct {
+	*volumeGroupSnapshotterBase
+}
+
+var _ VolumeGroupSnapshotter = &nvmeofVolumeGroupSnapshot{}
+
+func newNVMeOFVolumeGroupSnapshot(f *framework.Framework, namespace,
+	storageClass string,
+	blockPVC bool,
+	timeout, totalPVCCount, additionalVGSnapshotCount int,
+) (VolumeGroupSnapshotter, error) {
+	base, err := newVolumeGroupSnapshotBase(f, namespace, storageClass, blockPVC,
+		timeout, totalPVCCount, additionalVGSnapshotCount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create volumeGroupSnapshotterBase: %w", err)
+	}
+
+	return &nvmeofVolumeGroupSnapshot{
+		volumeGroupSnapshotterBase: base,
+	}, nil
+}
+
+func (nvgs *nvmeofVolumeGroupSnapshot) TestVolumeGroupSnapshot() error {
+	return nvgs.volumeGroupSnapshotterBase.testVolumeGroupSnapshot(nvgs)
+}
+
+func (nvgs *nvmeofVolumeGroupSnapshot) GetVolumeGroupSnapshotClass() (
+	*groupsnapapi.VolumeGroupSnapshotClass, error,
+) {
+	vgscPath := fmt.Sprintf("%s/%s", nvmeofExamplePath, "groupsnapshotclass.yaml")
+	vgsc := &groupsnapapi.VolumeGroupSnapshotClass{}
+	err := unmarshal(vgscPath, vgsc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal VolumeGroupSnapshotClass: %w", err)
+	}
+
+	vgsc.Parameters["csi.storage.k8s.io/group-snapshotter-secret-namespace"] = cephCSINamespace
+	vgsc.Parameters["csi.storage.k8s.io/group-snapshotter-secret-name"] = nvmeofProvisionerSecretName
+	vgsc.Parameters["pool"] = nvmeofPool
+
+	fsID, err := getClusterID(nvgs.framework)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get clusterID: %w", err)
+	}
+	vgsc.Parameters["clusterID"] = fsID
+
+	return vgsc, nil
+}
+
+func (nvgs *nvmeofVolumeGroupSnapshot) ValidateResourcesForCreate(
+	vgs *groupsnapapi.VolumeGroupSnapshot,
+) error {
+	vgsc, err := nvgs.groupclient.VolumeGroupSnapshotContents().Get(
+		context.TODO(),
+		*vgs.Status.BoundVolumeGroupSnapshotContentName,
+		metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get VolumeGroupSnapshotContent: %w", err)
+	}
+
+	sourcePVCCount := len(vgsc.Status.VolumeSnapshotInfoList)
+	clonePVCCount := len(vgsc.Status.VolumeSnapshotInfoList)
+	totalPVCCount := sourcePVCCount + clonePVCCount
+
+	validateOmapCount(nvgs.framework, totalPVCCount, rbdType, nvmeofPool, volumesType)
+
+	return nil
+}
+
+func (nvgs *nvmeofVolumeGroupSnapshot) ValidateResourcesForDelete() error {
+	validateOmapCount(nvgs.framework, 0, rbdType, nvmeofPool, volumesType)
+	validateOmapCount(nvgs.framework, 0, rbdType, nvmeofPool, snapsType)
+	validateOmapCount(nvgs.framework, 0, rbdType, nvmeofPool, groupSnapsType)
+	validateRBDImageCount(nvgs.framework, 0, nvmeofPool)
+
+	err := waitToRemoveImagesFromTrash(nvgs.framework, nvmeofPool, deployTimeout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/examples/nvmeof/groupsnapshot.yaml
+++ b/examples/nvmeof/groupsnapshot.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshot
+metadata:
+  name: new-groupsnapshot-demo-1
+spec:
+  source:
+    selector:
+      matchLabels:
+        # The PVCs will need to have this label for it to be
+        # included in the VolumeGroupSnapshot
+        group: test
+  volumeGroupSnapshotClassName: csi-nvmeofplugin-groupsnapclass

--- a/examples/nvmeof/groupsnapshotclass.yaml
+++ b/examples/nvmeof/groupsnapshotclass.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: csi-nvmeofplugin-groupsnapclass
+driver: nvmeof.csi.ceph.com
+parameters:
+  # String representing a Ceph cluster to provision storage from.
+  # Should be unique across all Ceph clusters in use for provisioning,
+  # cannot be greater than 36 bytes in length, and should remain immutable for
+  # the lifetime of the StorageClass in use
+  clusterID: <cluster-id>
+  # eg: pool: replicapool
+  pool: <rbd-pool-name>
+  # Group snapshot operations use the RBD backend credentials
+  csi.storage.k8s.io/group-snapshotter-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/group-snapshotter-secret-namespace: default
+deletionPolicy: Delete

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -52,6 +52,7 @@ var nvmeofMutableParams = []string{
 
 type Server struct {
 	csi.UnimplementedControllerServer
+	csi.UnimplementedGroupControllerServer
 
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID/volume name) return an Aborted error
@@ -70,16 +71,24 @@ type Server struct {
 
 	// backendServer handles the RBD requests
 	backendServer *rbd.ControllerServer
+
+	// backendGroupServer handles the RBD group controller requests
+	backendGroupServer csi.GroupControllerServer
 }
+
+var _ csi.GroupControllerServer = &Server{}
 
 // NewControllerServer initialize a controller server for nvmeof CSI driver.
 func NewControllerServer(d *csicommon.CSIDriver) (*Server, error) {
+	backendServer := rbddriver.NewControllerServer(d)
+
 	return &Server{
-		volumeLocks:    util.NewIDLocker(),
-		hostLocks:      util.NewIDLocker(),
-		subsystemLocks: util.NewIDLocker(),
-		backendServer:  rbddriver.NewControllerServer(d),
-		securityKeys:   nil, // Initialize lazily when needed
+		volumeLocks:        util.NewIDLocker(),
+		hostLocks:          util.NewIDLocker(),
+		subsystemLocks:     util.NewIDLocker(),
+		backendServer:      backendServer,
+		backendGroupServer: csicommon.ToGroupControllerServer(backendServer),
+		securityKeys:       nil, // Initialize lazily when needed
 	}, nil
 }
 
@@ -474,6 +483,38 @@ func (cs *Server) DeleteSnapshot(
 
 	// delete snapshot is handled by rbd backend server
 	return cs.backendServer.DeleteSnapshot(ctx, req)
+}
+
+// GroupControllerGetCapabilities delegates to the RBD backend group controller.
+func (cs *Server) GroupControllerGetCapabilities(
+	ctx context.Context,
+	req *csi.GroupControllerGetCapabilitiesRequest,
+) (*csi.GroupControllerGetCapabilitiesResponse, error) {
+	return cs.backendGroupServer.GroupControllerGetCapabilities(ctx, req)
+}
+
+// CreateVolumeGroupSnapshot delegates to the RBD backend group controller.
+func (cs *Server) CreateVolumeGroupSnapshot(
+	ctx context.Context,
+	req *csi.CreateVolumeGroupSnapshotRequest,
+) (*csi.CreateVolumeGroupSnapshotResponse, error) {
+	return cs.backendGroupServer.CreateVolumeGroupSnapshot(ctx, req)
+}
+
+// DeleteVolumeGroupSnapshot delegates to the RBD backend group controller.
+func (cs *Server) DeleteVolumeGroupSnapshot(
+	ctx context.Context,
+	req *csi.DeleteVolumeGroupSnapshotRequest,
+) (*csi.DeleteVolumeGroupSnapshotResponse, error) {
+	return cs.backendGroupServer.DeleteVolumeGroupSnapshot(ctx, req)
+}
+
+// GetVolumeGroupSnapshot delegates to the RBD backend group controller.
+func (cs *Server) GetVolumeGroupSnapshot(
+	ctx context.Context,
+	req *csi.GetVolumeGroupSnapshotRequest,
+) (*csi.GetVolumeGroupSnapshotResponse, error) {
+	return cs.backendGroupServer.GetVolumeGroupSnapshot(ctx, req)
 }
 
 // validateDHCHAPParameter helper function to validates the DH-CHAP parameters.

--- a/internal/nvmeof/driver/driver.go
+++ b/internal/nvmeof/driver/driver.go
@@ -75,6 +75,10 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 			csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
 			csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
 		})
+
+		cd.AddGroupControllerServiceCapabilities([]csi.GroupControllerServiceCapability_RPC_Type{
+			csi.GroupControllerServiceCapability_RPC_CREATE_DELETE_GET_VOLUME_GROUP_SNAPSHOT,
+		})
 	}
 
 	// Create gRPC servers
@@ -96,6 +100,7 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 			log.FatalLogMsg("failed to initialize controller server: %v", err)
 		}
 		srv.CS = cs
+		srv.GS = csicommon.ToGroupControllerServer(srv.CS)
 	default:
 		ns, err := nodeserver.NewNodeServer(cd, conf.NodeID, conf.Vtype)
 		if err != nil {
@@ -107,6 +112,7 @@ func (d *nvmeofDriver) Run(conf *util.Config) {
 			log.FatalLogMsg("failed to initialize controller server: %v", err)
 		}
 		srv.CS = cs
+		srv.GS = csicommon.ToGroupControllerServer(srv.CS)
 	}
 
 	server.Start(conf.Endpoint, srv, csicommon.MiddlewareServerOptionConfig{

--- a/internal/nvmeof/identity/identityserver.go
+++ b/internal/nvmeof/identity/identityserver.go
@@ -58,6 +58,13 @@ func (is *Server) GetPluginCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_GROUP_CONTROLLER_SERVICE,
+					},
+				},
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Implement VolumeGroupSnapshot (VGS) for the NVMe-oF driver by delegating
CreateVolumeGroupSnapshot, DeleteVolumeGroupSnapshot, and
GetVolumeGroupSnapshot RPCs to the RBD backend. No NVMe-oF gateway
interaction is needed for group snapshots, same as individual snapshots.

Part of: https://github.com/ceph/ceph-csi/issues/6387

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
