### PR TITLE
rbd: skip flatten for ROX snapshot restores

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -4607,9 +4607,12 @@ var _ = Describe("RBD", func() {
 			validateOmapCount(f, 0, rbdType, defaultRBDPool, snapsType)
 		})
 
-		It("validate clone depth triggers flatten when parents are in trash", func() {
-			validateCloneDepthFlattenWithTrashedParents(f)
-		})
+		It(
+			"validate ROX restore skips flatten and RW restore flattens with trashed parents",
+			func() {
+				validateCloneDepthFlattenWithTrashedParents(f)
+			},
+		)
 
 		It(
 			"validate PVC mounting if snapshot and parent PVC are deleted chained with depth 2",

--- a/e2e/rbd_clone_depth.go
+++ b/e2e/rbd_clone_depth.go
@@ -19,8 +19,13 @@ package e2e
 import (
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
+
+// parentRetentionTimeout is in minutes and gives the ROX restore enough time
+// to verify that its snapshot backing image still retains the parent.
+const parentRetentionTimeout = 1
 
 func validateCloneDepthFlattenWithTrashedParents(f *framework.Framework) {
 	err := createRBDSnapshotClass(f)
@@ -111,17 +116,38 @@ func validateCloneDepthFlattenWithTrashedParents(f *framework.Framework) {
 	}
 
 	// Restoring the second snapshot reaches the soft clone-depth limit only if
-	// clone depth is counted through the parents that are already in trash.
-	pvcClone2, err := loadPVC(pvcClonePath)
+	// clone depth is counted through the parents that are already in trash. A
+	// ROX restore must preserve this chain instead of flattening it.
+	pvcCloneROX, err := loadPVC(pvcClonePath)
 	if err != nil {
-		logAndFail("failed to load second PVC clone: %v", err)
+		logAndFail("failed to load ROX PVC clone: %v", err)
 	}
-	pvcClone2.Name = fmt.Sprintf("%s-trash-depth-1", pvcClone2.Name)
-	pvcClone2.Namespace = f.UniqueName
-	pvcClone2.Spec.DataSource.Name = snap2.Name
-	err = createPVCAndvalidatePV(f.ClientSet, pvcClone2, deployTimeout)
+	pvcCloneROX.Name = fmt.Sprintf("%s-trash-depth-1-rox", pvcCloneROX.Name)
+	pvcCloneROX.Namespace = f.UniqueName
+	pvcCloneROX.Spec.DataSource.Name = snap2.Name
+	pvcCloneROX.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}
+	err = createPVCAndvalidatePV(f.ClientSet, pvcCloneROX, deployTimeout)
 	if err != nil {
-		logAndFail("failed to create PVC from second snapshot: %v", err)
+		logAndFail("failed to create ROX PVC from second snapshot: %v", err)
+	}
+
+	err = ensureRBDImageHasParent(f, defaultRBDPool, snap2ImageName, parentRetentionTimeout)
+	if err != nil {
+		logAndFail("failed to validate second snapshot backing image retains its parent: %v", err)
+	}
+
+	// A RW restore from the same snapshot must retain the existing depth-based
+	// flattening behavior.
+	pvcCloneRW, err := loadPVC(pvcClonePath)
+	if err != nil {
+		logAndFail("failed to load RW PVC clone: %v", err)
+	}
+	pvcCloneRW.Name = fmt.Sprintf("%s-trash-depth-1-rw", pvcCloneRW.Name)
+	pvcCloneRW.Namespace = f.UniqueName
+	pvcCloneRW.Spec.DataSource.Name = snap2.Name
+	err = createPVCAndvalidatePV(f.ClientSet, pvcCloneRW, deployTimeout)
+	if err != nil {
+		logAndFail("failed to create RW PVC from second snapshot: %v", err)
 	}
 
 	err = waitForRBDImageFlattened(f, defaultRBDPool, snap2ImageName, deployTimeout)
@@ -133,9 +159,13 @@ func validateCloneDepthFlattenWithTrashedParents(f *framework.Framework) {
 	if err != nil {
 		logAndFail("failed to delete second snapshot: %v", err)
 	}
-	err = deletePVCAndValidatePV(f.ClientSet, pvcClone2, deployTimeout)
+	err = deletePVCAndValidatePV(f.ClientSet, pvcCloneRW, deployTimeout)
 	if err != nil {
-		logAndFail("failed to delete second PVC clone: %v", err)
+		logAndFail("failed to delete RW PVC clone: %v", err)
+	}
+	err = deletePVCAndValidatePV(f.ClientSet, pvcCloneROX, deployTimeout)
+	if err != nil {
+		logAndFail("failed to delete ROX PVC clone: %v", err)
 	}
 	err = deletePVCAndValidatePV(f.ClientSet, pvcClone, deployTimeout)
 	if err != nil {

--- a/e2e/rbd_helper.go
+++ b/e2e/rbd_helper.go
@@ -1267,18 +1267,11 @@ func waitForRBDImageFlattened(f *framework.Framework, poolName, imageName string
 	var errReason error
 	timeout := time.Duration(t) * time.Minute
 	err := wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(_ context.Context) (bool, error) {
-		imgInfoStr, err := getImageInfo(f, imageName, poolName)
+		parent, hasParent, err := getRBDImageParent(f, poolName, imageName)
 		if err != nil {
 			return false, err
 		}
-
-		imgInfo := map[string]json.RawMessage{}
-		err = json.Unmarshal([]byte(imgInfoStr), &imgInfo)
-		if err != nil {
-			return false, fmt.Errorf("failed to parse rbd image info for %q: %w", imageName, err)
-		}
-		parent, ok := imgInfo["parent"]
-		if !ok || string(parent) == "null" || string(parent) == `""` {
+		if !hasParent {
 			return true, nil
 		}
 
@@ -1293,6 +1286,56 @@ func waitForRBDImageFlattened(f *framework.Framework, poolName, imageName string
 	}
 
 	return err
+}
+
+func ensureRBDImageHasParent(f *framework.Framework, poolName, imageName string, t int) error {
+	var errReason error
+	timeout := time.Duration(t) * time.Minute
+	err := wait.PollUntilContextTimeout(context.TODO(), poll, timeout, true, func(_ context.Context) (bool, error) {
+		_, hasParent, err := getRBDImageParent(f, poolName, imageName)
+		if err != nil {
+			return false, err
+		}
+		if !hasParent {
+			errReason = fmt.Errorf("image %q no longer has a parent", imageName)
+
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if errReason != nil {
+		return errReason
+	}
+	if wait.Interrupted(err) {
+		return nil
+	}
+
+	return err
+}
+
+func getRBDImageParent(
+	f *framework.Framework,
+	poolName,
+	imageName string,
+) (json.RawMessage, bool, error) {
+	imgInfoStr, err := getImageInfo(f, imageName, poolName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	imgInfo := map[string]json.RawMessage{}
+	err = json.Unmarshal([]byte(imgInfoStr), &imgInfo)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse rbd image info for %q: %w", imageName, err)
+	}
+	parent, ok := imgInfo["parent"]
+	if !ok || string(parent) == "null" || string(parent) == `""` {
+		return parent, false, nil
+	}
+
+	return parent, true, nil
 }
 
 func getRBDSnapshotImageName(namespace, snapName string) (string, error) {

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -657,6 +657,30 @@ func IsReaderOnly(caps []*csi.VolumeCapability) bool {
 	return false
 }
 
+// AreAllCapabilitiesReaderOnly returns true when all capabilities use a reader-only access mode.
+func AreAllCapabilitiesReaderOnly(caps []*csi.VolumeCapability) bool {
+	if len(caps) == 0 {
+		return false
+	}
+
+	for _, cap := range caps {
+		accessMode := cap.GetAccessMode()
+		if accessMode == nil {
+			return false
+		}
+
+		switch accessMode.GetMode() { //nolint:exhaustive // only check what we want
+		case csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+			csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
+			continue
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
 // IsBlockMultiWriter validates the volume capability slice against the access modes and access type.
 // if the capability is of multi write the first return value will be set to true and if the request
 // is of type block, the second return value will be set to true.

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -748,6 +748,78 @@ func TestIsReaderOnly(t *testing.T) {
 	}
 }
 
+func TestAreAllCapabilitiesReaderOnly(t *testing.T) {
+	t.Parallel()
+
+	capability := func(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
+		return &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: mode},
+		}
+	}
+
+	tests := []struct {
+		name string
+		caps []*csi.VolumeCapability
+		want bool
+	}{
+		{
+			name: "single node reader only",
+			caps: []*csi.VolumeCapability{
+				capability(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
+			},
+			want: true,
+		},
+		{
+			name: "multi node reader only",
+			caps: []*csi.VolumeCapability{
+				capability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+			},
+			want: true,
+		},
+		{
+			name: "all reader only",
+			caps: []*csi.VolumeCapability{
+				capability(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
+				capability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+			},
+			want: true,
+		},
+		{
+			name: "writer",
+			caps: []*csi.VolumeCapability{
+				capability(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			},
+		},
+		{
+			name: "mixed reader and writer",
+			caps: []*csi.VolumeCapability{
+				capability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+				capability(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			},
+		},
+		{
+			name: "empty",
+		},
+		{
+			name: "nil capability",
+			caps: []*csi.VolumeCapability{nil},
+		},
+		{
+			name: "missing access mode",
+			caps: []*csi.VolumeCapability{{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := AreAllCapabilitiesReaderOnly(tt.caps); got != tt.want {
+				t.Errorf("AreAllCapabilitiesReaderOnly() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // killOnSlowGRPC tests must not run in parallel: they mutate the package-level
 // osExit variable and running them concurrently would cause a data race.
 //

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -491,7 +491,10 @@ func (cs *ControllerServer) CreateVolume(
 		return nil, err
 	}
 
-	err = flattenParentImage(ctx, parentVol, rbdSnap, cr)
+	// Pass the reader-only state so snapshot restores can preserve their parent
+	// chain for rbd diff changed-block tracking during incremental backups.
+	isReaderOnly := csicommon.AreAllCapabilitiesReaderOnly(req.GetVolumeCapabilities())
+	err = flattenParentImage(ctx, parentVol, rbdSnap, cr, isReaderOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -542,6 +545,7 @@ func flattenParentImage(
 	rbdVol *rbdVolume,
 	rbdSnap *rbdSnapshot,
 	cr *util.Credentials,
+	isReaderOnly bool,
 ) error {
 	// flatten the image's parent before the reservation to avoid
 	// stale entries in post creation if we return ABORT error and the
@@ -587,6 +591,17 @@ func flattenParentImage(
 				rbdSnap.Destroy(ctx)
 			}
 		}()
+		// Avoid flattening ROX snapshot restores so rbd diff can use the parent
+		// chain to track changed blocks for incremental backups.
+		if isReaderOnly {
+			log.DebugLog(ctx,
+				"rbd: skipping flatten for read-only snapshot restore %q to preserve the parent chain "+
+					"for incremental backup changed-block tracking",
+				rbdSnap.RbdSnapName,
+			)
+
+			return nil
+		}
 
 		// choosing 1, since restore from snapshot adds one depth.
 		const depthToAvoidFlatten = 1


### PR DESCRIPTION
## Summary

Preserve the RBD parent chain when restoring snapshots as read-only volumes. This allows rbd diff changed-block tracking to work for incremental backups.

CreateVolume passes the all-capabilities reader-only state to flattenParentImage. ROX snapshot restores return before flattening, while RW and mixed-capability restores retain the existing flattening behavior.

The clone-depth acceptance coverage now verifies both behaviors with trashed parents: ROX restores retain a parent, and RW restores flatten the image.

## Validation

- internal/csi-common unit tests
- internal/rbd unit tests
- go vet for touched packages and e2e
- E2E compile check
- PR acceptance E2E passed

Assisted-by: Claude Code <noreply@anthropic.com>


---

CI resource ordering.

Depends-on: #6490