### PR TITLE
nvmeof: Fix subsystem lock contention causing CreateVolume/DeleteVolume failures

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -233,7 +233,7 @@ func (cs *Server) CreateVolume(
 	if err != nil {
 		log.ErrorLog(ctx, "NVMe-oF resource setup failed for volumeID %s: %v", volumeID, err)
 
-		return nil, status.Errorf(codes.Internal, "NVMe-oF setup failed: %v", err)
+		return nil, err
 	}
 	// Step 5: Populate volume context for NodeServer
 	err = populateVolumeContext(backend, nvmeofData)
@@ -873,7 +873,7 @@ func (cs *Server) createNVMeoFResources(
 	nvmeofData := &nvmeof.NVMeoFVolumeData{}
 
 	if err := nvmeofData.SetFromParameters(params, volumeID); err != nil {
-		return nil, fmt.Errorf("failed to set NVMe-oF volume data: %w", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to set NVMe-oF volume data: %v", err)
 	}
 
 	// extract Qos parameters if any
@@ -884,7 +884,7 @@ func (cs *Server) createNVMeoFResources(
 	if err != nil {
 		log.ErrorLog(ctx, "failed to parse NVMe-oF QoS parameters: %v", err)
 
-		return nil, fmt.Errorf("failed to parse QoS parameters: %w", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse QoS parameters: %v", err)
 	}
 	// If VAC with hosts list is given (for external client)
 	// We need to parse the hosts list and pass it to the gateway for creating host entries
@@ -893,16 +893,16 @@ func (cs *Server) createNVMeoFResources(
 	if err != nil {
 		log.ErrorLog(ctx, "failed to parse NVMe-oF hosts parameters: %v", err)
 
-		return nil, fmt.Errorf("failed to parse hosts parameters: %w", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse hosts parameters: %v", err)
 	}
 	// Step 2: Connect to gateway
 	config, err := getGatewayConfigFromRequest(params)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid gateway config: %v", err)
 	}
 	gateway, err := connectGateway(ctx, config)
 	if err != nil {
-		return nil, fmt.Errorf("gateway connection failed: %w", err)
+		return nil, status.Errorf(codes.Internal, "gateway connection failed: %v", err)
 	}
 	defer func() {
 		if closeErr := gateway.Destroy(); closeErr != nil {
@@ -920,7 +920,7 @@ func (cs *Server) createNVMeoFResources(
 
 	// Step 3: Ensure subsystem exists (and listener)
 	if err := ensureSubsystem(ctx, gateway, nvmeofData.SubsystemNQN, networkMask, nvmeofData.ListenerInfo); err != nil {
-		return nvmeofData, fmt.Errorf("subsystem setup failed: %w", err)
+		return nvmeofData, status.Errorf(codes.Internal, "subsystem setup failed: %v", err)
 	}
 
 	log.DebugLog(ctx, "subsystem %s and Listener %s for the subsystem were created", nvmeofData.SubsystemNQN,
@@ -929,7 +929,7 @@ func (cs *Server) createNVMeoFResources(
 	// Step 4: Create namespace and set its uuid
 	nsid, err := gateway.CreateNamespace(ctx, nvmeofData.SubsystemNQN, rbdPoolName, rbdRadosNameSpace, rbdImageName)
 	if err != nil {
-		return nvmeofData, fmt.Errorf("namespace creation failed: %w", err)
+		return nvmeofData, status.Errorf(codes.Internal, "namespace creation failed: %v", err)
 	}
 	log.DebugLog(ctx, "Namespace created: %s/%s with NSID: %d", rbdPoolName, rbdImageName, nsid)
 	nvmeofData.NamespaceID = nsid
@@ -939,7 +939,7 @@ func (cs *Server) createNVMeoFResources(
 		log.DebugLog(ctx, "Setting QoS limits: %s", nvmeofQoS)
 		if err := gateway.SetQoSLimitsForNamespace(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID,
 			*nvmeofQoS); err != nil {
-			return nvmeofData, fmt.Errorf("setting QoS limits failed: %w", err)
+			return nvmeofData, status.Errorf(codes.Internal, "setting QoS limits failed: %v", err)
 		}
 	}
 	if hostsList != nil {
@@ -948,7 +948,7 @@ func (cs *Server) createNVMeoFResources(
 			// TODO - for now we create host with empty DH-CHAP keys,
 			// in the future we can extend the VAC parameters to allow passing DH-CHAP keys for each host if needed??
 			if err := gateway.AddHost(ctx, nvmeofData.SubsystemNQN, host, nvmeof.DHCHAPKeys{}); err != nil {
-				return nvmeofData, fmt.Errorf("adding host %s to subsystem failed: %w", host, err)
+				return nvmeofData, status.Errorf(codes.Internal, "adding host %s to subsystem failed: %v", host, err)
 			}
 		}
 	}
@@ -956,7 +956,7 @@ func (cs *Server) createNVMeoFResources(
 	if networkMask != "" {
 		autoListeners, err := gateway.ListListeners(ctx, nvmeofData.SubsystemNQN)
 		if err != nil {
-			return nvmeofData, fmt.Errorf("failed to list auto-created listeners: %w", err)
+			return nvmeofData, status.Errorf(codes.Internal, "failed to list auto-created listeners: %v", err)
 		}
 		nvmeofData.ListenerInfo = nvmeof.ConvertListenersFromProto(autoListeners.GetListeners())
 		log.DebugLog(ctx, "Retrieved %d auto-created listeners", len(nvmeofData.ListenerInfo))
@@ -964,7 +964,7 @@ func (cs *Server) createNVMeoFResources(
 
 	uuid, err := gateway.GetUUIDBySubsystemAndNameSpaceID(ctx, nvmeofData.SubsystemNQN, nvmeofData.NamespaceID)
 	if err != nil {
-		return nvmeofData, fmt.Errorf("get namespace uuid failed: %w", err)
+		return nvmeofData, status.Errorf(codes.Internal, "get namespace uuid failed: %v", err)
 	}
 	nvmeofData.NamespaceUUID = uuid
 

--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -910,11 +910,11 @@ func (cs *Server) createNVMeoFResources(
 		}
 	}()
 
-	// TODO: replace util.VolumeOperationAlreadyExistsFmt
-	if acquired := cs.subsystemLocks.TryAcquire(nvmeofData.SubsystemNQN); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+	if acquiredErr := cs.subsystemLocks.Acquire(ctx, nvmeofData.SubsystemNQN); acquiredErr != nil {
+		log.ErrorLog(ctx, "failed to acquire subsystem lock for %s: %v", nvmeofData.SubsystemNQN, acquiredErr)
+		grpcErr := status.FromContextError(acquiredErr).Err()
 
-		return nil, fmt.Errorf(util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+		return nil, grpcErr
 	}
 	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
 
@@ -992,10 +992,11 @@ func (cs *Server) cleanupNVMeoFResources(
 		}
 	}()
 
-	if acquired := cs.subsystemLocks.TryAcquire(nvmeofData.SubsystemNQN); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+	if acquiredErr := cs.subsystemLocks.Acquire(ctx, nvmeofData.SubsystemNQN); acquiredErr != nil {
+		log.ErrorLog(ctx, "failed to acquire subsystem lock for %s: %v", nvmeofData.SubsystemNQN, acquiredErr)
+		grpcErr := status.FromContextError(acquiredErr).Err()
 
-		return fmt.Errorf(util.VolumeOperationAlreadyExistsFmt, nvmeofData.SubsystemNQN)
+		return grpcErr
 	}
 	defer cs.subsystemLocks.Release(nvmeofData.SubsystemNQN)
 

--- a/internal/util/idlocker.go
+++ b/internal/util/idlocker.go
@@ -14,8 +14,10 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -65,6 +67,26 @@ func (vl *IDLocker) TryAcquire(id string) bool {
 	vl.locks.Insert(id)
 
 	return true
+}
+
+func (vl *IDLocker) Acquire(ctx context.Context, id string) error {
+	if vl.TryAcquire(id) {
+		return nil
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if vl.TryAcquire(id) {
+				return nil
+			}
+		}
+	}
 }
 
 // Release deletes the lock on an ID.


### PR DESCRIPTION
This PR fixes two related issues in how we handle concurrent requests
to the same NVMe-oF subsystem.

### Problem

subsystemLocks used TryAcquire, which fails immediately instead of
waiting when the lock is already held. Since multiple PVCs commonly
share the same subsystem (one per StorageClass), any two CreateVolume
or DeleteVolume calls landing close together on the same subsystem
would have one of them fail with:

  an operation with the given Volume ID <subsystemNQN> already exists

That failure also happened after the RBD image was already created, so
losing the race meant a wasted create + delete of the RBD image on top
of the failure itself.

On top of that, the failure was being wrapped as codes.Internal instead
of codes.Aborted further up the call chain. Per the CSI spec, Aborted
is meant to signal "operation already in progress, retry soon" - but
because it was reported as Internal, Kubernetes' external-provisioner
treated it as a generic failure and applied a much longer retry
backoff than necessary, in some cases minutes, which was enough to
fail e2e tests waiting on a 10 minute PVC Bound timeout.

### Fix

1. subsystemLocks.TryAcquire -> new blocking Acquire(ctx, id), so a
   request waits for the lock instead of failing outright. This is
   safe because the gateway itself processes operations on a given
   subsystem sequentially anyway, so there's no concurrency being lost
   by waiting here.
2. Every error path in createNVMeoFResources now
   returns a proper gRPC status code (Aborted for lock contention,
   Internal for genuine gateway failures) instead of a plain error that
   got blanket-wrapped as Internal by the caller..

the e2e running should run here:  https://github.com/ceph/ceph-csi-operator/pull/589
I will share the result soon.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
