### PR TITLE
rbd: return InvalidArgument for unrecognized QoS

### DIFF
--- a/docs/volumeattributesclass.md
+++ b/docs/volumeattributesclass.md
@@ -211,6 +211,20 @@ on systems with cgroup v2 enabled.
   (`csi.storage.k8s.io/node-publish-secret-name`) or CSI ConfigMap
   (`rbd.nodePublishSecretRef`)
 
+#### Cgroup v2 QoS Parameter Values
+
+Each parameter accepts a non-negative integer or the special value `"max"`:
+
+| Value            | Meaning                          |
+| ---------------- | -------------------------------- |
+| `"max"`          | Remove the limit (unlimited I/O) |
+| `"0"`            | Fully throttle I/O               |
+| positive integer | Set the limit to that value      |
+
+To revert all QoS limits applied by a VolumeAttributesClass, create a new
+VolumeAttributesClass with all values set to `"max"` and modify the PVC to
+reference it.
+
 #### Create a VolumeAttributesClass for Cgroup v2 QoS
 
 - Define a VolumeAttributesClass
@@ -223,7 +237,7 @@ metadata:
   name: cgroup-qos
 driverName: rbd.csi.ceph.com
 parameters:
-  # Cgroup v2 QoS parameters
+  # Cgroup v2 QoS parameters (non-negative integer or "max")
   maxReadIops: "1000"         # 1000 read IOPS
   maxWriteIops: "2000"        # 2000 write IOPS
   maxReadBps: "104857600"     # 100 MiB/s

--- a/examples/rbd/volumeattributesclass-cgroup.yaml
+++ b/examples/rbd/volumeattributesclass-cgroup.yaml
@@ -10,11 +10,13 @@ parameters:
   # providing QoS for krbd-mapped volumes.
   #
   # Cgroup v2 io.max parameters:
-  # Format for each parameter is a positive integer representing
-  # the limit value.
+  # Each parameter accepts a non-negative integer or the special
+  # value "max". Use "max" to remove a previously applied limit
+  # (resets the device to unlimited). Use "0" to fully throttle I/O.
   #
   # (optional) Max read IOPS per second for the device.
   # Example: "1000" allows up to 1000 read operations per second.
+  # Use "max" to remove the read IOPS limit.
   maxReadIops: "1000"
   #
   # (optional) Max write IOPS per second for the device.

--- a/internal/rbd/cgroup_qos.go
+++ b/internal/rbd/cgroup_qos.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -99,6 +101,11 @@ type cgroupQoSHandler struct {
 // newCgroupQoSHandler creates a new cgroup QoS handler.
 func newCgroupQoSHandler(volume *rbdVolume) QoSHandler {
 	return &cgroupQoSHandler{volume: volume}
+}
+
+// cgroupQoSKnownKeys returns the cgroup v2 QoS parameter keys.
+func cgroupQoSKnownKeys() []string {
+	return slices.Collect(maps.Keys(qosParamToMetadataKey))
 }
 
 // HasParams checks if cgroup v2 QoS parameters are present in the request.

--- a/internal/rbd/cgroup_qos.go
+++ b/internal/rbd/cgroup_qos.go
@@ -66,6 +66,9 @@ const (
 	qosMetadataMaxReadBps   = qosMetadataKeyPrefix + "cgroup_qos_max_read_bps"
 	qosMetadataMaxWriteBps  = qosMetadataKeyPrefix + "cgroup_qos_max_write_bps"
 
+	// cgroupQoSMaxLimit is the cgroup v2 value for unlimited I/O.
+	cgroupQoSMaxLimit = "max"
+
 	// io.max file for cgroup v2.
 	ioMaxFile = "io.max"
 
@@ -153,10 +156,10 @@ type cgroupQoS struct {
 // parseCgroupQoSParams extracts cgroup v2 QoS parameters from VolumeAttributesClass.
 func parseCgroupQoSParams(params map[string]string) *cgroupQoS {
 	qos := &cgroupQoS{
-		maxReadIops:  "max",
-		maxWriteIops: "max",
-		maxReadBps:   "max",
-		maxWriteBps:  "max",
+		maxReadIops:  cgroupQoSMaxLimit,
+		maxWriteIops: cgroupQoSMaxLimit,
+		maxReadBps:   cgroupQoSMaxLimit,
+		maxWriteBps:  cgroupQoSMaxLimit,
 	}
 
 	if val, ok := params[maxReadIops]; ok && val != "" {
@@ -295,12 +298,16 @@ func (qos *cgroupQoS) applyCgroupQoS(ctx context.Context, podUID string) error {
 func validateCgroupQoSParams(params map[string]string) error {
 	for key := range qosParamToMetadataKey {
 		if val, ok := params[key]; ok && val != "" {
+			// "max" means unlimited (removes the limit).
+			if val == cgroupQoSMaxLimit {
+				continue
+			}
 			parsed, err := strconv.ParseInt(val, 10, 64)
 			if err != nil {
-				return fmt.Errorf("invalid value for %s: %s, must be a positive integer", key, val)
+				return fmt.Errorf("invalid value for %s: %s, must be a non-negative integer or %q", key, val, cgroupQoSMaxLimit)
 			}
-			if parsed <= 0 {
-				return fmt.Errorf("invalid value for %s: %s, must be greater than 0", key, val)
+			if parsed < 0 {
+				return fmt.Errorf("invalid value for %s: %s, must be a non-negative integer or %q", key, val, cgroupQoSMaxLimit)
 			}
 		}
 	}

--- a/internal/rbd/cgroup_qos_test.go
+++ b/internal/rbd/cgroup_qos_test.go
@@ -267,7 +267,7 @@ func TestValidateCgroupQoSParams(t *testing.T) {
 			params: map[string]string{
 				maxReadIops: "0",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "negative maxWriteIops",
@@ -281,7 +281,7 @@ func TestValidateCgroupQoSParams(t *testing.T) {
 			params: map[string]string{
 				maxReadBps: "0",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "negative maxWriteBps",
@@ -289,6 +289,24 @@ func TestValidateCgroupQoSParams(t *testing.T) {
 				maxWriteBps: "-10485760",
 			},
 			wantErr: true,
+		},
+		{
+			name: "max value resets to unlimited",
+			params: map[string]string{
+				maxReadIops:  "max",
+				maxWriteIops: "max",
+				maxReadBps:   "max",
+				maxWriteBps:  "max",
+			},
+			wantErr: false,
+		},
+		{
+			name: "partial max values",
+			params: map[string]string{
+				maxReadIops: "max",
+				maxWriteBps: "1000",
+			},
+			wantErr: false,
 		},
 		{
 			name:    "empty parameters",

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strconv"
 
 	osdAdmin "github.com/ceph/go-ceph/common/admin/osd"
@@ -159,27 +160,65 @@ func validateQoSParameters(mutableParams map[string]string, mounter string) erro
 		// NBD mounter: only NBD QoS params are valid.
 		// The shared keys (maxReadIops, etc.) serve as NBD max limits here.
 		if HasQoSParams(mutableParams) {
+			if unknown := unrecognizedKeys(mutableParams, nbdQoSKnownKeys); len(unknown) > 0 {
+				return fmt.Errorf("mutable parameters %v are not recognized QoS parameters for %q mounter",
+					unknown, mounter)
+			}
+
 			return validateNBDQoSParams(mutableParams)
 		}
 
-		return nil
+		keys := slices.Sorted(maps.Keys(mutableParams))
+
+		return fmt.Errorf("mutable parameters %v for %q mounter are missing required base QoS parameters",
+			keys, mounter)
 	}
 
 	// krbd mounter: only cgroup v2 QoS params are supported.
 	// Reject any NBD-specific params that won't be applied via cgroup.
 	if HasQoSParams(mutableParams) {
-		return fmt.Errorf(
-			"NBD QoS parameters (baseIops, baseReadIops, etc.) are not supported with %q mounter, "+
-				"use cgroup QoS parameters (maxReadIops, maxWriteIops, maxReadBps, maxWriteBps)", mounter)
+		keys := slices.Sorted(maps.Keys(mutableParams))
+
+		return fmt.Errorf("mutable parameters %v contain NBD-specific QoS parameters not supported with %q mounter",
+			keys, mounter)
 	}
 
 	if hasCgroupQoSParams(mutableParams) {
+		if unknown := unrecognizedKeys(mutableParams, cgroupQoSKnownKeys()); len(unknown) > 0 {
+			return fmt.Errorf("mutable parameters %v are not recognized QoS parameters for %q mounter",
+				unknown, mounter)
+		}
+
 		if err := validateCgroupQoSParams(mutableParams); err != nil {
 			return fmt.Errorf("invalid cgroup QoS parameters: %w", err)
 		}
+
+		return nil
 	}
 
-	return nil
+	keys := slices.Sorted(maps.Keys(mutableParams))
+
+	return fmt.Errorf("mutable parameters %v for %q mounter are missing required cgroup QoS parameters",
+		keys, mounter)
+}
+
+// unrecognizedKeys returns parameter keys not present in the known set.
+func unrecognizedKeys(params map[string]string, known []string) []string {
+	knownSet := make(map[string]struct{}, len(known))
+	for _, k := range known {
+		knownSet[k] = struct{}{}
+	}
+
+	var unknown []string
+	for k := range params {
+		if _, ok := knownSet[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+
+	slices.Sort(unknown)
+
+	return unknown
 }
 
 // parseVolCreateRequest take create volume `request` argument and make use of the
@@ -2075,8 +2114,10 @@ func (cs *ControllerServer) ControllerModifyVolume(
 		return nil, status.Errorf(codes.Internal, "failed to determine volume mounter type: %v", err)
 	}
 
-	if err = validateQoSParameters(mutableParameters, rbdVol.Mounter); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if len(mutableParameters) > 0 {
+		if err = validateQoSParameters(mutableParameters, rbdVol.Mounter); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	// set RequestedVolSize, because calcQosBasedOnCapacity use it.
@@ -2085,6 +2126,10 @@ func (cs *ControllerServer) ControllerModifyVolume(
 	err = rbdVol.modifyVolumeAttributes(ctx, mutableParameters)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to modify volume: %s with error: %v", rbdVol, err)
+
+		if errors.Is(err, rbderrors.ErrInvalidArgument) {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/rbd/controllerserver_test.go
+++ b/internal/rbd/controllerserver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rbd
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -203,7 +204,7 @@ func TestValidateQoSParameters(t *testing.T) {
 			name:    "krbd with empty params",
 			params:  map[string]string{},
 			mounter: rbdDefaultMounter,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name:    "nbd with NBD params and max limits",
@@ -227,7 +228,37 @@ func TestValidateQoSParameters(t *testing.T) {
 			name:    "nbd with empty params",
 			params:  map[string]string{},
 			mounter: rbdNbdMounter,
-			wantErr: false,
+			wantErr: true,
+		},
+		{
+			name:    "krbd with misspelled cgroup param",
+			params:  map[string]string{"readIOPS": "1000"},
+			mounter: rbdDefaultMounter,
+			wantErr: true,
+		},
+		{
+			name:    "krbd with completely unknown param",
+			params:  map[string]string{"fooBar": "123"},
+			mounter: rbdDefaultMounter,
+			wantErr: true,
+		},
+		{
+			name:    "nbd with misspelled param",
+			params:  map[string]string{"readIOPS": "1000"},
+			mounter: rbdNbdMounter,
+			wantErr: true,
+		},
+		{
+			name:    "nbd with valid and unknown params",
+			params:  map[string]string{baseIops: "3000", "unknownKey": "value"},
+			mounter: rbdNbdMounter,
+			wantErr: true,
+		},
+		{
+			name:    "krbd with valid cgroup and unknown params",
+			params:  map[string]string{maxReadIops: "1000", "typoParam": "50"},
+			mounter: rbdDefaultMounter,
+			wantErr: true,
 		},
 	}
 
@@ -237,6 +268,67 @@ func TestValidateQoSParameters(t *testing.T) {
 			err := validateQoSParameters(tt.params, tt.mounter)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateQoSParameters() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUnrecognizedKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		params   map[string]string
+		known    []string
+		expected []string
+	}{
+		{
+			name:     "all keys recognized",
+			params:   map[string]string{"a": "1", "b": "2"},
+			known:    []string{"a", "b", "c"},
+			expected: nil,
+		},
+		{
+			name:     "some keys unrecognized",
+			params:   map[string]string{"a": "1", "x": "2", "y": "3"},
+			known:    []string{"a", "b"},
+			expected: []string{"x", "y"},
+		},
+		{
+			name:     "all keys unrecognized",
+			params:   map[string]string{"x": "1", "y": "2"},
+			known:    []string{"a", "b"},
+			expected: []string{"x", "y"},
+		},
+		{
+			name:     "empty params",
+			params:   map[string]string{},
+			known:    []string{"a"},
+			expected: nil,
+		},
+		{
+			name:     "empty known list",
+			params:   map[string]string{"a": "1"},
+			known:    []string{},
+			expected: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := unrecognizedKeys(tt.params, tt.known)
+			slices.Sort(got)
+			slices.Sort(tt.expected)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("unrecognizedKeys() = %v, expected %v", got, tt.expected)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("unrecognizedKeys() = %v, expected %v", got, tt.expected)
+
+					break
+				}
 			}
 		})
 	}

--- a/internal/rbd/qos.go
+++ b/internal/rbd/qos.go
@@ -112,6 +112,15 @@ func newNBDQoSHandler(volume *rbdVolume) QoSHandler {
 	return &nbdQoSHandler{volume: volume}
 }
 
+// nbdQoSKnownKeys lists all parameter keys recognized by the NBD QoS handler.
+var nbdQoSKnownKeys = []string{
+	baseIops, maxIops, baseReadIops, maxReadIops, baseWriteIops, maxWriteIops,
+	baseBps, maxBps, baseReadBps, maxReadBps, baseWriteBps, maxWriteBps,
+	iopsPerGiB, readIopsPerGiB, writeIopsPerGiB,
+	bpsPerGiB, readBpsPerGiB, writeBpsPerGiB,
+	baseVolSizeBytes,
+}
+
 // HasParams checks if traditional NBD QoS parameters are present in the request.
 func (h *nbdQoSHandler) HasParams(params map[string]string) bool {
 	return HasQoSParams(params)
@@ -125,16 +134,7 @@ func (h *nbdQoSHandler) Validate(params map[string]string) error {
 // validateNBDQoSParams validates traditional NBD QoS parameters.
 // Ensures all numeric values are valid and positive.
 func validateNBDQoSParams(params map[string]string) error {
-	// All NBD QoS parameter keys that accept numeric values
-	numericParams := []string{
-		baseIops, maxIops, baseReadIops, maxReadIops, baseWriteIops, maxWriteIops,
-		baseBps, maxBps, baseReadBps, maxReadBps, baseWriteBps, maxWriteBps,
-		iopsPerGiB, readIopsPerGiB, writeIopsPerGiB,
-		bpsPerGiB, readBpsPerGiB, writeBpsPerGiB,
-		baseVolSizeBytes,
-	}
-
-	for _, key := range numericParams {
+	for _, key := range nbdQoSKnownKeys {
 		if val, ok := params[key]; ok && val != "" {
 			parsed, err := strconv.ParseInt(val, 10, 64)
 			if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2571,11 +2571,12 @@ func (rv *rbdVolume) modifyVolumeAttributes(
 	}
 
 	// Find and apply the QoS type present in the request.
+	// Unrecognized keys are already rejected by validateQoSParameters.
 	for _, handler := range handlers {
 		if handler.HasParams(newMutableParameters) {
 			// Validate parameters before applying.
 			if err := handler.Validate(newMutableParameters); err != nil {
-				return err
+				return fmt.Errorf("%w: %w", rbderrors.ErrInvalidArgument, err)
 			}
 
 			// Apply the QoS settings.


### PR DESCRIPTION
Unrecognized or invalid QoS parameters in mutable volume attributes are a client input error, not an internal
server error. Wrap these errors with ErrInvalidArgument so callers return codes.InvalidArgument instead of codes.Internal.

Allow unsetting the Qos by setting the values as max