### PR TITLE
cleanup: check GetParameters() for nil in CSI requests

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -773,7 +773,11 @@ func (cs *cephfsControllerServer) CreateSnapshot(
 	}
 	defer cr.DeleteCredentials()
 
-	clusterData, err := store.GetClusterInformation(req.GetParameters())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	clusterData, err := store.GetClusterInformation(parameters)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -61,6 +61,9 @@ func (cs *cephfsControllerServer) validateCreateVolumeGroupSnapshotRequest(
 	}
 
 	param := req.GetParameters()
+	if param == nil {
+		return status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
 	// check for ClusterID and fsName
 	if value, ok := param["clusterID"]; !ok || value == "" {
 		return status.Error(codes.InvalidArgument, "missing or empty clusterID")

--- a/internal/cephfs/store/volumegroup.go
+++ b/internal/cephfs/store/volumegroup.go
@@ -45,6 +45,9 @@ func NewVolumeGroupOptions(
 	)
 
 	volOptions := req.GetParameters()
+	if volOptions == nil {
+		return nil, fmt.Errorf("parameters cannot be nil")
+	}
 	opts.VolumeOptions, err = getVolumeOptions(volOptions)
 	if err != nil {
 		return nil, err

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -277,6 +277,9 @@ func NewVolumeOptions(
 	)
 
 	volOptions := req.GetParameters()
+	if volOptions == nil {
+		return nil, fmt.Errorf("parameters cannot be nil")
+	}
 	opts, err = getVolumeOptions(volOptions)
 	if err != nil {
 		return nil, err

--- a/internal/csi-addons/cephfs/network_fence.go
+++ b/internal/csi-addons/cephfs/network_fence.go
@@ -70,7 +70,11 @@ func (fcs *FenceControllerServer) FenceClusterNetwork(
 	ctx context.Context,
 	req *fence.FenceClusterNetworkRequest,
 ) (*fence.FenceClusterNetworkResponse, error) {
-	err := validateNetworkFenceReq(req.GetCidrs(), req.GetParameters())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	err := validateNetworkFenceReq(req.GetCidrs(), parameters)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -99,7 +103,11 @@ func (fcs *FenceControllerServer) UnfenceClusterNetwork(
 	ctx context.Context,
 	req *fence.UnfenceClusterNetworkRequest,
 ) (*fence.UnfenceClusterNetworkResponse, error) {
-	err := validateNetworkFenceReq(req.GetCidrs(), req.GetParameters())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	err := validateNetworkFenceReq(req.GetCidrs(), parameters)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -222,6 +222,9 @@ func GetFenceClients(
 	enableFencing bool,
 ) (*fence.GetFenceClientsResponse, error) {
 	options := req.GetParameters()
+	if options == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
 	clusterID, err := util.GetClusterID(options)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/internal/csi-addons/rbd/network_fence.go
+++ b/internal/csi-addons/rbd/network_fence.go
@@ -65,7 +65,11 @@ func (fcs *FenceControllerServer) FenceClusterNetwork(
 	ctx context.Context,
 	req *fence.FenceClusterNetworkRequest,
 ) (*fence.FenceClusterNetworkResponse, error) {
-	err := validateNetworkFenceReq(req.GetCidrs(), req.GetParameters())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	err := validateNetworkFenceReq(req.GetCidrs(), parameters)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -94,7 +98,11 @@ func (fcs *FenceControllerServer) UnfenceClusterNetwork(
 	ctx context.Context,
 	req *fence.UnfenceClusterNetworkRequest,
 ) (*fence.UnfenceClusterNetworkResponse, error) {
-	err := validateNetworkFenceReq(req.GetCidrs(), req.GetParameters())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	err := validateNetworkFenceReq(req.GetCidrs(), parameters)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -265,7 +265,11 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	}
 	defer cr.DeleteCredentials()
 
-	err = validateSchedulingDetails(ctx, req.GetParameters())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	err = validateSchedulingDetails(ctx, parameters)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +281,7 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
+	mgr := rbd.NewManager(rs.driverInstance, parameters, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -349,7 +353,11 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	mgr := rbd.NewManager(rs.driverInstance, parameters, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -508,7 +516,11 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	}
 	defer rs.VolumeLocks.Release(volumeID)
 
-	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	mgr := rbd.NewManager(rs.driverInstance, parameters, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
@@ -626,7 +638,11 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer rs.VolumeLocks.Release(volumeID)
-	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	mgr := rbd.NewManager(rs.driverInstance, parameters, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -97,7 +97,11 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 		groupName = req.GetName()
 	)
 
-	mgr := rbd.NewManager(vs.driverInstance, req.GetParameters(), req.GetSecrets())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	mgr := rbd.NewManager(vs.driverInstance, parameters, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	// resolve all volumes
@@ -209,7 +213,11 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 
 		// extract the flatten mode
 		var flattenMode types.FlattenMode
-		flattenMode, err = getFlattenMode(ctx, req.GetParameters())
+		parameters := req.GetParameters()
+		if parameters == nil {
+			return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+		}
+		flattenMode, err = getFlattenMode(ctx, parameters)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -466,6 +466,9 @@ func validateDHCHAPParameter(dhchapMode string) error {
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 	// Validate required parameters
 	params := req.GetParameters()
+	if params == nil {
+		return errors.New("parameters cannot be nil")
+	}
 	if params["nvmeofGatewayAddress"] == "" {
 		return errors.New("missing required parameter nvmeofGatewayAddress")
 	}
@@ -798,6 +801,9 @@ func (cs *Server) createNVMeoFResources(
 ) (*nvmeof.NVMeoFVolumeData, error) {
 	// Step 1: Extract parameters (already validated)
 	params := req.GetParameters()
+	if params == nil {
+		return nil, errors.New("parameters cannot be nil")
+	}
 
 	networkMask := params["networkMask"]
 	nvmeofData := &nvmeof.NVMeoFVolumeData{}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -80,6 +80,9 @@ func (cs *ControllerServer) validateVolumeReq(ctx context.Context, req *csi.Crea
 		return status.Error(codes.InvalidArgument, "volume Capabilities cannot be empty")
 	}
 	options := req.GetParameters()
+	if options == nil {
+		return status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
 	if value, ok := options["clusterID"]; !ok || value == "" {
 		return status.Error(codes.InvalidArgument, "empty cluster ID to provision volume from")
 	}
@@ -1399,6 +1402,9 @@ func (cs *ControllerServer) validateSnapshotReq(ctx context.Context, req *csi.Cr
 	}
 
 	options := req.GetParameters()
+	if options == nil {
+		return status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
 	if value, ok := options["snapshotNamePrefix"]; ok && value == "" {
 		return status.Error(codes.InvalidArgument, "empty snapshot name prefix to provision snapshot from")
 	}

--- a/internal/rbd/group_controllerserver.go
+++ b/internal/rbd/group_controllerserver.go
@@ -75,7 +75,11 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 	}
 	defer cs.VolumeGroupLocks.Release(vgsName)
 
-	mgr := NewManager(cs.Driver.GetInstanceID(), req.GetParameters(), req.GetSecrets())
+	parameters := req.GetParameters()
+	if parameters == nil {
+		return nil, status.Error(codes.InvalidArgument, "parameters cannot be nil")
+	}
+	mgr := NewManager(cs.Driver.GetInstanceID(), parameters, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
 	// resolve all volumes, free them later on


### PR DESCRIPTION
Copilot reported a potential panic when there are no parameters passed in CSI
requests. It is unlikely that a StorageClass or other sources of requests do
not contain parameters, but technically users could do this and cause Ceph-CSI
to crash.

See-also: https://github.com/ceph/ceph-csi/pull/6458#discussion_r3727192267