### PR TITLE
release: update templates and docs for v3.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ environments.
 
 | Ceph CSI Version | Container Orchestrator Name | Version Tested      |
 | -----------------| --------------------------- | ------------------- |
+| v3.17.1          | Kubernetes                  | v1.34, v1.35, v1.36 |
 | v3.17.0          | Kubernetes                  | v1.33, v1.34, v1.35 |
 | v3.16.2          | Kubernetes                  | v1.32, v1.33, v1.34 |
 | v3.16.1          | Kubernetes                  | v1.32, v1.33, v1.34 |
@@ -147,6 +148,7 @@ in the Kubernetes documentation.
 | Ceph CSI Release/Branch | Container image name         | Image Tag |
 | ----------------------- | ---------------------------- | --------- |
 | devel (Branch)          | quay.io/cephcsi/cephcsi      | canary    |
+| v3.17.1 (Release)       | quay.io/cephcsi/cephcsi      | v3.17.1   |
 | v3.17.0 (Release)       | quay.io/cephcsi/cephcsi      | v3.17.0   |
 | v3.16.2 (Release)       | quay.io/cephcsi/cephcsi      | v3.16.2   |
 | v3.16.1 (Release)       | quay.io/cephcsi/cephcsi      | v3.16.1   |

--- a/build.env
+++ b/build.env
@@ -9,7 +9,7 @@
 # get proporly expanded.
 #
 # cephcsi image version
-CSI_IMAGE_VERSION=v3.17-canary
+CSI_IMAGE_VERSION=v3.17.1
 
 # The ceph-csi version used as the starting point
 # during upgrades. This version will be upgraded

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -138,7 +138,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.17-canary
+      tag: v3.17.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -149,7 +149,7 @@ nodeplugin:
   plugin:
     image:
       repository: quay.io/cephcsi/cephcsi
-      tag: v3.17-canary
+      tag: v3.17.1
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-cephfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -192,7 +192,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-cephfsplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--type=controller"
             - "--v=5"
@@ -213,7 +213,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=cephfs"
@@ -125,7 +125,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -40,7 +40,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: csi-nfsplugin
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"
@@ -169,7 +169,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=nfs"

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -47,7 +47,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-rbdplugin
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--type=rbd"
@@ -208,7 +208,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-rbdplugin-controller
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--type=controller"
             - "--v=5"
@@ -229,7 +229,7 @@ spec:
             - name: ceph-config
               mountPath: /etc/ceph/
         - name: liveness-prometheus
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -28,7 +28,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--nodeid=$(NODE_ID)"
             - "--pluginpath=/var/lib/kubelet/plugins"
@@ -135,7 +135,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/cephcsi/cephcsi:v3.17-canary
+          image: quay.io/cephcsi/cephcsi:v3.17.1
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -106,15 +106,15 @@ compatibility support and without prior notice.
 For example, upgrading from 3.14 to 3.17 is not recommended.
 
 **Refer to the Breaking Changes Section in the
-[release notes](https://github.com/ceph/ceph-csi/releases/tag/v3.17.0) before
+[release notes](https://github.com/ceph/ceph-csi/releases/tag/v3.17.1) before
 proceeding further.**
 
-git checkout v3.17.0 tag
+git checkout v3.17.1 tag
 
 ```bash
 git clone https://github.com/ceph/ceph-csi.git
 cd ./ceph-csi
-git checkout v3.17.0
+git checkout v3.17.1
 ```
 
 ```console


### PR DESCRIPTION
## Summary
- Update image tags from `v3.17-canary` to `v3.17.1` in deploy manifests, helm charts, and `build.env`
- Add v3.17.1 entry to README version/image tables (Kubernetes v1.34, v1.35, v1.36)
- Update `docs/ceph-csi-upgrade.md` to reference v3.17.1 tag

Ref: https://github.com/ceph/ceph-csi/issues/6300