### PR TITLE
rbd: add unit tests for volume info stash utils

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1742,7 +1742,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 		if lookupErr == nil && info.IsBlockMode {
 			checkerType = hc.NoOpCheckerType
 		} else if lookupErr != nil {
-			log.DebugLog(ctx, "could not lookup volume info for %s: %v", volumeId, lookupErr)
+			log.WarningLog(ctx, "could not lookup volume info for %s: %v", volumeId, lookupErr)
 		}
 
 		// Start the background checker and return

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2034,7 +2034,7 @@ func cleanupRBDImageMetadataStash(metaDataPath string) error {
 // The "/csi" directory inside the container is backed by the
 // host-path volume "socket-dir" (ref rbd-plugin DaemonSet yaml file)
 // which maps to "/var/lib/kubelet/plugins/rbd.csi.ceph.com" on the node.
-const volumeInfoDir = "/csi/volume-info"
+var volumeInfoDir = "/csi/volume-info"
 
 // Holds per-volume metadata that needs to persist across
 // node-plugin restarts, indexed by volumeID.

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -19,11 +19,13 @@ package rbd
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ceph/go-ceph/rados"
 	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
@@ -443,4 +445,76 @@ func Test_shouldRetryVolumeGeneration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVolumeInfo(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	origDir := volumeInfoDir
+	volumeInfoDir = tmpDir
+	t.Cleanup(func() { volumeInfoDir = origDir })
+
+	t.Run("stash block mode volume", func(t *testing.T) {
+		t.Parallel()
+		volID := "vol-block-001"
+		err := stashVolumeInfo(volID, &volumeInfo{IsBlockMode: true})
+		require.NoError(t, err)
+
+		fPath := filepath.Join(tmpDir, volID+".json")
+		_, statErr := os.Stat(fPath)
+		require.NoError(t, statErr, "stashed file should exist")
+
+		info, err := lookupVolumeInfo(volID)
+		require.NoError(t, err)
+		assert.True(t, info.IsBlockMode)
+	})
+
+	t.Run("stash filesystem mode volume", func(t *testing.T) {
+		t.Parallel()
+		volID := "vol-fs-002"
+		err := stashVolumeInfo(volID, &volumeInfo{IsBlockMode: false})
+		require.NoError(t, err)
+
+		info, err := lookupVolumeInfo(volID)
+		require.NoError(t, err)
+		assert.False(t, info.IsBlockMode)
+	})
+
+	t.Run("lookup non-existent volume", func(t *testing.T) {
+		t.Parallel()
+		info, err := lookupVolumeInfo("vol-does-not-exist")
+		assert.Nil(t, info)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("lookup corrupted JSON", func(t *testing.T) {
+		t.Parallel()
+		fPath := filepath.Join(tmpDir, "vol-corrupt.json")
+		err := os.WriteFile(fPath, []byte("not-valid-json"), 0o600)
+		require.NoError(t, err)
+
+		info, err := lookupVolumeInfo("vol-corrupt")
+		assert.Nil(t, info)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal volume info")
+	})
+
+	t.Run("remove existing volume info", func(t *testing.T) {
+		t.Parallel()
+		volID := "vol-to-remove"
+		err := stashVolumeInfo(volID, &volumeInfo{IsBlockMode: false})
+		require.NoError(t, err)
+
+		err = removeVolumeInfo(volID)
+		require.NoError(t, err)
+
+		_, err = lookupVolumeInfo(volID)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("remove non-existent volume info", func(t *testing.T) {
+		t.Parallel()
+		err := removeVolumeInfo("vol-never-existed")
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Follow-up of https://github.com/ceph/ceph-csi/pull/6382.

Adds units tests.
Changes DebugLog to WarningLog for NodeGetVolumeStats RPC.