### PR TITLE
cephfs: validate subvolumeName before setting metadata

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -43,6 +43,7 @@ var (
 	cephFSDeploymentName  = "csi-cephfsplugin-provisioner"
 	cephFSDeamonSetName   = "csi-cephfsplugin"
 	cephFSContainerName   = "csi-cephfsplugin"
+	cephFSContainersName  = []string{cephFSContainerName, "csi-cephfsplugin-controller", "csi-omap-generator"}
 	cephFSDirPath         = "../deploy/cephfs/kubernetes/"
 	cephFSExamplePath     = examplePath + "cephfs/"
 	subvolumegroup        = "e2e"
@@ -188,7 +189,7 @@ func NewCephFSDeployment(c clientset.Interface) CephFSDeploymentMethod {
 			deploymentName:   cephFSDeploymentName,
 			daemonsetName:    cephFSDeamonSetName,
 			helmPodLabelName: helmCephFSPodsLabel,
-			driverContainers: []string{cephFSContainerName},
+			driverContainers: cephFSContainersName,
 		},
 	}
 }
@@ -729,6 +730,19 @@ var _ = Describe(cephfsType, func() {
 			if err != nil {
 				logAndFail("failed to delete CephFS storageclass: %v", err)
 			}
+		})
+
+		// Regression test for legacy PVs (created before v3.0.0) that lack the
+		// "subvolumeName" volume attribute. The omap-generator controller must
+		// derive the subvolume name from the volumeID instead of operating on an
+		// empty name, which used to corrupt the parent subvolumegroup.
+		It("set metadata on a legacy PV without the subvolumeName attribute", func() {
+			err := validateCephFSController(f, pvcPath, appPath)
+			if err != nil {
+				logAndFail("failed to validate CephFS controller: %v", err)
+			}
+			validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+			validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
 		})
 
 		It("create PVC in storageClass with volumeNamePrefix", func() {

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -732,6 +732,198 @@ func removeCephFSSubvolumeMetadata(
 	return nil
 }
 
+// createCephFSStorageClassWithPolicy creates a CephFS StorageClass with the
+// given reclaim policy. createCephfsStorageClass always uses the default
+// (Delete) policy, so tests that need a Retain policy build the StorageClass
+// through this helper.
+func createCephFSStorageClassWithPolicy(
+	f *framework.Framework,
+	params map[string]string,
+	policy v1.PersistentVolumeReclaimPolicy,
+) error {
+	scPath := fmt.Sprintf("%s/%s", cephFSExamplePath, "storageclass.yaml")
+	sc, err := getStorageClass(scPath)
+	if err != nil {
+		return err
+	}
+	err = updateStorageClassParameters(&sc, params, true, f)
+	if err != nil {
+		return err
+	}
+	sc.ReclaimPolicy = &policy
+
+	return createStorageClass(f.ClientSet, &sc)
+}
+
+// waitForCephFSSubvolumeMetadata polls the metadata of the given subvolume
+// until it matches the expected PVC/PV identifiers, or the deploy timeout is
+// reached. It is used to observe the omap-generator controller (asynchronously)
+// setting metadata on a subvolume.
+func waitForCephFSSubvolumeMetadata(
+	f *framework.Framework,
+	subvolume,
+	pvcName,
+	pvcNamespace,
+	pvName string,
+) error {
+	timeout := time.Duration(deployTimeout) * time.Minute
+	ctx := context.TODO()
+
+	return wait.PollUntilContextTimeout(ctx, poll, timeout, true, func(_ context.Context) (bool, error) {
+		metadata, err := listCephFSSubvolumeMetadata(f, fileSystemName, subvolume, subvolumegroup)
+		if err != nil {
+			framework.Logf("failed to list metadata for subvolume %s: %v", subvolume, err)
+
+			return false, nil
+		}
+		if metadata.PVCNameKey != pvcName ||
+			metadata.PVCNamespaceKey != pvcNamespace ||
+			metadata.PVNameKey != pvName ||
+			metadata.ClusterNameKey != defaultClusterName {
+			framework.Logf("waiting for controller to set metadata on subvolume %s, current: %+v",
+				subvolume, metadata)
+
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+// validateCephFSController verifies that the omap-generator controller can set
+// metadata on a CephFS subvolume even when the PV predates ceph-csi v3.0.0 and
+// therefore lacks the "subvolumeName" volume attribute. For such legacy PVs an
+// unchecked lookup of volumeAttributes["subvolumeName"] returned an empty
+// string, which Ceph resolved to the parent subvolumegroup (/volumes/<group>)
+// and marked as a subvolume, breaking all further provisioning cluster-wide.
+//
+// The flow mirrors validateController (RBD) but deliberately keeps the RADOS
+// journal intact, because the fix derives the subvolume name from the volumeID
+// through the journal:
+//   - create a StorageClass with Retain policy and provision a PVC
+//   - record the bound PVC/PV objects and delete them (subvolume is retained)
+//   - clear the subvolume metadata so the controller has to re-set it
+//   - drop the "subvolumeName" attribute from the PV (legacy PV) and recreate
+//     the PVC/PV as a static binding so the controller reconciles it
+//   - confirm the controller sets metadata on the correct subvolume
+//   - mount the volume to an app (NodeStage resolves the name from the journal)
+//   - confirm a fresh PVC can still be provisioned (parent group not corrupted)
+func validateCephFSController(f *framework.Framework, pvcPath, appPath string) error {
+	// Retain policy keeps the backend subvolume and its journal after the
+	// PVC/PV are deleted below.
+	err := createCephFSStorageClassWithPolicy(f, nil, retainPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to create storageclass: %w", err)
+	}
+
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		return fmt.Errorf("failed to load PVC: %w", err)
+	}
+	pvc.Namespace = f.UniqueName
+	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create PVC: %w", err)
+	}
+	validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
+	validateOmapCount(f, 1, cephfsType, metadataPool, volumesType)
+
+	// back up the bound PVC and PV objects for the static re-binding.
+	pvc, pv, err := getPVCAndPV(f.ClientSet, pvc.Name, pvc.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get PVC and PV: %w", err)
+	}
+	subVols, err := listCephFSSubVolumes(f, fileSystemName, subvolumegroup)
+	if err != nil {
+		return fmt.Errorf("failed to list subvolumes: %w", err)
+	}
+	if len(subVols) != 1 {
+		return fmt.Errorf("expected 1 subvolume, got %d", len(subVols))
+	}
+	subVolName := subVols[0].Name
+
+	// delete the PVC/PV; Retain policy keeps the subvolume and its journal.
+	err = deletePVCAndPV(f.ClientSet, pvc, pv, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to delete PVC or PV: %w", err)
+	}
+	validateSubvolumeCount(f, 1, fileSystemName, subvolumegroup)
+
+	// clear the metadata that provisioning set, so its reappearance proves the
+	// controller re-derived the subvolume name and set it again.
+	metadataKeys := []string{
+		"csi.storage.k8s.io/pvc/name",
+		"csi.storage.k8s.io/pvc/namespace",
+		"csi.storage.k8s.io/pv/name",
+		"csi.ceph.com/cluster/name",
+	}
+	for _, key := range metadataKeys {
+		err = removeCephFSSubvolumeMetadata(f, fileSystemName, subVolName, subvolumegroup, key)
+		if err != nil {
+			return fmt.Errorf("failed to clear subvolume metadata %q: %w", key, err)
+		}
+	}
+
+	// simulate a legacy PV: drop the subvolumeName attribute and recreate the
+	// PVC/PV as a static binding with Delete policy for cleanup.
+	delete(pv.Spec.CSI.VolumeAttributes, "subvolumeName")
+	pv.Spec.ClaimRef = nil
+	pv.Spec.PersistentVolumeReclaimPolicy = deletePolicy
+	pvc.ResourceVersion = ""
+	pv.ResourceVersion = ""
+	err = createPVCAndPV(f.ClientSet, pvc, pv)
+	if err != nil {
+		return fmt.Errorf("failed to create PVC or PV: %w", err)
+	}
+
+	// the controller reconciles the recreated PV and must set metadata on the
+	// correct subvolume (name derived from the volumeID), not the parent group.
+	err = waitForCephFSSubvolumeMetadata(f, subVolName, pvc.Name, pvc.Namespace, pv.Name)
+	if err != nil {
+		return fmt.Errorf("controller failed to set metadata on legacy PV subvolume: %w", err)
+	}
+
+	// mount the volume; NodeStage resolves the subvolume from the journal, so
+	// the missing subvolumeName attribute must not break mounting.
+	app, err := loadApp(appPath)
+	if err != nil {
+		return err
+	}
+	app.Namespace = f.UniqueName
+	err = createApp(f.ClientSet, app, deployTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to create app: %w", err)
+	}
+	err = deletePVCAndApp("", f, pvc, app)
+	if err != nil {
+		return fmt.Errorf("failed to delete PVC and app: %w", err)
+	}
+	validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+	validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
+
+	// recreate the StorageClass with Delete policy so the fresh PVC provisioned
+	// below is cleaned up automatically.
+	err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to delete storageclass: %w", err)
+	}
+	err = createCephFSStorageClassWithPolicy(f, nil, deletePolicy)
+	if err != nil {
+		return fmt.Errorf("failed to create storageclass: %w", err)
+	}
+
+	// finally, confirm provisioning still works. Had the parent subvolumegroup
+	// been corrupted into a subvolume, this would fail with EINVAL.
+	err = validatePVCAndAppBinding(pvcPath, appPath, f)
+	if err != nil {
+		return fmt.Errorf("failed to provision new PVC after legacy PV reconcile: %w", err)
+	}
+	validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+	validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
+
+	return deleteResource(cephFSExamplePath + "storageclass.yaml")
+}
+
 // validateCephFSServiceAccountVolumeRestriction tests that CephFS volume access
 // can be restricted to a specific Kubernetes service account. It creates a PVC,
 // sets the given saMetadataKey metadata on the backing CephFS subvolume, then

--- a/e2e/operator.go
+++ b/e2e/operator.go
@@ -57,7 +57,7 @@ func NewCephFSOperatorDeployment(c clientset.Interface) CephFSDeploymentMethod {
 			clientSet:        c,
 			deploymentName:   operatorCephFSDeploymentName,
 			daemonsetName:    operatorCephFSDaemonsetName,
-			driverContainers: []string{cephFSContainerName},
+			driverContainers: cephFSContainersName,
 		},
 	}
 }

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -117,7 +117,7 @@ var (
 
 	operatorRBDDeploymentName = "rbd.csi.ceph.com-ctrlplugin"
 	operatorRBDDaemonsetName  = "rbd.csi.ceph.com-nodeplugin"
-	rbdContainersName         = []string{"csi-rbdplugin", "csi-rbdplugin-controller"}
+	rbdContainersName         = []string{"csi-rbdplugin", "csi-rbdplugin-controller", "csi-omap-generator"}
 
 	rbdDeployment RBDDeploymentMethod
 )

--- a/internal/cephfs/store/fsjournal.go
+++ b/internal/cephfs/store/fsjournal.go
@@ -471,6 +471,62 @@ func CheckSnapExists(
 	return sid, nil
 }
 
+// getSubvolumeNameFromID derives the subvolume name from volumeID by querying the RADOS journal.
+// The journal stores the actual subvolumeName (including custom prefix) and fallback
+// to "csi-vol-<uuid>" for very old volumes that predate imageName tracking.
+func getSubvolumeNameFromID(
+	ctx context.Context,
+	vi *util.CSIIdentifier,
+	monitors string,
+	radosNamespace string,
+	instanceID string,
+	cr *util.Credentials,
+) (string, error) {
+	volOptions := &VolumeOptions{
+		ClusterID: vi.ClusterID,
+		FscID:     vi.LocationID,
+	}
+
+	volOptions.Monitors = monitors
+	volOptions.RadosNamespace = radosNamespace
+
+	// Connect to cluster to get metadata pool
+	err := volOptions.Connect(cr)
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to cluster: %w", err)
+	}
+	defer volOptions.Destroy()
+
+	fs := core.NewFileSystem(volOptions.conn)
+	fsName, err := fs.GetFsName(ctx, volOptions.FscID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get filesystem name: %w", err)
+	}
+
+	metadataPool, err := fs.GetMetadataPool(ctx, fsName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get metadata pool: %w", err)
+	}
+
+	VolJournal = journal.NewCSIVolumeJournal(instanceID)
+	j, err := VolJournal.Connect(volOptions.Monitors, volOptions.RadosNamespace, cr)
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to journal: %w", err)
+	}
+	defer j.Destroy()
+
+	// Get image attributes from journal
+	imageAttributes, err := j.GetImageAttributes(ctx, metadataPool, vi.ObjectUUID, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to get image attributes from journal: %w", err)
+	}
+
+	log.DebugLog(ctx, "cephfs: resolved subvolumeName %s for volumeID %s",
+		imageAttributes.ImageName, vi.ObjectUUID)
+
+	return imageAttributes.ImageName, nil
+}
+
 // SetSubVolCSIMetadata sets CSI metadata (PV/PVC info) on a CephFS subvolume.
 func SetSubVolCSIMetadata(
 	ctx context.Context,
@@ -479,7 +535,8 @@ func SetSubVolCSIMetadata(
 	pvName,
 	pvcName,
 	pvcNamespace,
-	clusterName string,
+	clusterName,
+	instanceID string,
 	cr *util.Credentials,
 ) error {
 	var vi util.CSIIdentifier
@@ -504,9 +561,27 @@ func SetSubVolCSIMetadata(
 	}
 	defer conn.Destroy()
 
-	fsName := volumeAttributes["fsName"]
+	// Newer PVs (v3.0.0+) carry the subvolumeName in their volume attributes;
+	// use it directly to avoid extra RADOS/manager calls
+	// on every reconcile.
 	subvolName := volumeAttributes["subvolumeName"]
+	if subvolName == "" {
+		// Legacy PVs predate the subvolumeName attribute, so derive it from
+		// the volumeID through the RADOS journal.
+		radosNamespace, nsErr := util.GetCephFSRadosNamespace(util.CsiConfigFile, vi.ClusterID)
+		if nsErr != nil {
+			return fmt.Errorf("failed to fetch rados namespace using clusterID (%s): %w", vi.ClusterID, nsErr)
+		}
+		subvolName, err = getSubvolumeNameFromID(ctx, &vi, monitors, radosNamespace, instanceID, cr)
+		if err != nil {
+			return fmt.Errorf("failed to get subvolume name: %w", err)
+		}
+	}
+	if subvolName == "" {
+		return fmt.Errorf("failed to resolve subvolume name for volumeID %s", volumeID)
+	}
 
+	fsName := volumeAttributes["fsName"]
 	subVol := &core.SubVolume{
 		VolID:          subvolName,
 		FsName:         fsName,

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -151,6 +151,7 @@ func (r *ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime
 			pv.Spec.ClaimRef.Name,
 			pvcNamespace,
 			r.config.ClusterName,
+			r.config.InstanceID,
 			cr)
 		if err != nil {
 			log.ErrorLogMsg("failed to set CephFS subvolume metadata %s", err)


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
Problem:
Legacy PVs don't have "subvolumeName" in their volumeAttributes.
When SetSubVolCSIMetadata() is called on these PVs by the
csi-omap-generator controller an unchecked map lookup returns empty string.

This empty string gets passed to Ceph Manager's SubvolumeV2.open(),
which resolves it to the parent directory /volumes/csi and incorrectly marks
it with ceph.dir.subvolume=1.

Impact:
Once /volumes/csi is marked as a subvolume, CephFS prohibits creating
subvolumes inside it (nested subvolumes not allowed), causing 100% of
new CephFS PVC provisioning to fail cluster-wide with EINVAL until the
flag is manually cleared.

Fix:
Validate subvolumeName exists and is non-empty before proceeding.
If missing or empty, skip metadata update with warning log.

```

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
