### PR TITLE
doc: update docs for release-v3.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ environments.
 | Ceph CSI Version | Container Orchestrator Name | Version Tested      |
 | -----------------| --------------------------- | ------------------- |
 | devel (v3.18.0)  | Kubernetes                  | v1.34, v1.35, v1.36 |
+| v3.17.1          | Kubernetes                  | v1.34, v1.35, v1.36 |
 | v3.17.0          | Kubernetes                  | v1.33, v1.34, v1.35 |
 | v3.16.2          | Kubernetes                  | v1.32, v1.33, v1.34 |
 | v3.16.1          | Kubernetes                  | v1.32, v1.33, v1.34 |
@@ -150,6 +151,7 @@ in the Kubernetes documentation.
 | Ceph CSI Release/Branch | Container image name         | Image Tag |
 | ----------------------- | ---------------------------- | --------- |
 | devel (Branch)          | quay.io/cephcsi/cephcsi      | canary    |
+| v3.17.1 (Release)       | quay.io/cephcsi/cephcsi      | v3.17.1   |
 | v3.17.0 (Release)       | quay.io/cephcsi/cephcsi      | v3.17.0   |
 | v3.16.2 (Release)       | quay.io/cephcsi/cephcsi      | v3.16.2   |
 | v3.16.1 (Release)       | quay.io/cephcsi/cephcsi      | v3.16.1   |

--- a/docs/ceph-csi-upgrade.md
+++ b/docs/ceph-csi-upgrade.md
@@ -106,15 +106,15 @@ compatibility support and without prior notice.
 For example, upgrading from 3.14 to 3.17 is not recommended.
 
 **Refer to the Breaking Changes Section in the
-[release notes](https://github.com/ceph/ceph-csi/releases/tag/v3.17.0) before
+[release notes](https://github.com/ceph/ceph-csi/releases/tag/v3.17.1) before
 proceeding further.**
 
-git checkout v3.17.0 tag
+git checkout v3.17.1 tag
 
 ```bash
 git clone https://github.com/ceph/ceph-csi.git
 cd ./ceph-csi
-git checkout v3.17.0
+git checkout v3.17.1
 ```
 
 ```console


### PR DESCRIPTION
## Summary
- Add v3.17.1 entry to README version and image tables
- Update `docs/ceph-csi-upgrade.md` to reference v3.17.1 tag

Ref: https://github.com/ceph/ceph-csi/issues/6300