### PR TITLE
rbd: add missing rbdVol.Destroy() in replication handlers

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -284,6 +284,7 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	if err != nil {
 		return nil, getGRPCError(err)
 	}
+	defer rbdVol.Destroy(ctx)
 	mirror, err := rbdVol.ToMirror()
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -355,6 +356,7 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	if err != nil {
 		return nil, getGRPCError(err)
 	}
+	defer rbdVol.Destroy(ctx)
 	mirror, err := rbdVol.ToMirror()
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -424,6 +426,7 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	if err != nil {
 		return nil, getGRPCError(err)
 	}
+	defer rbdVol.Destroy(ctx)
 	mirror, err := rbdVol.ToMirror()
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -512,6 +515,7 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	if err != nil {
 		return nil, getGRPCError(err)
 	}
+	defer rbdVol.Destroy(ctx)
 	mirror, err := rbdVol.ToMirror()
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -629,6 +633,7 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	if err != nil {
 		return nil, getGRPCError(err)
 	}
+	defer rbdVol.Destroy(ctx)
 	mirror, err := rbdVol.ToMirror()
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -868,6 +873,7 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 
 		return nil, err
 	}
+	defer rbdVol.Destroy(ctx)
 	mirror, err := rbdVol.ToMirror()
 	if err != nil {
 		log.ErrorLog(ctx, "failed to convert volume %q to mirror type: %v", rbdVol, err)


### PR DESCRIPTION
## Summary
- All six `GetVolumeByID()` call sites in `replication.go` were missing `defer rbdVol.Destroy(ctx)`, leaking the volume resource
- Every other `GetVolumeByID()` call site in the codebase (14 total) already calls `Destroy()` correctly
- Adds `defer rbdVol.Destroy(ctx)` after the error check in each of the six replication handlers: `EnableVolumeReplication`, `DisableVolumeReplication`, `PromoteVolume`, `DemoteVolume`, `ResyncVolume`, `GetVolumeReplicationInfo`

## Test plan
- [x] `go build ./internal/csi-addons/rbd/` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)