### PR TITLE
ci: react with thumbsup to the comment triggering /queue

### DIFF
--- a/.github/workflows/queue-rebase-and-label.yaml
+++ b/.github/workflows/queue-rebase-and-label.yaml
@@ -29,6 +29,24 @@ jobs:
     # yamllint enable rule:line-length
     runs-on: ubuntu-latest
     steps:
+      - name: React to triggering comment
+        # yamllint disable-line rule:line-length
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          github-token: ${{ secrets.CEPH_CSI_BOT_TOKEN }}
+          script: |
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: '+1'
+              })
+            } catch (e) {
+              // 422 means the reaction already exists; ignore it
+              if (e.status !== 422) throw e
+            }
+
       - name: Get PR details
         id: pr
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
When a maintainer posts a /queue comment on a PR, immediately react
to that comment with a +1 emoji to acknowledge the workflow was
triggered.