### PR TITLE
rbd: include trashed parents in clone depth checks

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -4607,6 +4607,10 @@ var _ = Describe("RBD", func() {
 			validateOmapCount(f, 0, rbdType, defaultRBDPool, snapsType)
 		})
 
+		It("validate clone depth triggers flatten when parents are in trash", func() {
+			validateCloneDepthFlattenWithTrashedParents(f)
+		})
+
 		It(
 			"validate PVC mounting if snapshot and parent PVC are deleted chained with depth 2",
 			func() {

--- a/e2e/rbd_clone_depth.go
+++ b/e2e/rbd_clone_depth.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func validateCloneDepthFlattenWithTrashedParents(f *framework.Framework) {
+	err := createRBDSnapshotClass(f)
+	if err != nil {
+		logAndFail("failed to create storageclass: %v", err)
+	}
+	defer func() {
+		err = deleteRBDSnapshotClass()
+		if err != nil {
+			logAndFail("failed to delete VolumeSnapshotClass: %v", err)
+		}
+	}()
+
+	pvc, err := loadPVC(pvcPath)
+	if err != nil {
+		logAndFail("failed to load PVC: %v", err)
+	}
+	pvc.Namespace = f.UniqueName
+	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		logAndFail("failed to create PVC: %v", err)
+	}
+
+	sourceImageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
+	if err != nil {
+		logAndFail("failed to get ImageInfo from pvc: %v", err)
+	}
+
+	snap := getSnapshot(snapshotPath)
+	snap.Name = fmt.Sprintf("%s-trash-depth-0", snap.Name)
+	snap.Namespace = f.UniqueName
+	snap.Spec.Source.PersistentVolumeClaimName = &pvc.Name
+	err = createSnapshot(&snap, deployTimeout)
+	if err != nil {
+		logAndFail("failed to create snapshot: %v", err)
+	}
+
+	snapImageName, err := getRBDSnapshotImageName(snap.Namespace, snap.Name)
+	if err != nil {
+		logAndFail("failed to get snapshot backing image name: %v", err)
+	}
+
+	// Restore the first snapshot before deleting it. The restored PVC keeps the
+	// first snapshot backing image in its parent chain.
+	pvcClone, err := loadPVC(pvcClonePath)
+	if err != nil {
+		logAndFail("failed to load PVC: %v", err)
+	}
+	pvcClone.Name = fmt.Sprintf("%s-trash-depth-0", pvcClone.Name)
+	pvcClone.Namespace = f.UniqueName
+	pvcClone.Spec.DataSource.Name = snap.Name
+	err = createPVCAndvalidatePV(f.ClientSet, pvcClone, deployTimeout)
+	if err != nil {
+		logAndFail("failed to create PVC from snapshot: %v", err)
+	}
+
+	// Move both the original source image and first snapshot backing image into
+	// trash. The next snapshot restore must still count through these parents.
+	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+	if err != nil {
+		logAndFail("failed to delete source PVC: %v", err)
+	}
+	err = waitForRBDImageInTrash(f, defaultRBDPool, sourceImageData.imageName, deployTimeout)
+	if err != nil {
+		logAndFail("failed to validate source image in trash: %v", err)
+	}
+	err = deleteSnapshot(&snap, deployTimeout)
+	if err != nil {
+		logAndFail("failed to delete snapshot: %v", err)
+	}
+	err = waitForRBDImageInTrash(f, defaultRBDPool, snapImageName, deployTimeout)
+	if err != nil {
+		logAndFail("failed to validate snapshot backing image in trash: %v", err)
+	}
+
+	snap2 := getSnapshot(snapshotPath)
+	snap2.Name = fmt.Sprintf("%s-trash-depth-1", snap2.Name)
+	snap2.Namespace = f.UniqueName
+	snap2.Spec.Source.PersistentVolumeClaimName = &pvcClone.Name
+	err = createSnapshot(&snap2, deployTimeout)
+	if err != nil {
+		logAndFail("failed to create second snapshot: %v", err)
+	}
+
+	snap2ImageName, err := getRBDSnapshotImageName(snap2.Namespace, snap2.Name)
+	if err != nil {
+		logAndFail("failed to get second snapshot backing image name: %v", err)
+	}
+
+	// Restoring the second snapshot reaches the soft clone-depth limit only if
+	// clone depth is counted through the parents that are already in trash.
+	pvcClone2, err := loadPVC(pvcClonePath)
+	if err != nil {
+		logAndFail("failed to load second PVC clone: %v", err)
+	}
+	pvcClone2.Name = fmt.Sprintf("%s-trash-depth-1", pvcClone2.Name)
+	pvcClone2.Namespace = f.UniqueName
+	pvcClone2.Spec.DataSource.Name = snap2.Name
+	err = createPVCAndvalidatePV(f.ClientSet, pvcClone2, deployTimeout)
+	if err != nil {
+		logAndFail("failed to create PVC from second snapshot: %v", err)
+	}
+
+	err = waitForRBDImageFlattened(f, defaultRBDPool, snap2ImageName, deployTimeout)
+	if err != nil {
+		logAndFail("failed to validate second snapshot backing image flatten: %v", err)
+	}
+
+	err = deleteSnapshot(&snap2, deployTimeout)
+	if err != nil {
+		logAndFail("failed to delete second snapshot: %v", err)
+	}
+	err = deletePVCAndValidatePV(f.ClientSet, pvcClone2, deployTimeout)
+	if err != nil {
+		logAndFail("failed to delete second PVC clone: %v", err)
+	}
+	err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
+	if err != nil {
+		logAndFail("failed to delete PVC clone: %v", err)
+	}
+	validateRBDImageCount(f, 0, defaultRBDPool)
+	validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+	validateOmapCount(f, 0, rbdType, defaultRBDPool, snapsType)
+}

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1237,6 +1237,79 @@ func listRBDImagesInTrash(f *framework.Framework, poolName string) ([]trashInfo,
 	return trashInfos, nil
 }
 
+func waitForRBDImageInTrash(f *framework.Framework, poolName, imageName string, t int) error {
+	var errReason error
+	timeout := time.Duration(t) * time.Minute
+	err := wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(_ context.Context) (bool, error) {
+		imagesInTrash, err := listRBDImagesInTrash(f, poolName)
+		if err != nil {
+			return false, err
+		}
+		for _, image := range imagesInTrash {
+			if image.Name == imageName {
+				return true, nil
+			}
+		}
+		errReason = fmt.Errorf("image %q not found in trash. Image details %v", imageName, imagesInTrash)
+		framework.Logf("%v", errReason.Error())
+
+		return false, nil
+	})
+
+	if wait.Interrupted(err) {
+		err = errReason
+	}
+
+	return err
+}
+
+func waitForRBDImageFlattened(f *framework.Framework, poolName, imageName string, t int) error {
+	var errReason error
+	timeout := time.Duration(t) * time.Minute
+	err := wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(_ context.Context) (bool, error) {
+		imgInfoStr, err := getImageInfo(f, imageName, poolName)
+		if err != nil {
+			return false, err
+		}
+
+		imgInfo := map[string]json.RawMessage{}
+		err = json.Unmarshal([]byte(imgInfoStr), &imgInfo)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse rbd image info for %q: %w", imageName, err)
+		}
+		parent, ok := imgInfo["parent"]
+		if !ok || string(parent) == "null" || string(parent) == `""` {
+			return true, nil
+		}
+
+		errReason = fmt.Errorf("image %q still has parent %s", imageName, string(parent))
+		framework.Logf("%v", errReason.Error())
+
+		return false, nil
+	})
+
+	if wait.Interrupted(err) {
+		err = errReason
+	}
+
+	return err
+}
+
+func getRBDSnapshotImageName(namespace, snapName string) (string, error) {
+	snapHandle, err := getSnapshotHandle(namespace, snapName)
+	if err != nil {
+		return "", err
+	}
+
+	snapIDRegex := regexp.MustCompile(`(\w+\-?){5}$`)
+	snapID := snapIDRegex.FindString(snapHandle)
+	if snapID == "" {
+		return "", fmt.Errorf("failed to get image ID from snapshot handle %q", snapHandle)
+	}
+
+	return "csi-snap-" + snapID, nil
+}
+
 func waitToRemoveImagesFromTrash(f *framework.Framework, poolName string, t int) error {
 	var errReason error
 	timeout := time.Duration(t) * time.Minute

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -597,7 +597,11 @@ func flattenParentImage(
 			softLimit = rbdSoftMaxCloneDepth - depthToAvoidFlatten
 		}
 
-		err = rbdSnap.flattenRbdImage(ctx, false, hardLimit, softLimit)
+		snapVol := rbdSnap.toVolume()
+		snapVol.conn = rbdSnap.conn.Copy()
+		defer snapVol.Destroy(ctx)
+
+		err = snapVol.flattenRbdImage(ctx, false, hardLimit, softLimit)
 		if err != nil {
 			return getGRPCErrorForCreateVolume(err)
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -631,6 +631,27 @@ func (ri *rbdImage) openReadOnly() (*librbd.Image, error) {
 	return image, nil
 }
 
+// openReadOnlyByID opens the rbdImage by image ID in read-only mode. This is
+// useful when the image name no longer identifies the image, for example after
+// a parent image has moved to trash.
+func (ri *rbdImage) openReadOnlyByID() (*librbd.Image, error) {
+	err := ri.openIoctx()
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := librbd.OpenImageByIdReadOnly(ri.ioctx, ri.ImageID, librbd.NoSnapshot)
+	if err != nil {
+		if errors.Is(err, librbd.ErrNotFound) {
+			err = fmt.Errorf("Failed as %w (internal %w)", rbderrors.ErrImageNotFound, err)
+		}
+
+		return nil, err
+	}
+
+	return image, nil
+}
+
 // isInUse checks if there is a watcher on the image. It returns true if there
 // is a watcher on the image, otherwise returns false.
 // In case of mirroring, the image should be primary to check watchers if the
@@ -897,20 +918,38 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 		if vol.RbdImageName == "" {
 			return depth, nil
 		}
-		err := vol.openIoctx()
-		if err != nil {
-			return depth, err
+		var err error
+		// The first image may not have ImageID populated, so open it by name.
+		// ParentImageID is filled from image metadata and used for later
+		// iterations to traverse parents that may already be in trash.
+		if vol.ImageID != "" {
+			err = func() error {
+				image, err := vol.openReadOnlyByID()
+				if err != nil {
+					return err
+				}
+				defer func() {
+					if cErr := image.Close(); cErr != nil {
+						log.WarningLog(ctx, "resource leak, failed to close image: %v", cErr)
+					}
+				}()
+
+				return vol.setImageInfo(image)
+			}()
+		} else {
+			err = vol.getImageInfo()
 		}
 
-		err = vol.getImageInfo()
 		// FIXME: create and destroy the vol inside the loop.
 		// see https://github.com/ceph/ceph-csi/pull/1838#discussion_r598530807
-		vol.ioctx.Destroy()
-		vol.ioctx = nil
+		if vol.ioctx != nil {
+			vol.ioctx.Destroy()
+			vol.ioctx = nil
+		}
 		if err != nil {
-			// if the parent image is moved to trash the name will be present
-			// in rbd image info but the image will be in trash, in that case
-			// return the found depth
+			// Parent images in trash are opened by image ID when the ID is
+			// available. If the parent can no longer be opened by name or ID,
+			// return the depth found so far.
 			if errors.Is(err, rbderrors.ErrImageNotFound) {
 				return depth, nil
 			}
@@ -922,6 +961,7 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 			depth++
 		}
 		vol.RbdImageName = vol.ParentName
+		vol.ImageID = vol.ParentImageID
 		vol.Pool = vol.ParentPool
 	}
 }
@@ -1823,6 +1863,16 @@ func (ri *rbdImage) getImageInfo() error {
 		return err
 	}
 	defer image.Close() //nolint:errcheck // not a critical failure
+
+	return ri.setImageInfo(image)
+}
+
+// setImageInfo updates rbdImage metadata from an already opened RBD image.
+// The caller must pass a non-nil image and remains responsible for closing it.
+func (ri *rbdImage) setImageInfo(image *librbd.Image) error {
+	if image == nil {
+		return errors.New("failed to set image info: image is nil")
+	}
 
 	imageInfo, err := image.Stat()
 	if err != nil {


### PR DESCRIPTION
Open parent images by ID while walking clone ancestry so trashed
parents can still be included in clone depth calculation. Keep ID-based
opens scoped to this traversal path, and flatten snapshot-backed images
instead of the source volume when restoring from snapshots.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
