### PR TITLE
doc: mark fsName as required for CephFS static PV

### DIFF
--- a/docs/static-pvc.md
+++ b/docs/static-pvc.md
@@ -268,7 +268,7 @@ spec:
       # node stage secret namespace where above secret is created
       namespace: default
     volumeAttributes:
-      # optional file system to be mounted
+      # Required: CephFS filesystem name to be mounted
       "fsName": "myfs"
       # Required options from storageclass parameters need to be added in volumeAttributes
       "clusterID": "ba68226a-672f-4ba5-97bc-22840318b2ec"
@@ -298,7 +298,7 @@ static CephFS PV
 |  Attributes  |                                                                     Description                                                                      | Required |
 | :----------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: | :------: |
 |  clusterID   | The clusterID is used by the CSI plugin to uniquely identify and use a Ceph cluster (this is the key in configmap created duing ceph-csi deployment) |   Yes    |
-|    fsName    |                                      CephFS filesystem name to be mounted. Not passing this option mounts the default file system.                                       |   No    |
+|    fsName    |                                      CephFS filesystem name to be mounted                                       |   Yes    |
 | staticVolume |                                           Value must be set to `true` to mount and unmount static cephFS PVC                                         |   Yes    |
 |   rootPath   |                     Actual path of the subvolume in ceph cluster which can be retrieved by issuing getpath command as described above, or folder path of the volume                    |   Yes    |
 


### PR DESCRIPTION
# Describe what this PR does #

```
Update documentation to reflect that fsName is a required parameter for
static CephFS PVs. This aligns the documentation with the current
implementation after the mount syntax upgrade in commit 0c60fd28e.

The new kernel mount syntax (user@fsid.fsName=rootPath) requires an
explicit filesystem name, making fsName mandatory for proper mount
operations.
```

Fixes: #6275

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>