### PR TITLE
cephfs: use go-ceph PinSubVolumeInGroup() to pin a subvolume

### DIFF
--- a/internal/cephfs/core/volume.go
+++ b/internal/cephfs/core/volume.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -334,42 +333,19 @@ func checkSubvolumeHasFeature(feature string, subVolFeatures []string) bool {
 }
 
 // PinVolume sets an MDS pinning policy on the subvolume.
-// pinType can be "export", "distributed" or "random".
-// pinSetting is the value for the pin (e.g. MDS rank "2", "true"/"false").
-//
-// go-ceph's typed PinSubVolume helper does not accept a subvolume group, so it
-// would always target Ceph's default group and fail for subvolumes created in
-// a non-default group (as ceph-csi does). To support any group, the "fs
-// subvolume pin" manager command is issued directly with the group_name set.
-//
-// Similar To:
-//
-//	ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting> \
-//	  --group_name=<group>
 func (s *subVolumeClient) PinVolume(ctx context.Context, pinType, pinSetting string) error {
-	cmd := map[string]string{
-		"prefix":      "fs subvolume pin",
-		"format":      "json",
-		"vol_name":    s.FsName,
-		"sub_name":    s.VolID,
-		"group_name":  s.SubvolumeGroup,
-		"pin_type":    pinType,
-		"pin_setting": pinSetting,
+	fsa, err := s.conn.GetFSAdmin()
+	if err != nil {
+		log.ErrorLog(ctx, "could not get FSAdmin, can not pin subvolume %s: %s", s.VolID, err)
+
+		return err
 	}
 
-	buf, err := json.Marshal(cmd)
+	_, err = fsa.PinSubVolumeInGroup(s.FsName, s.SubvolumeGroup, s.VolID, pinType, pinSetting)
 	if err != nil {
-		return fmt.Errorf("failed to marshal pin command for subvolume %s: %w", s.VolID, err)
-	}
-
-	out, status, err := s.conn.MgrCommand([][]byte{buf})
-	if err != nil {
-		return fmt.Errorf("failed to pin subvolume %s in fs %s (group %s): %w",
+		log.ErrorLog(ctx, "failed to pin subvolume %s in fs %s (group %s): %s",
 			s.VolID, s.FsName, s.SubvolumeGroup, err)
 	}
 
-	log.DebugLog(ctx, "cephfs: pinned subvolume %s in fs %s (group %s), type=%s setting=%s: status=%q output=%q",
-		s.VolID, s.FsName, s.SubvolumeGroup, pinType, pinSetting, status, string(out))
-
-	return nil
+	return err
 }

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -170,14 +170,3 @@ func (cc *ClusterConnection) GetAddrs() (string, error) {
 
 	return cc.conn.GetAddrs()
 }
-
-// MgrCommand sends a raw JSON-encoded command to the Ceph manager and returns
-// its output. It is used for manager commands that are not (yet) exposed by a
-// typed go-ceph helper.
-func (cc *ClusterConnection) MgrCommand(args [][]byte) ([]byte, string, error) {
-	if cc.conn == nil {
-		return nil, "", errors.New("cluster is not connected yet")
-	}
-
-	return cc.conn.MgrCommand(args)
-}


### PR DESCRIPTION
# Describe what this PR does #

PinVolume() built the fs subvolume pin manager command by hand and sent it through ClusterConnection.MgrCommand(). go-ceph's PinSubVolume() could not be used because it takes no subvolume group and always look the subvolume up in Ceph's default group while ceph-csi creates subvolumes in a non-default group.

go-ceph v0.41.0 (#6479) adds PinSubVolumeInGroup() which takes the group. So that helper replaces the hand written command.

MgrCommand() was added for that single call site and has no other callers so it is removed in a second commit.

## Is there anything that requires special attention ##

Same fs subvolume pin operation with the same arguments, just issued through go-ceph instead of a hand built command.(backward compatible)
PinSubVolumeInGroup() is behind the ceph_preview build tag which is already part of GO_TAGS_LIST.

## Related issues ##

Fixes: #6482

## Future concerns ##

None.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the developer guide.
* [x] Reviewed the developer guide on Submitting a Pull Request
* [ ] Pending release notes updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

No release note or documentation change this is an internal refactor with no behaviour or API change. All testing covered by e2e rather than unit tests.
Verified locally with make containerized-build, make containerized-test TARGET=go-test (0 failures) and make containerized-test TARGET=static-check (golangci-lint clean).


