### PR TITLE
rbd: open image once in setAllMetadata/unsetAllMetadata

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2407,15 +2407,21 @@ func genVolFromVolIDWithMigration(
 
 // setAllMetadata set all the metadata from arg parameters on RBD image.
 func (rv *rbdVolume) setAllMetadata(parameters map[string]string) error {
+	image, err := rv.open()
+	if err != nil {
+		return err
+	}
+	defer image.Close() //nolint:errcheck // not a critical failure
+
 	for k, v := range parameters {
-		err := rv.SetMetadata(k, v)
+		err := image.SetMetadata(k, v)
 		if err != nil {
 			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w", k, v, err)
 		}
 	}
 
 	if rv.ClusterName != "" {
-		err := rv.SetMetadata(clusterNameKey, rv.ClusterName)
+		err := image.SetMetadata(clusterNameKey, rv.ClusterName)
 		if err != nil {
 			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w",
 				clusterNameKey, rv.ClusterName, err)
@@ -2423,7 +2429,7 @@ func (rv *rbdVolume) setAllMetadata(parameters map[string]string) error {
 	}
 
 	if rv.Mounter != "" {
-		err := rv.SetMetadata(mounterKey, rv.Mounter)
+		err := image.SetMetadata(mounterKey, rv.Mounter)
 		if err != nil {
 			return fmt.Errorf("failed to set metadata key %q, value %q on image: %w",
 				mounterKey, rv.Mounter, err)
@@ -2435,19 +2441,25 @@ func (rv *rbdVolume) setAllMetadata(parameters map[string]string) error {
 
 // unsetAllMetadata unset all the metadata from arg keys on RBD image.
 func (rv *rbdVolume) unsetAllMetadata(keys []string) error {
+	image, err := rv.open()
+	if err != nil {
+		return err
+	}
+	defer image.Close() //nolint:errcheck // not a critical failure
+
 	for _, key := range keys {
-		err := rv.RemoveMetadata(key)
+		err := image.RemoveMetadata(key)
 		if err != nil && !errors.Is(err, librbd.ErrNotExist) {
 			return fmt.Errorf("failed to unset metadata key %q on %q: %w", key, rv, err)
 		}
 	}
 
-	err := rv.RemoveMetadata(clusterNameKey)
+	err = image.RemoveMetadata(clusterNameKey)
 	if err != nil && !errors.Is(err, librbd.ErrNotExist) {
 		return fmt.Errorf("failed to unset metadata key %q on %q: %w", clusterNameKey, rv, err)
 	}
 
-	err = rv.RemoveMetadata(mounterKey)
+	err = image.RemoveMetadata(mounterKey)
 	if err != nil && !errors.Is(err, librbd.ErrNotExist) {
 		return fmt.Errorf("failed to unset metadata key %q on %q: %w", mounterKey, rv, err)
 	}


### PR DESCRIPTION
setAllMetadata called rbdImage.SetMetadata once per key, and each call opened and closed the RBD image on its own. On the CreateVolume path this meant the image was opened at least three times (the parameters map plus the clusterName and mounter keys), which is wasteful.

Open the image once at the start of setAllMetadata and issue all SetMetadata calls against that single handle, closing it via defer.

Apply the same change to the symmetric unsetAllMetadata, which had the identical open-per-key pattern.

Behaviour is unchanged: the same keys are set/unset, the same error messages are returned, and unsetAllMetadata still tolerates ErrNotExist.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
