### PR TITLE
cephfs: move fscrypt lock into the CephFS RADOS namespace

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -37,3 +37,10 @@
    different subvolume.
 
 ## NOTE
+
+- The RADOS lock that serializes fscrypt setup for encrypted CephFS volumes
+  is now taken in the CephFS RADOS namespace instead of the default
+  namespace of the metadata pool. This applies to every deployment with
+  encrypted volumes. `cephFS.radosNamespace` defaults to `csi`, so the lock
+  moves to this namespace even when the option was never directly
+  configured.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -43,4 +43,6 @@
   namespace of the metadata pool. This applies to every deployment with
   encrypted volumes. `cephFS.radosNamespace` defaults to `csi`, so the lock
   moves to this namespace even when the option was never directly
-  configured.
+  configured. During a rolling nodeplugin upgrade the locks in the default
+  namespace and `cephFS.radosNamespace` are taken, so that pods which have
+  not been upgraded yet stay serialized against upgraded ones.

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -646,6 +646,70 @@ var _ = Describe(cephfsType, func() {
 					}
 				})
 			}
+
+			It("verify the fscrypt lock is taken in the CephFS RADOS namespace", func() {
+				scOpts := map[string]string{
+					"encrypted":       "true",
+					"encryptionKMSID": "secrets-metadata-test",
+				}
+				err := createCephfsStorageClass(f.ClientSet, f, true, scOpts)
+				if err != nil {
+					logAndFail("failed to create CephFS storageclass: %v", err)
+				}
+
+				pvc, app, err := createPVCAndAppBinding(pvcPath, appPath, f, deployTimeout)
+				if err != nil {
+					logAndFail("failed to create PVC and application binding: %v", err)
+				}
+
+				imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
+				if err != nil {
+					logAndFail("failed to get image info from PVC: %v", err)
+				}
+
+				// Staging an encrypted volume serializes the fscrypt setup
+				// with a RADOS lock on an object named after the ObjectUUID
+				// of the volume. The lock must live in the RADOS namespace
+				// configured as cephFS.radosNamespace, where cephfsOptions()
+				// points the rados commands.
+				//
+				// The lock is released before NodeStageVolume returns, so it
+				// can not be observed directly. Instead this relies on
+				// cls_lock leaving the object behind on unlock, which holds
+				// for every lock type except LOCK_EXCLUSIVE_EPHEMERAL. If
+				// the fscrypt lock ever becomes ephemeral, this check needs
+				// a new way to observe the namespace of the lock.
+				_, stdErr, err := execCommandInToolBoxPod(f,
+					fmt.Sprintf("rados stat %s %s", imageData.imageID, cephfsOptions(metadataPool)),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					logAndFail("fscrypt lock object %s missing in the CephFS RADOS namespace: err=%v stdErr=%s",
+						imageData.imageID, err, stdErr)
+				}
+
+				// The transitional lock that serializes against nodeplugins
+				// which have not been upgraded yet is taken in the default
+				// RADOS namespace. Remove this check together with
+				// acquireLegacyEncryptionLock.
+				_, stdErr, err = execCommandInToolBoxPod(f,
+					fmt.Sprintf("rados stat %s --pool=%s", imageData.imageID, metadataPool),
+					rookNamespace)
+				if err != nil || stdErr != "" {
+					logAndFail("legacy fscrypt lock object %s missing in the default RADOS namespace: err=%v stdErr=%s",
+						imageData.imageID, err, stdErr)
+				}
+
+				err = deletePVCAndApp("", f, pvc, app)
+				if err != nil {
+					logAndFail("failed to delete PVC and application: %v", err)
+				}
+				validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
+
+				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					logAndFail("failed to delete CephFS storageclass: %v", err)
+				}
+			})
 		}
 
 		It("create a PVC and check PVC/PV metadata on CephFS subvolume", func() {

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -158,6 +158,15 @@ func maybeUnlockFileEncryption(
 
 	log.DebugLog(ctx, "Creating lock for the following volume ID %s", volID)
 
+	releaseLegacyLock, err := acquireLegacyEncryptionLock(ctx, volOptions, objectUUID,
+		lockName, lockCookie, lockDesc, lockDuration)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to create the legacy lock for volume ID %s: %v", volID, err)
+
+		return err
+	}
+	defer releaseLegacyLock()
+
 	ioctx, err := volOptions.GetConnection().GetIoctx(volOptions.MetadataPool)
 	if err != nil {
 		log.ErrorLog(ctx, "Failed to create ioctx: %s", err)
@@ -185,6 +194,57 @@ func maybeUnlockFileEncryption(
 	}
 
 	return nil
+}
+
+// acquireLegacyEncryptionLock takes the fscrypt lock in the default RADOS
+// namespace of the metadata pool, where releases before the lock moved to the
+// volume's RADOS namespace took it.
+//
+// The returned function releases the lock and must always be called.
+//
+// TODO: remove once upgrades from releases that lock in the default RADOS
+// namespace are no longer supported.
+func acquireLegacyEncryptionLock(
+	ctx context.Context,
+	volOptions *store.VolumeOptions,
+	objectUUID, lockName, lockCookie, lockDesc string,
+	lockDuration time.Duration,
+) (func(), error) {
+	noop := func() {}
+
+	// Skip when the volume has no RADOS namespace. In that case the caller
+	// already takes its lock in the default namespace of the pool, which is
+	// exactly where the legacy lock lives, and locking the same object twice
+	// with the same cookie fails with EEXIST.
+	if volOptions.RadosNamespace == "" {
+		return noop, nil
+	}
+
+	ioctx, err := volOptions.GetConnection().GetIoctx(volOptions.MetadataPool)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ioctx in the default namespace of pool %q: %w",
+			volOptions.MetadataPool, err)
+	}
+
+	lock := iolock.NewLock(ioctx, objectUUID, lockName, lockCookie, lockDesc, lockDuration)
+	if err = lock.LockExclusive(ctx); err != nil {
+		ioctx.Destroy()
+
+		if errors.Is(err, iolock.ErrLockNotPermitted) {
+			log.DebugLog(ctx, "not allowed to lock in the default namespace of pool %q, "+
+				"skipping the legacy lock for object %s: %v",
+				volOptions.MetadataPool, objectUUID, err)
+
+			return noop, nil
+		}
+
+		return nil, err
+	}
+
+	return func() {
+		lock.Unlock(ctx)
+		ioctx.Destroy()
+	}, nil
 }
 
 // generateLockCookie generates a consistent lock cookie for the client.

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -166,6 +166,8 @@ func maybeUnlockFileEncryption(
 	}
 	defer ioctx.Destroy()
 
+	ioctx.SetNamespace(volOptions.RadosNamespace)
+
 	lock := iolock.NewLock(ioctx, objectUUID, lockName, lockCookie, lockDesc, lockDuration)
 	err = lock.LockExclusive(ctx)
 	if err != nil {

--- a/internal/util/lock/lock.go
+++ b/internal/util/lock/lock.go
@@ -18,6 +18,7 @@ package lock
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"syscall"
 	"time"
@@ -26,6 +27,12 @@ import (
 
 	"github.com/ceph/ceph-csi/internal/util/log"
 )
+
+// ErrLockNotPermitted is returned when the CephX credentials are not allowed to
+// perform the lock operation. Locking is a RADOS class operation, so it needs
+// the class-exec permission on the pool, and caps that cover the RADOS
+// namespace of the IO context.
+var ErrLockNotPermitted = errors.New("not allowed to lock")
 
 // IOCtxLock provides methods for acquiring and releasing exclusive locks on a volume.
 // using rados IO context locks.
@@ -82,6 +89,8 @@ func (lck *lock) LockExclusive(ctx context.Context) error {
 		case -int(syscall.EEXIST):
 			return fmt.Errorf("lock is already held by the same client and cookie pair for %v volume",
 				lck.volID)
+		case -int(syscall.EPERM), -int(syscall.EACCES):
+			return fmt.Errorf("%w volume ID %v", ErrLockNotPermitted, lck.volID)
 		default:
 			return fmt.Errorf("failed to lock volume ID %v: %w", lck.volID, err)
 		}


### PR DESCRIPTION
# Describe what this PR does #

Fixes the first item of #6531: the RADOS lock that serializes fscrypt setup for encrypted volumes lives in the
default namespace of the metadata pool, while every other object Ceph-CSI creates for a CephFS cluster lives
in the configured RADOS namespace (`cephFS.radosNamespace`, default `csi`).

This PR places the lock in the RADOS namespace configured by `cephFS.radosNamespace`.

## Is there anything that requires special attention ##

Is the change backward compatible?

Yes, I implemented a transitional legacy lock mechanism that keeps mixed-version deployments safe. This
mechanism makes nodes that include the changes of this PR try to get both the new lock (placed in
`cephFS.radosNamespace`) and the old lock (placed in the default RADOS namespace).

However, the "old lock" in the default RADOS namespace is not required in two cases. If the CephX capabilities
of the node cannot access the default namespace, the mount continues without it (such a deployment could never
stage an encrypted volume before this change, so no old nodeplugin can be holding the old lock). Volumes
without a RADOS namespace (static volumes) take only one lock, in the default namespace, because both locks
would be the same object. Any other failure to take the old lock fails the mount.

The legacy lock is marked with a TODO for removal once upgrades from releases that lock in the default
namespace are no longer supported.

Do you have any questions?

* Is protecting the rolling-upgrade edge case worth the code it takes? The core fix is the single
  `SetNamespace()` call. The rest of the PR exists to keep an old nodeplugin and an upgraded one serialized
  while updating. The serialization only matters when the same encrypted volume is staged on a non-updated
  ceph-csi instance and an updated ceph-csi instance at the same time. If that window is considered
  unimportant, the legacy lock can be dropped (together with the sentinel-error commit it depends on and its
  e2e check). Instead the upgrade documentation would warn operators not to start pods that mount encrypted
  volumes while the nodeplugin upgrade is running. Ceph-CSI cannot enforce this since a nodeplugin does not
  know that a rolling upgrade is in progress, and the legacy lock is exactly the mechanism that serializes the
  two sides. Avoiding the race would be left entirely to the operator.

* Is the e2e test's dependency on RADOS lock internals acceptable? The lock is released before
  `NodeStageVolume` returns, so the test can not observe it held. Instead it checks for the object that
  cls_lock leaves behind on unlock, which holds for every lock type except `LOCK_EXCLUSIVE_EPHEMERAL`. Should
  cls_lock ever stop leaving the object behind, or the fscrypt lock become ephemeral, the test breaks without
  any product regression. An e2e test was asked for in #6531, so if this dependency is not acceptable, I would
  rework the check rather than drop it. However suggestions for a better way to observe the lock's namespace
  are welcome (I am unsure how to do it in a different manner).

## Related issues ##

Part of #6531.

## Future concerns ##

* Remove the transitional legacy lock once upgrades from releases that take the fscrypt lock in the default
  namespace are no longer supported (marked with a TODO in the code).


AI assistance: this code was developed with the help of an AI assistant (Claude). Each commit carries the
`Assisted-by: Claude Code <noreply@anthropic.com>` trailer, per AGENTS.md.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>

---

CI job ordering.

Depends-on: #6497