### PR TITLE
ci: let Mergify use the merge update_method

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,7 +16,7 @@ queue_rules:
   - name: default
     update_bot_account: ceph-csi-bot
     merge_method: rebase
-    update_method: rebase
+    update_method: merge
     batch_size: 1
     queue_conditions:
       - and:


### PR DESCRIPTION
This seems to be the simplest approach, we will have to test it out to
see if it works.

Mergify refuses rebasing, and reports the following message:

> GitHub refuses an OAuth token on its rebase API for a fork, so rebasing a
> fork's pull request on behalf of a GitHub user means impersonating that user
> to force-push the contributor's branch. Mergify does not do that.
> 
> Unset update_bot_account on the default queue to keep queueing pull requests
> from forks: with no account to impersonate, the update rebases through
> GitHub's API as Mergify, which the installation token is allowed to do. A
> fork pull request that changes GitHub Actions workflows, or that another
> GitHub App's bot opened, is the exception: GitHub lets Mergify queue one in
> place only with an update_bot_account, so a queue that receives those has to
> run its checks on a draft pull request instead. update_method: merge works
> too, and merges the base branch into the pull request rather than rebasing
> it.
