### PR TITLE
ci: pass --test-nvmeof=false where NVMe-oF should not run

### DIFF
--- a/mini-e2e-helm.groovy
+++ b/mini-e2e-helm.groovy
@@ -205,11 +205,11 @@ node('cico-workspace') {
 			timeout(time: 240, unit: 'MINUTES') {
 				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
-					t_type = '--test-cephfs=true --test-rbd=false --test-nfs=false'
+					t_type = '--test-cephfs=true --test-rbd=false --test-nfs=false --test-nvmeof=false'
 				} else if ("${test_type}" == "rbd"){
-					t_type = '--test-rbd=true --test-cephfs=false --test-nfs=false'
+					t_type = '--test-rbd=true --test-cephfs=false --test-nfs=false --test-nvmeof=false'
 				} else if ("${test_type}" == "nfs"){
-					t_type = '--test-nfs=true --test-cephfs=false --test-rbd=false'
+					t_type = '--test-nfs=true --test-cephfs=false --test-rbd=false --test-nvmeof=false'
 				} else if ("${test_type}" == "nvmeof"){
 					t_type = '--test-nvmeof=true --test-nfs=false --test-cephfs=false --test-rbd=false'
 				}

--- a/mini-e2e-operator.groovy
+++ b/mini-e2e-operator.groovy
@@ -205,11 +205,11 @@ node('cico-workspace') {
 			timeout(time: 240, unit: 'MINUTES') {
 				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
-					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"
+					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false --test-nvmeof=false"
 				} else if ("${test_type}" == "rbd"){
-					t_type = "--test-rbd=true --test-cephfs=false --test-nfs=false"
+					t_type = "--test-rbd=true --test-cephfs=false --test-nfs=false --test-nvmeof=false"
 				} else if ("${test_type}" == "nfs"){
-					t_type = "--test-nfs=true --test-cephfs=false --test-rbd=false"
+					t_type = "--test-nfs=true --test-cephfs=false --test-rbd=false --test-nvmeof=false"
 				} else if ("${test_type}" == "nvmeof"){
 					t_type = '--test-nvmeof=true --test-nfs=false --test-cephfs=false --test-rbd=false'
 				}

--- a/mini-e2e.groovy
+++ b/mini-e2e.groovy
@@ -192,11 +192,11 @@ node('cico-workspace') {
 			timeout(time: 240, unit: 'MINUTES') {
 				def t_type = "" // test all by default
 				if ("${test_type}" == "cephfs"){
-					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false"
+					t_type = "--test-cephfs=true --test-rbd=false --test-nfs=false --test-nvmeof=false"
 				} else if ("${test_type}" == "rbd"){
-					t_type = "--test-rbd=true --test-cephfs=false --test-nfs=false"
+					t_type = "--test-rbd=true --test-cephfs=false --test-nfs=false --test-nvmeof=false"
 				} else if ("${test_type}" == "nfs"){
-					t_type = "--test-nfs=true --test-cephfs=false --test-rbd=false"
+					t_type = "--test-nfs=true --test-cephfs=false --test-rbd=false --test-nvmeof=false"
 				} else if ("${test_type}" == "nvmeof"){
 					t_type = '--test-nvmeof=true --test-nfs=false --test-cephfs=false --test-rbd=false'
 				}

--- a/upgrade-tests.groovy
+++ b/upgrade-tests.groovy
@@ -201,9 +201,9 @@ node('cico-workspace') {
 		}
 		stage("run ${test_type} upgrade tests") {
 			timeout(time: 120, unit: 'MINUTES') {
-				upgrade_args = "--test-cephfs=false --test-rbd=true --upgrade-testing=true"
+				upgrade_args = "--test-cephfs=false --test-rbd=true --upgrade-testing=true --test-nvmeof=false"
 				if ("${test_type}" == "cephfs"){
-					upgrade_args = "--test-cephfs=true --test-rbd=false --upgrade-testing=true"
+					upgrade_args = "--test-cephfs=true --test-rbd=false --upgrade-testing=true --test-nvmeof=false"
 				}
 				ssh "cd /opt/build/go/src/github.com/ceph/ceph-csi && make run-e2e E2E_ARGS=\"--upgrade-version=${csi_upgrade_version} ${upgrade_args}\""
 			}


### PR DESCRIPTION
Single-driver jobs (cephfs, rbd, nfs) and upgrade testing jobs can now
explicitly opt out of NVMe-oF testing. release-v3.16 is the oldest
maintained release and already includes the --test-nvmeof parameter, so
all active branches support this flag.
