### PR TITLE
ci: use Rook v1.19.9 with new Ceph key format support

### DIFF
--- a/.github/workflows/e2e-minikube-acceptance.yaml
+++ b/.github/workflows/e2e-minikube-acceptance.yaml
@@ -75,20 +75,13 @@ jobs:
         run: >-
           docker pull "$ROOK_CEPH_CLUSTER_IMAGE"
 
-      - name: Deploy Rook + Ceph
-        run: scripts/minikube.sh deploy-rook
-        env:
-          ROOK_DEPLOY_TIMEOUT: "600"
-          KUBECTL_RETRY_DELAY: "5"
-
-      - name: Install snapshot controller
-        run: >-
-          scripts/minikube.sh install-snapshotter
-
       - name: Build ceph-csi image
         run: make image-cephcsi
         env:
           CONTAINER_CMD: docker
+
+      - name: Build e2e.test
+        run: make e2e.test
 
       - name: Load ceph-csi image
         run: scripts/minikube.sh cephcsi
@@ -100,8 +93,15 @@ jobs:
         run: >-
           scripts/deploy-ceph-csi-operator.sh deploy
 
-      - name: Build e2e.test
-        run: make e2e.test
+      - name: Install snapshot controller
+        run: >-
+          scripts/minikube.sh install-snapshotter
+
+      - name: Deploy Rook + Ceph
+        run: scripts/minikube.sh deploy-rook
+        env:
+          ROOK_DEPLOY_TIMEOUT: "600"
+          KUBECTL_RETRY_DELAY: "5"
 
       - name: Run acceptance e2e
         run: |

--- a/.github/workflows/e2e-minikube-acceptance.yaml
+++ b/.github/workflows/e2e-minikube-acceptance.yaml
@@ -81,7 +81,7 @@ jobs:
           CONTAINER_CMD: docker
 
       - name: Build e2e.test
-        run: make e2e.test
+        run: make containerized-build TARGET=e2e.test
 
       - name: Load ceph-csi image
         run: scripts/minikube.sh cephcsi

--- a/Makefile
+++ b/Makefile
@@ -268,9 +268,10 @@ else
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 endif
 
+image-cephcsi: CEPH_RELEASE_RPM ?= $(shell . $(CURDIR)/build.env ; echo $${CEPH_RELEASE_RPM})
 image-cephcsi: GOARCH ?= $(shell go env GOARCH 2>/dev/null)
 image-cephcsi: .container-cmd
-	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg CEPH_VERSION=$(CEPH_VERSION) --build-arg GO_BUILD_VERBOSE=$(GO_BUILD_VERBOSE)
+	$(CONTAINER_CMD) build $(CPUSET) -t $(CSI_IMAGE) -f deploy/cephcsi/image/Dockerfile . --build-arg CSI_IMAGE_NAME=$(CSI_IMAGE_NAME) --build-arg CSI_IMAGE_VERSION=$(CSI_IMAGE_VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GO_ARCH=$(GOARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg CEPH_RELEASE_RPM=$(CEPH_RELEASE_RPM) --build-arg GO_BUILD_VERBOSE=$(GO_BUILD_VERBOSE)
 
 push-image-cephcsi: GOARCH ?= $(shell go env GOARCH 2>/dev/null)
 push-image-cephcsi: .container-cmd image-cephcsi

--- a/build.env
+++ b/build.env
@@ -62,7 +62,7 @@ VM_DRIVER=none
 CHANGE_MINIKUBE_NONE_USER=true
 
 # Rook options
-ROOK_VERSION=v1.19.3
+ROOK_VERSION=v1.19.9
 # Provide ceph image path
 ROOK_CEPH_CLUSTER_IMAGE=quay.io/ceph/ceph:v20
 

--- a/build.env
+++ b/build.env
@@ -26,6 +26,7 @@ CEPH_CSI_OPERATOR_VERSION=latest
 # Ceph version to use
 BASE_IMAGE=quay.io/rockylinux/rockylinux:10
 CEPH_VERSION=tentacle
+CEPH_RELEASE_RPM=https://download.ceph.com/rpm-${CEPH_VERSION}/el10/noarch/ceph-release-1-1.el10.noarch.rpm
 
 # standard Golang options
 GOLANG_VERSION=1.26.2

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -5,9 +5,9 @@ ARG FINAL_BASE_IMAGE="quay.io/rockylinux/rockylinux:10-minimal"
 
 FROM ${BASE_IMAGE} as updated_base
 
-ARG CEPH_VERSION
+ARG CEPH_RELEASE_RPM
 
-RUN rpm -ivh https://download.ceph.com/rpm-${CEPH_VERSION}/el10/noarch/ceph-release-1-0.el10.noarch.rpm \
+RUN rpm -ivh ${CEPH_RELEASE_RPM} \
     && dnf -y install epel-release \
     && dnf -y update --nobest \
     && dnf -y install --enablerepo=crb --setopt=install_weak_deps=False nfs-utils \
@@ -69,7 +69,7 @@ RUN make cephcsi GO_BUILD_VERBOSE="${GO_BUILD_VERBOSE}"
 FROM ${FINAL_BASE_IMAGE}
 
 ARG SRC_DIR
-ARG CEPH_VERSION
+ARG CEPH_RELEASE_RPM
 
 LABEL maintainers="Ceph-CSI Authors" \
     version=${CSI_IMAGE_VERSION} \
@@ -79,7 +79,7 @@ LABEL maintainers="Ceph-CSI Authors" \
 COPY --from=builder ${SRC_DIR}/_output/cephcsi /usr/local/bin/cephcsi
 
 RUN true \
-  && rpm -ivh https://download.ceph.com/rpm-${CEPH_VERSION}/el10/noarch/ceph-release-1-0.el10.noarch.rpm \
+  && rpm -ivh ${CEPH_RELEASE_RPM} \
   && microdnf -y install kmod nfs-utils nvme-cli epel-release psmisc e2fsprogs xfsprogs cryptsetup attr --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
   && microdnf -y install --enablerepo=crb thrift librados2 librbd1 libcephfs2 ceph-common ceph-fuse rbd-nbd --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
   && microdnf clean all \

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -49,7 +49,7 @@ they have similar capability requirements.
 ```bash
 USER=csi-rbd
 POOL=csi
-ceph auth get-or-create client.$USER \
+ceph auth get-or-create --key-type=aes client.$USER \
   mgr "profile rbd pool=$POOL" \
   osd "profile rbd pool=$POOL"
   mon "profile rbd"
@@ -61,7 +61,7 @@ ceph auth get-or-create client.$USER \
 USER=csi-cephfs
 FS_NAME=cephfs
 SUB_VOL=csi
-ceph auth get-or-create client.$USER \
+ceph auth get-or-create --key-type=aes client.$USER \
   mgr "allow rw" \
   osd "allow rwx tag cephfs metadata=$FS_NAME, allow rw tag cephfs data=$FS_NAME" \
   mds "allow r fsname=$FS_NAME path=/volumes, allow rws fsname=$FS_NAME path=/volumes/$SUB_VOL" \

--- a/e2e/ceph_user.go
+++ b/e2e/ceph_user.go
@@ -25,6 +25,8 @@ import (
 
 //nolint:gosec // secret for test
 const (
+	// Linux kernel clients < 7.0 require "aes", do not support default "aes256k"
+	defaultCipher = "aes"
 	// ceph user names.
 	keyringRBDProvisionerUsername          = "cephcsi-rbd-provisioner"
 	keyringRBDNodePluginUsername           = "cephcsi-rbd-node"
@@ -97,7 +99,7 @@ func cephFSProvisionerCaps() []string {
 }
 
 func createCephUser(f *framework.Framework, user string, caps []string) (string, error) {
-	cmd := fmt.Sprintf("ceph auth get-or-create-key client.%s %s", user, strings.Join(caps, " "))
+	cmd := fmt.Sprintf("ceph auth get-or-create-key --key-type=%s client.%s %s", defaultCipher, user, strings.Join(caps, " "))
 	stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
 	if err != nil {
 		return "", err

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	adminUser = "admin"
+	adminUser = "csiadmin"
 )
 
 // validateSubvolumegroup validates whether subvolumegroup is present.

--- a/e2e/nvmeof/config.yaml
+++ b/e2e/nvmeof/config.yaml
@@ -79,8 +79,8 @@ data:
     port = 8009
 
     [ceph]
-    # TODO: create a dedicated user, make pool dynamic/replaceable.
-    id = admin
+    # Use csiadmin with AES key-type for compatibility with kernel clients
+    id = csiadmin
     pool = nvmeofpool
     config_file = /etc/ceph/ceph.conf
 

--- a/e2e/nvmeof/deployment.yaml
+++ b/e2e/nvmeof/deployment.yaml
@@ -72,7 +72,18 @@ spec:
               keyring = /etc/ceph/keyring
               EOF
 
-              cp /tmp/ceph/keyring /etc/ceph
+              # Create csiadmin user with AES key for kernel client
+              # compatibility. Use admin keyring temporarily.
+              CSIADMIN_KEY=$(ceph --keyring /tmp/ceph/keyring \
+                auth get-or-create-key --key-type=aes client.csiadmin \
+                mon 'allow all' mgr 'allow all' \
+                osd 'allow all' mds 'allow all')
+
+              # Create keyring file with csiadmin credentials
+              cat << EOF > /etc/ceph/keyring
+              [client.csiadmin]
+                  key = ${CSIADMIN_KEY}
+              EOF
 
               chmod 444 /etc/ceph/ceph.conf
               chmod 440 /etc/ceph/keyring
@@ -85,9 +96,12 @@ spec:
                   -e "s/@@POD_IP@@/${POD_IP}/g" \
                   < /config/ceph-nvmeof.conf > /etc/ceph/nvmeof.conf
 
-              # add the gateway to the Ceph configuration
-              ceph nvme-gw create ${POD_NAME} nvmeofpool ${ANA_GROUP}
-              ceph nvme-gw show nvmeofpool ${ANA_GROUP}
+              # Add the gateway to the Ceph configuration
+              # (use admin keyring for this)
+              ceph --keyring /tmp/ceph/keyring \
+                nvme-gw create ${POD_NAME} nvmeofpool ${ANA_GROUP}
+              ceph --keyring /tmp/ceph/keyring \
+                nvme-gw show nvmeofpool ${ANA_GROUP}
           env:
             - name: CEPH_MON_HOST
               valueFrom:

--- a/e2e/staticpvc.go
+++ b/e2e/staticpvc.go
@@ -394,7 +394,7 @@ func validateCephFsStaticPV(f *framework.Framework, appPath, scPath, fsName stri
 	if err != nil {
 		return err
 	}
-	adminKey, e, err := execCommandInPod(f, "ceph auth get-key client.admin", rookNamespace, &listOpt)
+	adminKey, e, err := execCommandInPod(f, fmt.Sprintf("ceph auth get-or-create-key --key-type=aes client.%s mon 'allow all' mgr 'allow all' osd 'allow all' mds 'allow all'", adminUser), rookNamespace, &listOpt)
 	if err != nil {
 		return err
 	}
@@ -569,7 +569,7 @@ func validateCephFsMonitorListPV(f *framework.Framework, appPath, scPath, fsName
 	if err != nil {
 		return err
 	}
-	adminKey, e, err := execCommandInPod(f, "ceph auth get-key client.admin", rookNamespace, &listOpt)
+	adminKey, e, err := execCommandInPod(f, fmt.Sprintf("ceph auth get-or-create-key --key-type=aes client.%s mon 'allow all' mgr 'allow all' osd 'allow all' mds 'allow all'", adminUser), rookNamespace, &listOpt)
 	if err != nil {
 		return err
 	}

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -23,7 +23,7 @@ RUN source /build.env \
 RUN dnf -y remove protobuf
 
 RUN source /build.env \
-    && rpm -ivh https://download.ceph.com/rpm-${CEPH_VERSION}/el10/noarch/ceph-release-1-0.el10.noarch.rpm \
+    && rpm -ivh ${CEPH_RELEASE_RPM} \
     && dnf -y install epel-release \
     && dnf -y --nobest update \
     && dnf -y install --enablerepo=crb \

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -131,7 +131,7 @@ fetch_template_values() {
     # fetch fsid to populate the clusterID in storageclass
     FS_ID=$(kubectl_retry -n rook-ceph exec "${TOOLBOX_POD}" -- ceph fsid)
     # fetch the admin key corresponding to the adminID
-    ADMIN_KEY=$(kubectl_retry -n rook-ceph exec "${TOOLBOX_POD}" -- ceph auth get-key client.admin)
+    ADMIN_KEY=$(kubectl_retry -n rook-ceph exec "${TOOLBOX_POD}" -- ceph auth get-or-create-key --key-type=aes client.csiadmin mon 'allow all' mgr 'allow all' osd 'allow all' mds 'allow all')
 }
 
 install() {
@@ -172,8 +172,8 @@ install_cephcsi_helm_charts() {
     # deploy secret if DEPLOY_SECRET flag is set
     if [ "${DEPLOY_SECRET}" -eq 1 ]; then
         fetch_template_values
-        RBD_SECRET_TEMPLATE_VALUES="--set secret.create=true --set secret.userID=admin --set secret.userKey=${ADMIN_KEY}"
-        CEPHFS_SECRET_TEMPLATE_VALUES="--set secret.create=true --set secret.userID=admin --set secret.userKey=${ADMIN_KEY}"
+        RBD_SECRET_TEMPLATE_VALUES="--set secret.create=true --set secret.userID=csiadmin --set secret.userKey=${ADMIN_KEY}"
+        CEPHFS_SECRET_TEMPLATE_VALUES="--set secret.create=true --set secret.userID=csiadmin --set secret.userKey=${ADMIN_KEY}"
     fi
     # enable read affinity
     if [ "${ENABLE_READ_AFFINITY}" -eq 1 ]; then

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -154,6 +154,11 @@ function check_ceph_cluster_health() {
 				echo "Creating CEPH cluster is done. [$CEPH_HEALTH]"
 				break
 			fi
+			if [ "$CEPH_HEALTH" = "HEALTH_WARN" ]; then
+				echo "Creating CEPH cluster is done, with warnings!"
+				kubectl_retry -n rook-ceph get cephclusters -o jsonpath='{.items[0].status.ceph.details}'
+				break
+			fi
 		fi
 	done
 


### PR DESCRIPTION
CI jobs fail deploying Rook, as Ceph Tentacle 20.2.4 uses new Ceph key formats.

See-also: https://github.com/rook/rook/releases/tag/v1.19.9