### PR TITLE
deploy: add CephNFS to the Rook e2e test cluster

### DIFF
--- a/scripts/k8s-storage/driver-nfs.yaml
+++ b/scripts/k8s-storage/driver-nfs.yaml
@@ -1,0 +1,82 @@
+---
+ShortName: cephcsi-nfs-test
+Timeouts:
+  ClaimProvision: 10m
+
+StorageClass:
+  FromExistingClassName: k8s-storage-e2e-nfs
+  # FromFile: sc-nfs.yaml
+
+SnapshotClass:
+  # Must be set to enable snapshotting tests
+  FromExistingClassName: k8s-storage-e2e-nfs
+
+DriverInfo:
+  # Internal name of the driver, display name in the test case and test objects
+  Name: nfs.csi.ceph.com
+
+  # The range of disk size supported by this driver
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
+
+  # Map of strings for supported mount options
+  SupportedMountOption:
+    rw: {}
+
+  # Map of strings for required mount options
+  RequiredMountOption:
+    rw: {}
+
+  # Optional list of access modes required for provisioning. Default is RWO
+  # RequiredAccessModes:
+
+  # Map that represents the capabilities the driver supports
+  Capabilities:
+    # Data is persisted across pod restarts
+    persistence: true
+
+    # Volume ownership via fsGroup
+    fsGroup: false
+
+    # multiple pods on a node can use the same volume concurrently
+    multipods: true
+
+    # support online expansion
+    onlineExpansion: true
+
+    # supports ReadWriteOncePod pod
+    readWriteOncePod: true
+
+    # supports ROX AccessMode in PVC
+    capReadOnlyMany: true
+
+    # Raw block mode
+    block: false
+
+    # Exec a file in the volume
+    exec: true
+
+    # Support for volume limits
+    volumeLimits: false
+
+    # Support for volume expansion in controllers
+    controllerExpansion: true
+
+    # Support for volume expansion in nodes
+    nodeExpansion: false
+
+    # Support volume that can run on single node only (like hostpath)
+    singleNodeVolume: false
+
+    # Support ReadWriteMany access modes
+    RWX: true
+
+    # Support topology
+    topology: false
+
+    # Support populate data from snapshot
+    snapshotDataSource: true
+
+    # Support populated data from PVC
+    pvcDataSource: true

--- a/scripts/k8s-storage/sc-nfs.yaml.in
+++ b/scripts/k8s-storage/sc-nfs.yaml.in
@@ -1,0 +1,19 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: k8s-storage-e2e-nfs
+provisioner: nfs.csi.ceph.com
+parameters:
+  clusterID: @@CLUSTER_ID@@
+  nfsCluster: my-nfs
+  server: rook-ceph-nfs-my-nfs-a.rook-ceph.svc.cluster.local
+  fsName: myfs
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+reclaimPolicy: Delete
+allowVolumeExpansion: true

--- a/scripts/k8s-storage/volumesnapshotclass-nfs.yaml.in
+++ b/scripts/k8s-storage/volumesnapshotclass-nfs.yaml.in
@@ -1,0 +1,11 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: k8s-storage-e2e-nfs
+driver: nfs.csi.ceph.com
+parameters:
+  clusterID: @@CLUSTER_ID@@
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph
+deletionPolicy: Delete

--- a/scripts/rook.sh
+++ b/scripts/rook.sh
@@ -25,6 +25,7 @@ function log_errors() {
 	kubectl -n rook-ceph get CephClusters -oyaml
 	kubectl -n rook-ceph get CephFilesystems -oyaml
 	kubectl -n rook-ceph get CephBlockPools -oyaml
+	kubectl -n rook-ceph get CephNFSes -oyaml
 
 	# this function should not return, a fatal error was caught!
 	exit 1
@@ -61,7 +62,8 @@ function deploy_rook() {
 	kubectl_retry create -f "${ROOK_URL}/toolbox.yaml"
 	kubectl_retry create -f "${ROOK_URL}/filesystem-test.yaml"
 	kubectl_retry create -f "${ROOK_URL}/pool-test.yaml"
-	
+	kubectl_retry create -f "${ROOK_URL}/nfs-test.yaml"
+
 	create_or_delete_subvolumegroup "create"
 
 	# Check if CephCluster is empty
@@ -81,10 +83,16 @@ function deploy_rook() {
 	if ! kubectl_retry -n rook-ceph get cephblockpools -oyaml | grep 'items: \[\]' &>/dev/null; then
 		check_rbd_stat "replicapool"
 	fi
+
+	# Check if CephNFS is empty
+	if ! kubectl_retry -n rook-ceph get cephnfses -oyaml | grep 'items: \[\]' &>/dev/null; then
+		check_nfs_stat
+	fi
 }
 
 function teardown_rook() {
 	create_or_delete_subvolumegroup "delete"
+	kubectl delete -f "${ROOK_URL}/nfs-test.yaml"
 	kubectl delete -f "${ROOK_URL}/pool-test.yaml"
 	kubectl delete -f "${ROOK_URL}/filesystem-test.yaml"
 	kubectl delete -f "${ROOK_URL}/toolbox.yaml"
@@ -231,6 +239,23 @@ function check_rbd_stat() {
 
 	if [ "$retry" -gt "$ROOK_DEPLOY_TIMEOUT" ]; then
 		echo "[Timeout] Failed to get RBD pool Ready"
+		return 1
+	fi
+	echo ""
+}
+
+function check_nfs_stat() {
+	for ((retry = 0; retry <= ROOK_DEPLOY_TIMEOUT; retry = retry + 5)); do
+		echo "Waiting for NFS server... ${retry}s" && sleep 5
+
+		if kubectl_retry -n rook-ceph get pod -l app=rook-ceph-nfs | grep Running &>/dev/null; then
+			echo "NFS server is successfully created..."
+			break
+		fi
+	done
+
+	if [ "$retry" -gt "$ROOK_DEPLOY_TIMEOUT" ]; then
+		echo "[Timeout] Failed to get NFS server pod Running"
 		return 1
 	fi
 	echo ""


### PR DESCRIPTION
# Describe what this PR does #

Add NFS coverage to upstream external-storage e2e suite to match CephFS and RBD.

Bring up a Ceph NFS in the test cluster like we do the filesystem and bloock pool, and add the driver manifests NFS needs to join the suite.

## Is there anything that requires special attention ##

I picked this up because it had been stale for some time, and I'm going through old NFS issues.  Sorry, @aryanswaroop!  My /assign bounced.

The issue's checklist asks for `driver-nfs.yaml` and `sc-nfs.yaml.in`.  To match CephFS and RBD, we've also added the `volumesnapshotclass-nfs.yaml.in`.

`shellcheck` and `bash -n` are both clean on `scripts/rook.sh`.  `yamllint` flags the same issues in the new `.yaml.in`s as the ones in CephFS and RBD.  I ran `scripts/rook.sh deploy` end to end on a lima VM to provide block devices.  2 OSDs came up, every PG went `active+clean`, CephFS `my-nfs` reached `Ready` and `check_nfs_stat` passed clean with no trap firing.

From what I was able to glean, the actual test against these files is a Jenkins job (`ci/centos/k8s-e2e-external-storage`) that needs both a maintainer and a Kubernetes version to trigger.  

If this looks good, can we kick one off?

## Related issues ##

Fixes: #4540

## Future concerns ##

None.  Contained to the e2e test-cluster scripts.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>

Get merging PRs in place without stepping on the CI jobs.

Depends-on: #6526