### PR TITLE
Deprecate netNamespaceFilePath for Pod networking/restart feature

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,3 +5,15 @@
 ## Features
 
 ## NOTE
+
+## Deprecations
+
+- The `netNamespaceFilePath` configuration option is now deprecated and will be
+  removed in a future release. Users should migrate to using host networking for
+  CSI plugin pods instead. When this feature is detected, a deprecation warning
+  will be logged at the WARNING level.
+   - `hostPID` was changed from `true` to `false` in all static manifests
+   - Static manifest users with `netNamespaceFilePath` must manually set
+     `hostPID: true`
+   - OpenShift users must also keep `allowHostPID: true` in their SCC (if they
+     were using it)

--- a/api/deploy/ocp/scc.yaml
+++ b/api/deploy/ocp/scc.yaml
@@ -14,8 +14,8 @@ priority:
 allowedCapabilities: ["SYS_ADMIN"]
 # Needed as we run liveness container on daemonset pods
 allowHostPorts: true
-# Needed as we are setting this in RBD plugin pod
-allowHostPID: true
+# Set to true when netNamespaceFilePath is configured
+allowHostPID: false
 # Required for encryption
 allowHostIPC: true
 # Set to false as we write to RootFilesystem inside csi containers

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -42,7 +42,16 @@ spec:
       priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
 {{- end }}
       hostNetwork: true
+{{- $hostPID := false }}
+{{- range .Values.csiConfig }}
+  {{- if and .cephFS .cephFS.netNamespaceFilePath }}
+    {{- $hostPID = true }}
+  {{- end }}
+{{- end }}
+{{- if $hostPID }}
+      # set to true when netNamespaceFilePath is configured
       hostPID: true
+{{- end }}
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-daemonset.yaml
@@ -39,7 +39,16 @@ spec:
       securityContext: {{ toYaml .Values.nodeplugin.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "ceph-csi-rbd.serviceAccountName.nodeplugin" . }}
       hostNetwork: true
+{{- $hostPID := false }}
+{{- range .Values.csiConfig }}
+  {{- if and .rbd .rbd.netNamespaceFilePath }}
+    {{- $hostPID = true }}
+  {{- end }}
+{{- end }}
+{{- if $hostPID }}
+      # set to true when netNamespaceFilePath is configured
       hostPID: true
+{{- end }}
 {{- if .Values.nodeplugin.priorityClassName }}
       priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
 {{- end }}

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -15,7 +15,8 @@ spec:
       serviceAccountName: cephfs-csi-nodeplugin
       priorityClassName: system-node-critical
       hostNetwork: true
-      hostPID: true
+      # set to true when netNamespaceFilePath is configured
+      hostPID: false
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -15,7 +15,8 @@ spec:
       serviceAccountName: nfs-csi-nodeplugin
       priorityClassName: system-node-critical
       hostNetwork: true
-      hostPID: true
+      # set to true when netNamespaceFilePath is configured
+      hostPID: false
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first
       dnsPolicy: ClusterFirstWithHostNet

--- a/deploy/nvmeof/kubernetes/csi-nvmeofplugin.yaml
+++ b/deploy/nvmeof/kubernetes/csi-nvmeofplugin.yaml
@@ -109,7 +109,8 @@ spec:
               name: registration-dir
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
-      hostPID: true
+      # set to true when netNamespaceFilePath is configured
+      hostPID: false
       priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       serviceAccountName: rbd-csi-nodeplugin
       hostNetwork: true
-      hostPID: true
+      # set to true when netNamespaceFilePath is configured
+      hostPID: false
       priorityClassName: system-node-critical
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first

--- a/deploy/scc.yaml
+++ b/deploy/scc.yaml
@@ -21,8 +21,8 @@ priority:
 allowedCapabilities: ["SYS_ADMIN"]
 # Needed as we run liveness container on daemonset pods
 allowHostPorts: true
-# Needed as we are setting this in RBD plugin pod
-allowHostPID: true
+# Set to true when netNamespaceFilePath is configured
+allowHostPID: false
 # Required for encryption
 allowHostIPC: true
 # Set to false as we write to RootFilesystem inside csi containers

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,6 +52,10 @@ option `clusterID`, can now be created on the cluster.
 
 ## Running CephCSI with pod networking
 
+> **DEPRECATION NOTICE**: The `netNamespaceFilePath` feature is deprecated and
+> will be removed in a future version. Users should migrate to using host
+> networking for CSI plugin pods.
+
 The current problem with Pod Networking, is when a CephFS/RBD/NFS volume is mounted
 in a pod using Ceph CSI and then the CSI CephFS/RBD/NFS plugin is restarted or
 terminated (e.g. by restarting or deleting its DaemonSet), all operations on

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -252,6 +252,10 @@ func (ns *cephfsNodeServer) NodeStageVolume(
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+		if volOptions.NetNamespaceFilePath != "" {
+			log.WarningLog(ctx, "netNamespaceFilePath is deprecated and will be removed in a future version. "+
+				"Please migrate to using host networking for CSI plugin pods.")
+		}
 	}
 
 	if volOptions.BackingSnapshot {

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -113,6 +113,10 @@ func (ns *nfsNodeServer) NodePublishVolume(
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+		if netNamespaceFilePath != "" {
+			log.WarningLog(ctx, "netNamespaceFilePath is deprecated and will be removed in a future version. "+
+				"Please migrate to using host networking for CSI plugin pods.")
+		}
 	}
 
 	err = ns.mountNFS(ctx,

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -392,6 +392,10 @@ func (ns *NodeServer) NodeStageVolume(
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	if rv.NetNamespaceFilePath != "" {
+		log.WarningLog(ctx, "netNamespaceFilePath is deprecated and will be removed in a future version. "+
+			"Please migrate to using host networking for CSI plugin pods.")
+	}
 	if isHealer {
 		err = healerStageTransaction(ctx, cr, rv, stagingParentPath)
 		if err != nil {

--- a/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
+++ b/vendor/github.com/ceph/ceph-csi/api/deploy/ocp/scc.yaml
@@ -14,8 +14,8 @@ priority:
 allowedCapabilities: ["SYS_ADMIN"]
 # Needed as we run liveness container on daemonset pods
 allowHostPorts: true
-# Needed as we are setting this in RBD plugin pod
-allowHostPID: true
+# Set to true when netNamespaceFilePath is configured
+allowHostPID: false
 # Required for encryption
 allowHostIPC: true
 # Set to false as we write to RootFilesystem inside csi containers


### PR DESCRIPTION
The feature is not commonly used. Rook and Ceph-CSI Operator have already
deprecated the feature and removed support for it.

Nodeplugins only have `hostPID: true` set because of this feature. By dropping
the feature, it is possible to reduce the permissions of the Nodeplugin a
little more.

Updates: #6415