### PR TITLE
ci: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Ceph-CSI CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for all files
+# Maintainers:
+#   - Madhu-1
+#   - nixpanic
+#   - Rakshith-R
+# Contributors:
+#   - black-dragon74
+#   - gadididi
+#   - iPraveenParihar
+#   - Nikhil-Ladha
+*       @ceph/ceph-csi-maintainers @ceph/ceph-csi-contributors


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` to automatically request reviews on PRs
- Assigns `@ceph/ceph-csi-maintainers` and `@ceph/ceph-csi-contributors` as default owners for all files
- Follows [GitHub CODEOWNERS format](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

### Maintainers
- Madhu-1
- nixpanic
- Rakshith-R

### Contributors
- black-dragon74
- gadididi
- iPraveenParihar
- Nikhil-Ladha

## Test plan
- [x] Verify review requests are automatically assigned on new PRs


Depends-on: #6444