### PR TITLE
e2e: implement setEnableFencing for OperatorDeployment

### DIFF
--- a/e2e/deploy-vault.go
+++ b/e2e/deploy-vault.go
@@ -66,36 +66,43 @@ func deleteVault() {
 }
 
 func createORDeleteVault(action kubectlAction) {
-	data, err := replaceNamespaceInTemplate(vaultExamplePath + vaultServicePath)
+	serviceData, err := replaceNamespaceInTemplate(vaultExamplePath + vaultServicePath)
 	if err != nil {
 		logAndFail("failed to read content from %s %v", vaultExamplePath+vaultServicePath, err)
 	}
+	serviceData = strings.ReplaceAll(serviceData, "vault.default", "vault."+cephCSINamespace)
+	serviceData = strings.ReplaceAll(serviceData, "value: default", "value: "+cephCSINamespace)
 
-	data = strings.ReplaceAll(data, "vault.default", "vault."+cephCSINamespace)
-
-	data = strings.ReplaceAll(data, "value: default", "value: "+cephCSINamespace)
-	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
-	if err != nil {
-		logAndFail("failed to %s vault statefulset %v", action, err)
-	}
-
-	data, err = replaceNamespaceInTemplate(vaultExamplePath + vaultRBACPath)
+	rbacData, err := replaceNamespaceInTemplate(vaultExamplePath + vaultRBACPath)
 	if err != nil {
 		logAndFail("failed to read content from %s %v", vaultExamplePath+vaultRBACPath, err)
 	}
-	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
-	if err != nil {
-		logAndFail("failed to %s vault statefulset %v", action, err)
-	}
 
-	data, err = replaceNamespaceInTemplate(vaultExamplePath + vaultConfigPath)
+	configData, err := replaceNamespaceInTemplate(vaultExamplePath + vaultConfigPath)
 	if err != nil {
 		logAndFail("failed to read content from %s %v", vaultExamplePath+vaultConfigPath, err)
 	}
-	data = strings.ReplaceAll(data, "default", cephCSINamespace)
-	err = retryKubectlInput(cephCSINamespace, action, data, deployTimeout)
-	if err != nil {
-		logAndFail("failed to %s vault configmap %v", action, err)
+	configData = strings.ReplaceAll(configData, "default", cephCSINamespace)
+
+	// On create: RBAC first so the ServiceAccount exists before the
+	// vault-init-job tries to use it. On delete: service before RBAC.
+	manifests := []struct {
+		data string
+		desc string
+	}{
+		{rbacData, "vault rbac"},
+		{serviceData, "vault service"},
+		{configData, "vault configmap"},
+	}
+	if action == kubectlDelete {
+		manifests[0], manifests[1] = manifests[1], manifests[0]
+	}
+
+	for _, m := range manifests {
+		err = retryKubectlInput(cephCSINamespace, action, m.data, deployTimeout)
+		if err != nil {
+			logAndFail("failed to %s %s: %v", action, m.desc, err)
+		}
 	}
 }
 

--- a/e2e/operator.go
+++ b/e2e/operator.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"

--- a/e2e/operator.go
+++ b/e2e/operator.go
@@ -17,10 +17,18 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -74,6 +82,193 @@ func (OperatorDeployment) setClusterName(value string) error {
 	}
 
 	return nil
+}
+
+func (r OperatorDeployment) setEnableFencing(enable bool) error {
+	oldGeneration, err := getDeploymentGeneration(r.clientSet, r.deploymentName, cephCSINamespace)
+	if err != nil {
+		return fmt.Errorf("failed to get deployment generation before patching: %w", err)
+	}
+
+	command := []string{
+		"operatorconfigs.csi.ceph.io",
+		OperatorConfigName,
+		"--type=merge",
+		"-p",
+		fmt.Sprintf(`{"spec": {"driverSpecDefaults": {"enableFencing": %t}}}`, enable),
+	}
+
+	err = retryKubectlArgs(cephCSINamespace, kubectlPatch, deployTimeout, command...)
+	if err != nil {
+		return fmt.Errorf("failed to set enable fencing: %w", err)
+	}
+
+	changed, err := waitForDeploymentGenerationChange(r.clientSet, r.deploymentName, cephCSINamespace, oldGeneration)
+	if err != nil {
+		return fmt.Errorf("error checking deployment %s generation: %w", r.deploymentName, err)
+	}
+
+	if !changed {
+		return nil
+	}
+
+	err = waitForCSI(r.clientSet, r.deploymentName, r.daemonsetName, cephCSINamespace, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed waiting for CSI rollout: %w", err)
+	}
+
+	err = waitForLeaderLeaseTransfer(r.clientSet, cephCSINamespace)
+	if err != nil {
+		return fmt.Errorf("failed waiting for leader lease transfer after rollout: %w", err)
+	}
+
+	return nil
+}
+
+func getDeploymentGeneration(c clientset.Interface, name, ns string) (int64, error) {
+	d, err := c.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get deployment %s/%s: %w", ns, name, err)
+	}
+
+	return d.Generation, nil
+}
+
+// waitForDeploymentGenerationChange waits briefly for the deployment's
+// generation to change from oldGeneration. Returns (true, nil) if a change
+// was detected, (false, nil) if the generation did not change within the
+// grace period (meaning no rollout is needed), or (false, err) on error.
+func waitForDeploymentGenerationChange(c clientset.Interface, name, ns string, oldGeneration int64) (bool, error) {
+	const reconcileGracePeriod = 30 * time.Second
+
+	err := wait.PollUntilContextTimeout(context.TODO(), poll, reconcileGracePeriod, true, func(ctx context.Context) (bool, error) {
+		d, err := c.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			if apierrs.IsNotFound(err) {
+				return false, err
+			}
+
+			return false, err
+		}
+
+		if d.Generation == oldGeneration {
+			framework.Logf("deployment %s/%s: generation still %d, waiting for operator reconciliation", ns, name, oldGeneration)
+
+			return false, nil
+		}
+
+		framework.Logf("deployment %s/%s: generation changed %d → %d", ns, name, oldGeneration, d.Generation)
+
+		return true, nil
+	})
+
+	if err != nil && (wait.Interrupted(err) || errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(err.Error(), "would exceed context deadline")) {
+		framework.Logf("deployment %s/%s: generation unchanged after %s, config already applied", ns, name, reconcileGracePeriod)
+
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// csiLeasePrefix lists the name prefixes of CSI sidecar leader election
+// leases. Only leases matching these prefixes are checked during transfer.
+var csiLeasePrefix = []string{
+	"external-attacher-leader-",
+	"external-provisioner-leader-",
+	"external-resizer-",
+	"external-snapshotter-leader-",
+	"csi-addons-",
+}
+
+func isCSILeaderLease(name string) bool {
+	for _, prefix := range csiLeasePrefix {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// waitForLeaderLeaseTransfer waits until all CSI sidecar leader election
+// leases in the namespace are held by a currently running pod. After a
+// Recreate-strategy rollout, old pod leases survive until the TTL (~15s)
+// expires — this function polls until the new pod's sidecars acquire them.
+func waitForLeaderLeaseTransfer(c clientset.Interface, ns string) error {
+	timeout := time.Duration(deployTimeout) * time.Minute
+
+	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		runningPodNames := make(map[string]bool)
+		for i := range pods.Items {
+			if pods.Items[i].Status.Phase == v1.PodRunning && pods.Items[i].DeletionTimestamp == nil {
+				// CSI sidecar leader election sanitizes pod names by
+				// replacing dots with dashes in holder identities.
+				normalized := strings.ReplaceAll(pods.Items[i].Name, ".", "-")
+				runningPodNames[normalized] = true
+			}
+		}
+
+		leases, err := c.CoordinationV1().Leases(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		for i := range leases.Items {
+			lease := &leases.Items[i]
+			if !isCSILeaderLease(lease.Name) {
+				continue
+			}
+
+			if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+				framework.Logf("CSI lease %s/%s has no holder, waiting", ns, lease.Name)
+
+				return false, nil
+			}
+
+			holder := *lease.Spec.HolderIdentity
+			heldByRunningPod := false
+			for podName := range runningPodNames {
+				if strings.HasPrefix(holder, podName) {
+					heldByRunningPod = true
+
+					break
+				}
+			}
+
+			if !heldByRunningPod {
+				framework.Logf("CSI lease %s/%s held by %q (not a running pod), waiting for transfer",
+					ns, lease.Name, holder)
+
+				return false, nil
+			}
+		}
+
+		framework.Logf("all CSI leader leases in %s held by running pods", ns)
+
+		return true, nil
+	})
 }
 
 func (OperatorDeployment) setDomainLabels(labels []string) error {

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -5925,7 +5925,7 @@ var _ = Describe("RBD", func() {
 		})
 
 		It("validate rbd image qos by volumeattributesclass", func() {
-			if !supportsVolumeAttributesClass(c, f) {
+			if !supportsVolumeAttributesClass(c, f, rbdDeployment.getDaemonsetName()) {
 				framework.Logf("skipping VolumeAttributesClass test, needs Kubernetes >= 1.34 and ceph-csi >= 3.17")
 
 				return
@@ -6304,7 +6304,7 @@ var _ = Describe("RBD", func() {
 		})
 
 		It("validate cgroup v2 qos by volumeattributesclass", func() {
-			if !supportsVolumeAttributesClass(c, f) {
+			if !supportsVolumeAttributesClass(c, f, rbdDeployment.getDaemonsetName()) {
 				framework.Logf("skipping VolumeAttributesClass test, needs Kubernetes >= 1.34 and ceph-csi >= 3.17")
 
 				return
@@ -6435,7 +6435,7 @@ var _ = Describe("RBD", func() {
 			if err != nil {
 				logAndFail("failed to get app pod: %v", err)
 			}
-			err = validateIOMax(f, appPod, pvc, wantsMedium)
+			err = validateIOMax(f, appPod, pvc, wantsMedium, rbdDeployment.getDaemonsetName())
 			if err != nil {
 				logAndFail("failed to validate io.max for RWO filesystem: %v", err)
 			}
@@ -6493,7 +6493,7 @@ var _ = Describe("RBD", func() {
 			if err != nil {
 				logAndFail("failed to get block app pod: %v", err)
 			}
-			err = validateIOMax(f, appBlockPod, pvcBlock, wantsLow)
+			err = validateIOMax(f, appBlockPod, pvcBlock, wantsLow, rbdDeployment.getDaemonsetName())
 			if err != nil {
 				logAndFail("failed to validate io.max for RWO block: %v", err)
 			}
@@ -6559,7 +6559,7 @@ var _ = Describe("RBD", func() {
 			if err != nil {
 				logAndFail("failed to get RWOP app pod: %v", err)
 			}
-			err = validateIOMax(f, appRWOPPod, pvcRWOP, wantsHigh)
+			err = validateIOMax(f, appRWOPPod, pvcRWOP, wantsHigh, rbdDeployment.getDaemonsetName())
 			if err != nil {
 				logAndFail("failed to validate io.max for RWOP: %v", err)
 			}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -122,9 +122,9 @@ func rbdOptions(pool string) string {
 
 // supportsVolumeAttributesClass returns true when both the Kubernetes cluster
 // (>= 1.34) and the deployed ceph-csi (>= 3.17) support VolumeAttributesClass.
-func supportsVolumeAttributesClass(c kubernetes.Interface, f *framework.Framework) bool {
+func supportsVolumeAttributesClass(c kubernetes.Interface, f *framework.Framework, daemonsetName string) bool {
 	return k8sVersionGreaterEquals(c, 1, 34) &&
-		cephcsiVersionGreaterEquals(f, rbdDaemonsetName, rbdContainerName, 3, 17)
+		cephcsiVersionGreaterEquals(f, daemonsetName, rbdContainerName, 3, 17)
 }
 
 func createRBDStorageClass(
@@ -2001,11 +2001,12 @@ func validateIOMax(
 	appPod *v1.Pod,
 	pvc *v1.PersistentVolumeClaim,
 	wants map[string]string,
+	daemonsetName string,
 ) error {
 	podUID := string(appPod.UID)
 	nodeName := appPod.Spec.NodeName
 
-	pluginPodName, err := getDaemonsetPodOnNode(f, rbdDaemonsetName, nodeName, cephCSINamespace)
+	pluginPodName, err := getDaemonsetPodOnNode(f, daemonsetName, nodeName, cephCSINamespace)
 	if err != nil {
 		return fmt.Errorf("failed to find csi-rbdplugin pod on node %s: %w", nodeName, err)
 	}


### PR DESCRIPTION
## Summary
- `OperatorDeployment` inherited the no-op `setEnableFencing` from `DriverInfo`, so `--enable-fencing` was never set in operator-based e2e runs.
- Implement `setEnableFencing` on `OperatorDeployment` by patching `OperatorConfig` CR's `driverSpecDefaults.enableFencing` field, then waiting for operator reconciliation (deployment generation change), CSI rollout, and leader lease transfer.
- Fix hardcoded `rbdDaemonsetName` in `supportsVolumeAttributesClass` and `validateIOMax` — use deployment-method-aware daemonset name.
- Fix vault e2e race: create RBAC before vault service so the ServiceAccount exists before the vault-init-job references it.

## Root cause
`DriverInfo.setEnableFencing()` (e2e/utils.go:162) is a no-op with comment "Required implementation in OperatorDeployment" — but never implemented. Flow:
1. `cephFSDeployment.setEnableFencing(true)` → no-op for operator deployment
2. CSI driver starts without `--enable-fencing`
3. `nodeserver.setClientAddress()` checks `IsFencingEnabled()` → false → returns nil
4. `clientaddress` metadata never set on subvolume
5. Test ENOENT on metadata key lookup

Additionally, after patching the CR, the original code returned immediately — before the operator reconciled. The fix waits for:
1. Deployment generation change (operator reconciled the CR)
2. Deployment + daemonset rollout (concurrent via `waitForCSI`)
3. CSI sidecar leader lease transfer to new pods (leases survive ~15s TTL after old pod termination)

## Commits
1. **e2e: implement setEnableFencing for OperatorDeployment** — patches OperatorConfig CR, waits for generation change, rollout, and leader lease transfer (with dot→dash pod name normalization for lease holder comparison)
2. **e2e: fix hardcoded daemonset name in RBD VAC tests** — `supportsVolumeAttributesClass` and `validateIOMax` accept daemonset name parameter
3. **e2e: create vault RBAC before vault service deployment** — fixes SA race condition in vault e2e setup

## CI logs
- Run 2 (initial failure): https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/rest/organizations/jenkins/pipelines/mini-e2e-operator_k8s-1.36/runs/2/nodes/104/log/?start=0
- Run 14 (passing): https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/rest/organizations/jenkins/pipelines/mini-e2e-operator_k8s-1.36/runs/14/nodes/104/log/?start=0

## Test plan
- [x] `mini-e2e-operator` CI — "verify client address metadata exists" passes
- [x] Fencing flag visible in CSI driver container args after patch
- [x] No-op config patch (already applied) returns early without timeout
- [x] Leader lease transfer completes for pods with dots in names

🤖 Generated with [Claude Code](https://claude.com/claude-code)