### PR TITLE
cleanup: use read-only image opens

### DIFF
--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	mount "k8s.io/mount-utils"
 
+	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
 
@@ -469,6 +470,9 @@ func killOnSlowGRPCWithThreshold(
 		case <-timer.C:
 			log.ExtendedLog(ctx,
 				"gRPC call %s stuck for %s, restarting process", info.FullMethod, threshold)
+			if !util.CleanupConnections() {
+				log.ExtendedLog(ctx, "timed out closing Ceph connections, exiting anyway")
+			}
 			osExit(1)
 		case <-done:
 		}

--- a/internal/rbd/group.go
+++ b/internal/rbd/group.go
@@ -42,7 +42,7 @@ func (rv *rbdVolume) AddToGroup(ctx context.Context, vg types.VolumeGroup) error
 
 	// check if the image is already part of a group
 	// "rbd: ret=-17, File exists" is returned if the image is part of ANY group
-	image, err := rv.open()
+	image, err := rv.openReadOnly()
 	if err != nil {
 		return fmt.Errorf("failed to open image %q: %w", rv, err)
 	}
@@ -90,7 +90,7 @@ func (rv *rbdVolume) RemoveFromGroup(ctx context.Context, vg types.VolumeGroup) 
 // belongs to. If the rbdVolume does not belong to a VolumeGroup, a
 // rbderrors.ErrGroupNotFound is returned.
 func (rv *rbdVolume) GetVolumeGroupID(ctx context.Context, resolver types.VolumeGroupResolver) (string, error) {
-	image, err := rv.open()
+	image, err := rv.openReadOnly()
 	if err != nil {
 		return "", fmt.Errorf("failed to open image %q: %w", rv, err)
 	}

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -149,7 +149,7 @@ func (rm *rbdMirror) DisableMirroring(ctx context.Context, force bool) error {
 
 // GetMirroringInfo gets mirroring information of an image.
 func (rm *rbdMirror) GetMirroringInfo(ctx context.Context) (types.MirrorInfo, error) {
-	image, err := rm.open()
+	image, err := rm.openReadOnly()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}
@@ -283,7 +283,7 @@ func (rm *rbdMirror) Resync(ctx context.Context) error {
 
 // GetGlobalMirroringStatus get the mirroring status of an image.
 func (rm *rbdMirror) GetGlobalMirroringStatus(ctx context.Context) (types.GlobalStatus, error) {
-	image, err := rm.open()
+	image, err := rm.openReadOnly()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open image %q with error: %w", rm, err)
 	}

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -66,6 +66,7 @@ func (rv *rbdVolume) HandleParentImageExistence(
 	if err != nil {
 		return fmt.Errorf("failed to get parent of image %s: %w", rv, err)
 	}
+	defer parent.Destroy(ctx)
 
 	pm, err := parent.ToMirror()
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -2215,6 +2215,13 @@ func (ri *rbdImage) GetMetadata(key string) (string, error) {
 }
 
 func (ri *rbdImage) SetMetadata(key, value string) error {
+	existingVal, err := ri.GetMetadata(key)
+	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
+		return err
+	}
+	if err == nil && existingVal == value {
+		return nil
+	}
 	image, err := ri.open()
 	if err != nil {
 		return err

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -551,7 +551,7 @@ func (ri *rbdImage) getImageID() error {
 // For an image with an erasure-coded data pool, this returns the EC poolID.
 // For an image without a separate data pool, this returns the regular poolID.
 func (ri *rbdImage) getDataPoolID() (int64, error) {
-	image, err := ri.open()
+	image, err := ri.openReadOnly()
 	if err != nil {
 		return util.InvalidPoolID, err
 	}
@@ -1074,7 +1074,7 @@ func (ri *rbdImage) flattenRbdImage(
 }
 
 func (ri *rbdImage) getParentName() (string, error) {
-	rbdImage, err := ri.open()
+	rbdImage, err := ri.openReadOnly()
 	if err != nil {
 		return "", err
 	}
@@ -1968,7 +1968,7 @@ ErrImageNotFound if provided image is not found, and ErrSnapNotFound if
 provided snap is not found in the images snapshot list.
 */
 func (ri *rbdImage) checkSnapExists(rbdSnap *rbdSnapshot) error {
-	image, err := ri.open()
+	image, err := ri.openReadOnly()
 	if err != nil {
 		return err
 	}
@@ -2323,7 +2323,7 @@ type snapAndChildrenInfo struct {
 // listSnapAndChildren returns list of snapshot names, volume snapshot images and
 // child temp clone images. Only child images which are not in trash are returned.
 func (ri *rbdImage) listSnapAndChildren() (*snapAndChildrenInfo, error) {
-	image, err := ri.open()
+	image, err := ri.openReadOnly()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -868,6 +868,7 @@ func (rv *rbdVolume) Delete(ctx context.Context) error {
 // deleteTempImage deletes the temporary image created for volume datasource.
 func (rv *rbdVolume) deleteTempImage(ctx context.Context) error {
 	tempClone := rv.generateTempClone()
+	defer tempClone.Destroy(ctx)
 	snap := &rbdSnapshot{}
 	defer snap.Destroy(ctx)
 
@@ -913,6 +914,7 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 	vol.RbdImageName = ri.RbdImageName
 	vol.RadosNamespace = ri.RadosNamespace
 	vol.conn = ri.conn.Copy()
+	defer vol.Destroy(ctx)
 
 	for {
 		if vol.RbdImageName == "" {
@@ -1122,6 +1124,7 @@ func (ri *rbdImage) checkImageChainHasFeature(ctx context.Context, feature uint6
 	rbdImg.Monitors = ri.Monitors
 	rbdImg.RbdImageName = ri.RbdImageName
 	rbdImg.conn = ri.conn.Copy()
+	defer rbdImg.Destroy(ctx)
 
 	for {
 		if rbdImg.RbdImageName == "" {

--- a/internal/rbd/snapshot.go
+++ b/internal/rbd/snapshot.go
@@ -428,7 +428,7 @@ func (rbdSnap *rbdSnapshot) getRBDSnapID(ctx context.Context) (uint64, error) {
 	vol.conn = rbdSnap.conn.Copy()
 	defer vol.Destroy(ctx)
 
-	image, err := vol.open()
+	image, err := vol.openReadOnly()
 	if err != nil {
 		return 0, err
 	}

--- a/internal/util/conn_pool_test.go
+++ b/internal/util/conn_pool_test.go
@@ -176,3 +176,25 @@ func TestConnPool(t *testing.T) {
 		}
 	})
 }
+
+//nolint:paralleltest // operates on the package-global connPool
+func TestCleanupConnections(t *testing.T) {
+	kf := t.TempDir() + "/cleanup_connections.keyfile"
+	if err := os.WriteFile(kf, []byte("key"), 0o600); err != nil {
+		t.Fatalf("failed to create keyfile: %v", err)
+	}
+	// CleanupConnections operates on the package-global connPool.
+	c, _, err := connPool.fakeGet("mon", "user", kf)
+	if err != nil {
+		t.Fatalf("fakeGet failed: %v", err)
+	}
+	_ = c
+	if len(connPool.conns) != 1 {
+		t.Fatalf("expected 1 conn, got %d", len(connPool.conns))
+	}
+	// CleanupConnections must not panic even with active users.
+	CleanupConnections()
+	if len(connPool.conns) != 0 {
+		t.Errorf("CleanupConnections should have removed all conns, got %d", len(connPool.conns))
+	}
+}

--- a/internal/util/connection.go
+++ b/internal/util/connection.go
@@ -46,6 +46,10 @@ var (
 	cpInterval = 15 * time.Minute
 	cpExpiry   = 10 * time.Minute
 	connPool   = NewConnPool(cpInterval, cpExpiry)
+
+	// cpCleanupTimeout bounds CleanupConnections so a wedged rados_shutdown
+	// on an unresponsive connection cannot block the caller's process exit.
+	cpCleanupTimeout = 30 * time.Second
 )
 
 // rbdVol.Connect() connects to the Ceph cluster and sets rbdVol.conn for further usage.
@@ -159,6 +163,41 @@ func (cc *ClusterConnection) GetNFSAdmin() (*nfs.Admin, error) {
 	}
 
 	return nfs.NewFromConn(cc.conn), nil
+}
+
+// CleanupConnections stops the garbage collector and forcefully closes all
+// pooled Ceph connections, regardless of whether they still have active
+// users. It is meant for unclean shutdown paths (e.g. stuck gRPC restart)
+// where the process is about to exit, in-flight operations cannot complete
+// anyway, and lingering RADOS sessions would cause the cluster to blocklist
+// the client IP.
+//
+// The cleanup runs in a separate goroutine bounded by cpCleanupTimeout:
+// rados_shutdown can block indefinitely on the very unresponsive connection
+// that triggered this call, and the caller is about to exit the process, so
+// closing sessions is best-effort and must never wedge. It returns true when
+// all connections were closed within the timeout, false otherwise.
+func CleanupConnections() bool {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		connPool.timer.Stop()
+		connPool.lock.Lock()
+		defer connPool.lock.Unlock()
+
+		for key, ce := range connPool.conns {
+			ce.destroy()
+			delete(connPool.conns, key)
+		}
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(cpCleanupTimeout):
+		return false
+	}
 }
 
 // GetAddrs returns the addresses of the RADOS session,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
Switch image opens that only read image metadata from open() to
openReadOnly() so they avoid interacting with the exclusive lock:
getDataPoolID, getParentName, checkSnapExists, listSnapAndChildren,
GetMirroringInfo, GetGlobalMirroringStatus, AddToGroup, GetVolumeGroupID
and getRBDSnapID.

```

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>

---

CI job ordering.

Depends-on: #6534