### PR TITLE
rbd: replace O(n) trash list scan with O(1) ID-based trash removal

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -989,8 +989,7 @@ func (cs *ControllerServer) checkErrAndUndoReserve(
 	}
 
 	if errors.Is(err, rbderrors.ErrImageNotFound) {
-		notFoundErr := rbdVol.ensureImageCleanup(ctx)
-		if notFoundErr != nil {
+		if notFoundErr := rbdVol.removeImageFromTrash(ctx); notFoundErr != nil {
 			return nil, status.Errorf(codes.Internal, "failed to cleanup image %q: %v", rbdVol, notFoundErr)
 		}
 	} else {
@@ -1162,7 +1161,9 @@ func cleanupRBDImage(ctx context.Context,
 	}
 
 	// delete the temporary rbd image created as part of volume clone during
-	// create volume
+	// create volume. This must run before rbdVol.Delete() so the volume
+	// image still exists and its parent info (ParentImageID) can identify
+	// a trashed temp clone without scanning the trash list.
 	err = rbdVol.DeleteTempImage(ctx)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to delete temporary rbd image: %v", err)
@@ -1641,9 +1642,9 @@ func cleanUpImageAndSnapReservation(ctx context.Context, rbdSnap *rbdSnapshot, c
 	defer rbdVol.Destroy(ctx)
 
 	// cleanup the image from trash if the error is image not found.
-	err = rbdVol.ensureImageCleanup(ctx)
+	err = rbdVol.removeImageFromTrash(ctx)
 	if err != nil {
-		log.ErrorLog(ctx, "failed to delete rbd image: %q with error: %v", rbdVol.Pool, rbdVol.VolName, err)
+		log.ErrorLog(ctx, "failed to delete rbd image %q: %v", rbdVol, err)
 
 		return status.Error(codes.Internal, err.Error())
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -723,31 +723,6 @@ func isCephMgrSupported(ctx context.Context, clusterID string, err error) (bool,
 	return true, nil
 }
 
-// ensureImageCleanup finds image in trash and if found removes it
-// from trash.
-func (ri *rbdImage) ensureImageCleanup(ctx context.Context) error {
-	err := ri.openIoctx()
-	if err != nil {
-		return err
-	}
-
-	trashInfoList, err := librbd.GetTrashList(ri.ioctx)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to list images in trash: %v", err)
-
-		return err
-	}
-	for _, val := range trashInfoList {
-		if val.Name == ri.RbdImageName {
-			ri.ImageID = val.Id
-
-			return ri.trashRemoveImage(ctx)
-		}
-	}
-
-	return nil
-}
-
 // Delete deletes a ceph image with provision and volume options.
 func (ri *rbdImage) Delete(ctx context.Context) error {
 	image := ri.RbdImageName
@@ -876,11 +851,20 @@ func (rv *rbdVolume) DeleteTempImage(ctx context.Context) error {
 	err = tempClone.Delete(ctx)
 	if err != nil {
 		if errors.Is(err, rbderrors.ErrImageNotFound) {
-			return tempClone.ensureImageCleanup(ctx)
-		} else {
-			// return error if it is not ErrImageNotFound
-			return err
+			if rv.ParentInTrash &&
+				rv.ParentName == tempClone.RbdImageName &&
+				rv.ParentImageID != "" {
+				tempClone.ImageID = rv.ParentImageID
+
+				return tempClone.removeImageFromTrash(ctx)
+			}
+
+			log.DebugLog(ctx, "temp clone %s not found and not in trash, already removed", tempClone)
+
+			return nil
 		}
+
+		return err
 	}
 
 	return nil

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -806,6 +806,11 @@ func (ri *rbdImage) trashRemoveImage(ctx context.Context) error {
 	}
 
 	_, err = ta.AddTrashRemove(admin.NewImageSpec(ri.Pool, ri.RadosNamespace, ri.ImageID))
+	if err != nil && errors.Is(err, rados.ErrNotFound) {
+		log.DebugLog(ctx, "image %s (ID %s) not found in trash, already removed", ri, ri.ImageID)
+
+		return nil
+	}
 
 	rbdCephMgrSupported, knownErr := isCephMgrSupported(ctx, ri.ClusterID, err)
 	if rbdCephMgrSupported && err != nil {
@@ -817,6 +822,12 @@ func (ri *rbdImage) trashRemoveImage(ctx context.Context) error {
 	if !rbdCephMgrSupported && knownErr != nil {
 		trashRemoveError := librbd.TrashRemove(ri.ioctx, ri.ImageID, true)
 		if trashRemoveError != nil {
+			if errors.Is(trashRemoveError, librbd.ErrNotFound) {
+				log.DebugLog(ctx, "image %s not found in trash, already removed", ri)
+
+				return nil
+			}
+
 			log.ErrorLog(ctx, "failed to delete rbd image: %s, %v", ri, trashRemoveError)
 
 			return fmt.Errorf(
@@ -830,6 +841,19 @@ func (ri *rbdImage) trashRemoveImage(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// removeImageFromTrash removes an image from trash by its known image ID.
+func (ri *rbdImage) removeImageFromTrash(ctx context.Context) error {
+	if ri.ImageID == "" {
+		return fmt.Errorf("image ID is empty, cannot remove %s from trash", ri)
+	}
+
+	if err := ri.openIoctx(); err != nil {
+		return err
+	}
+
+	return ri.trashRemoveImage(ctx)
 }
 
 // DeleteTempImage deletes the temporary image created for volume datasource.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -165,6 +165,9 @@ type rbdImage struct {
 
 	// ParentInTrash indicates the parent image is in trash.
 	ParentInTrash bool
+	// ParentImageID is the image ID of the parent image, populated by
+	// getImageInfo(). Valid even when the parent is in trash.
+	ParentImageID string
 
 	// RBD QoS configuration
 	QosParameters map[string]string
@@ -1814,6 +1817,9 @@ func (ri *rbdImage) getImageInfo() error {
 		// the parent is an error or not.
 		if errors.Is(err, librbd.ErrNotFound) {
 			ri.ParentName = ""
+			ri.ParentPool = ""
+			ri.ParentInTrash = false
+			ri.ParentImageID = ""
 		} else {
 			return err
 		}
@@ -1821,6 +1827,7 @@ func (ri *rbdImage) getImageInfo() error {
 		ri.ParentName = parentInfo.Image.ImageName
 		ri.ParentPool = parentInfo.Image.PoolName
 		ri.ParentInTrash = parentInfo.Image.Trash
+		ri.ParentImageID = parentInfo.Image.ImageID
 	}
 	// Get image creation time
 	tm, err := image.GetCreateTimestamp()


### PR DESCRIPTION
# Describe what this PR does #

Replace `ensureImageCleanup()` - which scans the entire RBD trash list
to find an image by name - with direct O(1) removal by image ID using
the new `removeImageFromTrash()` helper.

The image ID is always available: modern volumes store it in OMAP at
creation time, and legacy volumes get it backfilled by `storeImageID()`
during the first `generateVolumeFromVolumeID()` call.

**Commit 1** - `rbd: capture parent image ID in getImageInfo`

Add `ParentImageID` field to `rbdImage` and populate it in
`getImageInfo()` from `GetParent().Image.ImageID`. Valid even when the
parent is in trash.

**Commit 2** - `rbd: make trash remove idempotent and add removeImageFromTrash`

Add `removeImageFromTrash()` as an O(1) helper that removes a trashed
image by its known ID. Make `trashRemoveImage()` treat ENOENT as success
on both the ceph mgr and direct paths (image already purged).

**Commit 3** - `rbd: avoid trash ls in DeleteVolume/DeleteSnapshot retry paths`

In `checkErrAndUndoReserve()` and `cleanUpImageAndSnapReservation()`,
switch from `ensureImageCleanup()` to `removeImageFromTrash()`. Also fix
a pre-existing `ErrorLog` format string mismatch (2 format verbs, 3 args).

**Commit 4** - `rbd: remove ensureImageCleanup and use ID-based trash removal`

In `DeleteTempImage()`, use the volume's `ParentImageID` to identify a
trashed temp clone instead of scanning the trash list. Remove
`ensureImageCleanup()` entirely - no callers remain.

## Is there anything that requires special attention ##

- `DeleteTempImage()` relies on being called before `rbdVol.Delete()` so
  that `GetParent()` data is still valid. This ordering already exists in
  `cleanupRBDImage()` and is now documented with a comment.
- When parent info is unavailable in `DeleteTempImage()` (temp clone not
  in trash), it returns success - same behavior as the old code when the
  trash scan found nothing.

The change is backward compatible. No API or OMAP schema changes.

## Future concerns ##

- `GetTrashList` is still used in `waitForCleanTrash()` (e2e test helper).
  That is unrelated to production code paths.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
  N/A - internal optimization, no user-facing changes.
* [x] Documentation has been updated, if necessary.
  N/A - no doc changes needed, internal refactor only.
* [x] Unit tests have been added, if necessary.
  N/A - functions require a live Ceph cluster (librbd calls), not unit-testable.
  Existing e2e delete/snapshot tests exercise these code paths.
* [x] Integration tests have been added, if necessary.
  N/A - existing e2e tests for DeleteVolume, DeleteSnapshot, and volume
  cloning already cover the trash cleanup paths exercised by this change.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>