### PR TITLE
rbd, cephfs: return InvalidArgument for undecodable volume IDs in DeleteVolume

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -565,6 +565,13 @@ func (cs *cephfsControllerServer) DeleteVolume(
 
 		log.ErrorLog(ctx, "Error returned from newVolumeOptionsFromVolID: %v", err)
 
+		if errors.Is(err, cerrors.ErrInvalidVolID) {
+			// likely a static provisioned volume with a volume handle that
+			// was never encoded by ceph-csi; retrying will never succeed,
+			// so return a terminal error instead of codes.Internal.
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
 		// All errors other than ErrVolumeNotFound should return an error back to the caller
 		if !errors.Is(err, cerrors.ErrVolumeNotFound) {
 			return nil, status.Error(codes.Internal, err.Error())

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -207,6 +207,9 @@ func (cs *cephfsControllerServer) checkContentSource(
 			if errors.Is(err, cerrors.ErrSnapNotFound) {
 				return nil, nil, nil, status.Error(codes.NotFound, err.Error())
 			}
+			if errors.Is(err, cerrors.ErrInvalidVolID) {
+				return nil, nil, nil, status.Error(codes.InvalidArgument, err.Error())
+			}
 
 			return nil, nil, nil, status.Error(codes.Internal, err.Error())
 		}
@@ -1081,6 +1084,11 @@ func (cs *cephfsControllerServer) DeleteSnapshot(
 			}
 
 			return &csi.DeleteSnapshotResponse{}, nil
+		case errors.Is(err, cerrors.ErrInvalidVolID):
+			// likely a static provisioned snapshot with a snapshot handle
+			// that was never encoded by ceph-csi; retrying will never
+			// succeed, so return a terminal error instead of codes.Internal.
+			return nil, status.Error(codes.InvalidArgument, err.Error())
 		case errors.Is(err, cerrors.ErrVolumeNotFound):
 			// if the error is ErrVolumeNotFound, the subvolume is already deleted
 			// from backend, Hence undo the omap entries and return success
@@ -1672,6 +1680,12 @@ func (cs *cephfsControllerServer) ControllerModifyVolume(
 		if errors.Is(err, cerrors.ErrVolumeNotFound) || errors.Is(err, util.ErrKeyNotFound) ||
 			errors.Is(err, util.ErrPoolNotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
+		}
+
+		if errors.Is(err, cerrors.ErrInvalidVolID) {
+			// likely a static provisioned volume
+			// InvalidArgument indicates that the CO has specified capabilities not supported by the volume
+			return nil, status.Errorf(codes.InvalidArgument, "volume ID %s does not support modify", volID)
 		}
 
 		return nil, status.Error(codes.Internal, err.Error())

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -1062,49 +1062,7 @@ func (cs *cephfsControllerServer) DeleteSnapshot(
 	volOpt, snapInfo, sid, err := store.NewSnapshotOptionsFromID(ctx, snapshotID, cr,
 		req.GetSecrets(), cs.ClusterName)
 	if err != nil {
-		switch {
-		case errors.Is(err, util.ErrPoolNotFound):
-			// if error is ErrPoolNotFound, the pool is already deleted we dont
-			// need to worry about deleting snapshot or omap data, return success
-			log.WarningLog(ctx, "failed to get backend snapshot for %s: %v", snapshotID, err)
-
-			return &csi.DeleteSnapshotResponse{}, nil
-		case errors.Is(err, util.ErrKeyNotFound):
-			// if error is ErrKeyNotFound, then a previous attempt at deletion was complete
-			// or partially complete (snap and snapOMap are garbage collected already), hence return
-			// success as deletion is complete
-			return &csi.DeleteSnapshotResponse{}, nil
-		case errors.Is(err, cerrors.ErrSnapNotFound):
-			err = store.UndoSnapReservation(ctx, volOpt, *sid, sid.RequestName, cr)
-			if err != nil {
-				log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) (%s)",
-					sid.RequestName, sid.FsSnapshotName, err)
-
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-
-			return &csi.DeleteSnapshotResponse{}, nil
-		case errors.Is(err, cerrors.ErrInvalidVolID):
-			// likely a static provisioned snapshot with a snapshot handle
-			// that was never encoded by ceph-csi; retrying will never
-			// succeed, so return a terminal error instead of codes.Internal.
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		case errors.Is(err, cerrors.ErrVolumeNotFound):
-			// if the error is ErrVolumeNotFound, the subvolume is already deleted
-			// from backend, Hence undo the omap entries and return success
-			log.ErrorLog(ctx, "Volume not present")
-			err = store.UndoSnapReservation(ctx, volOpt, *sid, sid.RequestName, cr)
-			if err != nil {
-				log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) (%s)",
-					sid.RequestName, sid.FsSnapshotName, err)
-
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-
-			return &csi.DeleteSnapshotResponse{}, nil
-		default:
-			return nil, status.Error(codes.Internal, err.Error())
-		}
+		return handleSnapshotOptionsError(ctx, err, snapshotID, volOpt, sid, cr)
 	}
 	defer volOpt.Destroy()
 
@@ -1146,6 +1104,63 @@ func (cs *cephfsControllerServer) DeleteSnapshot(
 	}
 
 	return &csi.DeleteSnapshotResponse{}, nil
+}
+
+// handleSnapshotOptionsError translates an error returned by
+// store.NewSnapshotOptionsFromID() into a DeleteSnapshot result. Errors
+// showing that the snapshot, its subvolume or its pool is already gone are
+// reported as a successful deletion, undoing the reservation where needed.
+func handleSnapshotOptionsError(
+	ctx context.Context,
+	err error,
+	snapshotID string,
+	volOpt *store.VolumeOptions,
+	sid *store.SnapshotIdentifier,
+	cr *util.Credentials,
+) (*csi.DeleteSnapshotResponse, error) {
+	switch {
+	case errors.Is(err, util.ErrPoolNotFound):
+		// if error is ErrPoolNotFound, the pool is already deleted we dont
+		// need to worry about deleting snapshot or omap data, return success
+		log.WarningLog(ctx, "failed to get backend snapshot for %s: %v", snapshotID, err)
+
+		return &csi.DeleteSnapshotResponse{}, nil
+	case errors.Is(err, util.ErrKeyNotFound):
+		// if error is ErrKeyNotFound, then a previous attempt at deletion was complete
+		// or partially complete (snap and snapOMap are garbage collected already), hence return
+		// success as deletion is complete
+		return &csi.DeleteSnapshotResponse{}, nil
+	case errors.Is(err, cerrors.ErrSnapNotFound):
+		err = store.UndoSnapReservation(ctx, volOpt, *sid, sid.RequestName, cr)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) (%s)",
+				sid.RequestName, sid.FsSnapshotName, err)
+
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		return &csi.DeleteSnapshotResponse{}, nil
+	case errors.Is(err, cerrors.ErrInvalidVolID):
+		// likely a static provisioned snapshot with a snapshot handle
+		// that was never encoded by ceph-csi; retrying will never
+		// succeed, so return a terminal error instead of codes.Internal.
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, cerrors.ErrVolumeNotFound):
+		// if the error is ErrVolumeNotFound, the subvolume is already deleted
+		// from backend, Hence undo the omap entries and return success
+		log.ErrorLog(ctx, "Volume not present")
+		err = store.UndoSnapReservation(ctx, volOpt, *sid, sid.RequestName, cr)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) (%s)",
+				sid.RequestName, sid.FsSnapshotName, err)
+
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		return &csi.DeleteSnapshotResponse{}, nil
+	default:
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 }
 
 func deleteSnapshotAndUndoReservation(

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -119,6 +119,10 @@ func (cs *cephfsControllerServer) CreateVolumeGroupSnapshot(
 	if err != nil {
 		log.ErrorLog(ctx, "failed to get fs names and subvolume from volume ids: %v", err)
 
+		if errors.Is(err, cerrors.ErrInvalidVolID) {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	defer destroyFSConnections(fsMap)
@@ -725,6 +729,13 @@ func (cs *cephfsControllerServer) DeleteVolumeGroupSnapshot(ctx context.Context,
 
 	vgo, vgsi, err := store.NewVolumeGroupOptionsFromID(ctx, req.GetGroupSnapshotId(), cr)
 	if err != nil {
+		if errors.Is(err, cerrors.ErrInvalidVolID) {
+			// likely a static provisioned volume group snapshot with a handle
+			// that was never encoded by ceph-csi; retrying will never
+			// succeed, so return a terminal error instead of codes.Internal.
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
 		if !errors.Is(err, cerrors.ErrGroupNotFound) {
 			log.ErrorLog(ctx, "failed to get volume group options: %v", err)
 			err = extractDeleteVolumeGroupError(err)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -931,6 +931,9 @@ func checkContentSource(
 		if err != nil {
 			rbdSnap.Destroy(ctx)
 			log.ErrorLog(ctx, "failed to get backend snapshot for %s: %v", snapshotID, err)
+			if errors.Is(err, rbderrors.ErrInvalidVolID) {
+				return nil, nil, status.Error(codes.InvalidArgument, err.Error())
+			}
 			if !errors.Is(err, rbderrors.ErrSnapNotFound) {
 				return nil, nil, status.Error(codes.Internal, err.Error())
 			}
@@ -952,6 +955,9 @@ func checkContentSource(
 		if err != nil {
 			rbdvol.Destroy(ctx)
 			log.ErrorLog(ctx, "failed to get backend image for %s: %v", volID, err)
+			if errors.Is(err, rbderrors.ErrInvalidVolID) {
+				return nil, nil, status.Error(codes.InvalidArgument, err.Error())
+			}
 			if !errors.Is(err, rbderrors.ErrImageNotFound) {
 				return nil, nil, status.Error(codes.Internal, err.Error())
 			}
@@ -1248,6 +1254,8 @@ func (cs *ControllerServer) CreateSnapshot(
 		case errors.Is(err, util.ErrPoolNotFound):
 			log.ErrorLog(ctx, "failed to get backend volume for %s: %v", req.GetSourceVolumeId(), err)
 			err = status.Error(codes.NotFound, err.Error())
+		case errors.Is(err, rbderrors.ErrInvalidVolID):
+			err = status.Error(codes.InvalidArgument, err.Error())
 		default:
 			err = status.Error(codes.Internal, err.Error())
 		}
@@ -1575,6 +1583,13 @@ func (cs *ControllerServer) DeleteSnapshot(
 	if err != nil {
 		rbdSnap.Destroy(ctx)
 
+		if errors.Is(err, rbderrors.ErrInvalidVolID) {
+			// likely a static provisioned snapshot with a snapshot handle
+			// that was never encoded by ceph-csi; retrying will never
+			// succeed, so return a terminal error instead of codes.Internal.
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
 		// if error is ErrPoolNotFound, the pool is already deleted we don't
 		// need to worry about deleting snapshot or omap data, return success
 		if errors.Is(err, util.ErrPoolNotFound) {
@@ -1813,6 +1828,10 @@ func (cs *ControllerServer) getServiceAccountRestriction(
 			rv.Destroy(ctx)
 		}
 
+		if errors.Is(err, rbderrors.ErrInvalidVolID) {
+			return "", status.Errorf(codes.InvalidArgument, "volume ID %s does not support publish: %v", volumeID, err)
+		}
+
 		return "", status.Errorf(codes.Internal,
 			"failed to find volume %q for service account check: %v", volumeID, err)
 	}
@@ -1872,6 +1891,11 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 	rv, err := GenVolFromVolID(ctx, volumeId, credentials, secrets)
 	if err != nil {
 		rv.Destroy(ctx)
+
+		if errors.Is(err, rbderrors.ErrInvalidVolID) {
+			return nil, status.Errorf(codes.InvalidArgument, "volume ID %s does not support unpublish: %v",
+				volumeId, err)
+		}
 
 		return nil, status.Errorf(codes.Internal, "failed to generate volume from volume ID %s: %v",
 			volumeId, err)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -992,6 +992,13 @@ func (cs *ControllerServer) checkErrAndUndoReserve(
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 
+	if errors.Is(err, rbderrors.ErrInvalidVolID) {
+		// likely a static provisioned volume with a volume handle that was
+		// never encoded by ceph-csi; retrying will never succeed, so return
+		// a terminal error instead of codes.Internal.
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	if errors.Is(err, rbderrors.ErrImageNotFound) {
 		if notFoundErr := rbdVol.removeImageFromTrash(ctx); notFoundErr != nil {
 			return nil, status.Errorf(codes.Internal, "failed to cleanup image %q: %v", rbdVol, notFoundErr)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

`DeleteVolume` retries forever with `codes.Internal` when a static PV's
`volumeHandle` was never encoded by ceph-csi (e.g. a plain image/subvolume
name) and therefore can't be decoded as a CSI identifier. Since
`codes.Internal` is treated as retryable by external-provisioner, the PVC/PV
never gets cleaned up and is stuck behind the provisioner finalizer forever.

This PR makes both RBD's `checkErrAndUndoReserve` and CephFS's `DeleteVolume`
return `codes.InvalidArgument` for this case instead, since a volume ID that
fails to decode will never succeed on retry — it's a terminal error, not a
retryable one.

## Is there anything that requires special attention ##

This mirrors the `ErrInvalidVolID` handling that already exists in RBD's
`ControllerExpandVolume` and `ControllerModifyVolume` — same error, same fix
pattern, just missing from `DeleteVolume`.

Scope: the RBD and CephFS drivers have the identical structural gap (an
unhandled `ErrInvalidVolID`/decode error falling through to
`codes.Internal`), so this PR fixes both rather than RBD only.

Backward compatible: yes. This only changes the returned gRPC status code for
volume IDs that already fail to decode and were never going to succeed;
well-formed volume IDs are unaffected.

## Related issues ##

Fixes: #6489

## Future concerns ##

* No admission webhook currently rejects `staticVolume: "true"` combined with
  `persistentVolumeReclaimPolicy: Delete` at PV-creation time, which is how
  this class of static PV ends up misconfigured in the first place. That's a
  separate, larger piece of work.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>


---

Prevent too many CI jobs from running.

Depends-on: #6533