### PR TITLE
ci: add Rook v1.20.5 to the mirror registry

### DIFF
--- a/mirror/images.txt
+++ b/mirror/images.txt
@@ -7,7 +7,7 @@
 #
 
 # ceph-csi devel
-quay.io/rook/ceph:v1.19.3        rook/ceph:v1.19.3
+quay.io/rook/ceph:v1.20.5        rook/ceph:v1.20.5
 quay.io/ceph/ceph:v20            ceph/ceph:v20
 
 # ceph-csi-operator


### PR DESCRIPTION
Add the latest rook container image to the mirror so that the CI jobs can pull it.