### PR TITLE
rbd: add isClone(), rbdVolume.Delete() and move temp image cleanup

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -106,6 +106,12 @@ func (rv *rbdVolume) checkCloneImage(ctx context.Context, parentVol *rbdVolume) 
 	return true, nil
 }
 
+// generateTempCloneName returns the name of the temporary clone image for
+// this volume.
+func (rv *rbdVolume) generateTempCloneName() string {
+	return rv.RbdImageName + tempImageSuffix
+}
+
 func (rv *rbdVolume) generateTempClone() *rbdVolume {
 	tempClone := rbdVolume{}
 	tempClone.conn = rv.conn.Copy()
@@ -121,7 +127,7 @@ func (rv *rbdVolume) generateTempClone() *rbdVolume {
 	// The temp cloned image name will be always (rbd image name + "-temp")
 	// this name will be always unique, as cephcsi never creates an image with
 	// this format for new rbd images
-	tempClone.RbdImageName = rv.RbdImageName + tempImageSuffix
+	tempClone.RbdImageName = rv.generateTempCloneName()
 
 	return &tempClone
 }

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1160,17 +1160,6 @@ func cleanupRBDImage(ctx context.Context,
 		return nil, status.Errorf(codes.Aborted, "rbd %s is still being used", rbdVol.RbdImageName)
 	}
 
-	// delete the temporary rbd image created as part of volume clone during
-	// create volume. This must run before rbdVol.Delete() so the volume
-	// image still exists and its parent info (ParentImageID) can identify
-	// a trashed temp clone without scanning the trash list.
-	err = rbdVol.DeleteTempImage(ctx)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to delete temporary rbd image: %v", err)
-
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
 	// Deleting rbd image
 	log.DebugLog(ctx, "deleting image %s", rbdVol.RbdImageName)
 	if err = rbdVol.Delete(ctx); err != nil {

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -45,7 +45,7 @@ func (rv *rbdVolume) HandleParentImageExistence(
 	if mode == types.FlattenModeForce {
 		// Delete temp image that exists for volume datasource since
 		// it is no longer required when the live image is flattened.
-		err := rv.DeleteTempImage(ctx)
+		err := rv.deleteTempImage(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to delete temporary rbd image %s: %w", rv, err)
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -831,8 +831,21 @@ func (ri *rbdImage) removeImageFromTrash(ctx context.Context) error {
 	return ri.trashRemoveImage(ctx)
 }
 
-// DeleteTempImage deletes the temporary image created for volume datasource.
-func (rv *rbdVolume) DeleteTempImage(ctx context.Context) error {
+// Delete deletes the rbd volume. If the volume is a clone (its parent name
+// ends with the temp image suffix), the temporary clone image is cleaned up
+// first so that the parent image info is still accessible for trash lookup.
+func (rv *rbdVolume) Delete(ctx context.Context) error {
+	if rv.isClone() {
+		if err := rv.deleteTempImage(ctx); err != nil {
+			return fmt.Errorf("failed to delete temporary rbd image: %w", err)
+		}
+	}
+
+	return rv.rbdImage.Delete(ctx)
+}
+
+// deleteTempImage deletes the temporary image created for volume datasource.
+func (rv *rbdVolume) deleteTempImage(ctx context.Context) error {
 	tempClone := rv.generateTempClone()
 	snap := &rbdSnapshot{}
 	defer snap.Destroy(ctx)
@@ -1612,6 +1625,12 @@ func genSnapFromOptions(ctx context.Context, rbdVol *rbdVolume, snapOptions map[
 // hasSnapshotFeature checks if Layering is enabled for this image.
 func (ri *rbdImage) hasSnapshotFeature() bool {
 	return (uint64(ri.ImageFeatureSet) & librbd.FeatureLayering) == librbd.FeatureLayering
+}
+
+// isClone returns true when the volume's parent image is the temporary clone
+// image that was created as datasource for this volume.
+func (rv *rbdVolume) isClone() bool {
+	return rv.ParentName == rv.generateTempCloneName()
 }
 
 func (ri *rbdImage) createSnapshot(ctx context.Context, pOpts *rbdSnapshot) error {

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -32,6 +32,53 @@ import (
 	"github.com/ceph/ceph-csi/internal/util"
 )
 
+func TestIsClone(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		imageName  string
+		parentName string
+		want       bool
+	}{
+		{
+			name:       "no parent",
+			imageName:  "myimage",
+			parentName: "",
+			want:       false,
+		},
+		{
+			name:       "parent is the temp clone of this image",
+			imageName:  "myimage",
+			parentName: (&rbdVolume{rbdImage: rbdImage{RbdImageName: "myimage"}}).generateTempCloneName(),
+			want:       true,
+		},
+		{
+			name:       "parent is a different image",
+			imageName:  "myimage",
+			parentName: "otherimage",
+			want:       false,
+		},
+		{
+			name:       "parent ends with temp suffix but belongs to a different image",
+			imageName:  "myimage",
+			parentName: (&rbdVolume{rbdImage: rbdImage{RbdImageName: "otherimage"}}).generateTempCloneName(),
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rv := &rbdVolume{
+				rbdImage: rbdImage{
+					RbdImageName: tt.imageName,
+					ParentName:   tt.parentName,
+				},
+			}
+			assert.Equal(t, tt.want, rv.isClone())
+		})
+	}
+}
+
 func TestHasSnapshotFeature(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Add rbdImage.isClone() that returns true when the parent image name
ends with the temp image suffix ("-temp"), identifying images cloned
from a temporary datasource image.

Add rbdVolume.Delete() that calls deleteTempImage() before delegating
to rbdImage.Delete() when isClone() is true. This encapsulates the
temp image cleanup inside Delete() so callers do not need to call it
explicitly.

Rename DeleteTempImage() to deleteTempImage() (unexported) and remove
the explicit call from cleanupRBDImage() in controllerserver.go, which
is now handled automatically by rbdVolume.Delete().
