### PR TITLE
ci: add CODEOWNERS for ci/centos branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Ceph-CSI CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for all files, see also devel:.github/CODEOWNERS
+*       @ceph/ceph-csi-maintainers @ceph/ceph-csi-contributors


### PR DESCRIPTION
With the CODEOWNERS developers get notified about new PRs that are
available for review. This ideally speeds up the review and merge
process.
