### PR TITLE
cleanup: deprecate charts yamls manifests

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -2,6 +2,13 @@
 
 ## Breaking changes
 
+## Deprecations
+
+1. Helm charts and manual YAML deployments are deprecated in v3.18 and will
+   be removed in v3.19. The Ceph-CSI Operator is now the officially
+   supported deployment method for Kubernetes. See `deploy/DEPRECATION.md`
+   for migration guidance.
+
 ## Features
 
 1. Added `GetReplicationDestinationInfo` RPC to map source volume/volume

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Card](https://goreportcard.com/badge/github.com/ceph/ceph-csi)](https://goreport
 [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/ceph/ceph-csi/devel)](https://www.tickgit.com/browse?repo=github.com/ceph/ceph-csi&branch=devel)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5940/badge)](https://bestpractices.coreinfrastructure.org/projects/5940)
 
+> [!IMPORTANT]
+> **Deployment Method Change**: As of Ceph-CSI v3.17, the [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) is the **officially supported deployment method** for Kubernetes.
+>
+> **Helm charts and manual YAML deployments are deprecated** and will be removed in v3.19. Please migrate to the operator for automated lifecycle management, upgrades, and configuration.
+>
+> See the [deprecation notice](deploy/DEPRECATION.md) for migration guidance.
+
 - [Ceph CSI](#ceph-csi)
    - [Overview](#overview)
    - [Project status](#project-status)
@@ -34,12 +41,16 @@ Ceph CSI plugins implement an interface between a CSI-enabled Container Orchestr
 (CO) and Ceph clusters. They enable dynamically provisioning Ceph volumes and
 attaching them to workloads.
 
-Independent CSI plugins are provided to support RBD and CephFS backed volumes,
+Independent CSI plugins are provided to support RBD and CephFS backed volumes.
 
-- For details about configuration and deployment of RBD plugin, please refer
-  [rbd doc](https://ceph.github.io/ceph-csi/rbd/deploy/) and
-  for CephFS plugin configuration and deployment please
-  refer [cephFS doc](https://ceph.github.io/ceph-csi/cephfs/deploy/).
+**Recommended Deployment:**
+- Use the [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) for automated deployment and lifecycle management
+
+**Deprecated Deployment Methods (will be removed in v3.19):**
+- Manual YAML deployments: [RBD](https://ceph.github.io/ceph-csi/rbd/deploy/) | [CephFS](https://ceph.github.io/ceph-csi/cephfs/deploy/)
+- Helm charts in `./charts/` directory
+
+**Additional Resources:**
 - For example usage of the RBD and CephFS CSI plugins, see examples in `examples/`.
 - Stale resource cleanup, please refer [cleanup doc](https://ceph.github.io/ceph-csi/resource-cleanup/).
 

--- a/charts/ceph-csi-cephfs/Chart.yaml
+++ b/charts/ceph-csi-cephfs/Chart.yaml
@@ -1,10 +1,13 @@
 ---
 apiVersion: v1
 appVersion: canary
-description: "Container Storage Interface (CSI) driver,
+description: "DEPRECATED: This Helm chart is deprecated and will be removed in v3.19.
+Please use the Ceph-CSI Operator (https://ceph.github.io/ceph-csi-operator) instead.
+Container Storage Interface (CSI) driver,
 provisioner, snapshotter, resizer and attacher for Ceph cephfs"
 name: ceph-csi-cephfs
 version: 3-canary
+deprecated: true
 keywords:
   - ceph
   - cephfs

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -1,4 +1,16 @@
 ---
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# This Helm chart is DEPRECATED and will be removed in Ceph-CSI v3.19.
+#
+# The Ceph-CSI Operator is now the officially supported deployment method
+# for Kubernetes. Please migrate to the operator for automated lifecycle
+# management, upgrades, and configuration.
+#
+# Operator documentation: https://ceph.github.io/ceph-csi-operator
+# ============================================================================
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/charts/ceph-csi-rbd/Chart.yaml
+++ b/charts/ceph-csi-rbd/Chart.yaml
@@ -1,10 +1,13 @@
 ---
 apiVersion: v1
 appVersion: canary
-description: "Container Storage Interface (CSI) driver,
+description: "DEPRECATED: This Helm chart is deprecated and will be removed in v3.19.
+Please use the Ceph-CSI Operator (https://ceph.github.io/ceph-csi-operator) instead.
+Container Storage Interface (CSI) driver,
 provisioner, snapshotter, resizer and attacher for Ceph RBD"
 name: ceph-csi-rbd
 version: 3-canary
+deprecated: true
 keywords:
   - ceph
   - rbd

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -1,4 +1,16 @@
 ---
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# This Helm chart is DEPRECATED and will be removed in Ceph-CSI v3.19.
+#
+# The Ceph-CSI Operator is now the officially supported deployment method
+# for Kubernetes. Please migrate to the operator for automated lifecycle
+# management, upgrades, and configuration.
+#
+# Operator documentation: https://ceph.github.io/ceph-csi-operator
+# ============================================================================
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/deploy/DEPRECATION.md
+++ b/deploy/DEPRECATION.md
@@ -1,0 +1,25 @@
+# DEPRECATION NOTICE
+
+**These manual YAML deployment manifests are DEPRECATED and will be removed in Ceph-CSI v3.19.**
+
+## Recommended Migration Path
+
+The [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) is now the officially supported deployment method for Kubernetes. The operator provides:
+
+- **Automated lifecycle management**: Install, upgrade, and configure Ceph-CSI drivers automatically
+- **Simplified operations**: Declarative configuration through Custom Resources
+- **Better upgrade experience**: Seamless driver upgrades with minimal downtime
+- **Consistent deployment**: Ensures best practices and correct configuration
+
+## Migration Instructions
+
+Please refer to the [Ceph-CSI Operator documentation](https://ceph.github.io/ceph-csi-operator) for installation and migration guidance.
+
+## Support Timeline
+
+- **v3.18 (current)**: Manual YAML deployments are deprecated but still present in the repository (untested)
+- **v3.19**: Manual YAML deployment files will be removed
+
+If you have questions or need assistance migrating to the operator, please reach out on:
+- Slack: [#ceph-csi channel](https://ceph-storage.slack.com/archives/C05522L7P60)
+- GitHub: [Ceph-CSI Issues](https://github.com/ceph/ceph-csi/issues)

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 kind: Service
 apiVersion: v1

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin-provisioner.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 kind: Service
 apiVersion: v1

--- a/deploy/nfs/kubernetes/csi-nfsplugin.yaml
+++ b/deploy/nfs/kubernetes/csi-nfsplugin.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deploy/nvmeof/kubernetes/csi-nvmeofplugin-provisioner.yaml
+++ b/deploy/nvmeof/kubernetes/csi-nvmeofplugin-provisioner.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 kind: Deployment
 apiVersion: apps/v1

--- a/deploy/nvmeof/kubernetes/csi-nvmeofplugin.yaml
+++ b/deploy/nvmeof/kubernetes/csi-nvmeofplugin.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 kind: Service
 apiVersion: v1

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -1,3 +1,10 @@
+# ============================================================================
+# DEPRECATION NOTICE
+# ============================================================================
+# Manual YAML deployments are DEPRECATED and will be removed in v3.19.
+# Please use the Ceph-CSI Operator: https://ceph.github.io/ceph-csi-operator
+# See deploy/DEPRECATION.md for migration guidance.
+# ============================================================================
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/docs/cephfs/deploy.md
+++ b/docs/cephfs/deploy.md
@@ -1,10 +1,14 @@
 
 # CSI CephFS plugin
 
-> **Note:** The preferred deployment method for Kubernetes is the
-> [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator), which manages
-> driver lifecycle, upgrades, and configuration automatically. The manual steps
-> below are for advanced or non-operator deployments.
+!!! warning "DEPRECATED: Manual YAML Deployment"
+    **This deployment method is DEPRECATED and will be removed in Ceph-CSI v3.19.**
+    
+    The [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) is now the **only supported deployment method** for Kubernetes. It provides automated driver lifecycle management, upgrades, and configuration.
+    
+    **These manual YAML deployment instructions are no longer tested or supported.** Please migrate to the operator.
+    
+    See [deploy/DEPRECATION.md](../../deploy/DEPRECATION.md) for migration guidance.
 
 The CSI CephFS plugin is able to both provision new CephFS volumes
 and attach and mount existing ones to workloads.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,14 +27,18 @@ straightforward.
 
 ### Deployment
 
-The preferred way to deploy Ceph-CSI on Kubernetes is via the
-[Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator), which manages
-the full lifecycle of the drivers including upgrades and configuration.
+!!! important "Deployment Method Change"
+    **Helm charts and manual YAML deployments are DEPRECATED** as of v3.18 and will be removed in v3.19.
+    
+    The [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) is now the **only supported deployment method** for Kubernetes, managing the full lifecycle of the drivers including upgrades and configuration.
 
-- [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) - Operator-based
-  deployment (recommended)
-- [RBD Deployment Guide](rbd/deploy.md) - Deploy the RBD CSI driver manually
-- [CephFS Deployment Guide](cephfs/deploy.md) - Deploy the CephFS CSI driver manually
+**Supported Deployment:**
+- [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) - Operator-based deployment (**recommended and supported**)
+
+**Deprecated Deployment Methods (untested, will be removed in v3.19):**
+- [RBD Deployment Guide](rbd/deploy.md) - Manual YAML deployment (deprecated)
+- [CephFS Deployment Guide](cephfs/deploy.md) - Manual YAML deployment (deprecated)
+- Helm charts in `charts/` directory (deprecated)
 
 ### Features
 

--- a/docs/rbd/deploy.md
+++ b/docs/rbd/deploy.md
@@ -1,9 +1,13 @@
 # CSI RBD Plugin
 
-> **Note:** The preferred deployment method for Kubernetes is the
-> [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator), which manages
-> driver lifecycle, upgrades, and configuration automatically. The manual steps
-> below are for advanced or non-operator deployments.
+!!! warning "DEPRECATED: Manual YAML Deployment"
+    **This deployment method is DEPRECATED and will be removed in Ceph-CSI v3.19.**
+    
+    The [Ceph-CSI Operator](https://ceph.github.io/ceph-csi-operator) is now the **only supported deployment method** for Kubernetes. It provides automated driver lifecycle management, upgrades, and configuration.
+    
+    **These manual YAML deployment instructions are no longer tested or supported.** Please migrate to the operator.
+    
+    See [deploy/DEPRECATION.md](../../deploy/DEPRECATION.md) for migration guidance.
 
 The RBD CSI plugin is able to provision new RBD images and
 attach and mount those to workloads.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Helm charts and manual YAML deployments are deprecated in v3.18 and will
be removed in v3.19. The Ceph-CSI Operator is now the officially
supported deployment method for Kubernetes. See `deploy/DEPRECATION.md`
for migration guidance.

Part-of: https://github.com/ceph/ceph-csi/issues/6467
Depends-on: https://github.com/ceph/ceph-csi/pull/6512

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
