### PR TITLE
e2e: create the configmap before deploying the CSI plugins

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -216,12 +216,12 @@ var _ = Describe(cephfsType, func() {
 			}
 		}
 
-		if deployCephFS {
-			deployCephfsPlugin()
-		}
 		err := createConfigMap(cephFSDirPath, f.ClientSet, f)
 		if err != nil {
 			logAndFail("failed to create configmap: %v", err)
+		}
+		if deployCephFS {
+			deployCephfsPlugin()
 		}
 		// create cephFS provisioner secret
 		key, err := createCephUser(f, keyringCephFSProvisionerUsername, cephFSProvisionerCaps())

--- a/e2e/nfs.go
+++ b/e2e/nfs.go
@@ -386,15 +386,14 @@ var _ = Describe("nfs", func() {
 		}
 
 		createNFSPool(f)
-		if deployNFS {
-			deployNFSPlugin()
-		}
-
 		// cephfs testing might have changed the default subvolumegroup
 		subvolumegroup = defaultSubvolumegroup
 		err := createConfigMap(nfsDirPath, f.ClientSet, f)
 		if err != nil {
 			logAndFail("failed to create configmap: %v", err)
+		}
+		if deployNFS {
+			deployNFSPlugin()
 		}
 		// create nfs provisioner secret
 		key, err := createCephUser(f, keyringCephFSProvisionerUsername, cephFSProvisionerCaps())

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -379,12 +379,12 @@ var _ = Describe("RBD", func() {
 				logAndFail("failed to add node labels: %v", err)
 			}
 		}
-		if deployRBD {
-			deployRBDPlugin()
-		}
 		err := createConfigMap(rbdDirPath, f.ClientSet, f)
 		if err != nil {
 			logAndFail("failed to create configmap: %v", err)
+		}
+		if deployRBD {
+			deployRBDPlugin()
 		}
 		// Since helm deploys storageclass, skip storageclass creation if
 		// ceph-csi is deployed via helm.


### PR DESCRIPTION
The ceph-csi-config configmap is mounted by the CSI plugin pods.
Creating it after deploying the plugins can cause pods to fail
starting due to a missing volume reference.

Move createConfigMap() before the deployXxxPlugin() calls in the
BeforeEach blocks for CephFS, RBD, and NFS. This matches the order
already used in deployNVMeoFPlugin().