### PR TITLE
cephfs: refresh recursive stats before volume stats

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -946,6 +947,171 @@ var _ = Describe(cephfsType, func() {
 			err = deleteResource(cephFSExamplePath + "storageclass.yaml")
 			if err != nil {
 				logAndFail("failed to delete CephFS storageclass: %v", err)
+			}
+		})
+
+		It("refreshes stale quota-backed volume usage", func() {
+			const (
+				// Kernel CephFS statfs uses 4MB (1 << 22) blocks.
+				statFSUnitBytes    int64 = 1 << 22
+				quotaUnits         int64 = 32
+				seedUnits          int64 = 3
+				growthUnits        int64 = 1
+				metricsTimeoutMins       = 3
+			)
+
+			err := createCephfsStorageClass(f.ClientSet, f, false, map[string]string{
+				"mounter": "kernel",
+			})
+			if err != nil {
+				logAndFail("failed to create CephFS storageclass: %v", err)
+			}
+			defer func() {
+				err := deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					logAndFail("failed to delete CephFS storageclass: %v", err)
+				}
+			}()
+
+			pvc, err := loadPVC(pvcPath)
+			if err != nil {
+				logAndFail("failed to load PVC: %v", err)
+			}
+			pvc.Namespace = f.UniqueName
+			quotaBytes := quotaUnits * statFSUnitBytes
+			pvc.Spec.Resources.Requests[v1.ResourceStorage] = *resource.NewQuantity(quotaBytes, resource.BinarySI)
+
+			defer func() {
+				currentPVC, err := f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(
+					context.TODO(),
+					pvc.Name,
+					metav1.GetOptions{},
+				)
+				if apierrs.IsNotFound(err) {
+					return
+				}
+				if err != nil {
+					logAndFail("failed to get PVC for cleanup: %v", err)
+				}
+
+				if currentPVC.Spec.VolumeName == "" {
+					err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(
+						context.TODO(),
+						pvc.Name,
+						metav1.DeleteOptions{},
+					)
+				} else {
+					err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+				}
+				if err != nil && !apierrs.IsNotFound(err) {
+					logAndFail("failed to delete PVC: %v", err)
+				}
+			}()
+
+			err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
+			if err != nil {
+				logAndFail("failed to create PVC: %v", err)
+			}
+
+			app, err := loadApp(appPath)
+			if err != nil {
+				logAndFail("failed to load application: %v", err)
+			}
+			app.Namespace = f.UniqueName
+
+			_, err = f.ClientSet.CoreV1().Pods(app.Namespace).Create(context.TODO(), app, metav1.CreateOptions{})
+			if err != nil {
+				logAndFail("failed to create application: %v", err)
+			}
+			defer func() {
+				err := deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
+				if err != nil && !apierrs.IsNotFound(err) {
+					logAndFail("failed to delete application: %v", err)
+				}
+			}()
+
+			err = waitForPodInRunningState(app.Name, app.Namespace, f.ClientSet, deployTimeout, noError)
+			if err != nil {
+				logAndFail("failed waiting for application to run: %v", err)
+			}
+
+			mountPath := app.Spec.Containers[0].VolumeMounts[0].MountPath
+			filePath := mountPath + "/quota-usage"
+			containerName := app.Spec.Containers[0].Name
+			writeCmd := fmt.Sprintf(
+				"dd if=/dev/zero of=%s bs=%d count=%d status=none && sync",
+				filePath,
+				statFSUnitBytes,
+				seedUnits,
+			)
+			_, stdErr, err := execCommandInContainerByPodName(
+				f,
+				writeCmd,
+				app.Namespace,
+				app.Name,
+				containerName,
+			)
+			if err != nil || stdErr != "" {
+				logAndFail("failed to seed CephFS volume usage: %v, stderr: %s", err, stdErr)
+			}
+
+			seedBytes := float64(seedUnits * statFSUnitBytes)
+			metrics, err := waitForVolumeStatsMetrics(
+				f,
+				pvc,
+				metricsTimeoutMins,
+				func(metrics map[string]float64) (bool, error) {
+					used, found := metrics["kubelet_volume_stats_used_bytes"]
+					if !found {
+						return false, nil
+					}
+
+					return used >= seedBytes, nil
+				},
+			)
+			if err != nil {
+				logAndFail("failed waiting for seeded CephFS volume usage: %v", err)
+			}
+			baseline := metrics["kubelet_volume_stats_used_bytes"]
+
+			appendCmd := fmt.Sprintf(
+				"dd if=/dev/zero bs=%d count=%d status=none >> %s && sync",
+				statFSUnitBytes,
+				growthUnits,
+				filePath,
+			)
+			_, stdErr, err = execCommandInContainerByPodName(
+				f,
+				appendCmd,
+				app.Namespace,
+				app.Name,
+				containerName,
+			)
+			if err != nil || stdErr != "" {
+				logAndFail("failed to grow CephFS volume usage: %v, stderr: %s", err, stdErr)
+			}
+
+			expectedUsage := baseline + float64(growthUnits*statFSUnitBytes)
+			_, err = waitForVolumeStatsMetrics(
+				f,
+				pvc,
+				metricsTimeoutMins,
+				func(metrics map[string]float64) (bool, error) {
+					used, found := metrics["kubelet_volume_stats_used_bytes"]
+					if !found {
+						return false, nil
+					}
+
+					return used >= expectedUsage, nil
+				},
+			)
+			if err != nil {
+				logAndFail(
+					"failed waiting for CephFS volume usage to grow from %f to %f: %v",
+					baseline,
+					expectedUsage,
+					err,
+				)
 			}
 		})
 

--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -408,21 +408,25 @@ func checkPVSelectorValuesForPVC(f *framework.Framework, pvc *v1.PersistentVolum
 	return nil
 }
 
-func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t int) error {
+func waitForVolumeStatsMetrics(
+	f *framework.Framework,
+	pvc *v1.PersistentVolumeClaim,
+	timeoutMinutes int,
+	condition func(map[string]float64) (bool, error),
+) (map[string]float64, error) {
 	kubelet, err := getKubeletIP(f.ClientSet)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	isBlock := pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock
 
 	// kubelet needs to be started with --read-only-port=10255
 	cmd := fmt.Sprintf("curl --silent 'http://%s:10255/metrics'", kubelet)
 
 	// retry as kubelet does not immediately have the metrics available
-	timeout := time.Duration(t) * time.Minute
+	timeout := time.Duration(timeoutMinutes) * time.Minute
+	var matchingMetrics map[string]float64
 
-	return wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(_ context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(_ context.Context) (bool, error) {
 		stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
 		if err != nil {
 			framework.Logf("failed to get metrics for pvc %q (%v): %v", pvc.Name, err, stdErr)
@@ -446,8 +450,25 @@ func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t i
 			framework.Logf("found metric for pvc %s/%s: %s = %f", pvc.Namespace, pvc.Name, name, value)
 		}
 
+		matched, err := condition(metrics)
+		if matched {
+			matchingMetrics = metrics
+		}
+
+		return matched, err
+	})
+
+	return matchingMetrics, err
+}
+
+func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t int) error {
+	isBlock := pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock
+
+	_, err := waitForVolumeStatsMetrics(f, pvc, t, func(metrics map[string]float64) (bool, error) {
 		return validateVolumeStatsMetrics(metrics, isBlock)
 	})
+
+	return err
 }
 
 // parseVolumeStatsMetrics extracts kubelet_volume_stats_* metric values for a

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/pkg/xattr"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -57,6 +58,14 @@ type cephfsNodeServer struct {
 
 // Assert required implementation of CSI interfaces.
 var _ csi.NodeServer = &cephfsNodeServer{}
+
+func refreshRStats(targetPath string) error {
+	// Reading ceph.dir.rbytes forces the kernel CephFS client to refresh its
+	// cached recursive statistics.
+	_, err := xattr.Get(targetPath, "ceph.dir.rbytes")
+
+	return err
+}
 
 func getCredentialsForVolume(
 	volOptions *store.VolumeOptions,
@@ -1004,6 +1013,11 @@ func (ns *cephfsNodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
+		err = refreshRStats(targetPath)
+		if err != nil {
+			log.WarningLog(ctx, "failed to refresh CephFS rstats for %q: %v", targetPath, err)
+		}
+
 		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, false)
 	}
 


### PR DESCRIPTION
# Describe what this PR does #

Refreshes CephFS recursive statistics before collecting filesystem usage.

Linux CephFS `statfs()` overrides filesystem statistics for quota-backed mounts using the quota inode's cached `rbytes` value ([source](https://github.com/torvalds/linux/blob/26260251022fbc2f248a3d747a9b2b961b18d2d8/fs/ceph/quota.c#L531)) instead of using the fresh values like the regular `statfs()` path  ([source](https://github.com/torvalds/linux/blob/26260251022fbc2f248a3d747a9b2b961b18d2d8/fs/ceph/super.c#L74)).

On the other hand, Ceph MDS only broadcasts new statistics when usage changes by approx. 1/16 of the difference between the last reported usage and the max quota available ([source](https://github.com/ceph/ceph/blob/162eb4aeca88382affe501526ab04c3bcd087dad/src/mds/MDCache.cc#L2129)).

Slow growing volumes can remain for long periods with stale usage and consequently stale `kubelet_volume_stats_used_bytes`. In my cluster I noticed my metrics database had several PVCs reporting the same used bytes for a whole month, despite constant write activity.

Neither behavior is wrong on its own, so I wrote this patch intending to make the statistics accurate in ceph-csi.

I've ran the added E2E test on the latest commit at devel (f4ce351) and in this PR and I could reproduce a fail before and a pass after.

I've also replaced my production ceph-csi with this patch and all affected volumes started reporting the current usage.

This is my manual reproduction before the patch on my kubernetes host:

```bash
$ df -B1 <kubelet globalmount path>
Filesystem 1-blocks Used Available Use% Mounted on
<path> 10737418240 0 10737418240 0% <path>

$ # fetched ceph.dir.rbytes using a perl script as the host lacks getfattr
203487451

$ df -B1 <kubelet globalmount path>
Filesystem 1-blocks Used Available Use% Mounted on
<path> 10737418240 201326592 10536091648 2% <path>
```

## Is there anything that requires special attention ##

This is my first contribution to ceph-csi. I believe this change is backward compatible.

If this is accepted, is it worth updating the pending release notes? I was unsure about it, so I didn't include an update in this PR.

## Related issues ##

#2579

## Future concerns ##

This adds an MDS request when collecting CephFS volume statistics. If a CephFS-side change makes `statfs()` sufficient in the future, this patch could be reconsidered.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.