### PR TITLE
util: fix stripSecret re-appending the secret it redacted

### DIFF
--- a/internal/util/stripsecrets/stripsecrets.go
+++ b/internal/util/stripsecrets/stripsecrets.go
@@ -75,7 +75,7 @@ func stripSecret(out []string) bool {
 
 		out[i] = before + strippedSecret
 		if end != -1 {
-			out[i] += arg[end+len(secretArg):]
+			out[i] += after[end:]
 		}
 
 		return true

--- a/internal/util/stripsecrets/stripsecrets_test.go
+++ b/internal/util/stripsecrets/stripsecrets_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stripsecrets
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestInArgsStripsSecret(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "secret is the first option",
+			args: []string{"-o", "secret=AQBsecretkey,mds_namespace=abc"},
+			want: []string{"-o", "secret=***stripped***,mds_namespace=abc"},
+		},
+		{
+			name: "secret is preceded by another option",
+			args: []string{"-o", "name=admin,secret=AQBsecretkey,mds_namespace=abc"},
+			want: []string{"-o", "name=admin,secret=***stripped***,mds_namespace=abc"},
+		},
+		{
+			name: "prefix longer than the secret",
+			args: []string{"-o", "mon_addr=10.0.0.1:6789/10.0.0.2:6789,secret=AQtiny,mds_namespace=abc"},
+			want: []string{"-o", "mon_addr=10.0.0.1:6789/10.0.0.2:6789,secret=***stripped***,mds_namespace=abc"},
+		},
+		{
+			name: "secret is the last option",
+			args: []string{"-o", "name=admin,secret=AQBsecretkey"},
+			want: []string{"-o", "name=admin,secret=***stripped***"},
+		},
+		{
+			name: "no secret present",
+			args: []string{"-o", "name=admin,mds_namespace=abc"},
+			want: []string{"-o", "name=admin,mds_namespace=abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := InArgs(tt.args)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("InArgs()\n got: %q\nwant: %q", got, tt.want)
+			}
+			if joined := strings.Join(got, " "); strings.Contains(joined, "AQ") {
+				t.Errorf("secret material leaked into stripped output: %q", joined)
+			}
+		})
+	}
+}
+
+func TestInArgsStripsKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "--key is stripped",
+			args: []string{"rbd", "map", "--key=AQBsecretkey", "--pool=rbd"},
+			want: []string{"rbd", "map", "--key=***stripped***", "--pool=rbd"},
+		},
+		{
+			name: "--keyfile is stripped",
+			args: []string{"rbd", "map", "--keyfile=/tmp/csi/keys/keyfile-abc", "--pool=rbd"},
+			want: []string{"rbd", "map", "--keyfile=***stripped***", "--pool=rbd"},
+		},
+		{
+			name: "only one of key or secret is stripped, as documented",
+			args: []string{"--key=AQBsecretkey", "-o", "name=admin,secret=AQBsecretkey"},
+			want: []string{"--key=***stripped***", "-o", "name=admin,secret=AQBsecretkey"},
+		},
+		{
+			name: "neither key nor keyfile present",
+			args: []string{"rbd", "map", "--pool=rbd"},
+			want: []string{"rbd", "map", "--pool=rbd"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := InArgs(tt.args)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("InArgs()\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInArgsLeavesInputUnchanged(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"-o", "name=admin,secret=AQBsecretkey"}
+	original := slices.Clone(args)
+
+	InArgs(args)
+
+	if !slices.Equal(args, original) {
+		t.Errorf("InArgs() modified its input: got %q, want %q", args, original)
+	}
+}


### PR DESCRIPTION
## Describe what this PR does

`stripSecret` cuts the argument on `secret=` and computes the end of the secret as an offset into the *remainder*, but then slices the *original* argument by that offset:

```go
before, after, ok := strings.Cut(arg, secretArg)
end := strings.IndexByte(after, optionsArgSeparator)   // offset into `after`
out[i] = before + strippedSecret
if end != -1 {
    out[i] += arg[end+len(secretArg):]                 // ...but slices `arg`
}
```

The two coordinate systems only agree when `secret=` starts the argument. Any option before it shifts the tail and copies part of the secret back into the string that was just redacted.

## Is there anything that requires special attention?

Yes — the longer the prefix, the more leaks, and a realistic mount option string leaks the whole key.

Running the current `stripSecret` over three inputs:

```
secret first            -> secret=***stripped***,mds_namespace=abc
secret after an option  -> name=admin,secret=***stripped***ersecretkey,mds_namespace=abc
long prefix             -> mon_addr=10.0.0.1:6789/10.0.0.2:6789,secret=***stripped***.0.1:6789/10.0.0.2:6789,secret=AQtiny,mds_namespace=abc
```

In the third case the literal text `secret=AQtiny` appears inside the supposedly-redacted output. A real `mon_addr=...` prefix runs well over 60 characters while a Ceph key is around 40, so the offset overshoots and the entire key is reproduced.

`InArgs` exists solely to redact secrets before logging, and `ExecCommand` logs the sanitized arguments on the success path too (`internal/util/cephcmds.go`), so this is every invocation rather than only failures.

After the change, all three redact correctly and no secret material survives.

The trigger is `secret=` not being first in its argv element. The kernel mounter builds `mon_addr=...,secretfile=...`, which contains no `secret=` substring, but it then appends admin-supplied `kernelMountOptions` (a documented StorageClass field), and `secret=` is a valid `mount.ceph` option.

This package had no test file. The new one covers a secret that is first, preceded by another option, preceded by a prefix longer than itself, last, and absent. It fails without the fix:

```
--- FAIL: TestInArgsStripsSecret/prefix_longer_than_the_secret
     got: ["-o" "mon_addr=...,secret=***stripped***.0.1:6789/10.0.0.2:6789,secret=AQtiny,mds_namespace=abc"]
    want: ["-o" "mon_addr=...,secret=***stripped***,mds_namespace=abc"]
    stripsecrets_test.go:65: secret material leaked into stripped output
```

and passes with it.

The line dates to the file's original commit in February 2019 and was carried through the `strings.Index` → `strings.Cut` refactor unchanged.

I searched open and closed issues and PRs for `stripsecrets`, `stripSecret`, `strip secret`, `secret leak log` and `sanitize args`, and checked the open PR list for anything touching this file — I did not find a duplicate, but please close this if I missed one.

## Checklist

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages)
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release
* [ ] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
