### PR TITLE
Feat/nfs export names

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -22,5 +22,13 @@
       configuration
     - Backward compatibility with existing cluster-mapping.json via
       ClientProfileMapping integration
+1. Added a `friendlyExportNames` StorageClass parameter for the NFS driver.
+   When set to `"true"` and the external-provisioner runs with
+   `--extra-create-metadata=true`, NFS-exports are named
+   `<namespace>/<pvc-name>` instead of the generated volume ID. Off by
+   default, and gated behind the parameter rather than the provisioner flag
+   alone, since CephFS already reads that same metadata unconditionally for
+   per-tenant KMS scoping.  Existing StorageClasses keep today's export
+   names unless they opt in explicitly.
 
 ## NOTE

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -29,6 +29,11 @@
    default, and gated behind the parameter rather than the provisioner flag
    alone, since CephFS already reads that same metadata unconditionally for
    per-tenant KMS scoping.  Existing StorageClasses keep today's export
-   names unless they opt in explicitly.
+   names unless they opt in explicitly. Unlike the generated volume ID,
+   `<namespace>/<pvc-name>` is not guaranteed unique over time (e.g. a PVC
+   recreated under the same name before its old export was cleaned up);
+   `CreateVolume` now fails with `AlreadyExists` rather than silently
+   reusing another volume's export if the name is already claimed by a
+   different subvolume.
 
 ## NOTE

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -81,6 +81,7 @@ spec:
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
             - "--prevent-volume-mode-conversion=true"
+            - "--extra-create-metadata=true"
             - "--http-endpoint=$(POD_IP):8090"
           env:
             - name: ADDRESS

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -653,6 +653,34 @@ var _ = Describe("nfs", func() {
 			}
 		})
 
+		It("create a storageclass with friendly export names and a PVC then bind it to an app", func() {
+			err := createNFSStorageClass(f.ClientSet, f, false, map[string]string{
+				"friendlyExportNames": "true",
+			})
+			if err != nil {
+				logAndFail("failed to create NFS storageclass: %v", err)
+			}
+			pvc, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("Could not create PVC: 1 %v", err)
+			}
+			pvc.Namespace = f.UniqueName
+			err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC: %v", err)
+			}
+
+			expectedPseudoPath := fmt.Sprintf("/%s/%s", pvc.Namespace, pvc.Name)
+			if !checkExportPseudoPath(f, "my-nfs", expectedPseudoPath) {
+				logAndFail("failed to find export with friendly pseudo-path %q", expectedPseudoPath)
+			}
+
+			err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to delete PVC: %v", err)
+			}
+		})
+
 		It("create a PVC and bind it to an app", Label("acceptance"), func() {
 			err := createNFSStorageClass(f.ClientSet, f, false, nil)
 			if err != nil {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -2115,6 +2115,27 @@ func checkExports(f *framework.Framework, clusterID, clientString string) bool {
 	return true
 }
 
+// checkExportPseudoPath confirms an export with the given pseudo-path exists
+// for a cluster_id, for asserting on friendlyExportNames-derived paths.
+func checkExportPseudoPath(f *framework.Framework, clusterID, pseudoPath string) bool {
+	exportList, err := listExports(f, clusterID)
+	if err != nil {
+		framework.Logf("failed to fetch list of exports: %v", err)
+
+		return false
+	}
+
+	for i := range len(*exportList) {
+		if (*exportList)[i].Pseudo == pseudoPath {
+			return true
+		}
+	}
+
+	framework.Logf("Could not find an export with pseudo-path %q in the list of exports (%+v)", pseudoPath, exportList)
+
+	return false
+}
+
 // createSubvolumegroup creates a subvolumegroup.
 func createSubvolumegroup(f *framework.Framework, fileSystemName, subvolumegroup string) error {
 	cmd := fmt.Sprintf("ceph fs subvolumegroup create %s %s", fileSystemName, subvolumegroup)

--- a/examples/nfs/storageclass.yaml
+++ b/examples/nfs/storageclass.yaml
@@ -64,5 +64,13 @@ parameters:
   # VolumeAttributesClass (see volumeattributesclass.yaml example).
   # clients: <client-list>
 
+  # (optional) Name NFS-exports "<namespace>/<pvc-name>" instead of the
+  # generated volume ID. Requires the external-provisioner sidecar to run
+  # with --extra-create-metadata=true. If that flag is already set for an
+  # unrelated reason on this provisioner, leave this parameter unset unless
+  # friendly names are actually wanted: enabling it changes the export path
+  # of every volume this StorageClass provisions.
+  # friendlyExportNames: "true"
+
 reclaimPolicy: Delete
 allowVolumeExpansion: true

--- a/examples/nfs/storageclass.yaml
+++ b/examples/nfs/storageclass.yaml
@@ -70,6 +70,10 @@ parameters:
   # unrelated reason on this provisioner, leave this parameter unset unless
   # friendly names are actually wanted: enabling it changes the export path
   # of every volume this StorageClass provisions.
+  # Unlike the generated volume ID, "<namespace>/<pvc-name>" is not
+  # guaranteed unique over time: recreating a PVC under the same name
+  # before its old export is cleaned up will fail CreateVolume with
+  # AlreadyExists rather than silently reusing the old export.
   # friendlyExportNames: "true"
 
 reclaimPolicy: Delete

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -19,8 +19,10 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -33,6 +35,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/journal"
 	nfs "github.com/ceph/ceph-csi/internal/nfs/types"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
@@ -54,6 +57,7 @@ type nfsControllerServer struct {
 var nfsParameters = []string{
 	nfs.ParameterCluster,
 	nfs.ParameterSecTypes,
+	nfs.ParameterFriendlyExportNames,
 }
 
 // nfsMutableParameters contains the list of mutable parameters for NFS
@@ -104,6 +108,33 @@ func (cs *nfsControllerServer) ValidateVolumeCapabilities(
 	return cs.backendServer.ValidateVolumeCapabilities(ctx, req)
 }
 
+// friendlyExportName returns the "<namespace>/<pvc-name>" export name to
+// use, or "" if ParameterFriendlyExportNames is unset or "false".
+func friendlyExportName(nfsParams, csiParams map[string]string) (string, error) {
+	friendlyExportNames := false
+	if v, ok := nfsParams[nfs.ParameterFriendlyExportNames]; ok {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return "", fmt.Errorf("invalid value for %s:  %s, (should be a \"true\" or \"false\"): %w",
+				nfs.ParameterFriendlyExportNames, v, err)
+		}
+		friendlyExportNames = parsed
+	}
+
+	if !friendlyExportNames {
+		return "", nil
+	}
+
+	pvcNamespace := k8s.GetOwner(csiParams)
+	pvcName := k8s.GetPVCName(csiParams)
+	if pvcNamespace == "" || pvcName == "" {
+		return "", fmt.Errorf("%s requires the external-provisioner to run with --extra-create-metadata=true",
+			nfs.ParameterFriendlyExportNames)
+	}
+
+	return pvcNamespace + "/" + pvcName, nil
+}
+
 // CreateVolume creates the backing subvolume and on any error cleans up any
 // created entities.
 func (cs *nfsControllerServer) CreateVolume(
@@ -136,6 +167,14 @@ func (cs *nfsControllerServer) CreateVolume(
 		} else {
 			cephfsMutableParams[key] = value
 		}
+	}
+
+	// Validate friendlyExportNames before creating the backend volume: on
+	// error there is nothing to clean up yet, whereas validating after
+	// backendServer.CreateVolume would orphan the just-created subvolume.
+	exportName, err := friendlyExportName(nfsParams, req.GetParameters())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	// Create a modified request without mutable parameters for CephFS
@@ -183,6 +222,13 @@ func (cs *nfsControllerServer) CreateVolume(
 	vc := backend.GetVolumeContext()
 	maps.Copy(vc, nfsParams)
 	backend.VolumeContext = vc
+
+	if exportName != "" {
+		err = nfsVolume.SetExportName(exportName)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to set export name: %v", err)
+		}
+	}
 
 	err = nfsVolume.CreateExport(backend)
 	if err != nil {

--- a/internal/nfs/controller/controllerserver.go
+++ b/internal/nfs/controller/controllerserver.go
@@ -232,6 +232,10 @@ func (cs *nfsControllerServer) CreateVolume(
 
 	err = nfsVolume.CreateExport(backend)
 	if err != nil {
+		if errors.Is(err, nfs.ErrExportNameConflict) {
+			return nil, status.Errorf(codes.AlreadyExists, "failed to create export: %v", err)
+		}
+
 		return nil, status.Errorf(codes.InvalidArgument, "failed to create export: %v", err)
 	}
 

--- a/internal/nfs/controller/controllerserver_test.go
+++ b/internal/nfs/controller/controllerserver_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	nfs "github.com/ceph/ceph-csi/internal/nfs/types"
+)
+
+func Test_friendlyExportName(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		nfsParams map[string]string
+		csiParams map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "friendlyExportNames unset",
+			args: args{
+				nfsParams: map[string]string{},
+				csiParams: map[string]string{
+					"csi.storage.k8s.io/pvc/namespace": "default",
+					"csi.storage.k8s.io/pvc/name":      "my-pvc",
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "friendlyExportNames false",
+			args: args{
+				nfsParams: map[string]string{
+					nfs.ParameterFriendlyExportNames: "false",
+				},
+				csiParams: map[string]string{
+					"csi.storage.k8s.io/pvc/namespace": "default",
+					"csi.storage.k8s.io/pvc/name":      "my-pvc",
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "friendlyExportNames true with metadata present",
+			args: args{
+				nfsParams: map[string]string{
+					nfs.ParameterFriendlyExportNames: "true",
+				},
+				csiParams: map[string]string{
+					"csi.storage.k8s.io/pvc/namespace": "default",
+					"csi.storage.k8s.io/pvc/name":      "my-pvc",
+				},
+			},
+			want:    "default/my-pvc",
+			wantErr: false,
+		},
+		{
+			name: "friendlyExportNames true without extra-create-metadata",
+			args: args{
+				nfsParams: map[string]string{
+					nfs.ParameterFriendlyExportNames: "true",
+				},
+				csiParams: map[string]string{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "friendlyExportNames true with only the namespace present",
+			args: args{
+				nfsParams: map[string]string{
+					nfs.ParameterFriendlyExportNames: "true",
+				},
+				csiParams: map[string]string{
+					"csi.storage.k8s.io/pvc/namespace": "default",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "friendlyExportNames not a boolean",
+			args: args{
+				nfsParams: map[string]string{
+					nfs.ParameterFriendlyExportNames: "yes-please",
+				},
+				csiParams: map[string]string{
+					"csi.storage.k8s.io/pvc/namespace": "default",
+					"csi.storage.k8s.io/pvc/name":      "my-pvc",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := friendlyExportName(tt.args.nfsParams, tt.args.csiParams)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("friendlyExportName() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+			if got != tt.want {
+				t.Errorf("friendlyExportName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/nfs/types/errors.go
+++ b/internal/nfs/types/errors.go
@@ -40,4 +40,8 @@ var (
 	// ErrFilesystemNotFound is returned in case the filesystem
 	// does not exist.
 	ErrFilesystemNotFound = fmt.Errorf("filesystem %w", ErrNotFound)
+
+	// ErrExportNameConflict is returned when an export's pseudo-path is
+	// already in use by a different volume's subvolume.
+	ErrExportNameConflict = errors.New("export name conflict")
 )

--- a/internal/nfs/types/volume.go
+++ b/internal/nfs/types/volume.go
@@ -217,6 +217,20 @@ func (nv *NFSVolume) CreateExport(backend *csi.Volume) error {
 	case err == nil:
 		return nil
 	case strings.Contains(err.Error(), "Export already exists"):
+		// Only an idempotent retry if the existing export still points
+		// at this volume's subvolume path; a friendly export name isn't
+		// guaranteed unique the way a volume-ID derived one is.
+		existing, infoErr := nfsa.ExportInfo(nfsCluster, nv.GetExportPath())
+		if infoErr != nil {
+			return fmt.Errorf("export %q already exists in NFS-cluster %q, but failed to verify "+
+				"it belongs to this volume: %w", nv, nfsCluster, infoErr)
+		}
+		if existing.Path != path {
+			return fmt.Errorf("export path %q in NFS-cluster %q is already in use by a different "+
+				"volume (subvolume %q, expected %q): %w", nv.GetExportPath(), nfsCluster, existing.Path,
+				path, ErrExportNameConflict)
+		}
+
 		return nil
 	case strings.Contains(err.Error(), "rados: ret=-2"): // try with the old command
 		log.ErrorLogMsg("going to fallback to cli, "+

--- a/internal/nfs/types/volume.go
+++ b/internal/nfs/types/volume.go
@@ -37,6 +37,11 @@ const (
 	// NFS-cluster. It will be prefixed with the journal configuration.
 	clusterNameKey = "nfs.cluster"
 
+	// exportNameKey is the key in OMAP that contains a friendly export
+	// name, when one was set. It will be prefixed with the journal
+	// configuration, same as clusterNameKey.
+	exportNameKey = "nfs.exportName"
+
 	// ParameterServer is set in the parameters on volume creation and in
 	// the VolumeContext.
 	ParameterServer = "server"
@@ -53,6 +58,12 @@ const (
 	// ParameterSecTypes is set in the parameters on volume creation and in
 	// the VolumeContext.
 	ParameterSecTypes = "secTypes"
+
+	// ParameterFriendlyExportNames opts a StorageClass in to naming
+	// exports "<namespace>/<pvc-name>" instead of the generated volume
+	// ID. Requires the external-provisioner to run with
+	// --extra-create-metadata=true.
+	ParameterFriendlyExportNames = "friendlyExportNames"
 )
 
 // NFSVolume presents the API for consumption by the CSI-controller to create,
@@ -67,6 +78,9 @@ type NFSVolume struct {
 	mons       string
 	fscID      int64
 	objectUUID string
+
+	// exportName, when set, replaces volumeID in the export's pseudo-path.
+	exportName string
 
 	// TODO: drop in favor of a go-ceph connection
 	cr        *util.Credentials
@@ -134,9 +148,27 @@ func (nv *NFSVolume) Destroy() {
 }
 
 // GetExportPath returns the path on the NFS-server that can be used for
-// mounting.
+// mounting. Falls back to the volumeID when no friendly name was set
+// (SetExportName) or resolved (resolveExportName).
 func (nv *NFSVolume) GetExportPath() string {
+	if nv.exportName != "" {
+		return "/" + nv.exportName
+	}
+
 	return "/" + nv.volumeID
+}
+
+// SetExportName sets a friendly export name and persists it in the CephFS
+// journal.
+func (nv *NFSVolume) SetExportName(name string) error {
+	err := nv.setAttribute(exportNameKey, name)
+	if err != nil {
+		return fmt.Errorf("failed to store export name %q for %q: %w", name, nv, err)
+	}
+
+	nv.exportName = name
+
+	return nil
 }
 
 // CreateExport takes the (CephFS) CSI-volume and instructs Ceph Mgr to create
@@ -217,6 +249,10 @@ func (nv *NFSVolume) DeleteExport() error {
 		return fmt.Errorf("can not delete export for %q: not connected", nv)
 	}
 
+	if err := nv.resolveExportName(); err != nil {
+		return err
+	}
+
 	nfsCluster, err := nv.getNFSCluster()
 	if err != nil {
 		return fmt.Errorf("failed to identify NFS cluster: %w", err)
@@ -270,6 +306,10 @@ func (nv *NFSVolume) SetClients(clients string) error {
 		return fmt.Errorf("can not set clients for %q: %w", nv, ErrNotConnected)
 	}
 
+	if err := nv.resolveExportName(); err != nil {
+		return err
+	}
+
 	nfsCluster, err := nv.getNFSCluster()
 	if err != nil {
 		return fmt.Errorf("failed to identify NFS cluster: %w", err)
@@ -302,6 +342,19 @@ func (nv *NFSVolume) SetClients(clients string) error {
 	if err != nil {
 		return fmt.Errorf("failed to update export %q with new clients: %w", nv.GetExportPath(), err)
 	}
+
+	return nil
+}
+
+// resolveExportName loads a previously persisted friendly export name
+// (SetExportName) from the CephFS journal into nv.exportName.
+func (nv *NFSVolume) resolveExportName() error {
+	name, err := nv.getAttribute(exportNameKey)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return fmt.Errorf("failed to get export name for %q: %w", nv, err)
+	}
+
+	nv.exportName = name
 
 	return nil
 }

--- a/internal/nfs/types/volume_test.go
+++ b/internal/nfs/types/volume_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "testing"
+
+func TestGetExportPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		volumeID   string
+		exportName string
+		want       string
+	}{
+		{
+			name:     "falls back to the volumeID when no export name is set",
+			volumeID: "0001-0024-fed5480a-f00d-4c66-bede-11112222",
+			want:     "/0001-0024-fed5480a-f00d-4c66-bede-11112222",
+		},
+		{
+			name:       "uses the friendly export name when set",
+			volumeID:   "0001-0024-fed5480a-f00d-4c66-bede-11112222",
+			exportName: "default/my-pvc",
+			want:       "/default/my-pvc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			nv := &NFSVolume{
+				volumeID:   tt.volumeID,
+				exportName: tt.exportName,
+			}
+			if got := nv.GetExportPath(); got != tt.want {
+				t.Errorf("GetExportPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/util/k8s/parameters.go
+++ b/internal/util/k8s/parameters.go
@@ -54,6 +54,11 @@ func GetOwner(param map[string]string) string {
 	return param[pvcNamespaceKey]
 }
 
+// GetPVCName returns the pvc name from the parameter.
+func GetPVCName(param map[string]string) string {
+	return param[pvcNameKey]
+}
+
 // GetVolumeMetadata filter parameters, only return PV/PVC/PVCNamespace metadata.
 func GetVolumeMetadata(parameters map[string]string) map[string]string {
 	keys := []string{pvcNameKey, pvcNamespaceKey, pvNameKey}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

NFS export names are currently derived from `ComposeCSIID()`, a long alphanumeric string that's meaningless to humans.  This PR adds an opt-in `friendlyExportNames` StorageClass parameter that names exports `<namespace>/<pvc-name>` instead.

The name is sourced from PVC metadata supplied by the external provisioner, enabled with `--extra-create-metadata=true`, and persisted in the CephFS journal so that `DeleteExport` and `SetClients` can resolve the volume path later on.

## Is there anything that requires special attention ##

This feature is gated behind an explicit StorageClass parameter rather than firing automatically whenever `--extra-create-metadata` is set because that flag is already used unconditionally by the CephFS backend for per-tenant KMS scoping.

It's entirely backwards compatible, as the parameter is set to off by default.  No existing exports are affected

## Related issues ##

Fixes: #4414

## Future concerns ##

None.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>

---

CI job ordering.

Depends-on: #6512
