### PR TITLE
ci: test Kubernetes 1.36 and 1.37 on devel branch

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         branch: [release-v3.16, release-v3.17, devel]
-        k8s: ["1.32", "1.33", "1.34", "1.35", "1.36"]
+        k8s: ["1.32", "1.33", "1.34", "1.35", "1.36", "1.37"]
         exclude:
           - k8s: "1.36"
             branch: "release-v3.16"
@@ -38,6 +38,18 @@ jobs:
 
           - k8s: "1.33"
             branch: "devel"
+
+          - k8s: "1.34"
+            branch: "devel"
+
+          - k8s: "1.35"
+            branch: "devel"
+
+          - k8s: "1.37"
+            branch: "release-v3.16"
+
+          - k8s: "1.37"
+            branch: "release-v3.17"
 
 
     # watch out, matrix.branch can not be used in this if-statement :-/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -78,12 +78,10 @@ queue_rules:
                   - "status-success=ci/centos/upgrade-tests-rbd"
               - and:
                   - base=devel
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.34"
-                  - "status-success=ci/centos/k8s-e2e-external-storage/1.35"
                   - "status-success=ci/centos/k8s-e2e-external-storage/1.36"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.34"
-                  - "status-success=ci/centos/mini-e2e/k8s-1.35"
+                  - "status-success=ci/centos/k8s-e2e-external-storage/1.37"
                   - "status-success=ci/centos/mini-e2e/k8s-1.36"
+                  - "status-success=ci/centos/mini-e2e/k8s-1.37"
                   - "status-success=ci/centos/upgrade-tests-cephfs"
                   - "status-success=ci/centos/upgrade-tests-rbd"
               - and:


### PR DESCRIPTION
Add k8s 1.37 to the test matrix and restrict devel to only
1.36 and 1.37 by excluding 1.32, 1.33, 1.34 and 1.35.
k8s 1.37 is excluded from release-v3.16 and release-v3.17.

Update the Mergify queue conditions to match the updated CI
matrix: only k8s 1.36 and 1.37 are tested on devel, so drop
the 1.34 and 1.35 status-success requirements and add 1.37.

Closes: #6469