### PR TITLE
nvmeof: simplify subsystem deletion

### DIFF
--- a/internal/nvmeof/controller/controllerserver.go
+++ b/internal/nvmeof/controller/controllerserver.go
@@ -805,58 +805,6 @@ func ensureSubsystem(
 	return nil
 }
 
-// cleanupEmptySubsystem checks if the subsystem is empty (no namespaces), if so,
-// first deletes the listener and then deletes it.
-func cleanupEmptySubsystem(
-	ctx context.Context,
-	gateway *nvmeof.GatewayRpcClient,
-	subsystemNQN string,
-	listeners []nvmeof.ListenerDetails,
-) error {
-	if subsystemNQN == "" {
-		return nil
-	}
-	exists, err := gateway.SubsystemExists(ctx, subsystemNQN)
-	if err != nil {
-		return err
-	}
-	if !exists { // In case the subsystem already was deleted, return no error
-		log.DebugLog(ctx, "Subsystem %s does not exists", subsystemNQN)
-
-		return nil
-	}
-	// Check if subsystem has any remaining namespaces
-	namespaces, err := gateway.ListNamespaces(ctx, subsystemNQN)
-	if err != nil {
-		return fmt.Errorf("failed to list namespaces: %w", err)
-	}
-	if len(namespaces.GetNamespaces()) != 0 {
-		log.DebugLog(ctx, "Subsystem %s still has %d namespaces, keeping",
-			subsystemNQN, len(namespaces.GetNamespaces()))
-
-		return nil
-	}
-
-	// subsystem is empty delete listener first
-	for i, listener := range listeners {
-		if err := gateway.DeleteListener(ctx, subsystemNQN, listener); err != nil {
-			// Log and continue deleting other listeners. maybe on failure in creation some listeners were not created.
-			// anyway we want to delete the empty subsystem. deleting the subsystem will delete all listeners anyway.
-			log.WarningLog(ctx, "Failed to delete listener %d (%s) for subsystem %s: %v",
-				i, listener.String(), subsystemNQN, err)
-		}
-	}
-
-	log.DebugLog(ctx, "Subsystem %s is empty, deleting", subsystemNQN)
-	err = gateway.DeleteSubsystem(ctx, subsystemNQN)
-	if err != nil {
-		return fmt.Errorf("failed to delete empty subsystem: %w", err)
-	}
-	log.DebugLog(ctx, "Empty subsystem %s deleted", subsystemNQN)
-
-	return nil
-}
-
 // createNVMeoFResources sets up the NVMe-oF resources for the given RBD volume.
 func (cs *Server) createNVMeoFResources(
 	ctx context.Context,
@@ -971,7 +919,6 @@ func (cs *Server) createNVMeoFResources(
 	return nvmeofData, nil
 }
 
-// cleanupEmptySubsystem removes the subsystem if it exists and has no namespaces.
 // This function is idempotent and safe to call even if the subsystem doesn't exist
 // or has active namespaces.
 func (cs *Server) cleanupNVMeoFResources(
@@ -1013,9 +960,20 @@ func (cs *Server) cleanupNVMeoFResources(
 		log.DebugLog(ctx, "No namespace ID found in NVMe-oF metadata, skipping namespace deletion")
 	}
 
-	// Step 3: Cleanup empty subsystem
-	if err := cleanupEmptySubsystem(ctx, gateway, nvmeofData.SubsystemNQN, nvmeofData.ListenerInfo); err != nil {
-		return fmt.Errorf("failed to cleanup empty subsystem %s: %w", nvmeofData.SubsystemNQN, err)
+	// Step 3: Delete the subsystem if empty. DeleteSubsystem treats a missing or busy subsystem as success.
+	// The gateway automatically deletes all listeners when it deletes the subsystem.
+	if err := gateway.DeleteSubsystem(ctx, nvmeofData.SubsystemNQN); err != nil {
+		if errors.Is(err, nvmeoferrors.ErrSubsystemHasNamespaces) {
+			// The subsystem is shared by other volumes. Its namespace was removed
+			// above, and the gateway will delete the subsystem and listeners after
+			// All remaining namespaces are removed!
+			log.DebugLog(ctx, "Keeping subsystem %s because it still has namespaces",
+				nvmeofData.SubsystemNQN)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to delete subsystem %s: %w", nvmeofData.SubsystemNQN, err)
 	}
 
 	return nil

--- a/internal/nvmeof/errors/errors.go
+++ b/internal/nvmeof/errors/errors.go
@@ -32,6 +32,9 @@ var (
 	ErrMetadataNotFound = errors.New("metadata not found")
 	// ErrMetadataCorrupted is returned when NVMe-oF volume metadata(=rbd metadata) is corrupted or invalid.
 	ErrMetadataCorrupted = errors.New("metadata corrupted or invalid")
+	// ErrSubsystemHasNamespaces is returned when the user tries to delete a subsystem that
+	// still has namespaces.
+	ErrSubsystemHasNamespaces = errors.New("subsystem has namespaces")
 )
 
 // errorToGRPCCode maps custom errors to gRPC status codes.

--- a/internal/nvmeof/nvmeof.go
+++ b/internal/nvmeof/nvmeof.go
@@ -415,8 +415,13 @@ func (gw *GatewayRpcClient) DeleteSubsystem(ctx context.Context, subsystemNQN st
 	case err != nil:
 		return fmt.Errorf("failed to delete subsystem %s: %w", subsystemNQN, err)
 	case status.GetStatus() == int32(syscall.ENOENT):
-		// the subsystem was removed already
+		log.DebugLog(ctx, "Subsystem %s already deleted (not found)", subsystemNQN)
+
 		return nil
+	case status.GetStatus() == int32(syscall.EBUSY):
+		log.DebugLog(ctx, "subsystem %s has namespaces and cannot be deleted: %s", subsystemNQN, status.GetErrorMessage())
+
+		return fmt.Errorf("%w: %s", nvmeoferrors.ErrSubsystemHasNamespaces, status.GetErrorMessage())
 	case status.GetStatus() != 0:
 		return fmt.Errorf("gateway DeleteSubsystem returned error: %s", status.GetErrorMessage())
 	}


### PR DESCRIPTION
instead of call 4 GRPc calls to the nvmeof gw:
1. SubsystemExists
2. ListNamespaces  - this call takes really more time.
3. then it delete per listener DeleteListener
4. then finally delete the subsystem -  DeleteSubsystem

jsut call DeleteSubsystem, if subsystem not empty
will retrun `EBUSY`.
if subsystem does not exist, return `ENOENT`.
the GW automatically deletes the
listeners.

UPDATE:
tested manually on ODF cluster with 2 PVCs.
1. create pvc1 
2. create pvc2
3. delete pvc1 -> see this error (from GW)
```bash
I0903 09:43:03.516339       1 controllerserver.go:953] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-6efc92bb-024a-44ab-ad06-12147a2233d2 Deleting namespace 1 for subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:43:03.516347       1 nvmeof.go:157] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-6efc92bb-024a-44ab-ad06-12147a2233d2 Deleting namespace 1 from subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:43:03.772863       1 nvmeof.go:170] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-6efc92bb-024a-44ab-ad06-12147a2233d2 Namespace deleted successfully: 1
I0903 09:43:03.772893       1 controllerserver.go:958] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-6efc92bb-024a-44ab-ad06-12147a2233d2 Namespace 1 deleted for subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:43:03.772901       1 nvmeof.go:407] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-6efc92bb-024a-44ab-ad06-12147a2233d2 Deleting NVMe subsystem: nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:43:03.775376       1 nvmeof.go:422] ID: 17 Req-ID: 0001-0011-openshift-storage-0000000000000002-6efc92bb-024a-44ab-ad06-12147a2233d2 subsystem nqn.2016-06.io.ceph:subsystem.test-integration has namespaces and cannot be deleted: Failure deleting subsystem nqn.2016-06.io.ceph:subsystem.test-integration: Namespace 2 is still using the subsystem. Either remove it or use the "--force" command line option
```
we handle it by `EBUSY`

4. delete pvc1 -> success and subsystem were deleted. 
```bash
I0903 09:44:37.716509       1 controllerserver.go:953] ID: 19 Req-ID: 0001-0011-openshift-storage-0000000000000002-a675552c-1e8f-4339-a884-cf417b379105 Deleting namespace 2 for subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:44:37.716515       1 nvmeof.go:157] ID: 19 Req-ID: 0001-0011-openshift-storage-0000000000000002-a675552c-1e8f-4339-a884-cf417b379105 Deleting namespace 2 from subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:44:37.934015       1 nvmeof.go:170] ID: 19 Req-ID: 0001-0011-openshift-storage-0000000000000002-a675552c-1e8f-4339-a884-cf417b379105 Namespace deleted successfully: 2
I0903 09:44:37.934043       1 controllerserver.go:958] ID: 19 Req-ID: 0001-0011-openshift-storage-0000000000000002-a675552c-1e8f-4339-a884-cf417b379105 Namespace 2 deleted for subsystem nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:44:37.934050       1 nvmeof.go:407] ID: 19 Req-ID: 0001-0011-openshift-storage-0000000000000002-a675552c-1e8f-4339-a884-cf417b379105 Deleting NVMe subsystem: nqn.2016-06.io.ceph:subsystem.test-integration
I0903 09:44:37.978557       1 nvmeof.go:429] ID: 19 Req-ID: 0001-0011-openshift-storage-0000000000000002-a675552c-1e8f-4339-a884-cf417b379105 Subsystem deleted successfully: nqn.2016-06.io.ceph:subsystem.test-integration
```

---

Get CI jobs structured, wait for others to finish before starting more.

Depends-on: #6526 #6515