### PR TITLE
scripts: use per_page=50 for k8s releases

### DIFF
--- a/scripts/get_patch_release.py
+++ b/scripts/get_patch_release.py
@@ -19,9 +19,9 @@ import requests
 from requests.auth import HTTPBasicAuth
 import sys
 
-RELEASE_URL = 'https://api.github.com/repos/kubernetes/kubernetes/releases'
+RELEASE_URL = 'https://api.github.com/repos/kubernetes/kubernetes/releases?per_page=50'
 '''
-URL for fetching the releases. Add '?per_num=50' to increase the number of
+URL for fetching the releases. Add '?per_page=50' to increase the number of
 returned releases from default 30 to 50 (max 100).
 '''
 


### PR DESCRIPTION

```
Increase the number of fetched Kubernetes releases per page to 50,
and fix the '?per_num=50' typo in the docstring to '?per_page=50'.
```

@iPraveenParihar 1.32 does not come up when the script requests the k8s version from GH release. @nixpanic might have some info on this.

```
❯ ./get.py
v1.37.0
v1.36.4
v1.35.8
v1.34.11
v1.37.0-rc.1
v1.37.0-rc.0
v1.36.3
v1.35.7
v1.34.10
v1.37.0-beta.0
v1.37.0-alpha.3
v1.37.0-alpha.2
v1.36.2
v1.35.6
v1.34.9
v1.33.13
v1.37.0-alpha.1
v1.36.1
v1.35.5
v1.34.8
v1.33.12
v1.36.0
v1.35.4
v1.34.7
v1.33.11
v1.36.0-rc.1
v1.36.0-rc.0
v1.36.0-beta.0
v1.35.3
v1.34.6
```

_Originally posted by @black-dragon74 in https://github.com/ceph/ceph-csi/issues/6503#issuecomment-5491295475_
            

Now works 🎉 

```
python3 scripts/get_patch_release.py --version=v1.32         
v1.32.13
```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
